### PR TITLE
Ensure file exists before browsing for subtitles

### DIFF
--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -384,7 +384,10 @@ public class FileUtil {
 	}
 
 	public static boolean isSubtitlesExists(File file, DLNAMediaInfo media, boolean usecache) {
-		boolean found = browseFolderForSubtitles(file.getParentFile(), file, media, usecache);
+		boolean found = false;
+		if (file.exists()) {
+			found = browseFolderForSubtitles(file.getParentFile(), file, media, usecache);
+		}
 		String alternate = PMS.getConfiguration().getAlternateSubtitlesFolder();
 
 		if (isNotBlank(alternate)) { // https://code.google.com/p/ps3mediaserver/issues/detail?id=737#c5


### PR DESCRIPTION
Prevents an NPE from `getParentFile()`when `file` is really a url. The context is a call from the `isBravia` section of [DLNAResource.getString (#L1586)](https://github.com/UniversalMediaServer/UniversalMediaServer/blob/master/src/main/java/net/pms/dlna/DLNAResource.java#L1586) which assumes the video can only be a real file.
