### PR TITLE
Addressing #640 Windows 10 compatibility 

### DIFF
--- a/src/main/external-resources/documentation/installation.html
+++ b/src/main/external-resources/documentation/installation.html
@@ -261,8 +261,8 @@
 					permissions on the UMS install folder.
 					<ul>
 						<li>Check the base file system permissions.</li>
-						<li>On Windows Vista or Windows 7, reinstall with &quot;Run
-							as Administrator&quot; on the installer.</li>
+						<li>On Windows Vista, Windows 7, Windows 8 and Windows 10 reinstall 
+							with &quot;Run as Administrator&quot; on the installer.</li>
 						<li>Check if any filesystem protection programs are blocking
 							access (some antivirus or malware programs have this feature).</li>
 					</ul>
@@ -287,7 +287,7 @@
 		to look externally.</p>
 
 	<dl>
-		<dt>You have a Windows 7 box and it's using the
+		<dt>You have Windows 7, Windows 8 or Windows 10 and it's using the
 			&quot;Public&quot; settings instead of &quot;Private&quot;</dt>
 		<dd>
 			PUBLIC settings is used in non trusted network and PRIVATE is used in

--- a/src/main/external-resources/documentation/videolan.html
+++ b/src/main/external-resources/documentation/videolan.html
@@ -53,7 +53,7 @@
 	<p>
 		Use <a
 			href="http://www.codecguide.com/windows7_preferred_filter_tweaker.htm">preferred
-			filter tweaker for Windows 7</a> to change from preferred Microsoft
+			filter tweaker for Windows 7 and Windows 8</a> to change from preferred Microsoft
 		DTV/DVD Decoder to another
 	</p>
 

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -1295,7 +1295,7 @@ public class PMS {
 	 * Restart handling
 	 */
 	private static void killOld() {
-		if (configuration.isAdmin()) {
+		if (!Platform.isWindows() || configuration.isAdmin()) {
 			try {
 				killProc();
 			} catch (IOException e) {


### PR DESCRIPTION
@UniversalMediaServer/developers @SubJunk 
As far as I can see, ```PmsConfiguration.isAdmin()``` is the only part of UMS directly incompatible with Windows 10 - if anyone knows of any other issues please let me know.

I've updated ```PmsConfiguration.isAdmin()``` to work for Windows 10, or actually to work for any Windows version from Windows XP and upwards. I've tested this on Windows XP, Windows 7 and Windows 10, so I assume it's correct also for Windows Vista and Windows 8. When looking at Windows version instead of matching a specific OS name, it will work for Windows servers as well a future Windows versions as long as the method work. The day it doesn't work anymore, the Windows version simply has to be limited upwards.

But, since I was already in that method, I wanted to complete it by adding support for Linux and OS X as well. This is done and tested (don't let me start on how much trouble it was getting a OS X VM to run and to get git and maven to work on OS X).

This has created problems with the "single instance" logic though, since ```isAdmin()``` has always returned ```true``` for Linux and OS X until now. I've tried to suggest fixes in #668, but the only feedback has been negative. Until that is solved I think it's better to leave this unmerged.

Any suggested resolutions are welcome.