### PR TITLE
Fix FFmpeg Thumbnail AR

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -419,8 +419,8 @@ public class DLNAMediaInfo implements Cloneable {
 
 		args[7] = "-an";
 		args[8] = "-an";
-		args[9] = "-s";
-		args[10] = "320x180";
+		args[9] = "-vf";
+		args[10] = "\"scale='if(gt(a,16/9),320,-1)':'if(gt(a,16/9),-1,180)', pad=320:180:(320-iw)/2:(180-ih)/2\"";
 		args[11] = "-vframes";
 		args[12] = "1";
 		args[13] = "-f";


### PR DESCRIPTION
Fix aspect ratio of thumbnails generated by FFmpeg, just like MPlayer
does (fitting the thumb in a 320x180 rectangle with black padding).
