### PR TITLE
Fixes to SelectRenderers inspired by #633

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -179,9 +179,19 @@ http_engine_v2 =
 # Prevent Windows from sleeping
 # -----------------------------
 # If your host server has a power-saving mode, use this option to prevent the
-# server hibernating or sleeping while it is streaming data.
+# server from hibernating or sleeping while it is streaming data.
 # Default: false
 prevents_sleep_mode =
+
+# Selected renderers
+# ------------------
+# A comma-separated list of renderer configurations to load by renderer name as
+# defined in the configuration file. Two special values exist, "All renderers"
+# and "None". Group names made of the first word in the renderer name can be
+# used to specify all renderers in that group, e.g. "Panasonic".
+# Example: Yamaha RX-A1010, Panasonic
+# Default: "All renderers"
+selected_renderers =
 
 # Default renderer when automatic detection fails
 # -----------------------------------------------

--- a/src/main/external-resources/renderers/Apple-iDevice-AirPlayer.conf
+++ b/src/main/external-resources/renderers/Apple-iDevice-AirPlayer.conf
@@ -9,7 +9,7 @@
 # TODO: Set MediaInfo=true and configure the supported types correctly.
 #
 
-RendererName = AirPlayer
+RendererName = Apple AirPlayer
 RendererIcon = airplayer.png
 
 # ============================================================================

--- a/src/main/external-resources/renderers/Apple-iDevice.conf
+++ b/src/main/external-resources/renderers/Apple-iDevice.conf
@@ -11,7 +11,7 @@
 # TODO: rewrite to use MediaInfo
 #
 
-RendererName = iPad / iPhone
+RendererName = Apple iPad / iPhone
 RendererIcon = ipad-iphone.png
 
 # ============================================================================

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -371,7 +371,7 @@ public class PmsConfiguration extends RendererConfiguration {
 		under multiple profiles without fiddling with environment variables, properties or
 		command-line arguments.
 
-		1) if UMS_PROFILE is not set, UMS.conf is located in: 
+		1) if UMS_PROFILE is not set, UMS.conf is located in:
 
 			Windows:             %ALLUSERSPROFILE%\$build
 			Mac OS X:            $HOME/Library/Application Support/$build
@@ -1466,7 +1466,17 @@ public class PmsConfiguration extends RendererConfiguration {
 	 * @param value The comma-separated list of selected renderers.
 	 */
 	public void setSelectedRenderers(String value) {
+		if (value.isEmpty()) {
+			value = "None";
+		}
 		configuration.setProperty(KEY_SELECTED_RENDERERS, value);
+	}
+
+	/**
+	 * @param value a string list of renderers.
+	 */
+	public void setSelectedRenderers(List<String> value) {
+		setStringList(KEY_SELECTED_RENDERERS, value);
 	}
 
 	/**
@@ -2353,7 +2363,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	}
 
 	/**
-	 * @see #isFFmpegDeferToMEncoderForEmbeddedSubtitles() 
+	 * @see #isFFmpegDeferToMEncoderForEmbeddedSubtitles()
 	 * @deprecated
 	 */
 	@Deprecated
@@ -2960,7 +2970,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	public int liveSubtitlesLimit() {
 		return getInt(KEY_LIVE_SUBTITLES_LIMIT, 20);
 	}
-	
+
 	public boolean isLiveSubtitlesKeep() {
 		return getBoolean(KEY_LIVE_SUBTITLES_KEEP, false);
 	}

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -247,11 +247,11 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 						r.rank = rank++;
 						String rendererName = r.getConfName();
 						allRenderersNames.add(rendererName);
-						String renderersGroup = null; 
+						String renderersGroup = null;
 						if (rendererName.indexOf(" ") > 0) {
 							renderersGroup = rendererName.substring(0, rendererName.indexOf(" "));
 						}
-						
+
 						if (selectedRenderers.contains(rendererName) || selectedRenderers.contains(renderersGroup) || selectedRenderers.contains(pmsConf.ALL_RENDERERS)) {
 							enabledRendererConfs.add(r);
 						} else {
@@ -307,9 +307,28 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	}
 
 	public List<String> getStringList(String key, String def) {
-		return configurationReader.getStringList(key, def);
+		List<String> result = configurationReader.getStringList(key, def);
+		if (result.size() == 1 && result.get(0).equalsIgnoreCase("None")) {
+			return new ArrayList<String>();
+		} else {
+			return result;
+		}
 	}
-   	
+
+	public void setStringList(String key, List<String> value) {
+		String result = "";
+		for (String element : value) {
+			if (!result.isEmpty()) {
+				result += ", ";
+			}
+			result += element;
+		}
+		if (result.isEmpty()) {
+			result = "None";
+		}
+		configuration.setProperty(key, result);
+	}
+
 	public Color getColor(String key, String defaultValue) {
 		String colorString = getString(key, defaultValue);
 		Color color = StringUtil.parseColor(colorString);
@@ -434,7 +453,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		for (RendererConfiguration r : getConnectedRenderersConfigurations()) {
 			r.rootFolder = null;
 		}
-		// Resetting enabledRendererConfs isn't strictly speaking necessary any more, since 
+		// Resetting enabledRendererConfs isn't strictly speaking necessary any more, since
 		// these are now for reference only and never actually populate their root folders.
 		for (RendererConfiguration r : enabledRendererConfs) {
 			r.rootFolder = null;
@@ -1380,7 +1399,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 						if (getAddress() != null) {
 							put(Messages.getString("RendererPanel.11"), getAddress().getHostAddress().toString());
 						}
-					}	
+					}
 				};
 			}
 		}

--- a/src/main/java/net/pms/newgui/SelectRenderers.java
+++ b/src/main/java/net/pms/newgui/SelectRenderers.java
@@ -1,7 +1,7 @@
 /*
  * Universal Media Server, for streaming any medias to DLNA
  * compatible renderers based on the http://www.ps3mediaserver.org.
- * Copyright (C) 2012  UMS developers.
+ * Copyright (C) 2012 UMS developers.
  *
  * This program is a free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -21,26 +21,32 @@
 package net.pms.newgui;
 
 import java.awt.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.swing.*;
-import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
-import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import net.pms.Messages;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.configuration.RendererConfiguration;
+import net.pms.newgui.components.IllegalChildException;
+import net.pms.newgui.components.SearchableMutableTreeNode;
 import net.pms.util.tree.CheckTreeManager;
 
 public class SelectRenderers extends JPanel {
+	private static final Logger LOGGER = LoggerFactory.getLogger(SelectRenderers.class);
 	private static final long serialVersionUID = -2724796596060834064L;
 	private static PmsConfiguration configuration = PMS.getConfiguration();
 	private static List<String> selectedRenderers = configuration.getSelectedRenderers();
 	private CheckTreeManager checkTreeManager;
 	private JTree SrvTree;
-	private DefaultMutableTreeNode allRenderers;
+	private SearchableMutableTreeNode allRenderers;
 	private static final String allRenderersTreeName = configuration.ALL_RENDERERS;
 	private boolean init = false;
 
@@ -52,45 +58,41 @@ public class SelectRenderers extends JPanel {
 		JPanel checkPanel = new JPanel();
 		checkPanel.applyComponentOrientation(ComponentOrientation.getOrientation(new Locale(configuration.getLanguage())));
 		add(checkPanel, BorderLayout.LINE_START);
-		allRenderers = new DefaultMutableTreeNode(Messages.getString("GeneralTab.13"));
-		DefaultMutableTreeNode renderersGroup = null;
-		String lastGroup = null;
-		String groupName;
-		boolean firstLoop = true;
-		for (String renderer : RendererConfiguration.getAllRenderersNames()) {
-			if (lastGroup != null && renderer.startsWith(lastGroup)) {
-				if (renderer.indexOf(" ") > 0 ) {
-					renderersGroup.add(new DefaultMutableTreeNode(renderer.substring(renderer.indexOf(" "))));
-				} else {
-					renderersGroup.add(new DefaultMutableTreeNode(renderer));
-				}
+		allRenderers = new SearchableMutableTreeNode(Messages.getString("GeneralTab.13"));
 
+		Pattern pattern = Pattern.compile("^\\s*([^\\s]*) ?([^\\s].*?)?\\s*$");
+		for (String renderer : RendererConfiguration.getAllRenderersNames()) {
+			Matcher match = pattern.matcher(renderer);
+			if (match.find()) {
+				// Find or create group or single name renderer
+				SearchableMutableTreeNode node = null;
+				try {
+					 node = allRenderers.findChild(match.group(1));
+				} catch (IllegalChildException e) {}
+				if (node == null) {
+					node = new SearchableMutableTreeNode(match.group(1));
+					allRenderers.add(node);
+				}
+				// Find or create subgroup/name
+				if (match.groupCount() > 1 && match.group(2) != null) {
+					SearchableMutableTreeNode subNode = null;
+					try {
+						subNode = node.findChild(match.group(2));
+					} catch (IllegalChildException e) {}
+					if (subNode != null) {
+						LOGGER.warn("Renderer {} found twice, ignoring repeated entry", renderer);
+					} else {
+						subNode = new SearchableMutableTreeNode(match.group(2));
+						node.add(subNode);
+					}
+				}
 			} else {
-				if (!firstLoop) {
-					allRenderers.add(renderersGroup);
-				}
-				
-				if (renderer.indexOf(" ") > 0) {
-					groupName = renderer.substring(0, renderer.indexOf(" "));
-					renderersGroup = new DefaultMutableTreeNode(groupName);
-					renderersGroup.add(new DefaultMutableTreeNode(renderer.substring(renderer.indexOf(" "))));
-				} else {
-					groupName = renderer;
-					renderersGroup = new DefaultMutableTreeNode(groupName);
-				}
-				
-				lastGroup = groupName;
-				firstLoop = false;
+				LOGGER.warn("Can't parse renderer name \"{}\"", renderer);
 			}
 		}
 
-		// add the last group to the list
-		if (renderersGroup != null) {
-			allRenderers.add(renderersGroup);
-		}
-
 		SrvTree = new JTree(new DefaultTreeModel(allRenderers));
-		checkTreeManager = new CheckTreeManager(SrvTree); 
+		checkTreeManager = new CheckTreeManager(SrvTree);
 		checkPanel.add(new JScrollPane(SrvTree));
 		checkPanel.setSize(400, 500);
 	}
@@ -104,46 +106,33 @@ public class SelectRenderers extends JPanel {
 			build();
 			init = true;
 		}
+		SrvTree.validate();
 		// Refresh setting if modified
 		selectedRenderers = configuration.getSelectedRenderers();
-		TreePath[] renderersPath = new TreePath[selectedRenderers.size()];
 		TreePath root = new TreePath(allRenderers);
-		int i = 0;
-		for (String renderer : selectedRenderers) {
-			if (allRenderersTreeName.equals(renderer)) {
-				renderersPath[i] = root;
-			} else {
-				int childNumber = allRenderers.getChildCount();
-				for (int j = 0; j < childNumber; j++) {
-					TreeNode node = allRenderers.getChildAt(j); // node represents simple renderer or group of renderers family
-					int nodeChildren = node.getChildCount();
-					int endIndex = renderer.indexOf(" ");
-					if (node.toString().equals(renderer)) { // group has all children selected or renderer is only one word name
-						renderersPath[i] = root.pathByAddingChild(node);
-						i++;
-						break;
-					} else {
-						if (endIndex > 0 && nodeChildren > 0) {
-							if (node.toString().equals(renderer.substring(0, endIndex))) {
-								for (int jj = 0; jj < nodeChildren; jj++) {
-									if (node.getChildAt(jj).toString().equals(renderer.substring(renderer.indexOf(" ")))) {
-										renderersPath[i] = root.pathByAddingChild(node).pathByAddingChild(node.getChildAt(jj));
-										i++;
-										break;
-									}
-								}
-							
-								break;	
-							}
-						}
-						
+		if (selectedRenderers.isEmpty() || (selectedRenderers.size() == 1 && selectedRenderers.get(0) == null)) {
+			checkTreeManager.getSelectionModel().clearSelection();
+		} else if (selectedRenderers.size() == 1 && selectedRenderers.get(0).equals(allRenderersTreeName)) {
+			checkTreeManager.getSelectionModel().setSelectionPath(root);
+		} else {
+			if (root.getLastPathComponent() instanceof SearchableMutableTreeNode) {
+				SearchableMutableTreeNode rootNode = (SearchableMutableTreeNode) root.getLastPathComponent();
+				SearchableMutableTreeNode node = null;
+				List<TreePath> selectedRenderersPath = new ArrayList<TreePath>(selectedRenderers.size());
+				for (String selectedRenderer : selectedRenderers) {
+					try {
+						node = rootNode.findInBranch(selectedRenderer, true);
+					} catch (IllegalChildException e) {}
+					if (node != null) {
+						selectedRenderersPath.add(new TreePath(node.getPath()));
 					}
 				}
+				checkTreeManager.getSelectionModel().setSelectionPaths(selectedRenderersPath.toArray(new TreePath[selectedRenderersPath.size()]));
+			} else {
+				LOGGER.error("Illegal node class in SelectRenderers.showDialog(): {}", root.getLastPathComponent().getClass().getSimpleName());
 			}
 		}
 
-		SrvTree.validate();
-		checkTreeManager.getSelectionModel().setSelectionPaths(renderersPath);
 		int selectRenderers = JOptionPane.showOptionDialog(
 			(Component) PMS.get().getFrame(),
 			this,
@@ -156,35 +145,38 @@ public class SelectRenderers extends JPanel {
 		);
 
 		if (selectRenderers == JOptionPane.OK_OPTION) {
-			StringBuilder buildSelectedRenders = new StringBuilder();
 			TreePath[] selected = checkTreeManager.getSelectionModel().getSelectionPaths();
-			for (TreePath path : selected) {
-				String[] treePathString = path.toString().split(",");
-				StringBuilder nameStr = new StringBuilder();
-				int beginIndex;
-				int endIndex;
-				if (treePathString.length > 1) {
-					if (treePathString[0].contains(allRenderers.toString())) {
-						for (i = 1; i < treePathString.length; i++) {
-							beginIndex = treePathString[i].lastIndexOf("[") + 1;
-							endIndex = treePathString[i].indexOf("]");
-							if (endIndex > beginIndex) {
-								nameStr.append(treePathString[i].substring(beginIndex, endIndex).trim());
+			if (selected.length == 0) {
+				configuration.setSelectedRenderers("");
+			} else if (
+				selected.length == 1 && selected[0].getLastPathComponent() instanceof SearchableMutableTreeNode &&
+				((SearchableMutableTreeNode) selected[0].getLastPathComponent()).getNodeName().equals(allRenderers.getNodeName())
+			) {
+				configuration.setSelectedRenderers(allRenderersTreeName);
+			} else {
+				List<String> selectedRenderers = new ArrayList<String>();
+				for (TreePath path : selected) {
+					String rendererName = "";
+					if (path.getPathComponent(0).equals(allRenderers)) {
+						for (int i = 1; i < path.getPathCount(); i++) {
+							if (path.getPathComponent(i) instanceof SearchableMutableTreeNode) {
+								if (!rendererName.isEmpty()) {
+									rendererName += " ";
+								}
+								rendererName += ((SearchableMutableTreeNode) path.getPathComponent(i)).getNodeName();
 							} else {
-								nameStr.append(treePathString[i].trim()).append(" ");
+								LOGGER.error("Invalid tree node component class {}", path.getPathComponent(i).getClass().getSimpleName());
 							}
 						}
-					}
-				} else {
-					if (selected.length == 1) {
-						nameStr.append(allRenderersTreeName);
+						if (!rendererName.isEmpty()) {
+							selectedRenderers.add(rendererName);
+						}
+					} else {
+						LOGGER.warn("Invalid renderer treepath encountered: {}", path.toString());
 					}
 				}
-
-				buildSelectedRenders.append(nameStr).append(",");
+				configuration.setSelectedRenderers(selectedRenderers);
 			}
-
-			configuration.setSelectedRenderers(buildSelectedRenders.toString());
 		}
 	}
 }

--- a/src/main/java/net/pms/newgui/components/IllegalChildException.java
+++ b/src/main/java/net/pms/newgui/components/IllegalChildException.java
@@ -1,0 +1,46 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.newgui.components;
+
+public class IllegalChildException extends Exception {
+
+	private static final long serialVersionUID = 1152260088011461750L;
+
+	public IllegalChildException() {
+	}
+
+	public IllegalChildException(String message) {
+		super(message);
+	}
+
+	public IllegalChildException(Throwable cause) {
+		super(cause);
+	}
+
+	public IllegalChildException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public IllegalChildException(String message, Throwable cause,
+			boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+}

--- a/src/main/java/net/pms/newgui/components/SearchableMutableTreeNode.java
+++ b/src/main/java/net/pms/newgui/components/SearchableMutableTreeNode.java
@@ -1,0 +1,99 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.newgui.components;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
+
+public class SearchableMutableTreeNode extends DefaultMutableTreeNode {
+
+	private static final long serialVersionUID = 8466944555448955118L;
+
+	public SearchableMutableTreeNode(String nodeName) {
+		super(nodeName);
+	}
+
+	public SearchableMutableTreeNode(String nodeName, boolean allowsChildren) {
+		super(nodeName, allowsChildren);
+	}
+
+	protected SearchableMutableTreeNode findChild(String searchName, boolean recursive, boolean specialGroupRules) throws IllegalChildException {
+		if (getChildCount() > 0) {
+			for (int i = 0; i < getChildCount(); i++) {
+				TreeNode currentTNChild = getChildAt(i);
+				if (currentTNChild instanceof SearchableMutableTreeNode) {
+					SearchableMutableTreeNode currentChild = (SearchableMutableTreeNode) currentTNChild;
+					if (currentChild.getNodeName().equalsIgnoreCase(searchName)) {
+						return currentChild;
+					} else if (specialGroupRules && searchName.equalsIgnoreCase(currentChild.getParent().getNodeName() + " " + currentChild.getNodeName())) {
+						// Search for the special group rule where grouping is done on the first word (so that the parent has the first word in the name)
+						return currentChild;
+					}
+				} else {
+					throw new IllegalChildException("All children must be SearchMutableTreeNode or subclasses thereof");
+				}
+			}
+			// Do recursive search in separate loop to avoid finding a matching subnode before a potential match at the current level
+			if (recursive) {
+				SearchableMutableTreeNode result = null;
+				for (int i = 0; i < getChildCount(); i++) {
+					SearchableMutableTreeNode currentChild = (SearchableMutableTreeNode) getChildAt(i);
+					if (!currentChild.isLeaf()) {
+						result = currentChild.findChild(searchName, true, specialGroupRules);
+						if (result != null) {
+							return result;
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Search the node's immediate children
+	 * @param searchObject the object to search for
+	 * @return the found node or null
+	 * @throws IllegalChildException if a child that's not a SearchableMutableTreeNode or descendant is encountered
+	 */
+	public SearchableMutableTreeNode findChild(String searchName) throws IllegalChildException {
+
+		return findChild(searchName, false, false);
+	}
+
+	/**
+	 * Search the node's children recursively
+	 * @param searchObject the object to search for
+	 * @return the found node or null
+	 * @throws IllegalChildException if a child that's not a SearchableMutableTreeNode or descendant is encountered
+	 */
+	public SearchableMutableTreeNode findInBranch(String searchName, boolean specialGroupRules) throws IllegalChildException {
+		return findChild(searchName, true, specialGroupRules);
+	}
+
+	public String getNodeName() {
+		return (String) super.getUserObject();
+	}
+
+    public SearchableMutableTreeNode getParent() {
+        return (SearchableMutableTreeNode) parent;
+    }
+
+}

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -39,7 +39,7 @@ public class RendererConfigurationTest {
 	public void setUp() {
 		// Silence all log messages from the PMS code that is being tested
 		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-		context.reset(); 
+		context.reset();
 
 		// Set locale to EN to ignore translations for renderers
 		Locale.setDefault(Locale.ENGLISH);
@@ -72,8 +72,8 @@ public class RendererConfigurationTest {
 		testHeaders(null, "X-Unknown-Header: Unknown Content");
 
 		// AirPlayer:
-		testHeaders("AirPlayer", "User-Agent: AirPlayer/1.0.09 CFNetwork/485.13.9 Darwin/11.0.0");
-		testHeaders("AirPlayer", "User-Agent: Lavf52.54.0");
+		testHeaders("Apple AirPlayer", "User-Agent: AirPlayer/1.0.09 CFNetwork/485.13.9 Darwin/11.0.0");
+		testHeaders("Apple AirPlayer", "User-Agent: Lavf52.54.0");
 
 		// BraviaEX:
 		testHeaders("Sony Bravia EX", "X-AV-Client-Info: av=5.0; cn=\"Sony Corporation\"; mn=\"BRAVIA KDL-32CX520\"; mv=\"1.7\";");
@@ -85,10 +85,10 @@ public class RendererConfigurationTest {
 		testHeaders("D-Link DSM-510", "User-Agent: DLNADOC/1.50 INTEL_NMPR/2.1");
 
 		// iPad-iPhone:
-		testHeaders("iPad / iPhone", "User-Agent: 8player lite 2.2.3 (iPad; iPhone OS 5.0.1; nl_NL)");
-		testHeaders("iPad / iPhone", "User-Agent: yxplayer2%20lite/1.2.7 CFNetwork/485.13.9 Darwin/11.0.0");
-		testHeaders("iPad / iPhone", "User-Agent: MPlayer 1.0rc4-4.2.1");
-		testHeaders("iPad / iPhone", "User-Agent: NSPlayer/4.1.0.3856");
+		testHeaders("Apple iPad / iPhone", "User-Agent: 8player lite 2.2.3 (iPad; iPhone OS 5.0.1; nl_NL)");
+		testHeaders("Apple iPad / iPhone", "User-Agent: yxplayer2%20lite/1.2.7 CFNetwork/485.13.9 Darwin/11.0.0");
+		testHeaders("Apple iPad / iPhone", "User-Agent: MPlayer 1.0rc4-4.2.1");
+		testHeaders("Apple iPad / iPhone", "User-Agent: NSPlayer/4.1.0.3856");
 
 		// Microsoft Xbox One:
 		testHeaders("Xbox One", "FriendlyName.DLNA.ORG: Xbox-SystemOS");
@@ -218,7 +218,7 @@ public class RendererConfigurationTest {
 	 * Test a particular set of headers to see if it returns the correct
 	 * renderer. Set the correct renderer name to <code>null</code> to require
 	 * that nothing matches at all.
-	 * 
+	 *
 	 * @param correctRendererName
 	 *            The name of the renderer.
 	 * @param headerLines


### PR DESCRIPTION
When @valib posted 1182f560e534e1f6e40eb9a17e33cfa3f5e6d55e I was already looking at it and had discovered an additional problem: The logic building the groups relied on the incoming data being sorted. I always find that a bit scary and had written a different logic that wasn't hurt by it being unsorted.

Further testing revealed a couple of other issues as well:
* When selecting only some members of a group, the next time one opened the Select Renderers window that whole group would be cleared.
* If selecting no renderers (from some strange reason), the effect would be that all renderers would be selected (because the default, all renderers, would kick in).

Further logics rewrite have fixed that too. To try to move some "low level" logic out of ```SelectRenderers``` I created a new class ```SearchableMutableTreeNode``` extending ```DefaultMutableTreeNode``` that can be reused for similar tasks. The class is general except one "special logic" (controlled by a parameter) for handling search on both the current node and the parent node simultaneously (because names are split by the first space in the renderer name). I don't like this, but found it to be to most practical approach.

I also added "Apple" to the name of AirPlayer and iDevice renderers, so that they are grouped under "Apple" and documented ```Selected renderers``` in ```UMS.conf```.