### PR TITLE
Allow 5% distortion tolerance for AR=1.85 for avoiding unnecessary transcoding

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -1046,6 +1046,14 @@ vlc_path =
 
 # ---< Unsorted >-------------------------------------------------------------
 
+# Renderer.conf "KeepAspectRatio" option allows forcing transcoding
+# for fixing non 16:9 aspect ratios.
+# Skipping transcoding for files with almost invisible AR distortion
+# like AR = 1.85 (~5%) can be accepted by most users to minimize CPU and
+# network bandwidth overhead or to not loose flawless FF/RW experience.
+# Default: true
+force_exact_aspect_ratio =
+
 # Default: false
 transcode_block_multiple_connections =
 

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -261,6 +261,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_USE_MPLAYER_FOR_THUMBS = "use_mplayer_for_video_thumbs";
 	protected static final String KEY_UUID = "uuid";
 	protected static final String KEY_VIDEOTRANSCODE_START_DELAY = "videotranscode_start_delay";
+	protected static final String KEY_VIDEOTRANSCODE_FORCE_EXACT_ASPECT_RATIO = "force_exact_aspect_ratio"; 
 	protected static final String KEY_VIRTUAL_FOLDERS = "virtual_folders";
 	protected static final String KEY_VIRTUAL_FOLDERS_FILE = "virtual_folders_file";
 	protected static final String KEY_VLC_AUDIO_SYNC_ENABLED = "vlc_audio_sync_enabled";
@@ -2554,6 +2555,14 @@ public class PmsConfiguration extends RendererConfiguration {
 
 	public void setVideoTranscodeStartDelay(int value) {
 		configuration.setProperty(KEY_VIDEOTRANSCODE_START_DELAY, value);
+	}
+
+	public boolean isVideoTranscodeForceExactAR() {
+		return getBoolean(KEY_VIDEOTRANSCODE_FORCE_EXACT_ASPECT_RATIO, true);
+	}
+
+	public void setVideoTranscodeForceExactAR(boolean value) {
+		configuration.setProperty(KEY_VIDEOTRANSCODE_FORCE_EXACT_ASPECT_RATIO, value);
 	}
 
 	public boolean isAudioResample() {

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -859,18 +859,19 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				isIncompatible = true;
 				LOGGER.trace(prependTraceReason + "the audio will use the encoded audio passthrough feature", getName());
 			} else if (format.isVideo() && parserV2) {
-				if (
-					renderer.isKeepAspectRatio() &&
-					!"16:9".equals(media.getAspectRatioContainer())
-				) {
-					isIncompatible = true;
-					LOGGER.trace(prependTraceReason + "the renderer needs us to add borders to change the aspect ratio from {} to 16/9.", getName(), media.getAspectRatioContainer());
-				} else if (!renderer.isResolutionCompatibleWithRenderer(media.getWidth(), media.getHeight())) {
+				if (!renderer.isResolutionCompatibleWithRenderer(media.getWidth(), media.getHeight())) {
 					isIncompatible = true;
 					LOGGER.trace(prependTraceReason + "the resolution is incompatible with the renderer.", getName());
 				} else if (media.getBitrate() > (renderer.getMaxBandwidth() / 2)) {
 					isIncompatible = true;
 					LOGGER.trace(prependTraceReason + "the bitrate is too high.", getName());
+				} else if (renderer.isKeepAspectRatio() && !"16:9".equals(media.getAspectRatioContainer())) {
+					if ("1.85:1".equals(media.getAspectRatioContainer()) && !configuration.isVideoTranscodeForceExactAR()) {
+						LOGGER.trace("File \"{}\" will be streamed because the minimal distortion of aspect ratio 1.85:1 is allowed.");
+					} else {
+						isIncompatible = true;
+						LOGGER.trace(prependTraceReason + "the renderer needs us to add borders to change the aspect ratio from {} to 16/9.", getName(), media.getAspectRatioContainer());
+					}
 				}
 			}
 

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -900,8 +900,12 @@ public class FFMpegVideo extends Player {
 				LOGGER.trace(prependTraceReason + "the colorspace probably isn't supported by the renderer.");
 			}
 			if (deferToTsmuxer == true && params.mediaRenderer.isKeepAspectRatio() && !"16:9".equals(media.getAspectRatioContainer())) {
-				deferToTsmuxer = false;
-				LOGGER.trace(prependTraceReason + "the renderer needs us to add borders so it displays the correct aspect ratio of " + media.getAspectRatioContainer() + ".");
+				if ("1.85:1".equals(media.getAspectRatioContainer()) && !configuration.isVideoTranscodeForceExactAR()) {
+					LOGGER.trace("Muxing the video stream with tsMuxeR via FFmpeg is still not abandoned because the minimal distortion of aspect ratio 1.85:1 is allowed.");
+				} else {
+					deferToTsmuxer = false;
+					LOGGER.trace(prependTraceReason + "the renderer needs us to add borders so it displays the correct aspect ratio of " + media.getAspectRatioContainer() + ".");
+				}
 			}
 			if (deferToTsmuxer == true && !params.mediaRenderer.isResolutionCompatibleWithRenderer(media.getWidth(), media.getHeight())) {
 				deferToTsmuxer = false;

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -909,8 +909,12 @@ public class MEncoderVideo extends Player {
 			LOGGER.trace(prependTraceReason + "the colorspace probably isn't supported by the renderer.");
 		}
 		if (deferToTsmuxer == true && params.mediaRenderer.isKeepAspectRatio() && !"16:9".equals(media.getAspectRatioContainer())) {
-			deferToTsmuxer = false;
-			LOGGER.trace(prependTraceReason + "the renderer needs us to add borders so it displays the correct aspect ratio of " + media.getAspectRatioContainer() + ".");
+			if ("1.85:1".equals(media.getAspectRatioContainer()) && !configuration.isVideoTranscodeForceExactAR()) {
+				LOGGER.trace("Muxing the video stream with tsMuxeR via MEncoder is still not abandoned because the minimal distortion of aspect ratio 1.85:1 is allowed.");				
+			} else {
+				deferToTsmuxer = false;
+				LOGGER.trace(prependTraceReason + "the renderer needs us to add borders so it displays the correct aspect ratio of " + media.getAspectRatioContainer() + ".");
+			}
 		}
 		if (deferToTsmuxer == true && !params.mediaRenderer.isResolutionCompatibleWithRenderer(media.getWidth(), media.getHeight())) {
 			deferToTsmuxer = false;


### PR DESCRIPTION
Take 1.85:1 aspect ratio as 1.78:1 [16:9]. This will avoid transcoding for AR=1.85:1 if KeepAspectRatio=true is defined in renderer.conf and Force_Exact_Aspect_Ratio=false in UMS.conf.
This feature is disabled by default as for someone 5% distortion (1.78~1.85) can be confusing.
Or should it be enabled to avoid transcoding/network bandwidth overhead and for better experience of FF/RW?
![aspectratio](https://cloud.githubusercontent.com/assets/1260408/8270035/9de02cac-17c8-11e5-9850-94a240260016.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/578)

<!-- Reviewable:end -->
