### PR TITLE
Fix Timeseek Detection

### DIFF
--- a/src/main/java/net/pms/network/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/RequestHandlerV2.java
@@ -44,7 +44,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RequestHandlerV2.class);
 
 	private static final Pattern TIMERANGE_PATTERN = Pattern.compile(
-		"timeseekrange\\.dlna\\.org\\W*npt\\W*=\\W*([\\d\\.:]+)?\\-?([\\d\\.:]+)?",
+		"timeseekrange\\.dlna\\.org\\W*npt\\W*=\\W*([\\d.:]+)?-?([\\d.:]+)?",
 		Pattern.CASE_INSENSITIVE
 	);
 


### PR DESCRIPTION
The pattern to detect the timeseek was incorrect to detect the decimal
part of seconds (because period is always literal inside brackets, so
don't need to be escaped).
