### PR TITLE
MINOR optimization in RequestHandlerV2

### DIFF
--- a/src/main/java/net/pms/network/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/RequestHandlerV2.java
@@ -194,7 +194,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 						}
 
 						// It may be unusual but already known
-						if (renderer != null) {
+						if (!isKnown && renderer != null) {
 							String additionalHeader = renderer.getUserAgentAdditionalHttpHeader();
 							if (StringUtils.isNotBlank(additionalHeader) && lowerCaseHeaderLine.startsWith(additionalHeader)) {
 								isKnown = true;


### PR DESCRIPTION
Just a small thing that annoyed me while debugging - there's no reason to do those checks if ```isKnown``` is already true since the only goal of the checks is to set ```isKnown = true```.