### PR TITLE
Update iPad-iPhone.conf

### DIFF
--- a/src/main/external-resources/renderers/iPad-iPhone.conf
+++ b/src/main/external-resources/renderers/iPad-iPhone.conf
@@ -44,6 +44,27 @@ RendererIcon=ipad-iphone.png
 # User-Agent: AppleCoreMedia/1.0.0.9A405 (iPad; U; CPU OS 5_0_1 like Mac OS X; nl_nl)
 # User-Agent: Lavf52.79.0
 #
+# Added 3/6/2014
+#
+# App: nPlayer - MP4 and xvid works. But xvid only plays sound with AirPlay (no video)
+# User-Agent: Darwin/14.0.0 UPnP/1.0 DLNADOC/1.50 nPlayer/1.0 LGE_DLNA_SDK/1.5.0
+#             (Note: LG-42LA644V.conf tries to detect LGE_DLNA_SDK as well)
+# User-Agent: AppleCoreMedia/1.0.0.11B651 (iPad; U; CPU OS 7_0_6 like Mac OS X; en_us)
+# User-Agent: AppleCoreMedia/1.0.0.11B651 (Apple TV; U; CPU OS 7_0_6 like Mac OS X; en_us)
+# User-Agent: nPlayer/2.5 CFNetwork/672.0.8 Darwin/14.0.0
+#
+# App: skifta - MP4 works (with AirPlay), xvid does not
+# User-Agent: Darwin/14.0.0, Skifta, Qualcomm
+# User-Agent: AppleCoreMedia/1.0.0.11B651 (iPad; U; CPU OS 7_0_6 like Mac OS X; en_us)
+# User-Agent: AppleCoreMedia/1.0.0.11B651 (Apple TV; U; CPU OS 7_0_6 like Mac OS X; en_us)
+#
+# App: Twonky Beam - MP4 works, but not with AirPlay
+# User-Agent: TwonkyMedia-NMC DLNADOC/1.50 mobileview Mozilla/5.0 (iPad; CPU OS 7_0_6 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11B651 TwonkyBeamBrowser/3.5.1-60 (iPad iOS Ver:7.0.6)
+# User-Agent: Twonky-NMC-WebAPI DLNADOC/1.50, X-PV-CLIENTNAME: myTwonky
+# User-Agent: Twonky Beam 3.5.1 (iPad; iPhone OS 7.0.6; en_US)
+# User-Agent: AppleCoreMedia/1.0.0.11B651 (iPad; U; CPU OS 7_0_6 like Mac OS X; en_us)
+# User-Agent: AppleCoreMedia/1.0.0.11B651 (Apple TV; U; CPU OS 7_0_6 like Mac OS X; en_us)
+#
 # Not working:
 # ------------
 # App: Air Video Free
@@ -57,7 +78,11 @@ RendererIcon=ipad-iphone.png
 #
 
 # Combined regular expression of working user agents
-UserAgentSearch=8player|yxplayer2|MPlayer |NSPlayer/|AirAV|AcePlayer
+#     In previous config, regular expression was not searching for the additional User-Agents of each app, forcing UMS
+#     to "unknown renderer".  Do not leave off AppleCoreMedia, or Airplay breaks during renderer change.
+#UserAgentSearch=8player|yxplayer2|MPlayer |NSPlayer/|AirAV|AcePlayer
+# Instead of Darwin should we be searching for nPlayer|skifta ?
+UserAgentSearch=Darwin|AppleCoreMedia|nPlayer|Twonky|8player|yxplayer2|MPlayer |NSPlayer/|AirAV|AcePlayer
 
 # UserAgentAdditionalHeaders: additional http header for better detection
 #UserAgentAdditionalHeader=
@@ -148,7 +173,8 @@ MimeTypesChanges=
 TranscodeExtensions=
 # What extensions are forcefully streamed as is (and not transcoded)
 # Don't use this if MediaInfo=true, prefer codec configurations
-StreamExtensions=mkv,mov,ogg,hdmov,hdm,flac,fla,dts,asf,asx,m2v
+#StreamExtensions=mkv,mov,ogg,hdmov,hdm,flac,fla,dts,asf,asx,m2v
+StreamExtensions=asf,wmv,avi,divx,mp4,m4v,mov,3gp,3g2,mkv,ts,trp,tp,mts,m2ts,vob,mpg,mpeg,mp3,jpg,jpeg,jpe,jps,mpo,ogg,hdmov,hdm,flac,fla,dts,asx,m2v
 
 
 


### PR DESCRIPTION
I added support for the following iOS clients:
nPlayer ($4.99) - mp4 and xvid works. AirPlay works for mp4, but audio only for xvid.
skifta (free) - mp4 works. AirPlay works for mp4, but xvid is not working at all at this point.
TwonkyBeam (free) - mp4 works. AirPlay is not working at all, neither is xvid.

nPlayer was previously using the LG42LA644V configuration, and AirPlay was dropping to unknown renderer and failing (missing AppleCoreMedia in search string). Added multiple User-Agents to the search string and added MP4 to the StreamExtensions (among some others that were missing).
