### PR TITLE
The FreeDesktop.org Trash specification support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>
 			<artifactId>jna</artifactId>
-			<version>4.2.0</version>
+			<version>4.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -1,11 +1,16 @@
 package net.pms.util;
 
 import java.io.*;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.charset.IllegalCharsetNameException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +34,7 @@ import com.ibm.icu.text.CharsetMatch;
 public class FileUtil {
 	private static final Logger LOGGER = LoggerFactory.getLogger(FileUtil.class);
 	private static Map<File, File[]> cache;
+	private static int S_ISVTX = 512; // Unix sticky bit mask
 
 	// Signal an invalid parameter in getFileLocation() without raising an exception or returning null
 	private static final String DEFAULT_BASENAME = "NO_DEFAULT_BASENAME_SUPPLIED.conf";
@@ -124,6 +130,61 @@ public class FileUtil {
 		}
 
 		return new FileLocation(directory, file);
+	}
+
+	public final static class InvalidFileSystemException extends Exception {
+
+		private static final long serialVersionUID = -4545843729375389876L;
+
+		public InvalidFileSystemException() {
+			super();
+		}
+
+		public InvalidFileSystemException(String message) {
+			super(message);
+		}
+		public InvalidFileSystemException(Throwable cause) {
+			super(cause);
+		}
+		public InvalidFileSystemException(String message, Throwable cause) {
+			super(message, cause);
+		}
+	}
+
+	/**
+	 * A simple type holding mount point information for Unix file systems.
+	 *
+	 * @author Nadahar
+	 */
+	public static final class UnixMountPoint {
+		public String device;
+		public String folder;
+
+		@Override
+	    public boolean equals(Object obj) {
+			if (obj == null) {
+				return false;
+			}
+			if (this == obj) {
+				return true;
+			}
+	    	if (!(obj instanceof UnixMountPoint)) {
+	    		return false;
+	    	}
+	    	return
+	    		this.device.equals(((UnixMountPoint) obj).device) &&
+	    		this.folder.equals(((UnixMountPoint) obj).folder);
+	    }
+
+		@Override
+		public int hashCode() {
+			return device.hashCode() + folder.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return String.format("Device: \"%s\", folder: \"%s\"", device, folder);
+		}
 	}
 
 	public static File isFileExists(String f, String ext) {
@@ -1304,6 +1365,109 @@ public class FileUtil {
 			}
 			admin = false;
 			return false;
+		}
+	}
+
+	/**
+	 * Finds the {@link UnixMountPoint} for a {@link java.nio.file.Path} given
+	 * that the file resides on a Unix file system.
+	 *
+	 * @param path the {@link java.nio.file.Path} for which to find the Unix mount point.
+	 * @return The {@link UnixMountPoint} for the given path.
+	 *
+	 * @throws InvalidFileSystemException
+	 */
+	public static UnixMountPoint getMountPoint(Path path) throws InvalidFileSystemException {
+		UnixMountPoint mountPoint = new UnixMountPoint();
+		FileStore store;
+		try {
+			store = Files.getFileStore(path);
+		} catch (IOException e) {
+			throw new InvalidFileSystemException(
+				String.format("Could not get Unix mount point for file \"%s\": %s", path.toAbsolutePath(), e.getMessage()),
+				e
+			);
+		}
+
+		try {
+			Field entryField = store.getClass().getSuperclass().getDeclaredField("entry");
+			Field nameField = entryField.getType().getDeclaredField("name");
+			Field dirField = entryField.getType().getDeclaredField("dir");
+			entryField.setAccessible(true);
+			nameField.setAccessible(true);
+			dirField.setAccessible(true);
+			mountPoint.device = new String((byte[]) nameField.get(entryField.get(store)), StandardCharsets.UTF_8);
+			mountPoint.folder = new String((byte[]) dirField.get(entryField.get(store)), StandardCharsets.UTF_8);
+			return mountPoint;
+		} catch (NoSuchFieldException e) {
+			throw new InvalidFileSystemException(String.format("File \"%s\" is not on a Unix file system", path.isAbsolute()), e);
+		} catch (SecurityException | IllegalArgumentException | IllegalAccessException e) {
+			throw new InvalidFileSystemException(
+				String.format("An error occurred while trying to find mount point for file \"%s\": %s", path.toAbsolutePath(), e.getMessage()),
+				e
+			);
+		}
+	}
+
+	/**
+	 * Finds the {@link UnixMountPoint} for a {@link java.io.File} given
+	 * that the file resides on a Unix file system.
+	 *
+	 * @param file the {@link java.io.File} for which to find the Unix mount point.
+	 * @return The {@link UnixMountPoint} for the given path.
+	 *
+	 * @throws InvalidFileSystemException
+	 */
+	public static UnixMountPoint getMountPoint(File file) throws InvalidFileSystemException {
+		return getMountPoint(file.toPath());
+	}
+
+	public static boolean isUnixStickyBit(Path path) throws IOException, InvalidFileSystemException {
+		PosixFileAttributes attr = Files.readAttributes(path, PosixFileAttributes.class);
+		try {
+			Field st_modeField = attr.getClass().getDeclaredField("st_mode");
+			st_modeField.setAccessible(true);
+			int st_mode = st_modeField.getInt(attr);
+			return (st_mode & S_ISVTX) > 0;
+		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+			throw new InvalidFileSystemException("File is not on a Unix file system: " + e.getMessage(), e);
+		}
+	}
+
+	private static int unixUID = Integer.MIN_VALUE;
+	private static Object unixUIDLock = new Object();
+
+	/**
+	 * Gets the user ID on Unix based systems. This should not change during a
+	 * session and the lookup is expensive, so we cache the result.
+	 *
+	 * @return The Unix user ID
+	 * @throws IOException
+	 */
+	public static int getUnixUID() throws IOException {
+		if (
+			Platform.isAIX() || Platform.isFreeBSD() || Platform.isGNU() || Platform.iskFreeBSD() ||
+			Platform.isLinux() || Platform.isMac() || Platform.isNetBSD() || Platform.isOpenBSD() ||
+			Platform.isSolaris()
+		) {
+			synchronized (unixUIDLock) {
+				if (unixUID < 0) {
+					String response;
+				    Process id;
+					id = Runtime.getRuntime().exec("id -u");
+				    try (BufferedReader reader = new BufferedReader(new InputStreamReader(id.getInputStream(), Charset.defaultCharset()))) {
+				    	response = reader.readLine();
+				    }
+				    try {
+				    	unixUID = Integer.parseInt(response);
+				    } catch (NumberFormatException e) {
+				    	throw new UnsupportedOperationException("Unexpected response from OS: " + response, e);
+				    }
+				}
+				return unixUID;
+			}
+		} else {
+			throw new UnsupportedOperationException("getUnixUID can only be called on Unix based OS'es");
 		}
 	}
 }

--- a/src/main/java/net/pms/util/FreedesktopTrash.java
+++ b/src/main/java/net/pms/util/FreedesktopTrash.java
@@ -1,0 +1,344 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.util;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.security.SecureRandom;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.pms.util.FileUtil.InvalidFileSystemException;
+import net.pms.util.FileUtil.UnixMountPoint;
+
+public class FreedesktopTrash {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(FreedesktopTrash.class);
+	private static Path homeFolder = null;
+	private static Object homeFolderLock = new Object();
+	private static final String INFO = "info";
+	private static final String FILES = "files";
+    private static final SecureRandom random = new SecureRandom();
+
+    private static String generateRandomFileName(String fileName) {
+    	if (fileName.contains("/") || fileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid file name");
+    	}
+
+    	String prefix;
+		String suffix;
+		if (fileName.contains(".")) {
+			int i = fileName.lastIndexOf(".");
+			prefix = fileName.substring(0, i);
+			suffix = fileName.substring(i);
+		} else {
+			prefix = fileName;
+			suffix = "";
+		}
+
+        long n = random.nextLong();
+        n = (n == Long.MIN_VALUE) ? 0 : Math.abs(n);
+        String newName = prefix + Long.toString(n) + suffix;
+        return newName;
+    }
+
+	private static Path getVerifiedPath(String location) {
+		if (location != null && !location.trim().isEmpty()) {
+			Path path = Paths.get(location);
+			if (Files.exists(path)) {
+				return path.toAbsolutePath();
+			}
+		}
+		return null;
+	}
+
+	private static Path getHomeFolder() {
+		synchronized (homeFolderLock) {
+			if (homeFolder == null) {
+				homeFolder = getVerifiedPath(System.getenv("XDG_DATA_HOME"));
+				if (homeFolder == null) {
+					homeFolder = getVerifiedPath(System.getenv("HOME"));
+				}
+				if (homeFolder == null) {
+					homeFolder = getVerifiedPath(System.getProperty("user.home"));
+				}
+			}
+			// Make a copy so we don't have to hold the lock
+			return Paths.get(homeFolder.toString());
+		}
+	}
+
+	private static boolean verifyTrashFolder(Path path, boolean create) {
+		FilePermissions permissions;
+		try {
+			permissions = new FilePermissions(path);
+		} catch (FileNotFoundException e) {
+			if (create) {
+				LOGGER.trace("Trash folder \"{}\" doesn't exist, attempting to create it", path);
+				try {
+					Files.createDirectories(path);
+				} catch (IOException e1) {
+					LOGGER.debug("Could not create user trash folder \"{}\": {}", path, e1.getMessage());
+					LOGGER.trace("", e1);
+					return false;
+				}
+				try {
+					permissions = new FilePermissions(path);
+				} catch (FileNotFoundException e1) {
+					LOGGER.error("Impossible situation in verifyTrashFolder()", e1);
+					return false;
+				}
+			} else {
+				LOGGER.trace("Trash folder \"{}\" doesn't exist", path);
+				LOGGER.trace("", e);
+				return false;
+			}
+		}
+		if (!(permissions.isBrowsable() && permissions.isWritable() && permissions.isFolder())) {
+			if (!permissions.isFolder()) {
+				LOGGER.debug("Trash folder \"{}\" is not a folder", path);
+			} else {
+				LOGGER.debug("Insufficient permissions for trash folder \"{}\": {}", path, permissions.toString());
+			}
+			return false;
+		}
+		return true;
+	}
+
+	private static Path getTrashFolder(Path path) throws InvalidFileSystemException, IOException {
+
+		UnixMountPoint pathMountPoint;
+		try {
+			pathMountPoint = FileUtil.getMountPoint(path);
+		} catch (InvalidFileSystemException e) {
+			throw new InvalidFileSystemException("Invalid file system for file: " + path.toAbsolutePath(), e);
+		}
+		Path homeFolder = getHomeFolder();
+		Path trashFolder;
+		if (homeFolder != null) {
+			UnixMountPoint homeMountPoint = null;
+			try {
+				homeMountPoint = FileUtil.getMountPoint(homeFolder);
+			} catch (InvalidFileSystemException e) {
+				LOGGER.trace(e.getMessage(), e);
+				// homeMountPoint == null is ok, fails on .equals()
+			}
+			if (pathMountPoint.equals(homeMountPoint)) {
+				// The file is on the same partition as the home folder,
+				// use home folder Trash
+				trashFolder = Paths.get(homeFolder.toString(), ".Trash");
+				if (!Files.exists(trashFolder)) {
+					// This is outside specification but follows convention
+					trashFolder = Paths.get(homeFolder.toString(), ".local/share/Trash");
+				}
+				if (verifyTrashFolder(trashFolder, true)) {
+					return trashFolder;
+				} else {
+					return null;
+				}
+			}
+		}
+
+		// The file is on a different partition than the home folder
+		// or no home folder was found, look for $topdir/.Trash.
+		trashFolder = Paths.get(pathMountPoint.folder, ".Trash");
+		if (Files.exists(trashFolder, LinkOption.NOFOLLOW_LINKS)) {
+			if (!Files.isSymbolicLink(trashFolder)) {
+				try {
+					if (FileUtil.isUnixStickyBit(trashFolder)) {
+						if (verifyTrashFolder(trashFolder, false)) {
+							try {
+								trashFolder = Paths.get(trashFolder.toString(), String.valueOf(FileUtil.getUnixUID()));
+								if (verifyTrashFolder(trashFolder, true)) {
+									return trashFolder;
+								} else {
+									LOGGER.trace("Could not read or create trash folder \"{}\", trying next option", trashFolder);
+								}
+							} catch (IOException e) {
+								LOGGER.trace("Could not determine user id while resolving trash folder, trying next option", e);
+							}
+						} else {
+							LOGGER.trace("Insufficient permissions for trash folder \"{}\", trying next option", trashFolder);
+						}
+					} else {
+						LOGGER.trace("Trash folder \"{}\" doesn't have sticky bit set, trying next option", trashFolder);
+					}
+				} catch (IOException e) {
+					LOGGER.trace("Could not determine sticky bit for trash folder \"" + trashFolder + "\", trying next option", e);
+				}
+			} else {
+				LOGGER.trace("Trash folder \"{}\" is a symbolic link, trying next option");
+			}
+		} else {
+			LOGGER.trace("Trash folder \"{}\" doesn't exist, trying next option", trashFolder);
+		}
+
+		// $topdir/.Trash not found, looking for $topdir/.Trash-$uid
+		try {
+			trashFolder = Paths.get(pathMountPoint.folder, ".Trash-" + FileUtil.getUnixUID());
+		} catch (IOException e) {
+			throw new IOException ("Could not determine user id while resolving trash folder: " + e.getMessage(), e);
+		}
+		if (verifyTrashFolder(trashFolder, true)) {
+			return trashFolder;
+		} else {
+			LOGGER.debug("Unable to read or create trash folder \"{}\"", trashFolder);
+			return null;
+		}
+	}
+
+	private static boolean verifyTrashStructure(Path trashPath) {
+		String trashLocation = trashPath.toAbsolutePath().toString();
+		return verifyTrashFolder(Paths.get(trashLocation, INFO), true) && verifyTrashFolder(Paths.get(trashLocation, FILES), true);
+	}
+
+	public static void moveToTrash(Path path) throws InvalidFileSystemException, IOException {
+		final int LIMIT = 10;
+		path = path.toAbsolutePath();
+		FilePermissions pathPermissions = new FilePermissions(path);
+		if (!pathPermissions.isReadable() || !pathPermissions.isWritable()) {
+			throw new IOException("Insufficient permission to delete \"" + path.toString() + "\" - move to trash bin failed");
+		}
+
+		Path trashFolder = getTrashFolder(path);
+		Path infoFolder = trashFolder.resolve(INFO);
+		Path filesFolder = trashFolder.resolve(FILES);
+		if (!verifyTrashFolder(infoFolder, true) || !verifyTrashFolder(filesFolder, true)) {
+			throw new IOException(
+				"Could not move \"" + path.toString() + "\" to trash bin because " +
+				"of insufficient permissions for trash bin \"" + trashFolder.toString() + "\""
+			);
+		}
+
+		// Create the trash info
+		List<String> infoContent = new ArrayList<>();
+		infoContent.add("[Trash Info]");
+		infoContent.add("Path=" + URLEncoder.encode(path.toString(), Charset.defaultCharset().name()));
+		infoContent.add("DeletionDate=" + new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss").format(new Date()));
+
+		// Create the trash info file
+		String fileName = path.getFileName().toString();
+		Path infoFile;
+		int count = 0;
+		boolean created = false;
+		while (!created && count < LIMIT) {
+			infoFile = infoFolder.resolve(fileName + ".trashinfo");
+			try {
+				Files.write(infoFile, infoContent, Charset.defaultCharset(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+				created = true;
+			} catch (IOException e) {
+				fileName = generateRandomFileName(fileName);
+				count++;
+			}
+		}
+		if (!created) {
+			throw new IOException("Could not find a target filename for \"" + path.toString() + "\" in trash bin");
+		}
+
+		Path targetPath = filesFolder.resolve(fileName);
+		if (Files.exists(targetPath)) {
+			throw new IOException(
+				"Could not move \"" + path.toString() + "\" to trash bin since the trash bin \"" +
+				trashFolder.toString() + "\" is corrupted"
+			);
+		}
+
+		// Move the actual files
+		Files.move(path, targetPath, StandardCopyOption.ATOMIC_MOVE);
+
+		if (LOGGER.isTraceEnabled()) {
+			LOGGER.trace("{}{}\" moved to \"{}\"", Files.isDirectory(path) ? "Folder \"" : "File \"", path, targetPath);
+		}
+	}
+
+	public static void moveToTrash(File file) throws InvalidFileSystemException, IOException {
+		moveToTrash(file.toPath());
+	}
+
+	/**
+	 * Tries to determine if FreeDesktop.org Trash specification is applicable
+	 * for the given {@link Path}. Support can vary between partitions on the same
+	 * computer. Please note that this check will look for or try to create
+	 * the necessary folder structure, so this can be an expensive operation.
+	 *
+	 * The check could be used to evaluate a systems general ability, but a
+	 * better strategy is to attempt {@link #moveToTrash(Path)} and handle
+	 * a the {@link Exception} if it fails.
+	 *
+	 * @param path the path for which to evaluate trash bin support
+	 * @return The evaluation result
+	 */
+
+	public static boolean hasTrash(Path path) {
+		try {
+			return verifyTrashStructure(getTrashFolder(path));
+		} catch (IOException | InvalidFileSystemException e) {
+			LOGGER.warn("Error while trying to evaluate trash bin support: " + e.getMessage());
+			LOGGER.trace("", e);
+			return false;
+		}
+	}
+
+	/**
+	 * Tries to determine if FreeDesktop.org Trash specification is applicable
+	 * for the given {@link File}. Support can vary between partitions on the same
+	 * computer. Please note that this check will look for or try to create
+	 * the necessary folder structure, so this can be an expensive operation.
+	 *
+	 * The check could be used to evaluate a systems general ability, but a
+	 * better strategy is to attempt {@link #moveToTrash(File)} and handle
+	 * a the {@link Exception} if it fails.
+	 *
+	 * @param path the path for which to evaluate trash bin support
+	 * @return The evaluation result
+	 */
+	public static boolean hasTrash(File file) {
+		return hasTrash(file.toPath());
+	}
+
+	/**
+	 * Tries to determine if FreeDesktop.org Trash specification is applicable
+	 * for the system root. Support can vary between partitions on the same
+	 * computer. Please note that this check will look for or try to create
+	 * the necessary folder structure, so this can be an expensive operation.
+	 *
+	 * The check could be used to evaluate a systems general ability, but a
+	 * better strategy is to attempt {@link #moveToTrash(File)} and handle
+	 * a the {@link Exception} if it fails.
+	 *
+	 * @param path the path for which to evaluate trash bin support
+	 * @return The evaluation result
+	 */
+	public static boolean hasTrash() {
+		return hasTrash(Paths.get("/"));
+	}
+}


### PR DESCRIPTION
While it as always was a lot more work than I imagined, it's done. This implements the trash bin specification that's supposedly used by the most popular Linux desktops, the [The FreeDesktop.org Trash specification v1.0] (http://standards.freedesktop.org/trash-spec/trashspec-1.0.html).

The standard have several weak points and it didn't feel well thought through once I started to dig into it. That said, I've followed the standard to the best of my ability with one exception. The standard defines that the root partition trash folder should be located at ```/home/user/.Trash```, but the KDE and Gnome have abandoned that location and instead use ```/home/user/.local/share/Trash```. This implementation checks both locations, but the problem is when none of them exist. According to the standard, the implementation then have to create the folder, but I can't create and use both and have to pick one. I've gone for the non-standard ```/home/user/.local/share/Trash``` location simply because this is what will make it work on most modern Linux installations. There's no way to remedy this without finding a way to detect which desktop environment (both type and version) is running, and I wouldn't take it that far.

Further, neither Centos 7 nor Ubuntu 12.04 that I tested supports the standard properly. 

On Ubuntu the problem arises if you delete two or more files or folders with the same filename and then later restores them. This implementation adds random characters to the filename in such situations until an unused (in the trash bin) name is found. Ubuntu will not rename them back to their original name, but will keep the random characters added. The user will at least not loose his/her file.

On Centos with KDE that part works, but it can't handle absolute paths in the ```trashinfo``` on non-root partitions, and suffixes them with the partition root making it an invalid path when trying to restore files. That means that restoring fails and that the user will have to manually pick up his file from the trash folder, but again - the file isn't lost at least.

On Centos with Gnome I don't think I encountered any problems, but that's probably just because I didn't test long enough. As always with Linux, nothing is ever done properly and standards are interpreted as informal guides that you just look at from time to time while coding.

In any case, it should mostly work under "normal" circumstances, that is when the files to be trashed are on the root partition and multiple versions of the same filename isn't to be held in the trash bin at the same time. This implementation won't under any circumstances delete the files, but will throw exceptions if the move can't be performed. The calling code will have to choose how to deal with that.

Because whoever wrote ```java.nio``` decided to make about everything package private (including almost all the classes), I've had to use reflection to do some of these things. I hate to have to do that, but with Java's flawed OO model it's hard to come around doing that. The alternative would be to have to implement my own calls to glibc, and I couldn't get myself to do that as long as the information I needed was available in the hidden classes. Shame on those that came up with the idiotic rules for ```protected``` in Java and those that coded all of this in ```package private```. It would have been very simple to do this with subclassing otherwise.

The changes with comments are:
* Updated JNA to 4.2.1 - no reason really, I started out with the approach to subclass ```java.net.jna.platform.FileUtils``` and updated and added a package. But, I soon realized that I couldn't use any of their logic and abandoned that approach. I still kept the version upgrade though.
* Added the following to ```FileUtil```:
  * class ```InvalidFileSystemException``` - an ```Exception``` class used by some of the new methods.
  * class ```UnixMountPoint``` - a struct/record to hold the data fetched by ```getMountPoint()```
  * method ```getMountPoint()``` - finds the mount point for any given file or folder residing on a Unix based file system.
  * method ```getUnixUID()``` - finds the integer used id on Unix systems for the user UMS is running under.
* Created class ```FreedesktopTrash``` with support for The FreeDesktop.org Trash specification v1.0 - this is where most of the work is done.

The only change to existing code is the bump from 4.2.0 to 4.2.1 for JNA. Everything else is new and does nothing unless called, so I'd say this should be safe to merge.