### PR TITLE
Flash video adpcm parse error

### DIFF
--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -489,7 +489,7 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.AAC_HE;
 		} else if (value.startsWith("adpcm")) {
 			format = FormatConfiguration.ADPCM;
-		} else if (value.equals("pcm") || (value.equals("1") && (audio.getCodecA() == null || !audio.getCodecA().equals(FormatConfiguration.DTS)))) {
+		} else if (value.equals("pcm") || (value.equals("1") && (audio.getCodecA() == null))) {
 			format = FormatConfiguration.LPCM;
 		} else if (value.equals("alac")) {
 			format = FormatConfiguration.ALAC;


### PR DESCRIPTION
Flash video with ADPCM audio are wrongly parsed as LPCM.
This commit fix this but maybe breaks something else.
Please verify this change because I am not a skilled coder :)

Test files:
http://samples.mplayerhq.hu/FLV/flash_flv_adpcm_testfiles/

