### PR TITLE
urlresolver - rough patch for discussion

### DIFF
--- a/src/main/java/net/pms/dlna/WebStream.java
+++ b/src/main/java/net/pms/dlna/WebStream.java
@@ -118,6 +118,11 @@ public class WebStream extends DLNAResource {
 		return getUrl();
 	}
 
+	@Override
+	public void setSystemName(String name) {
+		setUrl(name);
+	}
+
 	/**
 	 * @return the url
 	 * @since 1.50

--- a/src/main/java/net/pms/encoders/FFmpegWebVideo.java
+++ b/src/main/java/net/pms/encoders/FFmpegWebVideo.java
@@ -31,7 +31,6 @@ import net.pms.configuration.RendererConfiguration;
 import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAResource;
 import net.pms.external.ExternalFactory;
-import net.pms.external.URLResolver.URLResult;
 import net.pms.formats.Format;
 import net.pms.formats.FormatFactory;
 import net.pms.formats.WEB;
@@ -152,9 +151,10 @@ public class FFmpegWebVideo extends FFMpegVideo {
 			customOptions.addAll(parseOptions(hdr));
 		}
 		// - attached options
-		String attached = (String) dlna.getAttachment(ID);
+		Object attached = dlna.getAttachment(ID);
 		if (attached != null) {
-			customOptions.addAll(parseOptions(attached));
+			customOptions.addAll(attached instanceof String ?
+				parseOptions((String)attached) : (List<String>)attached);
 		}
 		// - renderer options
 		if (StringUtils.isNotEmpty(renderer.getCustomFFmpegOptions())) {
@@ -179,17 +179,6 @@ public class FFmpegWebVideo extends FFMpegVideo {
 
 		params.input_pipes[0] = pipe;
 		int nThreads = configuration.getNumberOfCpuCores();
-		if (!dlna.isURLResolved()) {
-			URLResult r1 = ExternalFactory.resolveURL(fileName);
-			if (r1 != null) {
-				if (StringUtils.isNotEmpty(r1.url)) {
-					fileName = r1.url;
-				}
-				if (r1.args != null && r1.args.size() > 0) {
-					customOptions.addAll(r1.args);	
-				}
-			}
-		}
 
 		// build the command line
 		List<String> cmdList = new ArrayList<>();

--- a/src/main/java/net/pms/external/URLResolver.java
+++ b/src/main/java/net/pms/external/URLResolver.java
@@ -1,13 +1,15 @@
 package net.pms.external;
 
 import java.util.List;
+import net.pms.dlna.DLNAResource;
 
 public interface URLResolver extends ExternalListener {
+	public static final String ID = "URLResolver";
 	class URLResult {
 		public String url;
 		public List<String> args;
 		public int flags;
 	}
 
-	public URLResult urlResolve(String url);
+	public URLResult urlResolve(String url, DLNAResource dlna);
 }


### PR DESCRIPTION
@SharkHunter  - this is very roughly what I have in mind, but it does have some logical quirks still.  Basically the resolver gets to inspect/attach directly to the DLNAResource, and maybe even retrieve stuff it attached to it earlier. This lets us populate folders faster since we can go ahead and create the item when all we know is name and thumb and leave everything else for later (a lot of xbmc items come in this 2-stage way for instance).
