### PR TITLE
OSX Java 6/7/8 pom.xml updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1249,7 +1249,7 @@
                                                                 <configuration>
                                                                         <rules>
                                                                                 <requireJavaVersion>
-                                                                                        <version>[1.6.0]</version>
+                                                                                        <version>[1.6.0-65]</version>
                                                                                 </requireJavaVersion>
                                                                         </rules>
                                                                 </configuration>
@@ -1440,7 +1440,7 @@
                                                                 <configuration>
                                                                         <rules>
                                                                                 <requireJavaVersion>
-                                                                                        <version>[1.7]</version>
+                                                                                        <version>[1.7.0-80,1.7.0-100]</version>
                                                                                 </requireJavaVersion>
                                                                         </rules>
                                                                 </configuration>
@@ -1618,7 +1618,7 @@
                                                                 <configuration>
                                                                         <rules>
                                                                                 <requireJavaVersion>
-                                                                                        <version>[1.8]</version>
+                                                                                        <version>[1.8.0-51,1.8.0-100]</version>
                                                                                 </requireJavaVersion>
                                                                         </rules>
                                                                 </configuration>


### PR DESCRIPTION
Force use of Java versions JDK 1.7.0 u80, 1.8.0 u51, 1.6.0 u65 and above on OSX