### PR TITLE
Added opus extenstion

### DIFF
--- a/src/main/java/net/pms/formats/OGG.java
+++ b/src/main/java/net/pms/formats/OGG.java
@@ -53,6 +53,7 @@ public class OGG extends MP3 {
 			"mpc",
 			"ogg",
 			"oma",
+			"opus",
 			"ra",
 			"shn",
 			"tta",


### PR DESCRIPTION
Ogg files with Opus audio and .opus extension were not used in UMS.
Now with the opus extension added, these files can be opened.

Test files:
http://xiph.org/~giles/2012/opus/