### PR TITLE
Add all default constructors to the custom UI components

### DIFF
--- a/src/main/java/net/pms/newgui/components/CustomJButton.java
+++ b/src/main/java/net/pms/newgui/components/CustomJButton.java
@@ -2,6 +2,8 @@ package net.pms.newgui.components;
 
 import java.awt.Point;
 import java.awt.event.MouseEvent;
+
+import javax.swing.Action;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JToolTip;
@@ -9,8 +11,13 @@ import javax.swing.JToolTip;
 public class CustomJButton extends JButton {
 	private static final long serialVersionUID = -528428545289132331L;
 
-	public CustomJButton(String string) {
-		super(string);
+	public CustomJButton() {
+		super();
+		this.setRequestFocusEnabled(false);
+	}
+
+	public CustomJButton(Action a) {
+		super(a);
 		this.setRequestFocusEnabled(false);
 	}
 
@@ -19,8 +26,13 @@ public class CustomJButton extends JButton {
 		this.setRequestFocusEnabled(false);
 	}
 
-	public CustomJButton(String string, Icon icon) {
-		super(string, icon);
+	public CustomJButton(String text) {
+		super(text);
+		this.setRequestFocusEnabled(false);
+	}
+
+	public CustomJButton(String text, Icon icon) {
+		super(text, icon);
 		this.setRequestFocusEnabled(false);
 	}
 

--- a/src/main/java/net/pms/newgui/components/CustomJCheckBox.java
+++ b/src/main/java/net/pms/newgui/components/CustomJCheckBox.java
@@ -2,14 +2,41 @@ package net.pms.newgui.components;
 
 import java.awt.Point;
 import java.awt.event.MouseEvent;
+
+import javax.swing.Action;
+import javax.swing.Icon;
 import javax.swing.JCheckBox;
 import javax.swing.JToolTip;
 
 public class CustomJCheckBox extends JCheckBox  {
 	private static final long serialVersionUID = -8027836064057652678L;
 
+	public CustomJCheckBox(Action a) {
+	    super(a);
+	}
+
+	public CustomJCheckBox(Icon icon) {
+	    super(icon);
+	}
+
+	public CustomJCheckBox(Icon icon, boolean selected) {
+	    super(icon, selected);
+	}
+
 	public CustomJCheckBox(String text) {
 	    super(text);
+	}
+
+	public CustomJCheckBox(String text, boolean selected) {
+	    super(text, selected);
+	}
+
+	public CustomJCheckBox(String text, Icon icon) {
+	    super(text, icon);
+	}
+
+	public CustomJCheckBox(String text, Icon icon, boolean selected) {
+	    super(text, icon, selected);
 	}
 
 	public JToolTip createToolTip() {

--- a/src/main/java/net/pms/newgui/components/CustomJLabel.java
+++ b/src/main/java/net/pms/newgui/components/CustomJLabel.java
@@ -2,14 +2,36 @@ package net.pms.newgui.components;
 
 import java.awt.Point;
 import java.awt.event.MouseEvent;
+
+import javax.swing.Icon;
 import javax.swing.JLabel;
 import javax.swing.JToolTip;
 
 public class CustomJLabel extends JLabel {
 	private static final long serialVersionUID = -6726814430751911120L;
 
+	public CustomJLabel() {
+	    super();
+	}
+
+	public CustomJLabel(Icon image) {
+	    super(image);
+	}
+
+	public CustomJLabel(Icon image, int horizontalAlignment) {
+	    super(image, horizontalAlignment);
+	}
+
 	public CustomJLabel(String text) {
 	    super(text);
+	}
+
+	public CustomJLabel(String text, Icon icon, int horizontalAlignment) {
+	    super(text, icon, horizontalAlignment);
+	}
+
+	public CustomJLabel(String text, int horizontalAlignment) {
+	    super(text, horizontalAlignment);
 	}
 
 	public JToolTip createToolTip() {

--- a/src/main/java/net/pms/newgui/components/CustomJTextField.java
+++ b/src/main/java/net/pms/newgui/components/CustomJTextField.java
@@ -2,14 +2,32 @@ package net.pms.newgui.components;
 
 import java.awt.Point;
 import java.awt.event.MouseEvent;
+
 import javax.swing.JTextField;
 import javax.swing.JToolTip;
+import javax.swing.text.Document;
 
 public class CustomJTextField extends JTextField {
 	private static final long serialVersionUID = -5697643578934331831L;
 
+	public CustomJTextField() {
+	    super();
+	}
+
+	public CustomJTextField(Document doc, String text, int columns) {
+	    super(doc, text, columns);
+	}
+
+	public CustomJTextField(int columns) {
+	    super(columns);
+	}
+
 	public CustomJTextField(String text) {
 	    super(text);
+	}
+
+	public CustomJTextField(String text, int columns) {
+	    super(text, columns);
 	}
 
 	public JToolTip createToolTip() {


### PR DESCRIPTION
This pull request adds all default constructors for CustomJButton, CustomJCheckBox, CustomJLabel and CustomJTextField.
This way, the custom components can be used exactly as the default ones and all existing instantiations can easily be replaced if required.