### PR TITLE
Copy web resources into the working dir while debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target
 *.orig
 win32/
 *.sublime-*
+web/

--- a/pom.xml
+++ b/pom.xml
@@ -877,6 +877,36 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven-javadoc-plugin-version}</version>
 			</plugin>
+			
+			<!-- 
+			Plugin to move web resources (located in external-resources) into the working directory.
+			This allows out of the box debugging for web.
+			 -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.8</version>
+				<executions>
+					<execution>
+						<id>process-resources-web</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<!-- Make sure the destination folder exists. -->
+								<mkdir dir="${project.basedir}/web" />
+								
+								<!-- Copy all web resources into the working directory -->
+								<copy todir="${project.basedir}/web" overwrite="true">
+									<fileset dir="${project.external-resources}/web" />
+								</copy>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>


### PR DESCRIPTION
This pull request modifies the maven config to copy the web resources from external resources into the working dir during the process resource phase for all environments (win, osx, linux).
With this, the website will be available while debubugging from the IDE without having to manually copy files.