### PR TITLE
Replacing maven-assembly-plugin with maven-shade-plugin for building jar-with-dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -925,8 +925,48 @@
 
 			<build>
 				<plugins>
-					<!-- Plugin to assemble a jar with dependencies -->
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>2.4.2</version>
+						<configuration>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<minimizeJar>true</minimizeJar>
+							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>net.pms.PMS</mainClass>
+									<!--
+										this is required to make the ImageIo image "plugins" provided by jai-imageio-core-standalone work.
+										without it, the following exception is thrown when PMS starts:
+
+										Configuration error: java.util.ServiceConfigurationError: javax.imageio.spi.ImageInputStreamSpi:
+											Provider com.sun.media.imageioimpl.stream.ChannelImageInputStreamSpi could not be instantiated:
+												java.lang.IllegalArgumentException: vendorName == null!
+
+										See: https://thierrywasyl.wordpress.com/2009/07/24/jai-how-to-solve-vendorname-null-exception/
+									-->
+									<manifestEntries>
+										<Implementation-Title>${project.name}</Implementation-Title>
+										<Implementation-Version>${project.version}</Implementation-Version>
+										<Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+										<Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
+										<Implementation-URL>${project.url}</Implementation-URL>
+									</manifestEntries>
+								</transformer>
+							</transformers>						
+						</configuration>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<!-- Plugin to assemble a jar with dependencies -->
+					<!-- <plugin>
 						<artifactId>maven-assembly-plugin</artifactId>
 						<version>2.6</version>
 							<configuration>
@@ -935,7 +975,7 @@
 								</descriptors>
 								<archive>
 									<manifest>
-										<mainClass>net.pms.PMS</mainClass>
+										<mainClass>net.pms.PMS</mainClass> -->
 										<!--
 											this is required to make the ImageIo image "plugins" provided by jai-imageio-core-standalone work.
 											without it, the following exception is thrown when PMS starts:
@@ -946,7 +986,7 @@
 
 											See: https://thierrywasyl.wordpress.com/2009/07/24/jai-how-to-solve-vendorname-null-exception/
 										-->
-										<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+										<!-- <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 									</manifest>
 								</archive>
 							</configuration>
@@ -959,7 +999,7 @@
 								</goals>
 							</execution>
 						</executions>
-					</plugin>
+					</plugin> -->
 
 					<!--
 						Plugin to move the pms-x.x.x-jar-with-dependencies.jar to pms.jar


### PR DESCRIPTION
I had to add a dependency in another branch I'm working on to access a few lines of code. I noticed that this added 1.8 MiB to the packaged JAR, and started reading. From what I can understand `maven-assembly-plugin` packs every dependency into the JAR, whether it is used or not.

Surprisingly it doesn't seem like there's a good solution for this in Java, and the closest I've come is to use the `maven-shade-plugin` instead. It has an option `minimizeJar` that excludes any unused dependencies from the built JAR. Trying this immediately shaved of 11 MiB from the JAR, but introduced some problems as well.

The manifest had to be built differently, but I think I figured that one out. But, `minimizeJar` removes too many classes - that is, classes that's not imported "the normal way". Trying to start this JAR leads to multiple errors `ClassNotFoundException`. It is possible to manually include these as special cases and still get the benefit of not including everything else we don't need in the finished JAR. More information on this can be found [here](http://stackoverflow.com/questions/8817257/minimize-an-uber-jar-correctly-using-shade-plugin).

As of now I've only fiddled with the one in the `windows` profile. It seems to me like all the profiles first build an identical `jar-with-dependencies` and then add profile-specific files. If I got things right, that means that the building of the `jar-with-dependencies` could be done in the `build` section instead of in all the profiles, and then the profiles could take over.

This needs more work, some classes must be manually included and the packing structure must be rewritten.

Before I do any more on this I'd like to know if you think it's a good idea, and if you see any pitfalls?

