### PR TITLE
Possible fix for #551 NPE when updating progress bar continued

### DIFF
--- a/src/main/java/net/pms/newgui/GuiUtil.java
+++ b/src/main/java/net/pms/newgui/GuiUtil.java
@@ -8,10 +8,10 @@ import javax.swing.*;
 import org.apache.commons.lang3.StringUtils;
 
 public final class GuiUtil {
-	
+
 	/**
 	 * Wraps a {@link JComponent} into a {@link JPanel} using a {@link BorderLayout}, adding it to WEST.<br>
-	 * If using this method for e.g. a {@link JCheckBox} and adding it to a layout, the {@link JCheckBox} won't 
+	 * If using this method for e.g. a {@link JCheckBox} and adding it to a layout, the {@link JCheckBox} won't
 	 * span the entire space and thus, it won't change the checked state if clicking outside of it.
 	 *
 	 * @param component the component
@@ -235,11 +235,11 @@ public final class GuiUtil {
 				color = c;
 			}
 		}
-		ArrayList<Segment> segments;
-		ArrayList<Segment> mainLabel;
+		private ArrayList<Segment> segments;
+		private ArrayList<Segment> mainLabel;
 
-		int tickmarks;
-		String tickLabel;
+		private int tickmarks;
+		private String tickLabel;
 
 		public SegmentedProgressBarUI() {
 			this(null, null);
@@ -254,25 +254,25 @@ public final class GuiUtil {
 			tickLabel = "{}";
 		}
 
-		public int addSegment(String label, Color c) {
+		public synchronized int addSegment(String label, Color c) {
 			// Set color transparency to 50% so tickmarks are visible
 			segments.add(new Segment(label, new Color(c.getRed(), c.getGreen(), c.getBlue(), 128)));
 			return segments.size() - 1;
 		}
 
-		public void setActiveLabel(String label, Color c, int pct) {
+		public synchronized void setActiveLabel(String label, Color c, int pct) {
 			Segment s = new Segment(label, c);
 			// This label will be activated if progress equals or exceeds this percentage
 			s.val = pct;
 			mainLabel.add(s);
 		}
 
-		public void setTickMarks(int units, String label) {
+		public synchronized void setTickMarks(int units, String label) {
 			tickmarks = units;
 			tickLabel = label;
 		}
 
-		public void setValues(int min, int max, int... vals) {
+		public synchronized void setValues(int min, int max, int... vals) {
 			int total = 0;
 			for (int i = 0; i < vals.length; i++) {
 				segments.get(i).val = vals[i];
@@ -283,7 +283,7 @@ public final class GuiUtil {
 			progressBar.setValue(total);
 		}
 
-		public int total() {
+		private int total() {
 			int size = 0;
 			for (Segment s : segments) {
 				size += s.val;
@@ -292,7 +292,7 @@ public final class GuiUtil {
 		}
 
 		@Override
-		protected void paintDeterminate(Graphics g, JComponent c) {
+		protected synchronized void paintDeterminate(Graphics g, JComponent c) {
 			Insets b = progressBar.getInsets();
 			int w = progressBar.getWidth() - (b.right + b.left);
 			int h = progressBar.getHeight() - (b.top + b.bottom);
@@ -343,7 +343,7 @@ public final class GuiUtil {
 			}
 		}
 
-		public void paintTicks(Graphics g, int x0, int step, int max) {
+		private void paintTicks(Graphics g, int x0, int step, int max) {
 			if (step < 1) {
 				return;
 			}
@@ -376,12 +376,12 @@ public final class GuiUtil {
 		}
 
 		@Override
-		protected Color getSelectionForeground() {
+		protected synchronized Color getSelectionForeground() {
 			return fg;
 		}
 
 		@Override
-		protected Color getSelectionBackground() {
+		protected synchronized Color getSelectionBackground() {
 			return bg;
 		}
 	}

--- a/src/main/java/net/pms/newgui/StatusTab.java
+++ b/src/main/java/net/pms/newgui/StatusTab.java
@@ -66,7 +66,7 @@ public class StatusTab {
 		public GuiUtil.FixedPanel playing;
 		public JLabel time;
 		public JFrame frame;
-		public GuiUtil.SmoothProgressBar jpb;
+		public GuiUtil.SmoothProgressBar rendererProgressBar;
 		public RendererPanel panel;
 		public String name = " ";
 		private JPanel _panel = null;
@@ -83,12 +83,12 @@ public class StatusTab {
 			playing.add(playingLabel);
 			time = new JLabel(" ");
 			time.setForeground(Color.gray);
-			jpb = new GuiUtil.SmoothProgressBar(0, 100);
-			jpb.setUI(new GuiUtil.SimpleProgressUI(Color.gray, Color.gray));
-			jpb.setStringPainted(true);
-			jpb.setBorderPainted(false);
-			jpb.setString(r.getAddress().getHostAddress());
-			jpb.setForeground(bufColor);
+			rendererProgressBar = new GuiUtil.SmoothProgressBar(0, 100);
+			rendererProgressBar.setUI(new GuiUtil.SimpleProgressUI(Color.gray, Color.gray));
+			rendererProgressBar.setStringPainted(true);
+			rendererProgressBar.setBorderPainted(false);
+			rendererProgressBar.setString(r.getAddress().getHostAddress());
+			rendererProgressBar.setForeground(bufColor);
 		}
 
 		@Override
@@ -96,7 +96,7 @@ public class StatusTab {
 			BasicPlayer.State state = ((BasicPlayer) e.getSource()).getState();
 			time.setText((state.playback == BasicPlayer.STOPPED || StringUtil.isZeroTime(state.position)) ? " " :
 				UMSUtils.playedDurationStr(state.position, state.duration));
-			jpb.setValue((int) (100 * state.buffer / bufferSize));
+			rendererProgressBar.setValue((int) (100 * state.buffer / bufferSize));
 			String n = (state.playback == BasicPlayer.STOPPED || StringUtils.isBlank(state.name)) ? " " : state.name;
 			if (!name.equals(n)) {
 				name = n;
@@ -138,7 +138,7 @@ public class StatusTab {
 				CellConstraints cc = new CellConstraints();
 				b.add(icon, cc.xy(1, 1));
 				b.add(label, cc.xy(1, 3, CellConstraints.CENTER, CellConstraints.DEFAULT));
-				b.add(jpb, cc.xy(1, 5));
+				b.add(rendererProgressBar, cc.xy(1, 5));
 				b.add(playing, cc.xy(1, 7, CellConstraints.CENTER, CellConstraints.DEFAULT));
 				b.add(time, cc.xy(1, 9));
 				_panel = b.getPanel();
@@ -151,7 +151,7 @@ public class StatusTab {
 	private PmsConfiguration configuration;
 	private JPanel renderers;
 	private JLabel jl;
-	private JProgressBar jpb;
+	private JProgressBar memoryProgressBar;
 	private GuiUtil.SegmentedProgressBarUI memBarUI;
 	private JLabel bitrateLabel;
 	private JLabel currentBitrate;
@@ -166,10 +166,6 @@ public class StatusTab {
 	StatusTab(PmsConfiguration configuration) {
 		this.configuration = configuration;
 		bufferSize = configuration.getMaxMemoryBufferSize();
-	}
-
-	public JProgressBar getJpb() {
-		return jpb;
 	}
 
 	public void updateCurrentBitrate() {
@@ -251,21 +247,21 @@ public class StatusTab {
 		builder.add(imagePanel, FormLayoutUtil.flip(cc.xy(1, 9), colSpec, orientation));
 
 		// Memory
-		jpb = new JProgressBar(0, 100);
-		jpb.setStringPainted(true);
-		jpb.setForeground(new Color(75, 140, 181));
-		jpb.setString(Messages.getString("StatusTab.5"));
+		memoryProgressBar = new JProgressBar(0, 100);
+		memoryProgressBar.setStringPainted(true);
+		memoryProgressBar.setForeground(new Color(75, 140, 181));
+		memoryProgressBar.setString(Messages.getString("StatusTab.5"));
 		memBarUI = new GuiUtil.SegmentedProgressBarUI(Color.white, Color.gray);
 		memBarUI.setActiveLabel("{}", Color.white, 0);
 		memBarUI.setActiveLabel("{}", Color.red, 90);
 		memBarUI.addSegment("", memColor);
 		memBarUI.addSegment("", bufColor);
 		memBarUI.setTickMarks(getTickMarks(), "{}");
-		jpb.setUI(memBarUI);
+		memoryProgressBar.setUI(memBarUI);
 
 		JLabel mem = builder.addLabel("<html><b>" + Messages.getString("StatusTab.6") + "</b> (" + Messages.getString("StatusTab.12") + ")</html>", FormLayoutUtil.flip(cc.xy(3, 7), colSpec, orientation));
 		mem.setForeground(fgColor);
-		builder.add(jpb, FormLayoutUtil.flip(cc.xyw(3, 9, 1), colSpec, orientation));
+		builder.add(memoryProgressBar, FormLayoutUtil.flip(cc.xyw(3, 9, 1), colSpec, orientation));
 
 		// Bitrate
 		String bitColSpec = "left:pref, 3dlu, right:pref:grow";


### PR DESCRIPTION
This is a continuation of #663. I've had this build running on a separate computer for 3 days now without degradation of the memory bar. I've done the following in addition to what's done in #663.

- Made class ```SegmentedProgressBarUI``` thread safe by either synchronizing on the whole class or making variables and methods private (so that they are only called in a safe context).
- Renamed the ```ProgressBar``` variable names in ```StatusTab``` from ```jpb``` to ```rendererProgressBar``` and ```memoryProgressBar``` both for clarity and because I have a small suspicion that this common name could trigger some underlying java context bug under certain circumstances.