### PR TITLE
Made ProcessUtil.run() accept expected exit codes as ok

### DIFF
--- a/src/main/java/net/pms/util/WindowsUtil.java
+++ b/src/main/java/net/pms/util/WindowsUtil.java
@@ -20,7 +20,8 @@ public class WindowsUtil {
 	 */
 	public static boolean isUmsServiceInstalled() {
 		String[] commands = new String[]{ "sc", "query", "\"Universal Media Server\"" };
-		String response = ProcessUtil.run(commands);
+		int[] expectedExitCodes = { 0, 1060 };
+		String response = ProcessUtil.run(expectedExitCodes, commands);
 		return response.contains("TYPE");
 	}
 


### PR DESCRIPTION
When UMS checks if it's installed as a Windows Service the exit code from the process is 1060 if the service is not installed. ProcessUtil.run() logs this as a warning, while it's actually a legit result. I've added a parameter so that the caller can choose to accept non-zero exit code, and I've added an overloaded version to accept the current parameters with a warning (that is, behaving exactly like before).

I've also changed the log level from debug to warn on the log message, now that it's possible to filter out "false positives".