### PR TITLE
Fix issue 475 - hidden empty folder refresh

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1191,6 +1191,9 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				notifyRefresh();
 			} */
 			if (forced) {
+				// This seems to follow the same code path as the else below in the case of MapFile, because
+				// refreshChildren calls shouldRefresh -> isRefreshNeeded -> doRefreshChildren, which is what happens below
+				// (refreshChildren is not overridden in MapFile) 
 				if (refreshChildren(searchStr)) {
 					notifyRefresh();
 				}

--- a/src/main/java/net/pms/dlna/MapFile.java
+++ b/src/main/java/net/pms/dlna/MapFile.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 public class MapFile extends DLNAResource {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MapFile.class);
 	private List<File> discoverable;
+	private List<File> emptyFoldersToRescan;
 	private String forcedName;
 
 	private ArrayList<RealFile> searchList;
@@ -98,6 +99,14 @@ public class MapFile extends DLNAResource {
 					/* Optionally ignore empty directories */
 					if (f.isDirectory() && configuration.isHideEmptyFolders() && !FileUtil.isFolderRelevant(f, configuration)) {
 						LOGGER.debug("Ignoring empty/non-relevant directory: " + f.getName());
+						// Keep track of the fact that we have empty folders, so when we're asked if we should refresh,
+						// we can re-scan the folders in this list to see if they contain something relevant
+						if (emptyFoldersToRescan == null) {
+							emptyFoldersToRescan = new ArrayList<>();
+						}
+						if (!emptyFoldersToRescan.contains(f)) {
+							emptyFoldersToRescan.add(f);
+						}									
 					} else { // Otherwise add the file
 						RealFile rf = new RealFile(f);
 						if (searchList != null) {
@@ -207,6 +216,14 @@ public class MapFile extends DLNAResource {
 				}
 				if (f.isDirectory() && configuration.isHideEmptyFolders() && !FileUtil.isFolderRelevant(f, configuration)) {
 					LOGGER.debug("Ignoring empty/non-relevant directory: " + f.getName());
+					// Keep track of the fact that we have empty folders, so when we're asked if we should refresh,
+					// we can re-scan the folders in this list to see if they contain something relevant
+					if (emptyFoldersToRescan == null) {
+						emptyFoldersToRescan = new ArrayList<>();
+					}
+					if (!emptyFoldersToRescan.contains(f)) {
+						emptyFoldersToRescan.add(f);
+					}				
 					continue;
 				}
 
@@ -268,8 +285,18 @@ public class MapFile extends DLNAResource {
 				modified = Math.max(modified, f.lastModified());
 			}
 		}
-
-		return (getLastRefreshTime() < modified) || (configuration.getSortMethod(getPath()) == UMSUtils.SORT_RANDOM);
+		
+		// Check if any of our previously empty folders now have content
+		boolean emptyFolderNowNotEmpty = false;
+		if (emptyFoldersToRescan != null) {			
+			for (File emptyFile : emptyFoldersToRescan) {
+				if (FileUtil.isFolderRelevant(emptyFile, configuration)) {
+					emptyFolderNowNotEmpty = true;
+					break;
+				}
+			}			
+		}
+		return (getLastRefreshTime() < modified) || (configuration.getSortMethod(getPath()) == UMSUtils.SORT_RANDOM || emptyFolderNowNotEmpty);
 	}
 
 	@Override
@@ -329,6 +356,7 @@ public class MapFile extends DLNAResource {
 			addChild(new MapFile(f));
 		} */
 		getChildren().clear();
+		emptyFoldersToRescan = null; // Since we're re-scanning, reset this list so it can be built again
 		discoverable = null;
 		discoverChildren(str);
 		analyzeChildren(-1);


### PR DESCRIPTION
Add logic to MapFile that keeps track of empty folders we've ignored when configuration.isHideEmptyFolders is true. The empty folders are re-checked when isRefreshNeeded is called to see if they are now relevant, and if so, isRefreshNeeded will return True.