### PR TITLE
Exclude 'Duration: N/A' when parsing ffmpeg stderr output

### DIFF
--- a/src/main/java/net/pms/io/ProcessWrapperImpl.java
+++ b/src/main/java/net/pms/io/ProcessWrapperImpl.java
@@ -373,7 +373,8 @@ public class ProcessWrapperImpl extends Thread implements ProcessWrapper {
 	private String duration;
 
 	public void pubackDuration(String s) {
-		Pattern re = Pattern.compile("Duration:\\s*([^,]+),");
+		// match 'Duration: 00:17:17.00' but not 'Duration: N/A'
+		Pattern re = Pattern.compile("Duration:\\s+([\\d:.]+),");
 		Matcher m = re.matcher(s);
 		if (m.find()) {
 			duration = m.group(1);


### PR DESCRIPTION
The resume feature sometimes gets into trouble because of this.
