### PR TITLE
Restore external ass support (again)

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -1103,15 +1103,19 @@ public class FFMpegVideo extends Player {
 			cmdList.add("fatal");
 		}
 
-		if (
-			isNotBlank(configuration.getSubtitlesCodepage()) &&
-			params.sid.isExternal() &&
-			!params.sid.isExternalFileUtf8() &&
-			(params.sid.getExternalFileCharacterSet() == null || // ExternalFileCharacterSet can be null
-			!params.sid.getExternalFileCharacterSet().equals(configuration.getSubtitlesCodepage())) 
-		) {
-			cmdList.add("-sub_charenc");
-			cmdList.add(configuration.getSubtitlesCodepage());
+		// Try to specify input encoding if we have a non utf-8 external sub
+		if (params.sid.isExternal() && !params.sid.isExternalFileUtf8()) {
+			String encoding = params.sid.getExternalFileCharacterSet() != null ?
+					// actually detected
+					params.sid.getExternalFileCharacterSet() :
+				isNotBlank(configuration.getSubtitlesCodepage()) ?
+					// globally specified, may be wrong
+					configuration.getSubtitlesCodepage() :
+				null;
+			if (encoding != null) {
+				cmdList.add("-sub_charenc");
+				cmdList.add(encoding);
+			}
 		}
 
 		cmdList.add("-i");


### PR DESCRIPTION
@valib: It's happened again it seems :-).

I started to pepper in a lot of `getType() == SubtitleType.ASS` conditionals but it began to look silly, especially since `getSubtitles()` code now looks to be in a transitional state with a lot of duplication.  Anyhow I took the liberty of trying to simplify it in a (hopefully) beneficial way and I'd appreciate if you test and correct any flaws from your perspective. Also please note the second commit, which attempts to rely less on the `getSubtitlesCodepage()` user setting.
