### PR TITLE
New option: MuxNonMod4Resolution

### DIFF
--- a/src/main/external-resources/renderers/Bravia4500.conf
+++ b/src/main/external-resources/renderers/Bravia4500.conf
@@ -19,6 +19,7 @@ MuxH264ToMpegTS=true
 MuxDTSToMpeg=true
 WrapDTSIntoPCM=false
 MuxLPCMToMpeg=false
+MuxNonMod4Resolution=true
 MaxVideoBitrateMbps=0
 MaxVideoWidth=0
 MaxVideoHeight=0

--- a/src/main/external-resources/renderers/Bravia5500.conf
+++ b/src/main/external-resources/renderers/Bravia5500.conf
@@ -19,6 +19,7 @@ MuxH264ToMpegTS=true
 MuxDTSToMpeg=false
 WrapDTSIntoPCM=false
 MuxLPCMToMpeg=false
+MuxNonMod4Resolution=true
 MaxVideoBitrateMbps=0
 MaxVideoWidth=0
 MaxVideoHeight=0

--- a/src/main/external-resources/renderers/BraviaEX.conf
+++ b/src/main/external-resources/renderers/BraviaEX.conf
@@ -23,6 +23,7 @@ MuxH264ToMpegTS=true
 MuxDTSToMpeg=false
 WrapDTSIntoPCM=false
 MuxLPCMToMpeg=false
+MuxNonMod4Resolution=true
 MaxVideoBitrateMbps=0
 MaxVideoWidth=0
 MaxVideoHeight=0

--- a/src/main/external-resources/renderers/BraviaEX620.conf
+++ b/src/main/external-resources/renderers/BraviaEX620.conf
@@ -26,6 +26,7 @@ MuxH264ToMpegTS = true
 MuxDTSToMpeg = false
 WrapDTSIntoPCM = false
 MuxLPCMToMpeg = true
+MuxNonMod4Resolution = true
 MaxVideoBitrateMbps = 0
 MaxVideoWidth = 1920
 MaxVideoHeight = 1080

--- a/src/main/external-resources/renderers/BraviaHX.conf
+++ b/src/main/external-resources/renderers/BraviaHX.conf
@@ -25,6 +25,7 @@ MuxH264ToMpegTS=true
 MuxDTSToMpeg=false
 WrapDTSIntoPCM=false
 MuxLPCMToMpeg=false
+MuxNonMod4Resolution=true
 TranscodeFastStart=false
 MaxVideoBitrateMbps=0
 MaxVideoWidth=0

--- a/src/main/external-resources/renderers/BraviaW.conf
+++ b/src/main/external-resources/renderers/BraviaW.conf
@@ -25,6 +25,7 @@ MuxH264ToMpegTS=true
 MuxDTSToMpeg=false
 WrapDTSIntoPCM=true
 MuxLPCMToMpeg=true
+MuxNonMod4Resolution=true
 TranscodeFastStart=false
 MaxVideoBitrateMbps=0
 MaxVideoWidth=0

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -93,6 +93,7 @@ public class RendererConfiguration {
 	private static final String MUX_DTS_TO_MPEG = "MuxDTSToMpeg";
 	private static final String MUX_H264_WITH_MPEGTS = "MuxH264ToMpegTS";
 	private static final String MUX_LPCM_TO_MPEG = "MuxLPCMToMpeg";
+	private static final String MUX_NON_MOD4_RESOLUTION = "MuxNonMod4Resolution";
 	private static final String OVERRIDE_VF = "OverrideVideoFilter";
 	private static final String RENDERER_ICON = "RendererIcon";
 	private static final String RENDERER_NAME = "RendererName";
@@ -914,6 +915,10 @@ public class RendererConfiguration {
 		}
 
 		return getBoolean(MUX_LPCM_TO_MPEG, true);
+	}
+
+	public boolean isMuxNonMod4Resolution() {
+		return getBoolean(MUX_NON_MOD4_RESOLUTION, false);
 	}
 
 	public boolean isMpeg2Supported() {

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -312,7 +312,7 @@ public class DLNAMediaInfo implements Cloneable {
 				)
 			) ||
 			(
-				!mediaRenderer.isBRAVIA() &&
+				!mediaRenderer.isMuxNonMod4Resolution() &&
 				!isMod4()
 			)
 		) {


### PR DESCRIPTION
Allow a renderer to receive MPEG-TS video with non-mod4 resolution.
