### PR TITLE
Fix recognizing bmp files

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -511,7 +511,6 @@ AutoExifRotate =
 #    png      Portable Network Graphics                 image/png
 #    ra       RealAudio                                 audio/vnd.rn-realaudio
 #    rm       RealMedia (RMVB)                          application/vnd.rn-realmedia-vbr
-#    sorenson Sorenson Media
 #    tiff     Tagged Image File Format                  image/tiff
 #    theora   Ogg Theora                                video/theora
 #    truehd   Dolby TrueHD                              audio/vnd.dolby.mlp

--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -60,7 +60,6 @@ public class FormatConfiguration {
 	public static final String RA = "ra";
 	public static final String RM = "rm";
 	public static final String SHORTEN = "shn";
-	public static final String SORENSON = "sorenson";
 	public static final String TIFF = "tiff";
 	public static final String THEORA = "theora";
 	public static final String TRUEHD = "truehd";

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -415,8 +415,6 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.H264;
 		} else if (value.startsWith("hevc")) {
 			format = FormatConfiguration.H265;
-		} else if (value.startsWith("sorenson")) {
-			format = FormatConfiguration.SORENSON;
 		} else if (value.startsWith("vp6")) {
 			format = FormatConfiguration.VP6;
 		} else if (value.startsWith("vp7")) {


### PR DESCRIPTION
This adds support for BMP Picture files.
Without this, the debug gives:
Could not match any format to "H:\Test Files\1280x720.bmp"
