### PR TITLE
Bugfix for faking file extension when transcoding

### DIFF
--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -1242,9 +1242,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		if (isMediaParserV2()) {
 			// Use the supported information in the configuration to determine the transcoding mime type.
 			if (HTTPResource.VIDEO_TRANSCODE.equals(mimeType)) {
-				if (isTranscodeToMPEGPSMPEG2AC3()) { // Default video transcoding mime type. Check it first
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGPS, FormatConfiguration.MPEG2, FormatConfiguration.AC3);
-				} else if (isTranscodeToMPEGTSH264AC3()) {
+				if (isTranscodeToMPEGTSH264AC3()) {
 					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGTS, FormatConfiguration.H264, FormatConfiguration.AC3);
 				} else if (isTranscodeToMPEGTSH264AAC()) {
 					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGTS, FormatConfiguration.H264, FormatConfiguration.AAC);
@@ -1256,6 +1254,9 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGTS, FormatConfiguration.MPEG2, FormatConfiguration.AC3);
 				} else if (isTranscodeToWMV()) {
 					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.WMV, FormatConfiguration.WMV, FormatConfiguration.WMA);
+				} else {
+					// Default video transcoding mime type
+					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGPS, FormatConfiguration.MPEG2, FormatConfiguration.AC3);
 				}
 			} else if (HTTPResource.AUDIO_TRANSCODE.equals(mimeType)) {
 				if (isTranscodeToWAV()) {

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -289,6 +289,57 @@ public class DLNAMediaInfo implements Cloneable {
 
 	private boolean gen_thumb;
 
+	private int videoTrackCount = 0;
+	private int imageCount = 0;
+
+	public int getVideoTrackCount() {
+		return videoTrackCount;
+	}
+
+	public void setVideoTrackCount(int value) {
+		videoTrackCount = value;
+	}
+
+	public int getAudioTrackCount() {
+		return audioTracks.size();
+	}
+
+	public int getImageCount() {
+		return imageCount;
+	}
+
+	public void setImageCount(int value) {
+		imageCount = value;
+	}
+
+	public int getSubTrackCount() {
+		return subtitleTracks.size();
+	}
+
+	public boolean isVideo() {
+		return videoTrackCount > 0;
+	}
+
+	public boolean isAudio() {
+		return videoTrackCount == 0 && audioTracks.size() == 1;
+	}
+
+	public boolean hasAudio() {
+		return audioTracks.size() > 0;
+	}
+
+	/**
+	 * @return the number of subtitle tracks embedded in the media file.
+	 */
+
+	public boolean hasSubtitles() {
+		return subtitleTracks.size() > 0;
+	}
+
+	public boolean isImage() {
+		return videoTrackCount == 0 && audioTracks.size() == 0 && imageCount > 0;
+	}
+
 	/**
 	 * Used to determine whether tsMuxeR can mux the file to the renderer
 	 * instead of transcoding.
@@ -481,7 +532,7 @@ public class DLNAMediaInfo implements Cloneable {
 		} else {
 			args[2] = "" + configuration.getThumbnailSeekPos();
 		}
-		
+
 		args[3] = "-i";
 
 		if (file != null) {
@@ -703,7 +754,7 @@ public class DLNAMediaInfo implements Cloneable {
 								thumb = t.getArtworkList().get(0).getBinaryData();
 							} else {
 								if (configuration.getAudioThumbnailMethod() > 0) {
-									thumb = 
+									thumb =
 										CoverUtil.get().getThumbnailFromArtistAlbum(
 											configuration.getAudioThumbnailMethod() == 1 ?
 												CoverUtil.AUDIO_AMAZON :
@@ -798,6 +849,7 @@ public class DLNAMediaInfo implements Cloneable {
 					}
 
 					container = codecV;
+					imageCount++;
 				} catch (ImageReadException | IOException e) {
 					LOGGER.info("Error parsing image ({}) with Sanselan, switching to FFmpeg.", file.getAbsolutePath());
 				}
@@ -806,7 +858,7 @@ public class DLNAMediaInfo implements Cloneable {
 
 					// Create the thumbnail image using the Thumbnailator library
 					try {
-						ByteArrayOutputStream out = new ByteArrayOutputStream();	
+						ByteArrayOutputStream out = new ByteArrayOutputStream();
 						Thumbnails.of(file)
 								.size(320, 180)
 								.outputFormat("JPEG")
@@ -1089,6 +1141,7 @@ public class DLNAMediaInfo implements Cloneable {
 							String token = st.nextToken().trim();
 							if (token.startsWith("Stream")) {
 								codecV = token.substring(token.indexOf("Video: ") + 7);
+								videoTrackCount++;
 							} else if ((token.contains("tbc") || token.contains("tb(c)"))) {
 								// A/V sync issues with newest FFmpeg, due to the new tbr/tbn/tbc outputs
 								// Priority to tb(c)
@@ -1448,6 +1501,22 @@ public class DLNAMediaInfo implements Cloneable {
 		result.append(bitrate);
 		result.append(", size: ");
 		result.append(size);
+		if (videoTrackCount > 0) {
+			result.append(", video tracks: ");
+			result.append(videoTrackCount);
+		}
+		if (getAudioTrackCount() > 0) {
+			result.append(", audio tracks: ");
+			result.append(getAudioTrackCount());
+		}
+		if (imageCount > 0) {
+			result.append(", images: ");
+			result.append(imageCount);
+		}
+		if (getSubTrackCount() > 0) {
+			result.append(", subtitle tracks: ");
+			result.append(getSubTrackCount());
+		}
 		result.append(", video codec: ");
 		result.append(codecV);
 		result.append(", duration: ");
@@ -1567,7 +1636,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * plugins rely on it we can simplify things by removing that parameter.
 	 *
 	 * @param ratios
-	 * @return 
+	 * @return
 	 */
 	public String getAspectRatioMencoderMpegopts(boolean ratios) {
 		String a = null;
@@ -2555,9 +2624,9 @@ public class DLNAMediaInfo implements Cloneable {
 
 		return null;
 	}
-	
+
 	private boolean isAnaglyph;
-	
+
 	public boolean stereoscopyIsAnaglyph() {
 		get3DLayout();
 		return isAnaglyph;

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1222,7 +1222,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			if (forced) {
 				// This seems to follow the same code path as the else below in the case of MapFile, because
 				// refreshChildren calls shouldRefresh -> isRefreshNeeded -> doRefreshChildren, which is what happens below
-				// (refreshChildren is not overridden in MapFile) 
+				// (refreshChildren is not overridden in MapFile)
 				if (refreshChildren(searchStr)) {
 					notifyRefresh();
 				}
@@ -2388,7 +2388,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 						} else {
 							addAttribute(sb, "resolution", media.getResolution());
 						}
-						
+
 					}
 
 					addAttribute(sb, "bitrate", media.getRealVideoBitrate());
@@ -2469,13 +2469,24 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				endTag(sb);
 				// Add transcoded format extension to the output stream URL.
 				String transcodedExtension = "";
-				if (player != null) {
-					if (mediaRenderer.isTranscodeToMPEGPSMPEG2AC3()) {
-						transcodedExtension = "_transcoded_to.mpg";
-					} else if (mediaRenderer.isTranscodeToMPEGTS()) {
-						transcodedExtension = "_transcoded_to.ts";
-					} else if (mediaRenderer.isTranscodeToWMV() && !xbox360) {
-						transcodedExtension = "_transcoded_to.wmv";
+				if (player != null && media != null) {
+					// Note: Can't use instanceof below because the audio classes inherit the corresponding video class
+					if (media.isVideo()) {
+						if (mediaRenderer.isTranscodeToMPEGTS()) {
+							transcodedExtension = "_transcoded_to.ts";
+						} else if (mediaRenderer.isTranscodeToWMV() && !xbox360) {
+							transcodedExtension = "_transcoded_to.wmv";
+						} else {
+							transcodedExtension = "_transcoded_to.mpg";
+						}
+					} else if (media.isAudio()) {
+						if (mediaRenderer.isTranscodeToMP3()) {
+							transcodedExtension = "_transcoded_to.mp3";
+						} else if (mediaRenderer.isTranscodeToWAV()) {
+							transcodedExtension = "_transcoded_to.wav";
+						} else {
+							transcodedExtension = "_transcoded_to.pcm";
+						}
 					}
 				}
 

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -95,9 +95,9 @@ public class LibMediaInfoParser {
 				}
 
 				// set Video
-				int videos = MI.Count_Get(video);
-				if (videos > 0) {
-					for (int i = 0; i < videos; i++) {
+				media.setVideoTrackCount(MI.Count_Get(video));
+				if (media.getVideoTrackCount() > 0) {
+					for (int i = 0; i < media.getVideoTrackCount(); i++) {
 						// check for DXSA and DXSB subtitles (subs in video format)
 						if (MI.Get(video, i, "Title").startsWith("Subtitle")) {
 							currentSubTrack = new DLNAMediaSubtitle();
@@ -215,7 +215,8 @@ public class LibMediaInfoParser {
 				}
 
 				// set Image
-				if (MI.Count_Get(image) > 0) {
+				media.setImageCount(MI.Count_Get(image));
+				if (media.getImageCount() > 0) {
 					getFormat(image, media, currentAudioTrack, MI.Get(image, 0, "Format").toLowerCase(), file);
 					media.setWidth(getPixelValue(MI.Get(image, 0, "Width")));
 					media.setHeight(getPixelValue(MI.Get(image, 0, "Height")));


### PR DESCRIPTION
@SubJunk @valib 3b25f7a686381b644761ba5205940c65174baa8e didn't take into account that not all files are videos, and changed the extension to the renderer's video transcoding extension also for e.g audio files. This broke audio transcoding, as my two audio renderers wouldn't even try to play the audio files ending with .mpg. 

This is not quite ready to merge though, because I need your input on which engines to include for video and audio files. As there is no "good" way to determine if a file is a video or audio file in UMS (Format simply isn't enough as several formats can be both), I decided to separate them by transcoding/muxing engine. I don't know much about them though, as I have only used FFmpegAudio, so I need you to tell me which ones should use a faked extension for video and audio files, and where to place (if at all) ```TsMuxeRAudio, FFmpegDVRMSRemux, RAWThumbnailer```. I'm also unsure if the "web" formats should have the faked extension as I don't know what they do, but it's likely that they should.

This should make it before release as it breaks audio transcoding, so if you get back to me on the engines fast, I'll adjust them quickly.