### PR TITLE
Fixing exceptions spotted on Android

### DIFF
--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -260,7 +260,14 @@ public class RequestV2 extends HTTPResource {
 			// skip the leading "get/" and extract the
 			// resource ID from the first path element
 			// e.g. "get/0$1$5$3$4/Foo.mp4" -> "0$1$5$3$4"
-			String id = argument.substring(4, argument.lastIndexOf("/"));
+
+			// ExSport: I spotted on Android it is asking for "/get/0$2$4$2$1$3" which generates exception with response:
+			// "Http: Response, HTTP/1.1, Status: Internal server error, URL: /get/0$2$4$2$1$3"
+			// This should fix it
+			String id = argument.substring(4);
+			if (argument.substring(4).contains("/")) {
+				id = argument.substring(4, argument.lastIndexOf("/"));
+			}
 
 			// Some clients escape the separators in their request: unescape them.
 			id = id.replace("%24", "$");


### PR DESCRIPTION
When browsing on Android, UMS generates exceptions because renderer sent /get/0$1$... for folder but UMS expects files only where "/" is always present.
