### PR TITLE
Fixed a non-breaking bug in PmsConfiguration

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -507,7 +507,7 @@ public class PmsConfiguration extends RendererConfiguration {
 
 			if (pmsConfFile.isFile()) {
 				if (FileUtil.isFileReadable(pmsConfFile)) {
-					((PropertiesConfiguration)configuration).load(pmsConfFile.toURI().toString());
+					((PropertiesConfiguration)configuration).load(pmsConfFile);
 				} else {
 					LOGGER.warn("Can't load {}", PROFILE_PATH);
 				}

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -507,7 +507,7 @@ public class PmsConfiguration extends RendererConfiguration {
 
 			if (pmsConfFile.isFile()) {
 				if (FileUtil.isFileReadable(pmsConfFile)) {
-					((PropertiesConfiguration)configuration).load(PROFILE_PATH);
+					((PropertiesConfiguration)configuration).load(pmsConfFile.toURI().toString());
 				} else {
 					LOGGER.warn("Can't load {}", PROFILE_PATH);
 				}


### PR DESCRIPTION
PropertiesConfiguration.load() expects a valid URI as a parameter, while a path was sent. PropertiesConfiguration would figure it out and load correctly, but threw a couple of ```DEBUG``` messages complaining about it.

This is fixed.