### PR TITLE
 	Deal with UTF-8 encoded m3u8 playlist files - Fix

### DIFF
--- a/src/main/java/net/pms/dlna/PlaylistFolder.java
+++ b/src/main/java/net/pms/dlna/PlaylistFolder.java
@@ -4,12 +4,14 @@ import java.io.*;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+
 import net.pms.PMS;
 import net.pms.formats.Format;
 import net.pms.formats.FormatFactory;
 import net.pms.util.FileUtil;
 import net.pms.util.ProcessUtil;
 import net.pms.util.UMSUtils;
+
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,12 +85,28 @@ public class PlaylistFolder extends DLNAResource {
 		return null;
 	}
 
+
 	@Override
 	protected void resolveOnce() {
 		ArrayList<Entry> entries = new ArrayList<>();
 		boolean m3u = false;
 		boolean pls = false;
-		try (BufferedReader br = getBufferedReader()) {
+		
+		// START - Add lines to deal with UTF-8 encoded m3u8 playlist files
+		
+		//try (BufferedReader br = getBufferedReader()) {
+		try {
+			BufferedReader br = getBufferedReader();
+			File playlistfile = new File(uri);
+						
+			if ( (playlistfile.getName().toLowerCase().endsWith(".m3u8")) ) {
+					br = new BufferedReader(new InputStreamReader(new FileInputStream(playlistfile), "UTF-8"));
+					br.read();  // Skip byte order mark.
+			} else {
+					br = new BufferedReader(new FileReader(playlistfile));
+			}
+		// END
+			
 			String line;
 			while (!m3u && !pls && (line = br.readLine()) != null) {
 				line = line.trim();


### PR DESCRIPTION
Added these lines to deal with Unicode encodes/formatted (i.e UTF-8 encoding) m3u8 PlayList files.
This is to deal with Greek, Cyrillic, etc.. characters of the song titles listed in the m3u8 Playlist file(s).

I had to figure it out a bit. But I have tested it on my platform (PS3) works fine.
Hope you enjoy and/or approve this one :)