### PR TITLE
Sorenson Media support

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -511,6 +511,7 @@ AutoExifRotate =
 #    png      Portable Network Graphics                 image/png
 #    ra       RealAudio                                 audio/vnd.rn-realaudio
 #    rm       RealMedia (RMVB)                          application/vnd.rn-realmedia-vbr
+#    sorenson Sorenson Media
 #    tiff     Tagged Image File Format                  image/tiff
 #    theora   Ogg Theora                                video/theora
 #    truehd   Dolby TrueHD                              audio/vnd.dolby.mlp

--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -60,6 +60,7 @@ public class FormatConfiguration {
 	public static final String RA = "ra";
 	public static final String RM = "rm";
 	public static final String SHORTEN = "shn";
+	public static final String SORENSON = "sorenson";
 	public static final String TIFF = "tiff";
 	public static final String THEORA = "theora";
 	public static final String TRUEHD = "truehd";

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -415,6 +415,8 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.H264;
 		} else if (value.startsWith("hevc")) {
 			format = FormatConfiguration.H265;
+		} else if (value.startsWith("sorenson")) {
+			format = FormatConfiguration.SORENSON;
 		} else if (value.startsWith("vp6")) {
 			format = FormatConfiguration.VP6;
 		} else if (value.startsWith("vp7")) {


### PR DESCRIPTION
This adds support for Sorenson Media.
This codec is used in FLV video files.

Without this, FLV files with this codec were parsed as "und".
Now support for this codec can be given to the "supported = " lines.

Sorry about the additional senseless commits, still learning about this GitHub thing :)
And please check this code because I am not a skilled programmer.
