### PR TITLE
New option: AccurateDLNAOrgPN

### DIFF
--- a/src/main/external-resources/renderers/Bravia4500.conf
+++ b/src/main/external-resources/renderers/Bravia4500.conf
@@ -25,6 +25,7 @@ MaxVideoHeight=0
 DLNALocalizationRequired=true
 TranscodeExtensions=dvr-ms,dvr,mkv,dv,ty,mov,ogm,hdmov,hdm,rmv,rmvb,rm,asf,evo,asx,flv,m2v,mpe,mod,tivo,ty,tmf,ts,tp,m2p,mp4,m4v,avi,wmv,wm,divx,div,flac,mlp,fla,wma,m4a,aac,dts,mka,ape,ogg,shn,mpc,ra,mp2,wv,oma,aa3,gif,png,arw,cr2,crw,dng,raf,mrw,nef,pef,tif,tiff
 StreamExtensions=
+AccurateDLNAOrgPN=true
 
 # For Bravia TVs and Sony Blu-ray Disc players
 ForceJPGThumbnails=true

--- a/src/main/external-resources/renderers/Bravia5500.conf
+++ b/src/main/external-resources/renderers/Bravia5500.conf
@@ -26,6 +26,7 @@ H264Level41Limited=true
 DLNALocalizationRequired=true
 TranscodeExtensions=dvr-ms,dvr,mkv,dv,ty,mov,ogm,hdmov,hdm,rmv,rmvb,rm,asf,evo,asx,flv,m2v,mpe,mod,tivo,ty,tmf,ts,tp,m2p,mp4,m4v,avi,wmv,wm,divx,div,flac,mlp,fla,wma,m4a,aac,dts,mka,ape,ogg,shn,mpc,ra,mp2,wv,oma,aa3,gif,png,arw,cr2,crw,dng,raf,mrw,nef,pef,tif,tiff
 StreamExtensions=
+AccurateDLNAOrgPN=true
 
 # For Bravia TVs and Sony Blu-ray Disc players
 ForceJPGThumbnails=true

--- a/src/main/external-resources/renderers/BraviaEX.conf
+++ b/src/main/external-resources/renderers/BraviaEX.conf
@@ -34,6 +34,7 @@ ForceJPGThumbnails=true
 ThumbnailAsResource=true
 MediaInfo=true
 CreateDLNATreeFaster = true
+AccurateDLNAOrgPN=true
 
 # Our Bravia EX-specific notes:
 # DTS is not supported.

--- a/src/main/external-resources/renderers/BraviaEX620.conf
+++ b/src/main/external-resources/renderers/BraviaEX620.conf
@@ -44,6 +44,8 @@ ChunkedTransfer = false
 
 AutoExifRotate = true
 
+AccurateDLNAOrgPN = true
+
 Supported = f:mpegps|mpegts   v:mpeg1|mpeg2|mp4|h264   a:ac3|lpcm|aac|mpa         m:video/mpeg
 Supported = f:mp4             v:mp4|h264               a:ac3|aac                  m:video/mp4
 Supported = f:wmv             v:wmv|vc1                a:wma                n:2   m:video/x-ms-wmv

--- a/src/main/external-resources/renderers/BraviaHX.conf
+++ b/src/main/external-resources/renderers/BraviaHX.conf
@@ -40,6 +40,7 @@ ThumbnailAsResource=true
 
 MediaInfo=true
 CreateDLNATreeFaster = true
+AccurateDLNAOrgPN=true
 
 # Our Bravia HX-specific notes:
 # DTS is not supported.

--- a/src/main/external-resources/renderers/BraviaW.conf
+++ b/src/main/external-resources/renderers/BraviaW.conf
@@ -40,6 +40,7 @@ ThumbnailAsResource=true
 MediaInfo=true
 CreateDLNATreeFaster = true
 MediaParserV2_ThumbnailGeneration=true
+AccurateDLNAOrgPN=true
 
 # Our Bravia W-specific notes:
 # DTS is not supported.

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -64,6 +64,7 @@ public class RendererConfiguration {
 	private static final String WMV = "WMV";
 
 	// property names
+	private static final String ACCURATE_DLNA_ORGPN = "AccurateDLNAOrgPN";
 	private static final String AUDIO = "Audio";
 	private static final String AUTO_EXIF_ROTATE = "AutoExifRotate";
 	private static final String BYTE_TO_TIMESEEK_REWIND_SECONDS = "ByteToTimeseekRewindSeconds"; // Ditlew
@@ -1061,6 +1062,10 @@ public class RendererConfiguration {
 
 	public boolean isDLNAOrgPNUsed() {
 		return getBoolean(DLNA_ORGPN_USE, true);
+	}
+
+	public boolean isAccurateDLNAOrgPN() {
+		return getBoolean(ACCURATE_DLNA_ORGPN, false);
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1614,7 +1614,6 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 								boolean isFileMPEGTS = TsMuxeRVideo.ID.equals(getPlayer().id()) || VideoLanVideoStreaming.ID.equals(getPlayer().id());
 
 								boolean isMuxableResult = getMedia().isMuxable(mediaRenderer);
-								boolean isBravia = mediaRenderer.isBRAVIA();
 
 								// If the engine is MEncoder or FFmpeg, and the muxing settings are enabled, it may be MPEG-TS so we need to do more tests
 								if (
@@ -1631,7 +1630,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 									)
 								) {
 									/**
-									 * Sony Bravia TVs (and possibly other renderers) need ORG_PN to be accurate.
+									 * Media renderer needs ORG_PN to be accurate.
 									 * If the value does not match the media, it won't play the media.
 									 * Often we can lazily predict the correct value to send, but due to
 									 * MEncoder needing to mux via tsMuxeR, we need to work it all out
@@ -1645,7 +1644,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 									 *
 									 * This code block comes from Player.setAudioAndSubs()
 									 */
-									if (isBravia) {
+									if (mediaRenderer.isAccurateDLNAOrgPN()) {
 										boolean finishedMatchingPreferences = false;
 										OutputParams params = new OutputParams(configuration);
 										if (getMedia() != null) {


### PR DESCRIPTION
Allow non-Bravia renderers to have access to a piece of code that
generates accurate DLNA.ORG_PN info.
