### PR TITLE
Added web filter resources + logfix

### DIFF
--- a/contrib/ffmpegwebvideo-first.groovy
+++ b/contrib/ffmpegwebvideo-first.groovy
@@ -1,0 +1,58 @@
+import java.util.ArrayList;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import net.pms.PMS;
+import net.pms.encoders.PlayerFactory;
+import net.pms.encoders.FFmpegWebVideo;
+import net.pms.configuration.PmsConfiguration;
+
+import com.chocolatey.pmsencoder.PMSEncoder;
+
+// USAGE:
+//   Place this file in your pmsencoder scripts directory
+//   if you want to use PMSEncoder as a secondary engine
+//   after FFmpeg Web Video.
+
+init {
+	$PMS.debug("ffmpegwebvideo_first.groovy: initializing...")
+	def configuration = $PMS.getConfiguration()
+	
+	// register FFmpegWebVideo before PMSEncoder
+	PlayerFactory.registerPlayer(new FFmpegWebVideo(configuration))
+
+	// put ffmpegwebvideo first in engines list
+	def engines = new ArrayList<String>(configuration.getEnginesAsList($PMS.getRegistry()))
+	engines.removeAll([PMSEncoder.ID, FFmpegWebVideo.ID])
+	engines.add(0, FFmpegWebVideo.ID)
+	engines.add(1, PMSEncoder.ID)
+	configuration.setEnginesAsList(engines)
+
+	// spoof ID to disarm the upcoming Plugin.enable() call
+	def field = PMSEncoder.getDeclaredField("ID")
+	def modifiers = Field.class.getDeclaredField("modifiers");
+	modifiers.setAccessible(true)
+	modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL)
+	field.set(field.get(PMSEncoder), FFmpegWebVideo.ID)
+}
+
+// note: the block below will be triggered by the first call to launchTranscode()
+
+script {
+	profile ('cleanup') {
+		pattern {
+			if (! PMSEncoder.ID.equals("pmsencoder")) {
+				$PMS.debug("ffmpegwebvideo_first.groovy: cleaning up...")
+				// undo ID spoof
+				def field = PMSEncoder.getDeclaredField("ID")
+				def modifiers = Field.class.getDeclaredField("modifiers")
+				modifiers.setAccessible(true)
+				modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL)
+				final String id = "pmsencoder"
+				field.set(field.get(PMSEncoder), id)
+			}
+			match { false }
+		}
+	}
+}
+

--- a/src/main/external-resources/ffmpeg.webfilters
+++ b/src/main/external-resources/ffmpeg.webfilters
@@ -1,0 +1,46 @@
+# These are custom rules to fine-tune the behaviour of
+# FFmpeg Web Video transcoding with respect to specific urls.  
+
+
+########################## EXCLUDE ##############################
+# urls to be skipped (i.e. passed along to later engines)
+#    format:   <regex to match>
+#################################################################
+
+EXCLUDE
+
+# unresolved youtube urls
+gdata\.youtube\.com|youtube_gdata
+
+# other unresolved urls
+feeds\.feedburner\.com
+www\.gameswelt\.de
+eurogamer\.net
+gametrailers\.com
+giantbomb\.com
+icanhascheezburger\.com
+pcgames\.de
+winfuture\.de
+
+
+########################## OPTIONS ##############################
+# urls requiring specific FFmpeg options.
+#    format:   <regex to match> | <options to add>
+#################################################################
+
+OPTIONS
+
+trailers\.apple\.com | -user-agent QuickTime/7.6.2
+# uncomment the rule below if you experience audio problems with endgadget:
+#www\.viddler\.com | -target ntsc-dvd
+
+
+########################## REPLACE ##############################
+# urls to be modified (using capture groups).
+#    format:   <regex to match> | <replacement regex>
+#    example: .*somewhere\.com.* | $0\?somevar=true
+#################################################################
+
+REPLACE
+
+# no rules yet

--- a/src/main/java/net/pms/encoders/FFmpegWebVideo.java
+++ b/src/main/java/net/pms/encoders/FFmpegWebVideo.java
@@ -298,11 +298,6 @@ public class FFmpegWebVideo extends FFMpegVideo {
 		try {
 			filename = new File(configuration.getProfileDirectory() + File.separator + filename).getAbsolutePath();
 			File file = new File(filename);
-			if (file.exists()) {
-				LOGGER.debug("Web filters file was found");
-			} else {
-				LOGGER.debug("Web filters file was not found");
-			}
 			LineIterator it = FileUtils.lineIterator(new File(filename));
 			try {
 				while (it.hasNext()) {


### PR DESCRIPTION
Here are the two additional files:
- _ffmpeg.webfilters_ is in external-resources but still needs to be installed to the profile dir per your commit.
- _ffmpegwebvideo-first.groovy_ is only needed if pmsencoder is being used, so I put it in contrib.  You can distribute it separately instead, of course.
