### PR TITLE
Allow Format Icons

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1874,6 +1874,45 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	}
 
 	/**
+	 * Returns the input stream for this resource's generic thumbnail,
+	 * i.e. first of:
+	 *          - its Format icon, if any
+	 *          - the fallback image, if any
+	 *          - the default video icon
+	 *
+	 * @param fallback
+	 *            the fallback image, or null.
+	 *
+	 * @return The InputStream
+	 * @throws IOException
+	 */
+	public InputStream getGenericThumbnailInputStream(String fallback) throws IOException {
+
+		String thumb = (getFormat() != null && getFormat().getIcon() != null) ?
+			getFormat().getIcon() : fallback;
+
+		// thumb could be
+		if (thumb != null) {
+			// a local file
+			if (new File(thumb).exists()) {
+				return new FileInputStream(thumb);
+			}
+			// a jar resource
+			InputStream is;
+			if ((is = getResourceInputStream(thumb)) != null) {
+				return is;
+			}
+			// a url
+			try {
+				return downloadAndSend(thumb, true);
+			} catch (Exception e) {}
+		}
+
+		// or none of the above
+		return getResourceInputStream("images/thumbnail-video-256.png");
+	}
+
+	/**
 	 * Returns the input stream for this resource's thumbnail
 	 * (or a default image if a thumbnail can't be found).
 	 * Typically overridden by a subclass.
@@ -1882,7 +1921,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 * @throws IOException
 	 */
 	public InputStream getThumbnailInputStream() throws IOException {
-		return getResourceInputStream("images/thumbnail-video-256.png");
+		return getGenericThumbnailInputStream(null);
 	}
 
 	public String getThumbnailContentType() {

--- a/src/main/java/net/pms/dlna/DVDISOTitle.java
+++ b/src/main/java/net/pms/dlna/DVDISOTitle.java
@@ -317,7 +317,7 @@ public class DVDISOTitle extends DLNAResource {
 		} else if (getMedia() != null && getMedia().getThumb() != null) {
 			return getMedia().getThumbnailInputStream();
 		} else {
-			return getResourceInputStream("images/thumbnail-music.png");
+			return getGenericThumbnailInputStream("images/thumbnail-music.png");
 		}
 	}
 }

--- a/src/main/java/net/pms/formats/Format.java
+++ b/src/main/java/net/pms/formats/Format.java
@@ -159,6 +159,16 @@ public abstract class Format implements Cloneable {
 		return HTTPResource.getDefaultMimeType(type);
 	}
 
+	protected String icon = null;
+
+	public void setIcon(String filename) {
+		icon = filename;
+	}
+
+	public String getIcon() {
+		return icon;
+	}
+
 	public boolean match(String filename) {
 		boolean match = false;
 		if (filename == null) {


### PR DESCRIPTION
Currently the generic video icon is the thumbnail of last resort, which isn't always a good fit for the media in question.  This is a simple patch to allow specifying default format icons to be used instead at this point.

The context for me is jumpy's psuedo-formats, which are pretending to be text files, web pages, etc and could use a better icon when matched by UMS, but I thought it may be generally useful too, i.e flac vs wav etc.
