### PR TITLE
Apply general GPU acceleration setting for encoders capable to use it.

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -109,7 +109,7 @@ public class PmsConfiguration {
 	private static final String KEY_FORCED_SUBTITLE_TAGS = "forced_sub_tags";
 	private static final String KEY_FORCETRANSCODE = "forcetranscode";
 	private static final String KEY_FOLDER_LIMIT = "folder_limit";
-	private static final String KEY_GPU_ACCELERATION = "gpu_acceleration";
+	public static final String KEY_GPU_ACCELERATION = "gpu_acceleration";
 	private static final String KEY_HIDE_EMPTY_FOLDERS = "hide_empty_folders";
 	private static final String KEY_HIDE_ENGINENAMES = "hide_enginenames";
 	private static final String KEY_HIDE_EXTENSIONS = "hide_extensions";

--- a/src/main/java/net/pms/encoders/AviSynthFFmpeg.java
+++ b/src/main/java/net/pms/encoders/AviSynthFFmpeg.java
@@ -47,6 +47,9 @@ import net.pms.dlna.DLNAResource;
 import net.pms.formats.Format;
 import net.pms.formats.v2.SubtitleType;
 import net.pms.util.ProcessUtil;
+
+import org.apache.commons.configuration.event.ConfigurationEvent;
+import org.apache.commons.configuration.event.ConfigurationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,7 +170,7 @@ public class AviSynthFFmpeg extends FFMpegVideo {
 				movieLine = movieLine + ".ConvertToYV12()";
 
 				// Enable GPU to assist with CPU
-				if (configuration.getFfmpegAvisynthInterFrameGPU()){
+				if (configuration.getFfmpegAvisynthInterFrameGPU() && configuration.isGPUAcceleration()){
 					GPU = ", GPU=true";
 				}
 
@@ -301,6 +304,7 @@ public class AviSynthFFmpeg extends FFMpegVideo {
 				configuration.setFfmpegAvisynthInterFrameGPU((e.getStateChange() == ItemEvent.SELECTED));
 			}
 		});
+		interframegpu.setEnabled(configuration.isGPUAcceleration());
 		builder.add(interframegpu, cc.xy(2, 7));
 
 		convertfps = new JCheckBox(Messages.getString("AviSynthMEncoder.3"));
@@ -315,6 +319,18 @@ public class AviSynthFFmpeg extends FFMpegVideo {
 			}
 		});
 		builder.add(convertfps, cc.xy(2, 9));
+		
+		configuration.addConfigurationListener(new ConfigurationListener() {
+			@Override
+			public void configurationChanged(ConfigurationEvent event) {
+				if (event.getPropertyName() == null ) {
+					return;
+				}
+				if ((!event.isBeforeUpdate()) && event.getPropertyName().equals(PmsConfiguration.KEY_GPU_ACCELERATION)) {
+					interframegpu.setEnabled(configuration.isGPUAcceleration());
+				}
+			}
+		});
 
 		return builder.getPanel();
 	}

--- a/src/main/java/net/pms/encoders/AviSynthMEncoder.java
+++ b/src/main/java/net/pms/encoders/AviSynthMEncoder.java
@@ -42,6 +42,9 @@ import net.pms.dlna.DLNAResource;
 import net.pms.formats.Format;
 import net.pms.formats.v2.SubtitleType;
 import net.pms.util.ProcessUtil;
+
+import org.apache.commons.configuration.event.ConfigurationEvent;
+import org.apache.commons.configuration.event.ConfigurationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,6 +124,7 @@ public class AviSynthMEncoder extends MEncoderVideo {
 				configuration.setAvisynthInterFrameGPU((e.getStateChange() == ItemEvent.SELECTED));
 			}
 		});
+		interframegpu.setEnabled(configuration.isGPUAcceleration());
 		builder.add(interframegpu, cc.xy(2, 7));
 
 		convertfps = new JCheckBox(Messages.getString("AviSynthMEncoder.3"));
@@ -183,6 +187,18 @@ public class AviSynthMEncoder extends MEncoderVideo {
 		JScrollPane pane = new JScrollPane(textArea, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 		pane.setPreferredSize(new Dimension(500, 350));
 		builder.add(pane, cc.xy(2, 13));
+		
+		configuration.addConfigurationListener(new ConfigurationListener() {
+			@Override
+			public void configurationChanged(ConfigurationEvent event) {
+				if (event.getPropertyName() == null ) {
+					return;
+				}
+				if ((!event.isBeforeUpdate()) && event.getPropertyName().equals(PmsConfiguration.KEY_GPU_ACCELERATION)) {
+					interframegpu.setEnabled(configuration.isGPUAcceleration());
+				}
+			}
+		});
 
 		return builder.getPanel();
 	}
@@ -283,7 +299,7 @@ public class AviSynthMEncoder extends MEncoderVideo {
 				movieLine = movieLine + ".ConvertToYV12()";
 
 				// Enable GPU to assist with CPU
-				if (configuration.getAvisynthInterFrameGPU()){
+				if (configuration.getAvisynthInterFrameGPU() && configuration.isGPUAcceleration()){
 					GPU = ", GPU=true";
 				}
 


### PR DESCRIPTION
@SubJunk and @SharkHunter I try to finished applying general GPU acceleration setting for encoders capable to use it. Please check it or recommend different approach. Maybe the GPU acceleration setting in each encoders setting tabs could be removed and  used only general setting or it could be leaved as it is and and the general setting is not ussefull and it can be removed. What is your opinion?
