### PR TITLE
Prevent memory bar ui from reverting to LAF default

### DIFF
--- a/src/main/java/net/pms/newgui/GuiUtil.java
+++ b/src/main/java/net/pms/newgui/GuiUtil.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import javax.swing.*;
+import javax.swing.plaf.ProgressBarUI;
 import org.apache.commons.lang3.StringUtils;
 
 public final class GuiUtil {
@@ -383,6 +384,26 @@ public final class GuiUtil {
 		@Override
 		protected synchronized Color getSelectionBackground() {
 			return bg;
+		}
+	}
+
+	// A JProgressBar with a persistent custom ProgressBarUI.
+	// This is to prevent replacement of the initial custom ui with
+	// the laf's default ProgressBarUI as a result of future
+	// invocations of JProgressBar.UpdateUI()
+	public static class CustomUIProgressBar extends JProgressBar {
+		private ProgressBarUI ui;
+
+		public CustomUIProgressBar(int min, int max, ProgressBarUI ui) {
+			super(min, max);
+			this.ui = ui;
+			setUI(ui);
+		}
+
+		@Override
+		public void setUI(javax.swing.plaf.ProgressBarUI ui) {
+			// Always prefer our own ui if we have one
+			super.setUI(this.ui != null ? this.ui : ui);
 		}
 	}
 

--- a/src/main/java/net/pms/newgui/GuiUtil.java
+++ b/src/main/java/net/pms/newgui/GuiUtil.java
@@ -43,11 +43,15 @@ public final class GuiUtil {
 	}
 
 	// A progress bar with smooth transitions
-	public static class SmoothProgressBar extends JProgressBar {
+	public static class SmoothProgressBar extends CustomUIProgressBar {
 		private static final long serialVersionUID = 4418306779403459913L;
 
 		public SmoothProgressBar(int min, int max) {
-			super(min, max);
+			super(min, max, null);
+		}
+
+		public SmoothProgressBar(int min, int max, ProgressBarUI ui) {
+			super(min, max, ui);
 		}
 
 		@Override

--- a/src/main/java/net/pms/newgui/StatusTab.java
+++ b/src/main/java/net/pms/newgui/StatusTab.java
@@ -82,8 +82,7 @@ public class StatusTab {
 			playing.add(playingLabel);
 			time = new JLabel(" ");
 			time.setForeground(Color.gray);
-			rendererProgressBar = new GuiUtil.SmoothProgressBar(0, 100);
-			rendererProgressBar.setUI(new GuiUtil.SimpleProgressUI(Color.gray, Color.gray));
+			rendererProgressBar = new GuiUtil.SmoothProgressBar(0, 100, new GuiUtil.SimpleProgressUI(Color.gray, Color.gray));
 			rendererProgressBar.setStringPainted(true);
 			rendererProgressBar.setBorderPainted(false);
 			rendererProgressBar.setString(r.getAddress().getHostAddress());

--- a/src/main/java/net/pms/newgui/StatusTab.java
+++ b/src/main/java/net/pms/newgui/StatusTab.java
@@ -243,17 +243,16 @@ public class StatusTab {
 		builder.add(imagePanel, FormLayoutUtil.flip(cc.xy(1, 9), colSpec, orientation));
 
 		// Memory
-		memoryProgressBar = new JProgressBar(0, 100);
-		memoryProgressBar.setStringPainted(true);
-		memoryProgressBar.setForeground(new Color(75, 140, 181));
-		memoryProgressBar.setString(Messages.getString("StatusTab.5"));
 		memBarUI = new GuiUtil.SegmentedProgressBarUI(Color.white, Color.gray);
 		memBarUI.setActiveLabel("{}", Color.white, 0);
 		memBarUI.setActiveLabel("{}", Color.red, 90);
 		memBarUI.addSegment("", memColor);
 		memBarUI.addSegment("", bufColor);
 		memBarUI.setTickMarks(getTickMarks(), "{}");
-		memoryProgressBar.setUI(memBarUI);
+		memoryProgressBar = new GuiUtil.CustomUIProgressBar(0, 100, memBarUI);
+		memoryProgressBar.setStringPainted(true);
+		memoryProgressBar.setForeground(new Color(75, 140, 181));
+		memoryProgressBar.setString(Messages.getString("StatusTab.5"));
 
 		JLabel mem = builder.addLabel("<html><b>" + Messages.getString("StatusTab.6") + "</b> (" + Messages.getString("StatusTab.12") + ")</html>", FormLayoutUtil.flip(cc.xy(3, 7), colSpec, orientation));
 		mem.setForeground(fgColor);


### PR DESCRIPTION
This is a fix for #551 based on the observation that the error is easily reproduced by just calling [JProgressBar.updateUI()](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/javax/swing/JProgressBar.java#JProgressBar.updateUI%28%29), at which point the ProgressBarUI is reset to whatever the active LAF's default happens to be.  The assumption is that an eventual invocation of ```updateUI()``` in real life causes the bug.

To reproduce the error in the current master add the (hacky-ish :-) 'updateUI' button below and press it  on the gui:
```diff
diff --git a/src/main/java/net/pms/newgui/StatusTab.java b/src/main/java/net/pms/newgui/StatusTab.java
index 9dc1b19..e746b72 100644
--- a/src/main/java/net/pms/newgui/StatusTab.java
+++ b/src/main/java/net/pms/newgui/StatusTab.java
@@ -263,6 +263,13 @@ public class StatusTab {
 		mem.setForeground(fgColor);
 		builder.add(memoryProgressBar, FormLayoutUtil.flip(cc.xyw(3, 9, 1), colSpec, orientation));
 
+builder.add(new JButton(new AbstractAction("updateUI") {
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		memoryProgressBar.updateUI();
+	}
+}), FormLayoutUtil.flip(cc.xy(3, 7), colSpec, orientation));
+
 		// Bitrate
 		String bitColSpec = "left:pref, 3dlu, right:pref:grow";
 		PanelBuilder bitrateBuilder = new PanelBuilder(new FormLayout(bitColSpec, "p, 1dlu, p, 1dlu, p"));
```
