### PR TITLE
Replace external dependencies plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,7 @@
 language: java
+addons:
+  apt:
+    packages:
+    - mediainfo 
+install: mvn external:install 
+script: mvn install -Dmaven.javadoc.skip=true -B -V

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,9 @@
 		building the pms.jar and then assembling all application resources.
 
 		Note that Maven 3 does not automatically install all dependencies, unlike Maven 2.
-		To install all dependencies to your local repository, run the following commands:
+		To install external dependencies to your local repository, run the following commands:
 
-		mvn com.savage7.maven.plugins:maven-external-dependency-plugin:resolve-external
-		mvn com.savage7.maven.plugins:maven-external-dependency-plugin:install-external
+		mvn external:install
 
 		To build UMS, do:
 
@@ -111,26 +110,6 @@
 		</pluginRepository>
 	</pluginRepositories>
 	<repositories>
-		<!-- Java.net -->
-		<repository>
-			<id>java.net</id>
-			<name>Java.net Repository</name>
-			<url>https://maven.java.net/content/groups/public/</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-
-		<!-- Maven Central -->
-		<repository>
-			<id>maven-central</id>
-			<name>Maven Central Repository</name>
-			<url>http://repo.maven.apache.org/maven2/</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-
 		<!-- GSON -->
 		<repository>
 			<id>google-gson</id>
@@ -544,21 +523,24 @@
 								<pluginExecution>
 									<pluginExecutionFilter>
 										<groupId>
-											com.savage7.maven.plugins
+											com.universalmediaserver
 										</groupId>
 										<artifactId>
-											maven-external-dependency-plugin
+											external-maven-plugin
 										</artifactId>
 										<versionRange>
-											[0.5,)
-										</versionRange>
+											[0.1,)
+										</versionRange>										
 										<goals>
-											<goal>install-external</goal>
-											<goal>resolve-external</goal>
+											<goal>clean</goal>
+											<goal>deploy</goal>
+											<goal>install</goal>
+											<goal>resolve</goal>
+											<goal>localinstall</goal>
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<execute></execute>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>
@@ -636,48 +618,33 @@
 				"src/main/external-resources/lib" directory and have this plugin take care of
 				the installation at build time.
 
-				Note: The plugin does not work automatically in Maven 3. To install the required
-				dependencies execute the following commands:
-
-				mvn com.savage7.maven.plugins:maven-external-dependency-plugin:resolve-external
-				mvn com.savage7.maven.plugins:maven-external-dependency-plugin:install-external
-
 				Checksums can be calculated with "openssl sha1 [filename]".
-
-				See: http://code.google.com/p/maven-external-dependency-plugin/issues/detail?id=8#c4
 			-->
 			<plugin>
-				<groupId>com.savage7.maven.plugins</groupId>
-				<artifactId>maven-external-dependency-plugin</artifactId>
-				<version>0.5</version>
+				<groupId>com.universalmediaserver</groupId>
+				<artifactId>external-maven-plugin</artifactId>
+				<version>0.1</version>
 				<inherited>false</inherited>
 				<configuration>
 					<stagingDirectory>${project.build.directory}/dependencies/</stagingDirectory>
 					<createChecksum>true</createChecksum>
-					<skipChecksumVerification>false</skipChecksumVerification>
-					<force>false</force>
 					<artifactItems>
 						<artifactItem>
 							<groupId>sevenzip</groupId>
 							<artifactId>jbinding</artifactId>
 							<version>${sevenzip-version}</version>
-							<packaging>jar</packaging>
-							<install>true</install>
 							<downloadUrl>http://www.spirton.com/uploads/7-Zip-JBinding/7-Zip-JBinding-{version}.{packaging}</downloadUrl>
 						</artifactItem>
 						<artifactItem>
 							<groupId>sevenzip-allplatforms</groupId>
 							<artifactId>jbinding-allplatforms</artifactId>
 							<version>${sevenzip-version}</version>
-							<packaging>jar</packaging>
-							<install>true</install>
 							<downloadUrl>http://www.spirton.com/uploads/7-Zip-JBinding/7-Zip-JBinding-AllPlatforms-{version}.{packaging}</downloadUrl>
 						</artifactItem>
 						<artifactItem>
 							<groupId>jwbroek.cuelib</groupId>
 							<artifactId>cuelib</artifactId>
 							<version>${cuelib-version}</version>
-							<packaging>jar</packaging>
 							<downloadUrl>http://cuelib.googlecode.com/files/cuelib-${cuelib-version}.jar</downloadUrl>
 							<checksum>d03b6b960b3b83a2a419e8b5f07b6ba4bd18387b</checksum>
 						</artifactItem>
@@ -685,9 +652,6 @@
 							<groupId>mediautil</groupId>
 							<artifactId>mediautil</artifactId>
 							<version>${mediautil-version}</version>
-							<packaging>jar</packaging>
-							<install>true</install>
-							<force>false</force>
 							<downloadUrl>http://downloads.sourceforge.net/project/mediachest/MediaUtil/Version%201.0/mediautil-1.zip</downloadUrl>
 							<checksum>aa7ae51bb24a9268a8e57c6afe478c4293f84fda</checksum>
 							<extractFile>mediautil-${mediautil-version}/mediautil-${mediautil-version}.jar</extractFile>
@@ -700,20 +664,7 @@
 						<id>clean-external-dependencies</id>
 						<phase>clean</phase>
 						<goals>
-							<!-- mvn com.savage7.maven.plugins:maven-external-dependency-plugin:clean-external -->
-							<goal>clean-external</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>resolve-install-external-dependencies</id>
-						<!-- Note: this phase works in Maven 2. In Maven 3, it needs to be triggered manually. See above -->
-						<phase>validate</phase>
-						<goals>
-							<!-- mvn com.savage7.maven.plugins:maven-external-dependency-plugin:resolve-external -->
-							<goal>resolve-external</goal>
-
-							<!-- mvn com.savage7.maven.plugins:maven-external-dependency-plugin:install-external -->
-							<goal>install-external</goal>
+							<goal>clean</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -909,19 +860,6 @@
 					<family>windows</family>
 				</os>
 			</activation>
-
-			<pluginRepositories>
-				<pluginRepository>
-					<id>Codehaus Snapshots</id>
-					<url>http://nexus.codehaus.org/snapshots/</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-					<releases>
-						<enabled>true</enabled>
-					</releases>
-				</pluginRepository>
-			</pluginRepositories>
 
 			<build>
 				<plugins>

--- a/src/main/java/net/pms/dlna/MediaInfo.java
+++ b/src/main/java/net/pms/dlna/MediaInfo.java
@@ -121,7 +121,7 @@ public class MediaInfo {
 		Menu,
 		Other;
 	}
-	
+
 	// Enums
 	@Deprecated
 	public enum InfoKind {
@@ -160,7 +160,7 @@ public class MediaInfo {
 		 */
 		Domain;
 	}
-	
+
 	public enum InfoType {
 		/**
 		 * Unique name of parameter.
@@ -205,7 +205,7 @@ public class MediaInfo {
 			Handle = MediaInfoDLL_Internal.INSTANCE.New();
 			LOGGER.info("Loaded " + Option_Static("Info_Version"));
 		} catch (Throwable e) {
-			LOGGER.info("Error loading MediaInfo library: " + e.getMessage());
+			LOGGER.error("Error loading MediaInfo library: " + e.getMessage());
 			if (!Platform.isWindows() && !Platform.isMac()) {
 				LOGGER.info("Make sure you have libmediainfo and libzen installed");
 			}

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -21,6 +21,7 @@ package net.pms.configuration;
 
 import ch.qos.logback.classic.LoggerContext;
 import java.util.*;
+import net.pms.PMS;
 import net.pms.configuration.RendererConfiguration.SortedHeaderMap;
 import static net.pms.configuration.RendererConfiguration.getRendererConfigurationByHeaders;
 import static net.pms.configuration.RendererConfiguration.loadRendererConfigurations;
@@ -43,22 +44,20 @@ public class RendererConfigurationTest {
 
 		// Set locale to EN to ignore translations for renderers
 		Locale.setDefault(Locale.ENGLISH);
+		PMS.setLocale(Locale.ENGLISH);
 	}
 
 	/**
 	 * Test the RendererConfiguration class and the consistency of the renderer
 	 * .conf files it reads. This is done by feeding it known headers and
 	 * checking whether it recognizes the correct renderer.
+	 * @throws ConfigurationException
 	 */
 	@Test
-	public void testKnownHeaders() {
+	public void testKnownHeaders() throws ConfigurationException {
 		PmsConfiguration pmsConf = null;
 
-		try {
-			pmsConf = new PmsConfiguration(false);
-		} catch (ConfigurationException e) {
-			// This should be impossible since no configuration file will be loaded.
-		}
+		pmsConf = new PmsConfiguration(false);
 
 		// Initialize the RendererConfiguration
 		loadRendererConfigurations(pmsConf);
@@ -165,54 +164,48 @@ public class RendererConfigurationTest {
 
 	/**
 	 * Test recognition with a forced default renderer configured.
+	 * @throws ConfigurationException
 	 */
 	@Test
-	public void testForcedDefault() {
+	public void testForcedDefault() throws ConfigurationException {
 		PmsConfiguration pmsConf = null;
 
-		try {
-			pmsConf = new PmsConfiguration(false);
+		pmsConf = new PmsConfiguration(false);
 
-			// Set default to PlayStation 3
-			pmsConf.setRendererDefault("PlayStation 3");
-			pmsConf.setRendererForceDefault(true);
+		// Set default to PlayStation 3
+		pmsConf.setRendererDefault("PlayStation 3");
+		pmsConf.setRendererForceDefault(true);
 
-			// Initialize the RendererConfiguration
-			loadRendererConfigurations(pmsConf);
+		// Initialize the RendererConfiguration
+		loadRendererConfigurations(pmsConf);
 
-			// Known and unknown renderers should always return default
-			testHeaders("PlayStation 3", "User-Agent: AirPlayer/1.0.09 CFNetwork/485.13.9 Darwin/11.0.0");
-			testHeaders("PlayStation 3", "User-Agent: Unknown Renderer");
-			testHeaders("PlayStation 3", "X-Unknown-Header: Unknown Content");
-		} catch (ConfigurationException e) {
-			// This should be impossible since no configuration file will be loaded.
-		}
+		// Known and unknown renderers should always return default
+		testHeaders("PlayStation 3", "User-Agent: AirPlayer/1.0.09 CFNetwork/485.13.9 Darwin/11.0.0");
+		testHeaders("PlayStation 3", "User-Agent: Unknown Renderer");
+		testHeaders("PlayStation 3", "X-Unknown-Header: Unknown Content");
 	}
 
 	/**
 	 * Test recognition with a forced bogus default renderer configured.
+	 * @throws ConfigurationException
 	 */
 	@Test
-	public void testBogusDefault() {
+	public void testBogusDefault() throws ConfigurationException {
 		PmsConfiguration pmsConf = null;
 
-		try {
-			pmsConf = new PmsConfiguration(false);
+		pmsConf = new PmsConfiguration(false);
 
-			// Set default to non existent renderer
-			pmsConf.setRendererDefault("Bogus Renderer");
-			pmsConf.setRendererForceDefault(true);
+		// Set default to non existent renderer
+		pmsConf.setRendererDefault("Bogus Renderer");
+		pmsConf.setRendererForceDefault(true);
 
-			// Initialize the RendererConfiguration
-			loadRendererConfigurations(pmsConf);
+		// Initialize the RendererConfiguration
+		loadRendererConfigurations(pmsConf);
 
-			// Known and unknown renderers should return "Unknown renderer"
-			testHeaders("Unknown renderer", "User-Agent: AirPlayer/1.0.09 CFNetwork/485.13.9 Darwin/11.0.0");
-			testHeaders("Unknown renderer", "User-Agent: Unknown Renderer");
-			testHeaders("Unknown renderer", "X-Unknown-Header: Unknown Content");
-		} catch (ConfigurationException e) {
-			// This should be impossible since no configuration file will be loaded.
-		}
+		// Known and unknown renderers should return "Unknown renderer"
+		testHeaders("Unknown renderer", "User-Agent: AirPlayer/1.0.09 CFNetwork/485.13.9 Darwin/11.0.0");
+		testHeaders("Unknown renderer", "User-Agent: Unknown Renderer");
+		testHeaders("Unknown renderer", "X-Unknown-Header: Unknown Content");
 	}
 
 	/**

--- a/src/test/java/net/pms/test/formats/FormatRecognitionTest.java
+++ b/src/test/java/net/pms/test/formats/FormatRecognitionTest.java
@@ -59,18 +59,14 @@ public class FormatRecognitionTest {
 	private boolean mediaInfoParserIsValid;
 
 	@Before
-	public void setUp() {
+	public void setUp() throws ConfigurationException {
 		// Silence all log messages from the PMS code that is being tested
 		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
         context.reset(); 
 
 		PmsConfiguration pmsConf = null;
 
-		try {
-			pmsConf = new PmsConfiguration(false);
-		} catch (ConfigurationException e) {
-			// This should be impossible since no configuration file will be loaded.
-		}
+		pmsConf = new PmsConfiguration(false);
 
 		// Initialize the RendererConfiguration
 		RendererConfiguration.loadRendererConfigurations(pmsConf);
@@ -245,7 +241,7 @@ public class FormatRecognitionTest {
 	 * Test the backwards compatibility of
 	 * {@link Format#isCompatible(DLNAMediaInfo, RendererConfiguration)} and
 	 * {@link Format#ps3compatible()}.
-	 * 
+	 *
 	 */
 	@SuppressWarnings("deprecation")
 	@Test
@@ -385,7 +381,7 @@ public class FormatRecognitionTest {
 
 		// Continue the test if the LibMediaInfoParser can be loaded, otherwise skip it.
 		assumeTrue(LibMediaInfoParser.isValid());
-		
+
 		// Construct media info exactly as VirtualVideoAction does
 		DLNAMediaInfo info = new DLNAMediaInfo();
 		info.setContainer("mpegps");
@@ -403,5 +399,5 @@ public class FormatRecognitionTest {
 		assertEquals("VirtualVideoAction is initialized as compatible with null configuration",
 				true, format.isCompatible(info, null));
 	}
-	
+
 }


### PR DESCRIPTION
I've replaced the ```com.savage7.maven.plugins:maven-external-dependency-plugin``` with [my fork] (https://github.com/Nadahar/external-dependency-maven-plugin).

It was nowhere as quick and easy as I'd hoped to modify the plugin, since it were made for Maven 2 and a lot of stuff didn't exist anymore or were deprecated. I've managed to replace most of the Maven 2 logic, but because of Maven's infamous no-documentation strategy I haven't been able to find new ways of doing everything. The Maven 2 stuff I've kept is available in [org.apache.maven:maven-compat:3.3.3] (https://maven.apache.org/ref/3.3.3/maven-compat/) so until they ditch ```maven-compat``` or somebody really want to vacuum every last corner of internet or read the Maven source code to find the "modern alternatives" I feel like letting them stay.

The good thing is that it now seems to be working. The Maven repository is yet to be solved, but except from that it seems good from my testing so far. Creating this PR will be the next test.