### PR TITLE
Minor improvement: Logged information if help file is not found.

### DIFF
--- a/src/main/java/net/pms/newgui/HelpTab.java
+++ b/src/main/java/net/pms/newgui/HelpTab.java
@@ -25,6 +25,7 @@ import java.awt.Color;
 import java.awt.Desktop;
 import java.awt.Dimension;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -111,18 +112,20 @@ public class HelpTab {
 	 */
 	public void updateContents() {
 		if (editorPane != null) {
-			try {
-				// Read the HTML help file
-				String documentationDir = PropertiesUtil.getProjectProperties().get("project.documentation.dir");
-				String helpPage = PMS.getHelpPage();
-				File file = new File(documentationDir + "/" + helpPage);
-
-				// Display the HTML help file in the editor
-				editorPane.setPage(file.toURI().toURL());
-			} catch (MalformedURLException e) {
-				LOGGER.debug("Caught exception", e);
-			} catch (IOException e) {
-				LOGGER.debug("Caught exception", e);
+			String documentationDir = PropertiesUtil.getProjectProperties().get("project.documentation.dir");
+			String helpPage = PMS.getHelpPage();
+			File file = new File(documentationDir + "/" + helpPage);
+			if (file.exists()) {
+				try {
+					// Display the HTML help file in the editor
+					editorPane.setPage(file.toURI().toURL());
+				} catch (MalformedURLException e) {
+					LOGGER.debug("Caught exception", e);
+				} catch (IOException e) {
+					LOGGER.debug("Caught exception", e);
+				}
+			} else {
+				LOGGER.info("Couldn't find help file \"{}/{}\". Help will not be available.", documentationDir, helpPage);
 			}
 		}
 	}


### PR DESCRIPTION
In some cases (Java 6 at least) an exception will be thrown if the help file is not found. In Java 7 it seems to be just silently ignored. In any case, I find it useful that this is mentioned in the log (since the help tab will be blank).