### PR TITLE
Fix bug in H.264 codec detection

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -298,7 +298,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 */
 	public boolean isMuxable(RendererConfiguration mediaRenderer) {
 		// Make sure the file is H.264 video
-		if (getCodecV() != null && getCodecV().equals("h264")) {
+		if (isH264()) {
 			muxable = true;
 		}
 
@@ -1097,7 +1097,7 @@ public class DLNAMediaInfo implements Cloneable {
 	}
 
 	public boolean isH264() {
-		return getCodecV() != null && getCodecV().contains("264");
+		return getCodecV() != null && getCodecV().contains("h264");
 	}
 
 	public int getFrameNumbers() {
@@ -1192,7 +1192,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 */
 	public synchronized boolean isVideoWithinH264LevelLimits(InputFile f, RendererConfiguration mediaRenderer) {
 		if (!h264_parsed) {
-			if ("h264".equals(getCodecV())) {
+			if (isH264()) {
 				if (
 					getContainer() != null &&
 					(

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -732,7 +732,7 @@ public class FFMpegVideo extends Player {
 			params.forceFps = media.getValidFps(false);
 
 			if (media.getCodecV() != null) {
-				if (media.getCodecV().equals("h264")) {
+				if (media.isH264()) {
 					params.forceType = "V_MPEG4/ISO/AVC";
 				} else if (media.getCodecV().startsWith("mpeg2")) {
 					params.forceType = "V_MPEG-2";

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -944,7 +944,7 @@ public class MEncoderVideo extends Player {
 				params.forceFps = media.getValidFps(false);
 
 				if (media.getCodecV() != null) {
-					if (media.getCodecV().equals("h264")) {
+					if (media.isH264()) {
 						params.forceType = "V_MPEG4/ISO/AVC";
 					} else if (media.getCodecV().startsWith("mpeg2")) {
 						params.forceType = "V_MPEG-2";
@@ -1067,7 +1067,7 @@ public class MEncoderVideo extends Player {
 					configuration.isMencoderRemuxMPEG2()
 				)
 				// Disable LPCM transcoding for MP4 container with non-H.264 video as workaround for MEncoder's A/V sync bug
-				&& !(media.getContainer().equals("mp4") && !media.getCodecV().equals("h264"))
+				&& !(media.getContainer().equals("mp4") && !media.isH264())
 				&& params.aid != null &&
 				(
 					(params.aid.isDTS() && params.aid.getAudioProperties().getNumberOfChannels() <= 6) || // disable 7.1 DTS-HD => LPCM because of channels mapping bug

--- a/src/main/java/net/pms/encoders/TsMuxeRVideo.java
+++ b/src/main/java/net/pms/encoders/TsMuxeRVideo.java
@@ -296,7 +296,7 @@ public class TsMuxeRVideo extends Player {
 				boolean pcm;
 
 				// Disable LPCM transcoding for MP4 container with non-H264 video as workaround for MEncoder's A/V sync bug
-				boolean mp4_with_non_h264 = (media.getContainer().equals("mp4") && !media.getCodecV().equals("h264"));
+				boolean mp4_with_non_h264 = (media.getContainer().equals("mp4") && !media.isH264());
 
 				if (numAudioTracks <= 1) {
 					ffAudioPipe = new PipeIPCProcess[numAudioTracks];
@@ -553,7 +553,7 @@ public class TsMuxeRVideo extends Player {
 			pw.println(videoType + ", \"" + ffVideoPipe.getOutputPipe() + "\", " + (fps != null ? ("fps=" + fps + ", ") : "") + (width != -1 ? ("video-width=" + width + ", ") : "") + (height != -1 ? ("video-height=" + height + ", ") : "") + videoparams);
 
 			// disable LPCM transcoding for MP4 container with non-H264 video as workaround for mencoder's A/V sync bug
-			boolean mp4_with_non_h264 = (media.getContainer().equals("mp4") && !media.getCodecV().equals("h264"));
+			boolean mp4_with_non_h264 = (media.getContainer().equals("mp4") && !media.isH264());
 			if (ffAudioPipe != null && ffAudioPipe.length == 1) {
 				String timeshift = "";
 				boolean ac3Remux;


### PR DESCRIPTION
When detecting if media is H.264 using getCodecV(), sometimes the
function return more than "h264" (in my tests, it returned "h264
(High)"), and isH264() is already here to help (and I also did a little
fix in it), so I used it instead using getCodecV() directly.
