### PR TITLE
Add application category for OS X

### DIFF
--- a/src/main/external-resources/osx/Info.plist-template.xml
+++ b/src/main/external-resources/osx/Info.plist-template.xml
@@ -36,5 +36,7 @@
 		</dict>
 		<key>NSHighResolutionCapable</key>
 		<true/>
+		<key>LSApplicationCategoryType</key>
+		<string>public.app-category.entertainment</string>
 	</dict>
 </plist>


### PR DESCRIPTION
The /Application folder tends not to be subfoldered so since Lion, this folder's had View --> Arrange by Application Category -- but without the metadata it gets sorted into "Other" at the bottom. "public.app-category.entertainment" is the category used by media servers in the App Store.
