### PR TITLE
New plugin type FileProvider

### DIFF
--- a/src/main/java/net/pms/external/FileProvider.java
+++ b/src/main/java/net/pms/external/FileProvider.java
@@ -1,0 +1,54 @@
+package net.pms.external;
+
+import javax.swing.JPanel;
+
+import net.pms.dlna.DLNAResource;
+
+/**
+ * All classes implementing the FileProvider Interface will be loaded when UMS
+ * is being started and can be selected as file providers in the
+ * 'Navigation/Share Settings' tab.
+ */
+public interface FileProvider {
+
+	/**
+	 * Gets the configuration panel which will be displayed in the
+	 * 'Navigation/Share Settings' tab if the file provider is the active one.
+	 *
+	 * @return the configuration panel
+	 */
+	public JPanel getConfigurationPanel();
+
+	/**
+	 * Gets the root folder.</br></br> All children of the root folder (files
+	 * and folders) will be shown on the first level when browsing on the
+	 * renderer.
+	 *
+	 * @return the root folder
+	 */
+	public DLNAResource getRootFolder();
+
+	/**
+	 * Gets the name which will be displayed in the 'Navigation/Share Settings'
+	 * tab.</br></br> This method has to be functional before
+	 * {@link #activate()} is being called.
+	 * 
+	 * @return the name of the file provider
+	 */
+	public String getName();
+
+	/**
+	 * Activates the file provider.</br></br> This method is being called when
+	 * UMS has been completely initialized and the file provider is the active
+	 * one.</br> If the plugin has to access UMS functionality, do it here and
+	 * not in the constructor.
+	 */
+	public void activate();
+
+	/**
+	 * Deactivates the file provider.</br></br> This method is being called when
+	 * UMS shuts down or when the file provider is currently the active one and
+	 * another one is being activated,
+	 */
+	public void deactivate();
+}


### PR DESCRIPTION
I've been maintaining a separate build for the media library extension (mlx) for the last years for pms and have plugged it on top of ums lately.
To avoid the hassle of merging new code all the time I got the idea of creating a new plugin type, which would allow to choose the way files and folders are being presented on the renderer. By default, the current one, where the files and folders would represent the file system would be available. If the user wants to change, a plugin could be dropped into the plugins folder and selected in the 'Navigation/Share settings' tab.
Before starting I wanted to have your opinion to see if you'd be willing to merge it, if I get everything working. Architecture-wise I think it would be nice to decouple how files and folders are being presented from how files are being streamed.

For now, only the interface for FileProvider exists and has been chaecked in.

How it would work in the GUI:
In the 'Navigation/Share settings' tab, an additional combo-box would be displayed if there is more than one FileProvider available, allowing to choose which one to use. Underneath, a panel to configure the properties would be shown.
The plugins for AdditionalFoldersAtRoot won't be part of the global plugins anymore, as they are dependent on the current implementation. They would still be available though.

For the end-user nothing would change after a fresh install. AdditionalFoldersAtRoot would be shown somewhere else, I haven't figured out where to put them for now though.

I hope you like the idea :)

Tasks:
- [ ] Create FileSystemFileProvider in ums code. It will contain the current GUI from 'Navigation/Share settings' tab as well as implementation specific parts of DLNAResource (e.g. resume option). Use RootFolder code to create final DLNAResource
- [ ] Remove RootFolder from ums and do required code changes
- [ ] Move AdditionalFolder(s)AtRoot interfaces to FileSystemFileProvider 
- [ ] Show instanciated AdditionalFolder(s)AtRoot in FileSystemFileProvider GUI
- [ ] Add loading mechanism for FileProvider plugins
- [ ] Add GUI to select FileProvider plugins
- [ ] Persist selected FileProvider plugin
- [ ] Add code to properly activate/deactivate FileProvider plugins upon change