### PR TITLE
Implementation of #688

### DIFF
--- a/src/main/external-resources/documentation/commandline.html
+++ b/src/main/external-resources/documentation/commandline.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+	Universal Media Server, for streaming any medias to DLNA
+	compatible renderers based on the http://www.ps3mediaserver.org.
+	Copyright (C) 2012 UMS developers.
+	
+	This program is a free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; version 2
+	of the License only.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Command line arguments</title>
+		<link href="css/style.css" rel="stylesheet" type="text/css" />
+	</head>
+	<body>
+		<h1>Command line arguments</h1>
+		
+		<p>UMS can be launched with command line arguments. These arguments can either be used from the command line directly, be used from scripts or be used from shortcuts. The <code>Universal Media Server (Select Profile)</code> shortcut made by the Universal Media Server Windows installer is an example of this (launched with the <code>profiles</code> argument). <abbr>UMS</abbr> will be used as an abbreviation for Universal Media Server in the rest of this document.</p>
+		
+		<h2>Arguments</h2>
+		
+		<ul>
+			<li><code>headless</code> - This starts UMS without a <a href="https://en.wikipedia.org/wiki/Graphical_user_interface">GUI</a>. It can be useful for running UMS in the background without any user interface, but be aware that under Windows there is no other way than using the task manager to stop UMS again. This option in most useful under Linux, where you can stop UMS again simply by pressing <code>Ctrl + c</code>. If no graphical environment is available, UMS will automatically start in this mode.</li>
+			<li><code>console</code> - This is identical to <code>headless</code>.</li>
+			<li><code>noconsole</code> - This will refuse UMS to start in headless/console mode if it cannot initialize the <a href="https://en.wikipedia.org/wiki/Graphical_user_interface">GUI</a>.</li>
+			<li><code>nativelook</code> - This only works under Linux and attempts to use the graphical environment's native look.</li>
+			<li><code>scrollbars</code> - This creates horizontal and vertical scroll bars in UMS' main windows, allowing the window to be smaller than UMS is designed for. It can be useful on low resolution desktops.</li>
+			<li><code>profiles</code> - This will launch the <code>Profile Chooser</code> during UMS startup, allowing you to choose a profile file or folder for UMS to use.</li>
+			<li><code>profile=&lt;path&gt;</code> or <code>profile:&lt;path&gt;</code> - This will start UMS with the profile from the file or folder specified in <code>&lt;path&gt;</code>. This is mostly useful for starting a specific profile from a script or shortcut.</li>
+			<li><code>trace</code> - This will start UMS in &quot;forced trace&quot; mode, where the log level is forced to &lt;trace&gt; level regardless of the log level specified in the profile. It's not possible to change log level in this mode.</li> 			
+		</ul>	
+			
+	<!--  Navigation -->
+	<hr />
+	<ul>
+		<li>Next: <a href="plugins.html">Plugins</a>
+		</li>
+		<li>Previous: <a href="coreavc.html">CoreAVC</a>
+		</li>
+		<li>Top: <a href="index.html">Help</a>
+		</li>
+	</ul>
+	</body>
+</html>

--- a/src/main/external-resources/documentation/coreavc.html
+++ b/src/main/external-resources/documentation/coreavc.html
@@ -69,7 +69,7 @@
 	<!--  Navigation -->
 	<hr />
 	<ul>
-		<li>Next: <a href="plugins.html">Plugins</a>
+		<li>Next: <a href="commandline.html">Command line arguments</a>
 		</li>
 		<li>Previous: <a href="avisynth.html">AviSynth</a>
 		</li>

--- a/src/main/external-resources/documentation/index.html
+++ b/src/main/external-resources/documentation/index.html
@@ -53,6 +53,7 @@
 					<li><a href="coreavc.html">CoreAVC</a></li>
 				</ul>
 			</li>
+			<li><a href="commandline.html">Command line arguments</a></li>
 			<li><a href="plugins.html">Plugins</a></li>
 			<li><a href="http://www.universalmediaserver.com/faq/">Frequently Asked Questions (FAQ)</a></li>
 			<li><a href="links.html">Useful links</a></li>

--- a/src/main/external-resources/documentation/plugins.html
+++ b/src/main/external-resources/documentation/plugins.html
@@ -53,7 +53,7 @@
 		<hr/>
 		<ul>
 			<li>Next: <a href="links.html">Useful Links</a> or <a href="http://www.ps3mediaserver.org/forum/viewtopic.php?f=6&t=3507">FAQ (External)</a></li>
-			<li>Previous: <a href="coreavc.html">CoreAVC</a></li>
+			<li>Previous: <a href="commandline.html">Command line arguments</a></li>
 			<li>Top: <a href="index.html">Help</a></li>
 		</ul>
 		

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -76,6 +76,7 @@ public class PMS {
 	private static final String SCROLLBARS = "scrollbars";
 	private static final String NATIVELOOK = "nativelook";
 	private static final String CONSOLE = "console";
+	private static final String HEADLESS = "headless";
 	private static final String NOCONSOLE = "noconsole";
 	private static final String PROFILES = "profiles";
 	private static final String PROFILE = "^(?i)profile(?::|=)([^\"*<>?]+)$";
@@ -1061,6 +1062,7 @@ public class PMS {
 			Pattern pattern = Pattern.compile(PROFILE);
 			for (String arg : args) {
 				switch (arg) {
+					case HEADLESS:
 					case CONSOLE:
 						System.setProperty(CONSOLE, Boolean.toString(true));
 						break;

--- a/src/main/java/net/pms/newgui/HelpTab.java
+++ b/src/main/java/net/pms/newgui/HelpTab.java
@@ -112,20 +112,25 @@ public class HelpTab {
 	 */
 	public void updateContents() {
 		if (editorPane != null) {
-			String documentationDir = PropertiesUtil.getProjectProperties().get("project.documentation.dir");
+			File documentationDir = new File(PropertiesUtil.getProjectProperties().get("project.documentation.dir"));
 			String helpPage = PMS.getHelpPage();
-			File file = new File(documentationDir + "/" + helpPage);
-			if (file.exists()) {
+			if (!documentationDir.exists()) {
+				// Try to load help files from the source tree if not found to make it work while running from an IDE
+				File sourceDocumentationDir = new File("src/main/external-resources/documentation");
+				if (sourceDocumentationDir.exists()) {
+					documentationDir = sourceDocumentationDir;
+				}
+			}
+			File helpFile = new File(documentationDir, helpPage);
+			if (helpFile.exists()) {
 				try {
 					// Display the HTML help file in the editor
-					editorPane.setPage(file.toURI().toURL());
-				} catch (MalformedURLException e) {
-					LOGGER.debug("Caught exception", e);
+					editorPane.setPage(helpFile.toURI().toURL());
 				} catch (IOException e) {
-					LOGGER.debug("Caught exception", e);
+					LOGGER.debug("Exception while trying to display help file: ", e);
 				}
 			} else {
-				LOGGER.info("Couldn't find help file \"{}/{}\". Help will not be available.", documentationDir, helpPage);
+				LOGGER.info("Couldn't find help file \"{}\". Help will not be available.", helpFile.getAbsolutePath());
 			}
 		}
 	}


### PR DESCRIPTION
@UniversalMediaServer/developers @SubJunk 
I think #688 sounds like a good idea. Is this something we want or not? Yea or nay?

This implementation accepts ```profile=<file or folder name>``` or ```profile:<file or folder name>```. File or folder names with space can be given with ```profile=|:"<file or folder name>"```. If specified, it overrides the ```profiles``` argument and doesn't open the profile chooser.

If implemented, we need to document it. I found nothing in the help files regarding this or command line arguments in general. If found some explanation on the Wiki that I didn't really understand about profile choosing. Where do we put it?