### PR TITLE
ignore obvious bad lowranges (ie >100GB)

### DIFF
--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -114,7 +114,13 @@ public class RequestV2 extends HTTPResource {
 	 * @param lowRange The byte to start from.
 	 */
 	public void setLowRange(long lowRange) {
-		this.lowRange = lowRange;
+		if(lowRange > 100000000000L) {
+			// ignore anything insane
+			//LOGGER.debug("setLowRange: " + lowRange);
+		}
+		else {
+			this.lowRange = lowRange;
+		}
 	}
 
 	public String getTransferMode() {


### PR DESCRIPTION
this fixes timeout for PhilipsTV (fw QN141E_012.003.026.128) when using dlna transcoding.