### PR TITLE
Bugfix transcoding audio with embedded images

### DIFF
--- a/src/main/java/net/pms/encoders/FFmpegAudio.java
+++ b/src/main/java/net/pms/encoders/FFmpegAudio.java
@@ -165,7 +165,7 @@ public class FFmpegAudio extends FFMpegVideo {
 		cmdList.add(executable());
 
 		cmdList.add("-loglevel");
-		
+
 		if (LOGGER.isTraceEnabled()) { // Set -loglevel in accordance with LOGGER setting
 			cmdList.add("info"); // Could be changed to "verbose" or "debug" if "info" level is not enough
 		} else {
@@ -185,6 +185,9 @@ public class FFmpegAudio extends FFMpegVideo {
 
 		cmdList.add("-i");
 		cmdList.add(filename);
+
+		// Make sure FFmpeg doesn't try to encode embedded images into the stream
+		cmdList.add("-vn");
 
 		// Encoder threads
 		if (nThreads > 0) {


### PR DESCRIPTION
If an audio file has embedded images (e.g cover art), FFmpeg will interpret that as a "video stream" and transcode that together with the audio stream. The result is unreadable. By setting the ```-vn``` switch (video none), FFmpeg simply ignores video streams when transcoding. This should be safe to do in any audio file transcoding.