### PR TITLE
Show live subtitles folder configurable per DLNAResource

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -382,6 +382,15 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	}
 
 	/**
+	 * Checks if is live subtitle folder available.
+	 *
+	 * @return true, if the live subtitle folder should be shown
+	 */
+	public boolean isLiveSubtitleFolderAvailable() {
+		return true;
+	}
+
+	/**
 	 * Any {@link DLNAResource} needs to represent the container or item with a String.
 	 *
 	 * @return String to be showed in the UPNP client.
@@ -3763,7 +3772,8 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		if (
 			configuration.isDisableSubtitles() ||
 			!configuration.isAutoloadExternalSubtitles() ||
-			configuration.isHideLiveSubtitlesFolder()
+			configuration.isHideLiveSubtitlesFolder() ||
+			!isLiveSubtitleFolderAvailable()
 		) {
 			return null;
 		}


### PR DESCRIPTION
I'd like to be able to decide for each `DLNAResource` if the live subtitles folder should be displayed. I've added the same logic as for the transcode folder to do this.
This change will NOT modify the current behavior at all, but it allows to override `DLNAResource.isLiveSubtitleFolderAvailable()` in classes extending `DLNAResource` to decide if the live subtitles folder should be displayed.