### PR TITLE
Add aspect ratio distortion tolerance

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -407,8 +407,18 @@ SubtitleHttpHeader =
 # If some videos on your renderer looked either stretched or squashed, enabling
 # this setting may fix that.
 # This is only reliable when MediaInfo = true.
+# TODO: PanTV doesn't require AR fix for streamed DivX/XviD files!
 # Default: false
 KeepAspectRatio = 
+
+# The number represents percentage tolerance from ideal 16:9 AR. Within this
+# tolerance file will not be transcoded due to wrong AR.
+# Useful for files with almost invisible AR distortion like AR = 1.85 (~5%).
+# User can tune value between acceptable distortion and transcoding overhead
+# invoked by transcoding.
+# Mostly used wide AR: 1.78[16:9], 1.85 (~5%), 2.35 (~33%), 2.40 (~36%)
+# Default: 0
+KeepAspectRatioTolerance =
 
 # If this is false, FFmpeg will upscale videos with resolutions lower than SD
 # (720 pixels wide) to the maximum resolution your renderer supports.

--- a/src/main/external-resources/renderers/Panasonic-Viera.conf
+++ b/src/main/external-resources/renderers/Panasonic-Viera.conf
@@ -45,6 +45,7 @@ TranscodeAudio = WAV
 MaxVideoBitrateMbps = 90
 TranscodeFastStart = true
 KeepAspectRatio = true
+KeepAspectRatioTolerance = 5
 RescaleByRenderer = false
 SendDateMetadata = false
 AutoExifRotate = true

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -145,6 +145,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String IGNORE_TRANSCODE_BYTE_RANGE_REQUEST = "IgnoreTranscodeByteRangeRequests";
 	protected static final String IMAGE = "Image";
 	protected static final String KEEP_ASPECT_RATIO = "KeepAspectRatio";
+	protected static final String KEEP_ASPECT_RATIO_TOLERANCE = "KeepAspectRatioTolerance";
 	protected static final String LIMIT_FOLDERS = "LimitFolders";
 	protected static final String LOADING_PRIORITY = "LoadingPriority";
 	protected static final String MAX_VIDEO_BITRATE = "MaxVideoBitrateMbps";
@@ -2078,6 +2079,19 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 */
 	public boolean isKeepAspectRatio() {
 		return getBoolean(KEEP_ASPECT_RATIO, false);
+	}
+
+	/**
+	 * The number represents percentage tolerance from ideal 16:9 AR. Within this
+	 * tolerance file will not be transcoded due to wrong AR.
+	 * Useful for files with almost invisible AR distortion like AR = 1.85 (~5%).
+	 * User can tune value between acceptable distortion and transcoding overhead
+	 * invoked by transcoding.
+	 *
+	 * @return
+	 */
+	public int getKeepAspectRatioTolerance() {
+		return getInt(KEEP_ASPECT_RATIO_TOLERANCE, 0);
 	}
 
 	/**

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -900,8 +900,12 @@ public class FFMpegVideo extends Player {
 				LOGGER.trace(prependTraceReason + "the colorspace probably isn't supported by the renderer.");
 			}
 			if (deferToTsmuxer == true && params.mediaRenderer.isKeepAspectRatio() && !"16:9".equals(media.getAspectRatioContainer())) {
-				deferToTsmuxer = false;
-				LOGGER.trace(prependTraceReason + "the renderer needs us to add borders so it displays the correct aspect ratio of " + media.getAspectRatioContainer() + ".");
+				if (params.mediaRenderer.getKeepAspectRatioTolerance() >= ((Float.parseFloat(media.getAspectRatioContainer())/1.777777777777778*100.0f)-100)) {
+					LOGGER.trace("Video aspect ratio distortion [" + media.getAspectRatioContainer() + "] is within defined tolerance [" + params.mediaRenderer.getKeepAspectRatioTolerance() + "%].");
+				} else {
+					deferToTsmuxer = false;
+					LOGGER.trace(prependTraceReason + "the renderer needs us to add borders so it displays the correct aspect ratio of " + media.getAspectRatioContainer() + ".");
+				}
 			}
 			if (deferToTsmuxer == true && !params.mediaRenderer.isResolutionCompatibleWithRenderer(media.getWidth(), media.getHeight())) {
 				deferToTsmuxer = false;

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -20,11 +20,13 @@ package net.pms.encoders;
 
 import bsh.EvalError;
 import bsh.Interpreter;
+
 import com.jgoodies.forms.builder.PanelBuilder;
 import com.jgoodies.forms.factories.Borders;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.FormLayout;
 import com.sun.jna.Platform;
+
 import java.awt.*;
 import java.awt.event.*;
 import java.io.File;
@@ -32,7 +34,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.*;
 import java.util.List;
+
 import javax.swing.*;
+
 import net.pms.Messages;
 import net.pms.PMS;
 import net.pms.configuration.DeviceConfiguration;
@@ -49,10 +53,13 @@ import net.pms.newgui.GuiUtil;
 import net.pms.newgui.components.CustomJButton;
 import net.pms.util.*;
 import static net.pms.util.StringUtil.quoteArg;
+
 import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.apache.commons.configuration.event.ConfigurationListener;
+
 import static org.apache.commons.lang.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -909,8 +916,12 @@ public class MEncoderVideo extends Player {
 			LOGGER.trace(prependTraceReason + "the colorspace probably isn't supported by the renderer.");
 		}
 		if (deferToTsmuxer == true && params.mediaRenderer.isKeepAspectRatio() && !"16:9".equals(media.getAspectRatioContainer())) {
-			deferToTsmuxer = false;
-			LOGGER.trace(prependTraceReason + "the renderer needs us to add borders so it displays the correct aspect ratio of " + media.getAspectRatioContainer() + ".");
+			if (params.mediaRenderer.getKeepAspectRatioTolerance() >= ((Float.parseFloat(media.getAspectRatioContainer())/1.777777777777778*100.0f)-100)) {
+				LOGGER.trace("Video aspect ratio distortion [" + media.getAspectRatioContainer() + "] is within defined tolerance [" + params.mediaRenderer.getKeepAspectRatioTolerance() + "%].");
+			} else {
+				deferToTsmuxer = false;
+				LOGGER.trace(prependTraceReason + "the renderer needs us to add borders so it displays the correct aspect ratio of " + media.getAspectRatioContainer() + ".");
+			}
 		}
 		if (deferToTsmuxer == true && !params.mediaRenderer.isResolutionCompatibleWithRenderer(media.getWidth(), media.getHeight())) {
 			deferToTsmuxer = false;


### PR DESCRIPTION
For avoiding unnecessary transcoding.
TODO: Panasonic TV and maybe others don't require to fix AR for all files as e.g. streamed XviD/DivX files are correctly shown without transcoding.