### PR TITLE
New Media folders that have no new files are now correctly hidden

### DIFF
--- a/src/main/java/net/pms/dlna/MediaMonitor.java
+++ b/src/main/java/net/pms/dlna/MediaMonitor.java
@@ -1,12 +1,5 @@
 package net.pms.dlna;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
 import net.pms.Messages;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
@@ -17,166 +10,166 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.*;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
 public class MediaMonitor extends VirtualFolder {
-	private static final Logger LOGGER = LoggerFactory.getLogger(MediaMonitor.class);
-	private File[] dirs;
-	private ArrayList<String> oldEntries;
-	private PmsConfiguration config;
+    private static final Logger LOGGER = LoggerFactory.getLogger(MediaMonitor.class);
+    private File[] dirs;
+    private Set<String> oldEntries;
+    private PmsConfiguration config;
 
-	public MediaMonitor(File[] dirs) {
-		super(Messages.getString("VirtualFolder.2"), "images/thumbnail-video-256.png");
-		this.dirs = dirs;
-		oldEntries = new ArrayList<>();
-		config = PMS.getConfiguration();
-		parseMonitorFile();
-	}
+    public MediaMonitor(File[] dirs) {
+        super(Messages.getString("VirtualFolder.2"), "images/thumbnail-video-256.png");
+        this.dirs = dirs;
+        oldEntries = new HashSet<>();
+        config = PMS.getConfiguration();
+        parseMonitorFile();
+    }
 
-	private File monitorFile() {
-		return new File(PMS.getConfiguration().getDataFile("UMS.mon"));
-	}
+    private File monitorFile() {
+        return new File(config.getDataFile("UMS.mon"));
+    }
 
-	private void parseMonitorFile() {
-		File f = monitorFile();
-		if (!f.exists()) {
-			return;
-		}
-		try {
-			try (BufferedReader in = new BufferedReader(new FileReader(f))) {
-				String str;
+    private void parseMonitorFile() {
+        File f = monitorFile();
+        if (!f.exists()) {
+            return;
+        }
+        try {
+            try (BufferedReader in = new BufferedReader(new FileReader(f))) {
+                String str;
 
-				while ((str = in.readLine()) != null) {
-					if (StringUtils.isEmpty(str)) {
-						continue;
-					}
-					str = str.trim();
-					if (str.startsWith("#")) {
-						continue;
-					}
-					if (str.startsWith("entry=")) {
-						String entry = str.substring(6);
-						if (!new File(entry.trim()).exists()) {
-							continue;
-						}
-						if (!oldEntries.contains(entry.trim())) {
-							oldEntries.add(entry.trim());
-						}
-					}
-				}
-			}
-			dumpFile();
-		} catch (IOException e) {
-		}
-	}
+                while ((str = in.readLine()) != null) {
+                    if (StringUtils.isEmpty(str)) {
+                        continue;
+                    }
+                    str = str.trim();
+                    if (str.startsWith("#")) {
+                        continue;
+                    }
+                    if (str.startsWith("entry=")) {
+                        String entry = str.substring(6);
+                        if (!new File(entry.trim()).exists()) {
+                            continue;
+                        }
+                        oldEntries.add(entry.trim());
+                    }
+                }
+            }
+            dumpFile();
+        } catch (IOException e) {
+        }
+    }
 
-	public void scanDir(File[] files, DLNAResource res) {
-		final DLNAResource start = res;
-		res.addChild(new VirtualVideoAction(Messages.getString("PMS.139"), true) {
-			@Override
-			public boolean enable() {
-				for (DLNAResource r : start.getChildren()) {
-					if (!(r instanceof RealFile)) {
-						continue;
-					}
-					RealFile rf = (RealFile) r;
-					if (old(rf.getFile().getAbsolutePath())) { // no duplicates!
-						continue;
-					}
-					oldEntries.add(rf.getFile().getAbsolutePath());
-				}
-				start.setDiscovered(false);
-				start.getChildren().clear();
-				try {
-					dumpFile();
-				} catch (IOException e) {
-				}
-				return true;
-			}
-		});
+    public void scanDir(File[] files, final DLNAResource res) {
+        final DLNAResource mm = this;
+        res.addChild(new VirtualVideoAction(Messages.getString("PMS.139"), true) {
+            @Override
+            public boolean enable() {
+                for (DLNAResource r : res.getChildren()) {
+                    if (!(r instanceof RealFile)) {
+                        continue;
+                    }
+                    RealFile rf = (RealFile) r;
+                    oldEntries.add(rf.getFile().getAbsolutePath());
+                }
+                mm.setDiscovered(false);
+                mm.getChildren().clear();
+                try {
+                    dumpFile();
+                } catch (IOException e) {
+                }
+                return true;
+            }
+        });
 
-		for (File f : files) {
-			if (f.isFile()) {
-				// regular file
-				LOGGER.debug("file " + f + " is old? " + old(f.getAbsolutePath()));
-				if (old(f.getAbsolutePath())) {
-					continue;
-				}
-				res.addChild(new RealFile(f));
-			}
-			if (f.isDirectory()) {
-				boolean add = true;
-				if (config.isHideEmptyFolders()) {
-					add = FileUtil.isFolderRelevant(f, PMS.getConfiguration());
-				}
-				if (add) {
-					res.addChild(new MonitorEntry(f, this));
-				}
-			}
-		}
-	}
+        for (File f : files) {
+            if (f.isFile()) {
+                // regular file
+                LOGGER.debug("file " + f + " is old? " + old(f.getAbsolutePath()));
+                if (old(f.getAbsolutePath())) {
+                    continue;
+                }
+                res.addChild(new RealFile(f));
+            }
+            if (f.isDirectory()) {
+                boolean add = true;
+                if (config.isHideEmptyFolders()) {
+                    add = FileUtil.isFolderRelevant(f, config, oldEntries);
+                }
+                if (add) {
+                    res.addChild(new MonitorEntry(f, this));
+                }
+            }
+        }
+    }
 
-	@Override
-	public void discoverChildren() {
-		for (File f : dirs) {
-			scanDir(f.listFiles(), this);
-		}
-	}
+    @Override
+    public void discoverChildren() {
+        for (File f : dirs) {
+            scanDir(f.listFiles(), this);
+        }
+    }
 
-	@Override
-	public boolean isRefreshNeeded() {
-		return true;
-	}
+    @Override
+    public boolean isRefreshNeeded() {
+        return true;
+    }
 
-	private boolean monitorClass(DLNAResource res) {
-		return (res instanceof MonitorEntry) || (res instanceof MediaMonitor);
-	}
+    private boolean monitorClass(DLNAResource res) {
+        return (res instanceof MonitorEntry) || (res instanceof MediaMonitor);
+    }
 
-	public void stopped(DLNAResource res) {
-		if (!(res instanceof RealFile)) {
-			return;
-		}
-		RealFile rf = (RealFile) res;
-		DLNAResource tmp = res.getParent();
-		while (tmp != null) {
-			if (monitorClass(tmp)) {
-				if (old(rf.getFile().getAbsolutePath())) { // no duplicates!
-					return;
-				}
-				oldEntries.add(rf.getFile().getAbsolutePath());
-				setDiscovered(false);
-				getChildren().clear();
-				try {
-					dumpFile();
-				} catch (IOException e) {
-				}
-				return;
-			}
-			tmp = tmp.getParent();
-		}
-	}
+    public void stopped(DLNAResource res) {
+        if (!(res instanceof RealFile)) {
+            return;
+        }
+        RealFile rf = (RealFile) res;
+        DLNAResource tmp = res.getParent();
+        while (tmp != null) {
+            if (monitorClass(tmp)) {
+                if (old(rf.getFile().getAbsolutePath())) { // no duplicates!
+                    return;
+                }
+                oldEntries.add(rf.getFile().getAbsolutePath());
+                setDiscovered(false);
+                getChildren().clear();
+                try {
+                    dumpFile();
+                } catch (IOException e) {
+                }
+                return;
+            }
+            tmp = tmp.getParent();
+        }
+    }
 
-	private boolean old(String str) {
-		return oldEntries.contains(str);
-	}
+    private boolean old(String str) {
+        return oldEntries.contains(str);
+    }
 
-	private void dumpFile() throws IOException {
-		File f = monitorFile();
-		Date now = new Date();
-		try (FileWriter out = new FileWriter(f)) {
-			StringBuilder sb = new StringBuilder();
-			sb.append("######\n");
-			sb.append("## NOTE!!!!!\n");
-			sb.append("## This file is auto generated\n");
-			sb.append("## Edit with EXTREME care\n");
-			sb.append("## Generated: ");
-			sb.append(now.toString());
-			sb.append("\n");
-			for (String str : oldEntries) {
-				sb.append("entry=");
-				sb.append(str);
-				sb.append("\n");
-			}
-			out.write(sb.toString());
-			out.flush();
-		}
-	}
+    private void dumpFile() throws IOException {
+        File f = monitorFile();
+        Date now = new Date();
+        try (FileWriter out = new FileWriter(f)) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("######\n");
+            sb.append("## NOTE!!!!!\n");
+            sb.append("## This file is auto generated\n");
+            sb.append("## Edit with EXTREME care\n");
+            sb.append("## Generated: ");
+            sb.append(now.toString());
+            sb.append("\n");
+            for (String str : oldEntries) {
+                sb.append("entry=");
+                sb.append(str);
+                sb.append("\n");
+            }
+            out.write(sb.toString());
+            out.flush();
+        }
+    }
 }


### PR DESCRIPTION
 When the "Hide Empty Folders" option is selected, the "New Media" folder was still displaying all folders, even if they had no new media in them (just a "Clear All" option).

This hides those folders so you only have folders which have new videos in them.

A lot of the diff is actually just white space.

I also changed the oldEntires list into a HashSet so it should be faster to lookup old values when dealing with a large number of files.

I haven't broken the "New Media" functionality more than it already is...
On my old Sony Bravia, after I watch a video, I cannot watch any other video in that folder until I return to the root folder and then let it build the DLNAResources again. I _fixes_ the "Clear All" option to work the same way, otherwise it was leaving empty folders in the structure until I restarted the server.
