### PR TITLE
Fix FFmpeg subtitle convert

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -1331,6 +1331,7 @@ public class FFMpegVideo extends Player {
 
 		try {
 			pw.join(); // Wait until the conversion is finished
+			pw.stopProcess(); // Avoid creating a pipe for this process and messing up with buffer progress bar
 		} catch (InterruptedException e) {
 			LOGGER.debug("Subtitles conversion finished wih error: " + e);
 			return null;


### PR DESCRIPTION
Added a stopProcess() at the end of FFmpeg subtitle SRT to ASS
converting process. Without this, a pipe is created and a timer keeps
messing up the buffer progress bar, showing 0 MB/XX MB intermittently.
We can see this happening both in GUI interface and trace log when
playing a video with on-the-fly conversion of SRT subtitle to ASS with
FFmpeg.
