### PR TITLE
Add aspect ratio distortion tolerance in % for avoiding unnecessary transcoding (globally defined)

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -1046,6 +1046,15 @@ vlc_path =
 
 # ---< Unsorted >-------------------------------------------------------------
 
+# The number represents percentage tolerance from ideal 16:9 AR. Within this
+# tolerance file will not be transcoded due to wrong AR.
+# Useful for files with almost invisible AR distortion like AR = 1.85 (~5%).
+# User can tune value between acceptable distortion and overhead
+# invoked by transcoding.
+# Mostly used wide AR: 1.78[16:9], 1.85 (~5%), 2.35 (~33%), 2.40 (~36%)
+# Default: 5
+keep_aspect_ratio_tolerance =
+
 # Default: false
 transcode_block_multiple_connections =
 

--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -407,6 +407,7 @@ SubtitleHttpHeader =
 # If some videos on your renderer looked either stretched or squashed, enabling
 # this setting may fix that.
 # This is only reliable when MediaInfo = true.
+# TODO: PanTV doesn't require AR fix for streamed DivX/XviD files!
 # Default: false
 KeepAspectRatio = 
 

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -19,6 +19,7 @@
 package net.pms.configuration;
 
 import com.sun.jna.Platform;
+
 import java.awt.Color;
 import java.awt.Component;
 import java.io.File;
@@ -27,8 +28,10 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
+
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+
 import net.pms.Messages;
 import net.pms.PMS;
 import net.pms.dlna.CodeEnter;
@@ -39,6 +42,7 @@ import net.pms.util.FileUtil.FileLocation;
 import net.pms.util.PropertiesUtil;
 import net.pms.util.UMSUtils;
 import net.pms.util.WindowsRegistry;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -261,6 +265,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_USE_MPLAYER_FOR_THUMBS = "use_mplayer_for_video_thumbs";
 	protected static final String KEY_UUID = "uuid";
 	protected static final String KEY_VIDEOTRANSCODE_START_DELAY = "videotranscode_start_delay";
+	protected static final String KEY_VIDEOTRANSCODE_ASPECT_RATIO_TOLERANCE = "keep_aspect_ratio_tolerance";
 	protected static final String KEY_VIRTUAL_FOLDERS = "virtual_folders";
 	protected static final String KEY_VIRTUAL_FOLDERS_FILE = "virtual_folders_file";
 	protected static final String KEY_VLC_AUDIO_SYNC_ENABLED = "vlc_audio_sync_enabled";
@@ -2579,6 +2584,24 @@ public class PmsConfiguration extends RendererConfiguration {
 
 	public void setVideoTranscodeStartDelay(int value) {
 		configuration.setProperty(KEY_VIDEOTRANSCODE_START_DELAY, value);
+	}
+
+	/**
+	 * The number represents percentage tolerance from ideal 16:9 AR. Within this
+	 * tolerance file will not be transcoded due to wrong AR.
+	 * Useful for files with almost invisible AR distortion like AR = 1.85 (~5%).
+	 * User can tune value between acceptable distortion and overhead
+	 * invoked by transcoding.
+	 *
+	 * @return
+	 */
+
+	public int getVideoTranscodeARTolerance() {
+		return getInt(KEY_VIDEOTRANSCODE_ASPECT_RATIO_TOLERANCE, 5);
+	}
+
+	public void setVideoTranscodeARTolerance(int value) {
+		configuration.setProperty(KEY_VIDEOTRANSCODE_ASPECT_RATIO_TOLERANCE, value);
 	}
 
 	public boolean isAudioResample() {

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -24,7 +24,9 @@ import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.util.*;
+
 import javax.imageio.ImageIO;
+
 import net.coobird.thumbnailator.Thumbnails;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
@@ -42,6 +44,7 @@ import net.pms.util.ProcessUtil;
 import static net.pms.util.StringUtil.*;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import org.apache.sanselan.ImageInfo;
 import org.apache.sanselan.ImageReadException;
 import org.apache.sanselan.Sanselan;
@@ -1912,7 +1915,10 @@ public class DLNAMediaInfo implements Cloneable {
 				return aspect;
 			} else {
 				double exactAspectRatio = Double.parseDouble(aspect);
-				if (exactAspectRatio > 1.7 && exactAspectRatio <= 1.8) {
+				double arDistortion = Math.abs(1-(exactAspectRatio/1.777777777777778))*100d;
+				double arTolerance = configuration.getVideoTranscodeARTolerance();
+				if (arTolerance >= arDistortion) {
+					LOGGER.trace("Video aspect ratio distortion [" + exactAspectRatio + " (" + arDistortion + "%)] is within defined tolerance [" + arTolerance + "%].");
 					return "16:9";
 				} else if (exactAspectRatio > 1.3 && exactAspectRatio < 1.4) {
 					return "4:3";

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1909,14 +1909,19 @@ public class DLNAMediaInfo implements Cloneable {
 	 */
 	public String getFormattedAspectRatio(String aspect) {
 		if (isBlank(aspect)) {
+			LOGGER.info("~Aspect is blank");
 			return null;
 		} else {
 			if (aspect.contains(":")) {
+				LOGGER.info("~Aspect = " + aspect);
 				return aspect;
 			} else {
 				double exactAspectRatio = Double.parseDouble(aspect);
 				double arDistortion = Math.abs(1-(exactAspectRatio/1.777777777777778))*100d;
 				double arTolerance = configuration.getVideoTranscodeARTolerance();
+				LOGGER.info("~exactAspectRatio = " + exactAspectRatio);
+				LOGGER.info("~arDistortion = " + arDistortion);
+				LOGGER.info("~arTolerance = " + arTolerance);
 				if (arTolerance >= arDistortion) {
 					LOGGER.trace("Video aspect ratio distortion [" + exactAspectRatio + " (" + arDistortion + "%)] is within defined tolerance [" + arTolerance + "%].");
 					return "16:9";
@@ -1925,6 +1930,7 @@ public class DLNAMediaInfo implements Cloneable {
 				} else if (exactAspectRatio > 1.2 && exactAspectRatio < 1.3) {
 					return "5:4";
 				} else {
+					LOGGER.info("~Aspect set to null");
 					return null;
 				}
 			}

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -862,6 +862,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 					!"16:9".equals(media.getAspectRatioContainer())
 				) {
 					isIncompatible = true;
+					LOGGER.info("#Forcing transcode due to not 16:9 AR = " + media.getAspectRatioContainer());
 					LOGGER.trace(prependTraceReason + "the renderer needs us to add borders to change the aspect ratio from {} to 16/9.", getName(), media.getAspectRatioContainer());
 				} else if (!renderer.isResolutionCompatibleWithRenderer(media.getWidth(), media.getHeight())) {
 					isIncompatible = true;

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -22,6 +22,7 @@ import com.jgoodies.forms.builder.PanelBuilder;
 import com.jgoodies.forms.factories.Borders;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.FormLayout;
+
 import java.awt.Font;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
@@ -33,8 +34,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
+
 import net.pms.Messages;
 import net.pms.PMS;
 import net.pms.configuration.DeviceConfiguration;
@@ -54,9 +57,12 @@ import net.pms.util.PlayerUtil;
 import net.pms.util.ProcessUtil;
 import static net.pms.util.StringUtil.*;
 import net.pms.util.SubtitleUtils;
+
 import org.apache.commons.lang3.StringUtils;
+
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -907,6 +907,7 @@ public class FFMpegVideo extends Player {
 			}
 			if (deferToTsmuxer == true && params.mediaRenderer.isKeepAspectRatio() && !"16:9".equals(media.getAspectRatioContainer())) {
 				deferToTsmuxer = false;
+				LOGGER.info("#Aspect will be forced = " + media.getAspectRatioContainer());
 				LOGGER.trace(prependTraceReason + "the renderer needs us to add borders so it displays the correct aspect ratio of " + media.getAspectRatioContainer() + ".");
 			}
 			if (deferToTsmuxer == true && !params.mediaRenderer.isResolutionCompatibleWithRenderer(media.getWidth(), media.getHeight())) {

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -20,11 +20,13 @@ package net.pms.encoders;
 
 import bsh.EvalError;
 import bsh.Interpreter;
+
 import com.jgoodies.forms.builder.PanelBuilder;
 import com.jgoodies.forms.factories.Borders;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.FormLayout;
 import com.sun.jna.Platform;
+
 import java.awt.*;
 import java.awt.event.*;
 import java.io.File;
@@ -32,7 +34,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.*;
 import java.util.List;
+
 import javax.swing.*;
+
 import net.pms.Messages;
 import net.pms.PMS;
 import net.pms.configuration.DeviceConfiguration;
@@ -49,10 +53,13 @@ import net.pms.newgui.GuiUtil;
 import net.pms.newgui.components.CustomJButton;
 import net.pms.util.*;
 import static net.pms.util.StringUtil.quoteArg;
+
 import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.apache.commons.configuration.event.ConfigurationListener;
+
 import static org.apache.commons.lang.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Code simplified and reworked from renderer based to globally based configuration.
TODO: Panasonic TV and maybe others don't require to fix AR for every file as e.g. streamed XviD/DivX files are correctly shown without transcoding.
TODO2: Not possible to configure it via GUI right now.