### PR TITLE
Update SamsungAllShare.conf

### DIFF
--- a/src/main/external-resources/renderers/SamsungAllShare.conf
+++ b/src/main/external-resources/renderers/SamsungAllShare.conf
@@ -22,7 +22,7 @@ RendererIcon=samsung.png
 # Note: the "[TV]PS51D6900" is the default type name.
 # It can be edited via the TV menu into any string.
 # ====================================================
-UserAgentSearch=SEC_HHP
+UserAgentSearch=SEC_HHP_[TV]|SEC_HHP_[HT]|SEC_HHP_ Family
 
 # Recent firmware (0016 and 0019) has been reported to no longer send additional headers info
 # Leaving this in for backwards compatibility with older firmware


### PR DESCRIPTION
Edited for a more detailed UserAgentSearch; "SEC_HHP" is too general and  conflicts with Samsung Galaxy S3
