### PR TITLE
Document chromecast_extension option in UMS.conf

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -206,6 +206,12 @@ ignored_renderers =
 # Default: false
 renderer_force_default =
 
+# ChromeCast Extension
+# --------------------
+# Whether to load Chromecast extension API or not.
+# Default: true
+chromecast_extension =
+
 # Enable external network
 # -----------------------
 # Whether to enable functionality that uses external networks like the


### PR DESCRIPTION
Adding undocumented option "chromecast_extension"
Useful when troubleshooting possible UMS problems.