### PR TITLE
Update UMS.launch to point to project "ums"

### DIFF
--- a/UMS.launch
+++ b/UMS.launch
@@ -11,7 +11,7 @@
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="net.pms.PMS"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="ps3mediaserver"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="ums"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx768M -Djava.net.preferIPv4Stack=true -Djava.encoding=UTF-8"/>
 </launchConfiguration>


### PR DESCRIPTION
@UniversalMediaServer/developers @SubJunk 
This only regards Eclipse users (as far as I know). We have a file ```UMS.launch``` in the repository root that's a "shortcut file" for Eclipse. You can run UMS in Eclipse simply by rightclicking this and choose ```Run As -> UMS``` (instead of having to configure a run profile).

The problem is that the file tries to run a project called ```ps3mediaserver```, while the default name for the project if you import it into Eclipse is ```ums```. That mean that you either have to rename the project after importing it, or you have to edit the file. Editing the file is bad, because then you have to keep remembering not to commit this. Renaming the project is better, but that could trigger a lot of reference probems and updating/refreshing.

From the first time I cloned UMS this has bothered me. Every time I clone UMS  and import it into Eclipse, I have to perform the same exercise. This happens for example every time I'm going to debug on a new VM/platform. While it's not that often, it's a bit bothersome. More seriously though, is that this will probably confuse anyone that clones/checks out UMS and tries to run it from within Eclipse.

The reason why I haven't done anything about it earlier is that I expected that you kept it this way because you were all used to it and already had renamed the project to ```ps3mediaserver``` and changing this would force all of you to rename it locally. But, as I've learned now, most of you don't even use Eclipse (it's you and me @valib only, isn't it?). Others that do but follow the description from the Wiki don't use the shortcut but goes through a much more cumbersome process of creating a Maven runnable profile of all things.

I therefore conclude that the impact probably would be very small by making this change, and it would make life easier for anyone cloning UMS and setting it up in Eclipse in the future. What do you guys think?