### PR TITLE
Improve GUI font scaling to better support high-DPI displays (#709):

### DIFF
--- a/src/main/external-resources/documentation/css/style.css
+++ b/src/main/external-resources/documentation/css/style.css
@@ -16,19 +16,21 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+ 
+ /*
+  * Please note:
+  * Any sizes that are to be relative to the OS base font size must be set
+  * in HelpTab.buildStyleSheet(). This is done to support OS font scaling
+  * used on example for high DPI monitors.
+  */
+  
 body {
 	font-family: Arial;
-	font-size: 14pt;
 	color: #000000;
-	padding: 10px;
 }
 
 dt {
 	font-weight: bold;
-}
-
-dd {
-	margin-bottom: 20px;
 }
 
 blockquote {
@@ -38,5 +40,4 @@ blockquote {
 }
 pre, tt {
 	font-family: Courier New, Courier;
-	font-size: 12pt;
 }

--- a/src/main/java/net/pms/newgui/HelpTab.java
+++ b/src/main/java/net/pms/newgui/HelpTab.java
@@ -25,9 +25,7 @@ import java.awt.Color;
 import java.awt.Desktop;
 import java.awt.Dimension;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.swing.BorderFactory;
@@ -36,6 +34,9 @@ import javax.swing.JEditorPane;
 import javax.swing.JScrollPane;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.StyleSheet;
 import net.pms.PMS;
 import net.pms.util.PropertiesUtil;
 import org.slf4j.Logger;
@@ -73,6 +74,11 @@ public class HelpTab {
 		editorPane.setEditable(false);
 		editorPane.setContentType("text/html");
 		editorPane.setBackground(Color.WHITE);
+		HTMLEditorKit editorKit = new HTMLEditorKit();
+		StyleSheet styleSheet = ((HTMLDocument) editorKit.createDefaultDocument()).getStyleSheet();
+		buildStyleSheet(styleSheet);
+		editorKit.setStyleSheet(styleSheet);
+		editorPane.setEditorKit(editorKit);
 
 		updateContents();
 
@@ -133,5 +139,37 @@ public class HelpTab {
 				LOGGER.info("Couldn't find help file \"{}\". Help will not be available.", helpFile.getAbsolutePath());
 			}
 		}
+	}
+
+	/**
+	 * This sets all sizes that should be relative to the font size in the HTML
+	 * document. This is to respect the OS font size setting used for example
+	 * on high DPI monitors.
+	 *
+	 * @param styleSheet the <code>StyleSheet</code> to modify
+	 */
+	public void buildStyleSheet(StyleSheet styleSheet) {
+		int baseSize = editorPane.getFont().getSize();
+		String rule = String.format(
+			"body { font-size: %dpt; padding: %dpx; }",
+			Math.round(baseSize * 7 / 6),
+			Math.round(baseSize * 5 / 6)
+		);
+		styleSheet.addRule(rule);
+
+		rule = String.format("h1 { font-size: %dpx; }", baseSize * 2);
+		styleSheet.addRule(rule);
+
+		rule = String.format("h2 { font-size: %dpx; }", Math.round(baseSize * 1.5));
+		styleSheet.addRule(rule);
+
+		rule = String.format("h3 { font-size: %dpx; }", Math.round(baseSize * 1.17));
+		styleSheet.addRule(rule);
+
+		rule = String.format("pre, tt { font-size: %dpt; }", baseSize);
+		styleSheet.addRule(rule);
+
+		rule = String.format("dd { margin-bottom: %dpx; }", Math.round(baseSize * 10 / 6));
+		styleSheet.addRule(rule);
 	}
 }

--- a/src/main/java/net/pms/newgui/NavigationShareTab.java
+++ b/src/main/java/net/pms/newgui/NavigationShareTab.java
@@ -27,10 +27,12 @@ import java.awt.Component;
 import java.awt.ComponentOrientation;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.FontMetrics;
 import java.awt.event.*;
 import java.io.File;
 import java.util.Vector;
 import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumn;
 import net.pms.Messages;
@@ -648,6 +650,14 @@ public class NavigationShareTab {
 		TableColumn column = FList.getColumnModel().getColumn(0);
 		column.setMinWidth(650);
 
+		/* An attempt to set the correct row height adjusted for font scaling.
+		 * It sets all rows based on the font size of cell (0, 0). The + 4 is
+		 * to allow 2 pixels above and below the text. */
+		DefaultTableCellRenderer cellRenderer = (DefaultTableCellRenderer) FList.getCellRenderer(0,0);
+		FontMetrics metrics = cellRenderer.getFontMetrics(cellRenderer.getFont());
+		FList.setRowHeight(metrics.getLeading() + metrics.getMaxAscent() + metrics.getMaxDescent() + 4);
+		FList.setIntercellSpacing(new Dimension(8, 2));
+
 		CustomJButton but = new CustomJButton(LooksFrame.readImageIcon("button-adddirectory.png"));
 		but.setToolTipText(Messages.getString("FoldTab.9"));
 		but.addActionListener(new ActionListener() {
@@ -796,7 +806,7 @@ public class NavigationShareTab {
 
 		JScrollPane pane = new JScrollPane(FList);
 		Dimension d = FList.getPreferredSize();
-		pane.setPreferredSize(new Dimension(d.width, FList.getRowHeight() * 8));
+		pane.setPreferredSize(new Dimension(d.width, FList.getRowHeight() * 2));
 		builderFolder.add(pane, FormLayoutUtil.flip(cc.xyw(1, 5, 7), colSpec, orientation));
 
 		return builderFolder;

--- a/src/main/java/net/pms/newgui/PluginTab.java
+++ b/src/main/java/net/pms/newgui/PluginTab.java
@@ -9,6 +9,7 @@ import java.awt.Component;
 import java.awt.ComponentOrientation;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.FontMetrics;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -119,8 +120,14 @@ public class PluginTab {
 
 		refresh(table, cols);
 
-		table.setRowHeight(22);
-		table.setIntercellSpacing(new Dimension(8, 0));
+		/* An attempt to set the correct row height adjusted for font scaling.
+		 * It sets all rows based on the font size of cell (0, 0). The + 4 is
+		 * to allow 2 pixels above and below the text. */
+		DefaultTableCellRenderer cellRenderer = (DefaultTableCellRenderer) table.getCellRenderer(0,0);
+		FontMetrics metrics = cellRenderer.getFontMetrics(cellRenderer.getFont());
+		table.setRowHeight(metrics.getLeading() + metrics.getMaxAscent() + metrics.getMaxDescent() + 4);
+
+		table.setIntercellSpacing(new Dimension(8, 2));
 
 		// Define column widths
 		TableColumn nameColumn = table.getColumnModel().getColumn(0);
@@ -237,8 +244,14 @@ public class PluginTab {
 		cmp = (JComponent) cmp.getComponent(0);
 		cmp.setFont(cmp.getFont().deriveFont(Font.BOLD));
 
-		credTable.setRowHeight(22);
-		credTable.setIntercellSpacing(new Dimension(8, 0));
+		/* An attempt to set the correct row height adjusted for font scaling.
+		 * It sets all rows based on the font size of cell (0, 0). The + 4 is
+		 * to allow 2 pixels above and below the text. */
+		cellRenderer = (DefaultTableCellRenderer) credTable.getCellRenderer(0,0);
+		metrics = cellRenderer.getFontMetrics(cellRenderer.getFont());
+		credTable.setRowHeight(metrics.getLeading() + metrics.getMaxAscent() + metrics.getMaxDescent() + 4);
+
+		credTable.setIntercellSpacing(new Dimension(8, 2));
 
 		// Define column widths
 		TableColumn ownerColumn = credTable.getColumnModel().getColumn(0);

--- a/src/main/java/net/pms/newgui/TracesTab.java
+++ b/src/main/java/net/pms/newgui/TracesTab.java
@@ -384,7 +384,7 @@ public class TracesTab {
 		jList = new TextAreaFIFO(configuration.getLoggingLogsTabLinebuffer());
 		jList.setEditable(false);
 		jList.setBackground(Color.WHITE);
-		jList.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+		jList.setFont(new Font(Font.MONOSPACED, Font.PLAIN, jList.getFont().getSize()));
 
 		final JPopupMenu popup = new JPopupMenu();
 		Action copy = jList.getActionMap().get("copy-to-clipboard");


### PR DESCRIPTION
@UniversalMediaServer/developers @SubJunk 
In response to #709 I've made the following changes:
- Made font sizes and padding in help files CSS scale with OS font size
- Made the log view/traces scale with OS font size
- Made row height in tables in PluginTab and NavigationShareTab scale with OS font size

Please note that since I don't own a high-DPI display, it's a bit hard for me to test this, but I've tuned my Windows font size to 150% while testing and the results looks reasonable. While I don't say that this makes the GUI properly support font scaling, it is better than today and at least makes it functional. Maybe you can test it @valib, since you use font scaling above 100%. 