### PR TITLE
Removes extra close on InputStream

### DIFF
--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -921,12 +921,7 @@ public class RequestV2 extends HTTPResource {
 						LOGGER.trace("  isSuccess: " + future.isSuccess());
 						LOGGER.trace("  isCancelled: " + future.isCancelled());
 						LOGGER.trace("  getCause: ", future.cause());
-						try {
-							PMS.get().getRegistry().reenableGoToSleep();
-							inputStream.close();
-						} catch (IOException e) {
-							LOGGER.debug("Caught exception", e);
-						}
+						PMS.get().getRegistry().reenableGoToSleep();
 
 						// Always close the channel after the response is sent because of
 						// a freeze at the end of video when the channel is not closed.


### PR DESCRIPTION
The ChunkedWriteHandler already automatically closes the InputStream
that we send to it when the Channel goes inactive (i.e. the client
disconnects) and when the InputStream is at its end.

If we also call .close(), it causes a warning to be logged by the
ChunkedWriteHandler when it tries to close the stream because an
IOException is thrown.