### PR TITLE
Fixed JoranConfigurator/logOverrides bug

### DIFF
--- a/src/main/java/net/pms/configuration/ConfigurationReader.java
+++ b/src/main/java/net/pms/configuration/ConfigurationReader.java
@@ -32,12 +32,11 @@ import org.slf4j.LoggerFactory;
 /**
  * Helper class that implements common getters for the various types stored in renderer confs and PMS.conf.
  */
-// this class and all its methods are package private
-class ConfigurationReader {
+public class ConfigurationReader {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationReader.class);
 	private Map<String, Object> logMap = new HashMap<>();
 	private final Configuration configuration;
-	private final boolean logOverrides;
+	private boolean logOverrides;
 	private Configuration dConf;
 	private String dTag;
 
@@ -285,5 +284,13 @@ class ConfigurationReader {
 
 		log(key, value, def);
 		return value;
+	}
+	
+	public boolean getLogOverrides() {
+		return logOverrides;
+	}
+	
+	public void setLogOverrides(boolean logOverrides) {
+		this.logOverrides = logOverrides;
 	}
 }

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -211,6 +211,10 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		return defaultConf;
 	}
 
+	public ConfigurationReader getConfigurationReader() {
+		return configurationReader;
+	}
+
 	/**
 	 * Load all renderer configuration files and set up the default renderer.
 	 *

--- a/src/main/java/net/pms/logging/DebugLogPropertyDefiner.java
+++ b/src/main/java/net/pms/logging/DebugLogPropertyDefiner.java
@@ -23,6 +23,7 @@ import com.sun.jna.Platform;
 import java.io.File;
 import java.io.IOException;
 import net.pms.PMS;
+import net.pms.configuration.ConfigurationReader;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.util.FileUtil;
 import org.apache.commons.io.FileUtils;
@@ -42,13 +43,18 @@ public class DebugLogPropertyDefiner extends PropertyDefinerBase {
 
 	@Override
 	public String getPropertyValue() {
+		String result = null;
+		ConfigurationReader configurationReader = configuration.getConfigurationReader();
+		boolean saveLogOverride = configurationReader.getLogOverrides();
+		configurationReader.setLogOverrides(false);
 		switch (key) {
 			case "debugLogPath":
-				return getDebugLogPath();
+				result = getDebugLogPath();
 			case "rootLevel":
-				return getRootLevel();
+				result = getRootLevel();
 		}
-		return null;
+		configurationReader.setLogOverrides(saveLogOverride);
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
This bug is a bit hard to explain and I doubt any of you ever noticed it, but here we go: The problem has it's roots in commit 68819e6beadda88a092221b6470d1b3465c48a61 which logs overridden (non default) configuration values for some (?) configuration options. At the same time, ```DebugLogPropertyDefiner``` is called during Joran/LogBack configuration, which gets two values from ```PmsConfiguration```, ```DebugLogPath``` and ```RootLevel``` for injection into ```logback.xml``` or ```logback.headless.xml```.

```DebugLogPropertyDefiner``` is called while LogBack is in an unconfigured state (since it's a part of the configuration), and as such any logging will fail at that time. The ```logOverrides``` functionality *only* logs the value if it's different than default value, and as such it's probably not seen very frequently. Still, if ```DebugLogPath``` or ```RootLevel``` is changed in ```UMS.conf```, this error will occur. It's not fatal, the log entries will simply go nowhere, but it makes LogBack throw a warning and as a result, dumping the whole configuration debug information to the console.

The way I solved it was simply to temporarily turn off ```logOverrides``` while ```DebugLogPropertyDefiner``` is working. To be able to do that, I had to expose the setting. It might be that there's a better way to solve this, but I've been using quite some time to try to figure this one out and couldn't find it. I simply don't know the reason for logging if these values are changed, and thus I just disabled it at the time where it won't work anyway.