### PR TITLE
Possible fix for #551 NPE when updating progress bar

### DIFF
--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -138,10 +138,26 @@ public class PMS {
 	private static PMS instance = null;
 
 	/**
-	 * Array of {@link net.pms.configuration.RendererConfiguration} that have been found by PMS.
+	 * Array of {@link net.pms.configuration.RendererConfiguration} that have
+	 * been found by UMS.<br><br>
+	 *
+	 * Important! If iteration is done on this list it's not thread safe unless
+	 * the iteration loop is enclosed by a <code>synchronized</code> block on
+	 * the <code>List itself</code>.
 	 */
-	private final ArrayList<RendererConfiguration> foundRenderers = new ArrayList<>();
+	private final List<RendererConfiguration> foundRenderers = Collections.synchronizedList(new ArrayList<RendererConfiguration>());
 
+	/**
+	 * The returned <code>List</code> itself is thread safe, but the objects
+	 * it's holding is not. Any looping/iterating of this <code>List</code>
+	 * MUST be enclosed in:
+	 * S<pre><code>
+	 * synchronized(getFoundRenderers()) {
+	 *      ..code..
+	 * }
+	 * </code></pre>
+	 * @return {@link #foundRenderers}
+	 */
 	public List<RendererConfiguration> getFoundRenderers() {
 		return foundRenderers;
 	}
@@ -1495,10 +1511,6 @@ public class PMS {
 
 	public static boolean isReady() {
 		return get().ready;
-	}
-
-	public List<RendererConfiguration> getRenders() {
-		return foundRenderers;
 	}
 
 	public static GlobalIdRepo getGlobalRepo() {


### PR DESCRIPTION
@skeptical 's tip in #661 made me remember this one, and just as I thought ```SwingUtilities.invokeLater()``` wasn't used. It takes patience to test this, so I haven't done that, but anyone that feels like it is free to do so. I think the ```foundRenderers``` ```List``` requires some more work to be properly thread safe, but I don't think that's what's causing this problem so testing can start without it.

- Removed method PMS.getRenders() that was a duplicate of PMS.getFoundRenderers()
- Made PMS.foundRenderers a Collections.synchronizedList for thread safety
- Used SwingUtilities.invokeLater() to call memBarUI.setValues()