### PR TITLE
More precise network speed detection

### DIFF
--- a/src/main/java/net/pms/network/SpeedStats.java
+++ b/src/main/java/net/pms/network/SpeedStats.java
@@ -139,14 +139,19 @@ public class SpeedStats {
 			failsafe.start();
 			pw.runInSameThread();
 			List<String> ls = pw.getOtherResults();
-			int time = 0;
+			double time = 0;
 			int c = 0;
+			String timeString = null;
 
 			for (String line : ls) {
 				int msPos = line.indexOf("ms");
 
 				if (msPos > -1) {
-					String timeString = line.substring(line.lastIndexOf("=", msPos) + 1, msPos).trim();
+					if (line.lastIndexOf("<", msPos) > -1){
+						timeString = "0.5";
+					} else {
+						timeString = line.substring(line.lastIndexOf("=", msPos) + 1, msPos).trim();
+					}
 					try {
 						time += Double.parseDouble(timeString);
 						c++;
@@ -162,7 +167,7 @@ public class SpeedStats {
 			}
 
 			if (time > 0) {
-				int speedInMbits = 1024 / time;
+				int speedInMbits = (int)(512 / time);
 				LOGGER.info("Address " + addr + " has an estimated network speed of: " + speedInMbits + " Mb/s");
 				synchronized(speedStats) {
 					CompletedFuture<Integer> result = new CompletedFuture<>(speedInMbits);


### PR DESCRIPTION
On 1 GBit network it is possible to receive speed <1ms for 64000B of PING size.
This speed were not parsed correctly so no speed was shown.
Also TIME value was set as INTEGER where e.g. 5/3 returns 1 instead of 1.6666666 so counted speed should be more precise now with DOUBLE format.
Anyway speed test is still quite inaccurate because <1ms gives 1GBit and =1ms gives 512Mbit....but better anything than nothing:-)
