### PR TITLE
Fix recognizing BMP files

### DIFF
--- a/src/main/java/net/pms/formats/BMP.java
+++ b/src/main/java/net/pms/formats/BMP.java
@@ -1,0 +1,42 @@
+/*
+ * PS3 Media Server, for streaming any medias to your PS3.
+ * Copyright (C) 2008  A.Brochard
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.formats;
+
+public class BMP extends JPG {
+	/**
+	 * {@inheritDoc} 
+	 */
+	@Override
+	public Identifier getIdentifier() {
+		return Identifier.BMP;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String[] getSupportedExtensions() {
+		return new String[] { "bmp" };
+	}
+
+	@Override
+	public String mimeType() {
+		return "image/bmp";
+	}
+}

--- a/src/main/java/net/pms/formats/Format.java
+++ b/src/main/java/net/pms/formats/Format.java
@@ -45,6 +45,7 @@ public abstract class Format implements Cloneable {
 
 	public enum Identifier {
 		AUDIO_AS_VIDEO,
+		BMP,
 		DVRMS,
 		FLAC,
 		GIF,

--- a/src/main/java/net/pms/formats/FormatFactory.java
+++ b/src/main/java/net/pms/formats/FormatFactory.java
@@ -38,6 +38,7 @@ public final class FormatFactory {
 	 * Initial list of known formats.
 	 */
 	private static final Format[] FORMATS = new Format[] {
+		new BMP(),
 		new DVRMS(),
 		new FLAC(),
 		new GIF(),


### PR DESCRIPTION
This adds support for BMP picture files.

Without this, the debug gives:
Could not match any format to "H:\Test Files\1280x720.bmp"
with "Supported = f:bmp   m:image/bmp" given in the renderer config file.
Now it can be played on my Android device.

Sorry about the additional senseless commits, still learning about this GitHub thing :)
And please check this code because I am not a skilled programmer.
