### PR TITLE
Toggle the state of the install service button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pms.iml
 target
 *.orig
 
+/win32/service

--- a/pom.xml
+++ b/pom.xml
@@ -876,33 +876,6 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven-javadoc-plugin-version}</version>
 			</plugin>
-
-			<!-- Plugin to move the service wrapper into the working directory (for debugging in IDE) -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>${maven-antrun-plugin-version}</version>
-				<executions>
-					<execution>
-						<id>process-resources-web</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<target>
-								<!-- Make sure the destination folders exist. -->
-								<mkdir dir="${project.basedir}/win32/service" />
-								
-								<!-- Copy all the resources into the working directory -->
-								<copy todir="${project.basedir}/win32/service" overwrite="true">
-									<fileset dir="${project.binaries}/win32/service" />
-								</copy>
-							</target>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 	<profiles>
@@ -944,7 +917,7 @@
 			</pluginRepositories>
 
 			<build>
-				<plugins>
+				<plugins>					
 					<!-- Plugin to assemble a jar with dependencies -->
 					<plugin>
 						<artifactId>maven-assembly-plugin</artifactId>
@@ -1067,6 +1040,12 @@
 										<get src="${project.binaries-base}/win32/service/wrapper.dll?p=${binary-revision}" dest="${project.binaries}/win32/service/wrapper.dll" usetimestamp="true" />
 										<get src="${project.binaries-base}/win32/service/wrapper.exe?p=${binary-revision}" dest="${project.binaries}/win32/service/wrapper.exe" usetimestamp="true" />
 										<get src="${project.binaries-base}/win32/service/wrapper.jar?p=${binary-revision}" dest="${project.binaries}/win32/service/wrapper.jar" usetimestamp="true" />
+										
+										<!-- Make sure the destination folder for the service wrapper exists and copy the files. -->
+										<mkdir dir="${project.basedir}/win32/service" />
+										<copy todir="${project.basedir}/win32/service" overwrite="true">
+											<fileset dir="${project.binaries}/win32/service" />
+										</copy>
 									</target>
 								</configuration>
 							</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -876,6 +876,33 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven-javadoc-plugin-version}</version>
 			</plugin>
+
+			<!-- Plugin to move the service wrapper into the working directory (for debugging in IDE) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>${maven-antrun-plugin-version}</version>
+				<executions>
+					<execution>
+						<id>process-resources-web</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<!-- Make sure the destination folders exist. -->
+								<mkdir dir="${project.basedir}/win32/service" />
+								
+								<!-- Copy all the resources into the working directory -->
+								<copy todir="${project.basedir}/win32/service" overwrite="true">
+									<fileset dir="${project.binaries}/win32/service" />
+								</copy>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -797,39 +797,6 @@ public class PMS {
 	}
 
 	/**
-	 * Executes the needed commands in order to install the Windows service
-	 * that starts whenever the machine is started.
-	 * This function is called from the General tab.
-	 * @return true if UMS could be installed as a Windows service.
-	 * @see net.pms.newgui.GeneralTab#build()
-	 */
-	public boolean installWin32Service() {
-		PMS.get().uninstallWin32Service();
-		String cmdArray[] = new String[]{"win32/service/wrapper.exe", "-i", "wrapper.conf"};
-		ProcessWrapperImpl pwinstall = new ProcessWrapperImpl(cmdArray, new OutputParams(configuration));
-		pwinstall.runInSameThread();
-		return pwinstall.isSuccess();
-	}
-
-	/**
-	 * Executes the needed commands in order to remove the Windows service.
-	 * This function is called from the General tab.
-	 *
-	 * TODO: Make it detect if the uninstallation was successful
-	 *
-	 * @return true
-	 * @see net.pms.newgui.GeneralTab#build()
-	 */
-	public boolean uninstallWin32Service() {
-		String cmdArray[] = new String[]{"win32/service/wrapper.exe", "-r", "wrapper.conf"};
-		OutputParams output = new OutputParams(configuration);
-		output.noexitcheck = true;
-		ProcessWrapperImpl pwuninstall = new ProcessWrapperImpl(cmdArray, output);
-		pwuninstall.runInSameThread();
-		return true;
-	}
-
-	/**
 	 * @deprecated Use {@link #getSharedFoldersArray()} instead.
 	 */
 	@Deprecated

--- a/src/main/java/net/pms/newgui/GeneralTab.java
+++ b/src/main/java/net/pms/newgui/GeneralTab.java
@@ -23,6 +23,7 @@ import com.jgoodies.forms.factories.Borders;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.FormLayout;
 import com.sun.jna.Platform;
+
 import java.awt.*;
 import java.awt.event.*;
 import java.io.*;
@@ -31,7 +32,9 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+
 import javax.swing.*;
+
 import net.pms.Messages;
 import net.pms.PMS;
 import net.pms.configuration.Build;
@@ -41,6 +44,8 @@ import net.pms.network.NetworkConfiguration;
 import net.pms.newgui.components.CustomJButton;
 import net.pms.util.FormLayoutUtil;
 import net.pms.util.KeyedComboBoxModel;
+import net.pms.util.WindowsUtil;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,6 +78,7 @@ public class GeneralTab {
 	private JCheckBox runWizardOnProgramStartup;
 	private LooksFrame looksFrame;
 	private JCheckBox singleInstance;
+	private CustomJButton installService;
 
 	GeneralTab(PmsConfiguration configuration, LooksFrame looksFrame) {
 		this.configuration = configuration;
@@ -190,53 +196,10 @@ public class GeneralTab {
 		ypos += 2;
 
 		if (!configuration.isHideAdvancedOptions()) {
-			CustomJButton service = new CustomJButton(Messages.getString("NetworkTab.4"));
-			service.setToolTipText(Messages.getString("NetworkTab.63"));
-			service.addActionListener(new ActionListener() {
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					if (PMS.get().installWin32Service()) {
-						LOGGER.info(Messages.getString("PMS.41"));
-						JOptionPane.showMessageDialog(
-							looksFrame,
-							Messages.getString("NetworkTab.11") +
-							Messages.getString("NetworkTab.12"),
-							Messages.getString("Dialog.Information"),
-							JOptionPane.INFORMATION_MESSAGE
-						);
-					} else {
-						JOptionPane.showMessageDialog(
-							looksFrame,
-							Messages.getString("NetworkTab.14"),
-							Messages.getString("Dialog.Error"),
-							JOptionPane.ERROR_MESSAGE
-						);
-					}
-				}
-			});
-			builder.add(service, FormLayoutUtil.flip(cc.xy(1, ypos), colSpec, orientation));
-			if (System.getProperty(LooksFrame.START_SERVICE) != null || !Platform.isWindows()) {
-				service.setEnabled(false);
-			}
+			installService = new CustomJButton();
+			refreshInstallServiceButtonState();
 
-			CustomJButton serviceUninstall = new CustomJButton(Messages.getString("GeneralTab.2"));
-			serviceUninstall.addActionListener(new ActionListener() {
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					PMS.get().uninstallWin32Service();
-					LOGGER.info(Messages.getString("GeneralTab.3"));
-					JOptionPane.showMessageDialog(
-						looksFrame,
-						Messages.getString("GeneralTab.3"),
-						Messages.getString("Dialog.Information"),
-						JOptionPane.INFORMATION_MESSAGE
-					);
-				}
-			});
-			builder.add(serviceUninstall, FormLayoutUtil.flip(cc.xy(3, ypos), colSpec, orientation));
-			if (System.getProperty(LooksFrame.START_SERVICE) != null || !Platform.isWindows()) {
-				serviceUninstall.setEnabled(false);
-			}
+			builder.add(installService, FormLayoutUtil.flip(cc.xy(1, ypos), colSpec, orientation));
 			ypos += 2;
 		}
 
@@ -555,6 +518,93 @@ public class GeneralTab {
 		);
 		scrollPane.setBorder(BorderFactory.createEmptyBorder());
 		return scrollPane;
+	}
+
+	/**
+	 * Refreshes the state of the button to install/uninstall the Windows service for UMS
+	 * depending if the service has been installed or not.
+	 *  - Set the button and tooltip text
+	 *  - Add the correct action listener
+	 */
+	private void refreshInstallServiceButtonState() {		
+		if (System.getProperty(LooksFrame.START_SERVICE) != null || !Platform.isWindows()) {
+			installService.setEnabled(false);
+		} else {
+			installService.setEnabled(true);
+			
+			boolean isUmsServiceInstalled = WindowsUtil.isUmsServiceInstalled();
+			
+			if(isUmsServiceInstalled) {
+				// The 'Universal Media Server' service is installed
+				
+				// Update button text and tooltip
+				installService.setText(Messages.getString("GeneralTab.2"));
+				installService.setToolTipText(null);
+
+				// Remove all attached action listeners
+				for(ActionListener al : installService.getActionListeners()){
+					installService.removeActionListener(al);
+				}
+
+				// Attach the button clicked action listener
+				installService.addActionListener(new ActionListener() {
+					@Override
+					public void actionPerformed(ActionEvent e) {
+						WindowsUtil.uninstallWin32Service();
+						LOGGER.info(Messages.getString("GeneralTab.3"));
+
+						// Refresh the button state after it has been clicked
+						refreshInstallServiceButtonState();
+						
+						JOptionPane.showMessageDialog(
+							looksFrame,
+							Messages.getString("GeneralTab.3"),
+							Messages.getString("Dialog.Information"),
+							JOptionPane.INFORMATION_MESSAGE
+						);
+					}
+				});
+			} else {
+				// The 'Universal Media Server' service is not installed
+				
+				// Update button text and tooltip
+				installService.setText(Messages.getString("NetworkTab.4"));
+				installService.setToolTipText(Messages.getString("NetworkTab.63"));
+
+				// Remove all attached action listeners
+				for(ActionListener al : installService.getActionListeners()){
+					installService.removeActionListener(al);
+				}
+				
+				// Attach the button clicked action listener
+				installService.addActionListener(new ActionListener() {
+					@Override
+					public void actionPerformed(ActionEvent e) {
+						if (WindowsUtil.installWin32Service()) {
+							LOGGER.info(Messages.getString("PMS.41"));
+							
+							// Refresh the button state after it has been clicked
+							refreshInstallServiceButtonState();
+							
+							JOptionPane.showMessageDialog(
+								looksFrame,
+								Messages.getString("NetworkTab.11") +
+								Messages.getString("NetworkTab.12"),
+								Messages.getString("Dialog.Information"),
+								JOptionPane.INFORMATION_MESSAGE
+							);
+						} else {
+							JOptionPane.showMessageDialog(
+								looksFrame,
+								Messages.getString("NetworkTab.14"),
+								Messages.getString("Dialog.Error"),
+								JOptionPane.ERROR_MESSAGE
+							);
+						}
+					}
+				});
+			}
+		}
 	}
 
 	private KeyedComboBoxModel createNetworkInterfacesModel() {

--- a/src/main/java/net/pms/newgui/components/CustomJButton.java
+++ b/src/main/java/net/pms/newgui/components/CustomJButton.java
@@ -7,6 +7,10 @@ import javax.swing.JToolTip;
 public class CustomJButton extends JButton {
 	private static final long serialVersionUID = -528428545289132331L;
 
+	public CustomJButton() {
+		super();
+	}
+	
 	public CustomJButton(String string) {
 		super(string);
 		this.setRequestFocusEnabled(false);

--- a/src/main/java/net/pms/util/StringUtil.java
+++ b/src/main/java/net/pms/util/StringUtil.java
@@ -35,6 +35,7 @@ public class StringUtil {
 	private static final int[] MULTIPLIER = new int[] {3600, 60, 1};
 	public static final String SEC_TIME_FORMAT = "%02d:%02d:%02.0f";
 	public static final String DURATION_TIME_FORMAT = "%02d:%02d:%05.2f";
+	public static final String NEWLINE_CHARACTER = System.getProperty("line.separator");
 
 	/**
 	 * Appends "&lt;<u>tag</u> " to the StringBuilder. This is a typical HTML/DIDL/XML tag opening.

--- a/src/main/java/net/pms/util/WindowsUtil.java
+++ b/src/main/java/net/pms/util/WindowsUtil.java
@@ -1,0 +1,59 @@
+package net.pms.util;
+
+import net.pms.PMS;
+import net.pms.io.OutputParams;
+import net.pms.io.ProcessWrapperImpl;
+
+/**
+ * Utility class for Windows
+ */
+public class WindowsUtil {	
+	/**
+	 * Private constructor to avoid instantiating this class
+	 */
+	private WindowsUtil() {}
+
+	/**
+	 * Checks if is the Universal Media Server service is installed.
+	 *
+	 * @return true, if a service named Universal Media Server is installed
+	 */
+	public static boolean isUmsServiceInstalled() {
+		String[] commands = new String[]{ "sc", "query", "\"Universal Media Server\"" };
+		String response = ProcessUtil.run(commands);
+		return response.contains("TYPE");
+	}
+
+	/**
+	 * Executes the needed commands in order to install the Windows service
+	 * that starts whenever the machine is started.
+	 * This function is called from the General tab.
+	 * @return true if UMS could be installed as a Windows service.
+	 * @see net.pms.newgui.GeneralTab#build()
+	 */
+	public static boolean installWin32Service() {
+		String cmdArray[] = new String[]{"win32/service/wrapper.exe", "-i", "wrapper.conf"};
+		ProcessWrapperImpl pwinstall = new ProcessWrapperImpl(cmdArray, new OutputParams(PMS.getConfiguration()));
+		pwinstall.runInSameThread();
+		return pwinstall.isSuccess();
+	}
+
+	/**
+	 * Executes the needed commands in order to remove the Windows service.
+	 * This function is called from the General tab.
+	 *
+	 * TODO: Make it detect if the uninstallation was successful
+	 *
+	 * @return true
+	 * @see net.pms.newgui.GeneralTab#build()
+	 */
+	public static boolean uninstallWin32Service() {
+		String cmdArray[] = new String[]{"win32/service/wrapper.exe", "-r", "wrapper.conf"};
+		OutputParams output = new OutputParams(PMS.getConfiguration());
+		output.noexitcheck = true;
+		ProcessWrapperImpl pwuninstall = new ProcessWrapperImpl(cmdArray, output);
+		pwuninstall.runInSameThread();
+		return true;
+	}
+
+}


### PR DESCRIPTION
 Instead of having two active buttons to install and uninstall UMS as a windows service, have a single one, which shows install or uninstall depending on the installation state of the service.

I have tested it only on win7.
~~I might have put the plugin to copy the wrapper in the wrong spot which might lead to errors on other platforms.~~ Please test :)

Changes:
- Added WindowsUtil class with method isUmsServiceInstalled()
- Moved install and unistall service methods from PMS to WindowsUtil
- Added constant NEWLINE_CHARACTER to StringUtil
- Added empty constructor to CustomJButton
- Removed the unistall button
- Update text, tooltip and executed action for installService button in new method refreshInstallServiceButtonState() depending on the installation state of the service
- Copy the service wrapper into the working directory in order to be able to debug this functionality and add thisdirectory to the git ignore list