### PR TITLE
Minor Maven pom changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -923,6 +923,27 @@
 					<plugin>
 						<artifactId>maven-assembly-plugin</artifactId>
 						<version>2.5.4</version>
+							<configuration>
+								<descriptors>
+									<descriptor>${project.basedir}/src/main/assembly/jar-with-dependencies.xml</descriptor>
+								</descriptors>
+								<archive>
+									<manifest>
+										<mainClass>net.pms.PMS</mainClass>
+										<!--
+											this is required to make the ImageIo image "plugins" provided by jai-imageio-core-standalone work.
+											without it, the following exception is thrown when PMS starts:
+
+											Configuration error: java.util.ServiceConfigurationError: javax.imageio.spi.ImageInputStreamSpi:
+												Provider com.sun.media.imageioimpl.stream.ChannelImageInputStreamSpi could not be instantiated:
+													java.lang.IllegalArgumentException: vendorName == null!
+
+											See: https://thierrywasyl.wordpress.com/2009/07/24/jai-how-to-solve-vendorname-null-exception/
+										-->
+										<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+									</manifest>
+								</archive>
+							</configuration>
 						<executions>
 							<execution>
 								<id>make-jar-with-dependencies-win</id>
@@ -930,27 +951,6 @@
 								<goals>
 									<goal>single</goal>
 								</goals>
-								<configuration>
-									<descriptors>
-										<descriptor>${project.basedir}/src/main/assembly/jar-with-dependencies.xml</descriptor>
-									</descriptors>
-									<archive>
-										<manifest>
-											<mainClass>net.pms.PMS</mainClass>
-											<!--
-												this is required to make the ImageIo image "plugins" provided by jai-imageio-core-standalone work.
-												without it, the following exception is thrown when PMS starts:
-
-												Configuration error: java.util.ServiceConfigurationError: javax.imageio.spi.ImageInputStreamSpi:
-													Provider com.sun.media.imageioimpl.stream.ChannelImageInputStreamSpi could not be instantiated:
-														java.lang.IllegalArgumentException: vendorName == null!
-
-												See: https://thierrywasyl.wordpress.com/2009/07/24/jai-how-to-solve-vendorname-null-exception/
-											-->
-											<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-										</manifest>
-									</archive>
-								</configuration>
 							</execution>
 						</executions>
 					</plugin>
@@ -961,7 +961,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-antrun-plugin</artifactId>
-						<version>1.8</version>
+						<version>1.7</version>
 						<executions>
 							<execution>
 								<id>process-resources-windows</id>


### PR DESCRIPTION
I've changed the following in the Maven Windows profile:
- Changed ```maven-antrun-plugin``` version to ```1.7```
- Separated ```maven-assembly-plugin``` configuration and execution

It seems to me like the ```maven-antrun-plugin``` version numbers indicate the JDK version that's being used. When I try to build when the version is set to ```1.8``` I get the same errors as I do when I try to compile using JDK 1.8 in Eclipse. If that's the case, the version should probably be adjusted also in the Java6 branch. I've tried in vain to find documentation about the ```maven-antrun-plugin``` version number - it looks like they consider it to be self-explanatory. Adjusting the version to ```1.7``` removes the Java 8 related errors, so I interpret that as a strong indication for such a correlation.

Regarding the ```maven-assembly-plugin``` plugin changes I hope I haven't broken anything as I'm very unsure about anything Maven, but all I've done is to move the ```<configuration>``` section out of the ```executions``` section as explained [here] (http://stackoverflow.com/questions/29282515/maven-error-reading-assemblies-no-assembly-descriptors-found) and [here] (http://stackoverflow.com/questions/5183460/error-reading-assemblies-no-assembly-descriptors-found). The reason is that when I try "Maven build" from Eclipse, I get the following error:
```
Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.5.4:assembly (default-cli) on project ums: Error reading assemblies: No assembly descriptors found.
```
Separating ```<configuration>``` and ```<executions>``` solves that, and the explanation is supposedly that when they are mixed the link 
```xml
<descriptor>${project.basedir}/src/main/assembly/jar-with-dependencies.xml</descriptor>
``` 
is no longer valid at the parse point since the execution has started packing. 