### PR TITLE
Suggested fix to DLNAResource.resolve() synchronization

### DIFF
--- a/src/main/java/net/pms/dlna/ChapterFileTranscodeVirtualFolder.java
+++ b/src/main/java/net/pms/dlna/ChapterFileTranscodeVirtualFolder.java
@@ -35,7 +35,7 @@ public class ChapterFileTranscodeVirtualFolder extends VirtualFolder {
 	 * Constructor for a {@link ChapterFileTranscodeVirtualFolder}. The constructor
 	 * does not create the children for this instance, it only sets the name, the
 	 * icon for a thumbnail and the interval at which chapter markers must be placed
-	 * when the children are created by {@link #resolve()}. 
+	 * when the children are created by {@link #syncResolve()}.
 	 * @param name The name of this instance.
 	 * @param thumbnailIcon The thumbnail for this instance.
 	 * @param interval The interval (in minutes) at which a chapter marker will be
@@ -53,7 +53,7 @@ public class ChapterFileTranscodeVirtualFolder extends VirtualFolder {
 	protected void resolveOnce() {
 		if (getChildren().size() == 1) { // OK
 			DLNAResource child = getChildren().get(0);
-			child.resolve();
+			child.syncResolve();
 			int nbMinutes = (int) (child.getMedia().getDurationInSeconds() / 60);
 			int nbIntervals = nbMinutes / interval;
 

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1243,9 +1243,9 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	@Override
 	public void run() {
 		if (first == null) {
-			resolve();
+			syncResolve();
 			if (second != null) {
-				second.resolve();
+				second.syncResolve();
 			}
 		}
 	}
@@ -1417,7 +1417,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 * Hook to lazily initialise immutable resources e.g. ISOs, zip files &amp;c.
 	 *
 	 * @since 1.90.0
-	 * @see #resolve()
+	 * @see #syncResolve()
 	 */
 	protected void resolveOnce() { }
 
@@ -1439,7 +1439,14 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 * removed from it (if supported). There are other mechanisms for that e.g.
 	 * {@link #doRefreshChildren()} (see {@link Feed} for an example).
 	 */
-	public synchronized void resolve() {
+	public synchronized final void syncResolve() {
+		resolve();
+	}
+
+	/**
+	 * @deprecated Use {@link #syncResolve()} instead
+	 */
+	public void resolve() {
 		if (!resolved) {
 			resolveOnce();
 			// if resolve() isn't overridden, this file/folder is immutable
@@ -3981,7 +3988,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				setDefaultRenderer(r);
 				// Now add the item and resolve its rendering details
 				add(d);
-				d.resolve();
+				d.syncResolve();
 				// Restore our previous renderer
 				setDefaultRenderer(prev);
 			}

--- a/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
+++ b/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
@@ -179,7 +179,7 @@ public class FileTranscodeVirtualFolder extends VirtualFolder {
 	protected void resolveOnce() {
 		if (getChildren().size() == 1) { // OK
 			DLNAResource child = getChildren().get(0);
-			child.resolve();
+			child.syncResolve();
 
 			RendererConfiguration renderer = null;
 			if (this.getParent() != null) {

--- a/src/main/java/net/pms/dlna/PlaylistFolder.java
+++ b/src/main/java/net/pms/dlna/PlaylistFolder.java
@@ -207,7 +207,7 @@ public class PlaylistFolder extends DLNAResource {
 		}
 
 		for (DLNAResource r : getChildren()) {
-			r.resolve();
+			r.syncResolve();
 		}
 	}
 

--- a/src/main/java/net/pms/dlna/RootFolder.java
+++ b/src/main/java/net/pms/dlna/RootFolder.java
@@ -245,7 +245,7 @@ public class RootFolder extends DLNAResource {
 						child.refreshChildren();
 					} else {
 						if (child instanceof DVDISOFile || child instanceof DVDISOTitle) { // ugly hack
-							child.resolve();
+							child.syncResolve();
 						}
 						child.discoverChildren();
 						child.analyzeChildren(-1);


### PR DESCRIPTION
While DLNAResource.resolve() itself has been synchronized, overridden methods e.g. in plugins aren't necessarily synchronized. This created all kind of mess, and this is my suggested resolution. Being such a central part of UMS, I think every consideration should be made before merge, I do not have the full overview.

I have been working with the MovieInfo plugin lately (https://github.com/SharkHunter/MovieInfo/pull/6). Originally I just wanted to replace deprecated methods with updated ones, but after doing that and fixing a couple of null exception bugs, I noticed a huge memory leak. Starting UMS and browsing with a renderer looking at some of the ```MovieInfo``` folders, quickly (within a minute or so) consumed 3.5 GB RAM, without me streaming anything. It wouldn't go down again either, and soon the java VM would crash. I, being me, wanted to find the cause, and this has taken me some days. I ended up changing quite a few things, and I can't be really sure what fixed the memory leak, but here's what I think happened: Since MovieInfo overrides ```resolve()```, unsynchronized, several threads (usually two or three) ended up being in ```resolve()``` at the same time. The ```resolved``` variable is read in the beginning of the method and sat in the end, and the method involves looking up google and IMDB, so it can take a second or so to complete, so they all started this in parallell. Working on the same variables, I can imagine that pointers have been thrown off and that the reference counting were compromized so that large chunks of allocated memory was "lost".

At first I made ```resolve()``` synchronized, but then I thought about it and found that to be a bad solution. That would mean that any plugin would have to do that, or UMS could display very strange behaviour. My solution is therefor instead to "wrap" resolve in synchronization so that it's always synchronized in any subclass. I also made ```resolve()``` deprecated, not because it really is, but as a warning not to use it. The wrapping method is called ```syncResolve()```, and is final so it cannot be overridden. The problem is still that ```resolve()``` could still be called by code directly, but I've updated all references to it in UMS to point to ```syncResolve()```. The right solution would have been to design something like this from the beginning, where ```resolve()``` was final and then called some abstract ```doResolve()``` method - but that's water under the bridge now.

The synchronization in plugins need to be handled in some way, and I couldn't think of a better way at the moment.

Discuss....