### PR TITLE
Fix missing or wrong sample frequency and audio channels when transcoding to LPCM (#588) (#726)

### DIFF
--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -17,6 +17,7 @@ import net.pms.PMS;
 import net.pms.dlna.*;
 import net.pms.encoders.Player;
 import net.pms.formats.Format;
+import net.pms.formats.v2.AudioProperties;
 import net.pms.io.OutputParams;
 import net.pms.network.HTTPResource;
 import net.pms.network.SpeedStats;
@@ -1251,7 +1252,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 *            configured for this renderer.
 	 * @return The mime type.
 	 */
-	public String getMimeType(String mimeType) {
+	public String getMimeType(String mimeType, DLNAMediaInfo media) {
 		if (mimeType == null) {
 			return null;
 		}
@@ -1287,10 +1288,20 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.LPCM, null, null);
 
 					if (matchedMimeType != null) {
-						if (isTranscodeAudioTo441()) {
-							matchedMimeType += ";rate=44100;channels=2";
-						} else {
-							matchedMimeType += ";rate=48000;channels=2";
+						if (pmsConfiguration.isAudioResample()) {
+							if (isTranscodeAudioTo441()) {
+								matchedMimeType += ";rate=44100;channels=2";
+							} else {
+								matchedMimeType += ";rate=48000;channels=2";
+							}
+						} else if (media != null) {
+							AudioProperties audio = media.getFirstAudioTrack().getAudioProperties();
+							if (audio.getSampleFrequency() > 0) {
+								matchedMimeType += ";rate=" + Integer.toString(audio.getSampleFrequency());
+							}
+							if (audio.getNumberOfChannels() > 0) {
+								matchedMimeType += ";channels=" + Integer.toString(audio.getNumberOfChannels());
+							}
 						}
 					}
 				}
@@ -1315,10 +1326,20 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 					// Default audio transcoding mime type
 					matchedMimeType = HTTPResource.AUDIO_LPCM_TYPEMIME;
 
-					if (isTranscodeAudioTo441()) {
-						matchedMimeType += ";rate=44100;channels=2";
-					} else {
-						matchedMimeType += ";rate=48000;channels=2";
+					if (pmsConfiguration.isAudioResample()) {
+						if (isTranscodeAudioTo441()) {
+							matchedMimeType += ";rate=44100;channels=2";
+						} else {
+							matchedMimeType += ";rate=48000;channels=2";
+						}
+					} else if (media != null) {
+						AudioProperties audio = media.getFirstAudioTrack().getAudioProperties();
+						if (audio.getSampleFrequency() > 0) {
+							matchedMimeType += ";rate=" + Integer.toString(audio.getSampleFrequency());
+						}
+						if (audio.getNumberOfChannels() > 0) {
+							matchedMimeType += ";channels=" + Integer.toString(audio.getNumberOfChannels());
+						}
 					}
 				}
 			}

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -361,6 +361,11 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 */
 	public void setSampleFrequency(String sampleFrequency) {
 		this.sampleFrequency = sampleFrequency;
+		try {
+			audioProperties.setSampleFrequency(Integer.parseInt(sampleFrequency));
+		} catch (NumberFormatException e) {
+			LOGGER.warn("Audio sample frequency \"{}\" cannot be parsed, using (probably wrong) default", sampleFrequency);
+		}
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -886,7 +886,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			// 2) transcoding is preferred and not prevented by configuration
 			if (forceTranscode || (preferTranscode && !isSkipTranscode())) {
 				if (parserV2) {
-					LOGGER.trace("Final verdict: \"{}\" will be transcoded with player \"{}\" with mime type \"{}\"", getName(), player.toString(), renderer != null ? renderer.getMimeType(mimeType(player)) : media.getMimeType());
+					LOGGER.trace("Final verdict: \"{}\" will be transcoded with player \"{}\" with mime type \"{}\"", getName(), player.toString(), renderer != null ? renderer.getMimeType(mimeType(player), media) : media.getMimeType());
 				} else {
 					LOGGER.trace("Final verdict: \"{}\" will be transcoded with player \"{}\"", getName(), player.toString());
 				}
@@ -2223,7 +2223,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		// is determined for the default renderer. This renderer may rewrite the
 		// mime type based on its configuration. Looking up that mime type is
 		// not guaranteed to return a match for another renderer.
-		String mime = mediaRenderer.getMimeType(mimeType());
+		String mime = mediaRenderer.getMimeType(mimeType(), media);
 
 		// Use our best guess if we have no valid mime type
 		if (mime == null || mime.contains("/transcode")) {

--- a/src/main/java/net/pms/network/HTTPResource.java
+++ b/src/main/java/net/pms/network/HTTPResource.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import net.pms.PMS;
 import net.pms.configuration.RendererConfiguration;
+import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAResource;
 import net.pms.formats.Format;
 import net.pms.util.PropertiesUtil;
@@ -164,11 +165,11 @@ public class HTTPResource {
 	 */
 	protected static byte[] downloadAndSendBinary(String u, boolean saveOnDisk, File f) throws IOException {
 		URL url = new URL(u);
-		
+
 		// The URL may contain user authentication information
 		Authenticator.setDefault(new HTTPResourceAuthenticator());
 		HTTPResourceAuthenticator.addURL(url);
-		
+
 		LOGGER.debug("Retrieving " + url.toString());
 		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
 		URLConnection conn = url.openConnection();
@@ -206,8 +207,8 @@ public class HTTPResource {
 	 * @param renderer media renderer to customize the MIME type for.
 	 * @return The MIME type
 	 */
-	public String getRendererMimeType(String mimetype, RendererConfiguration renderer) {
-		return renderer.getMimeType(mimetype);
+	public String getRendererMimeType(String mimetype, RendererConfiguration renderer, DLNAMediaInfo media) {
+		return renderer.getMimeType(mimetype, media);
 	}
 
 	public int getDLNALocalesCount() {

--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -356,7 +356,7 @@ public class Request extends HTTPResource {
 						LOGGER.error("There is no inputstream to return for " + name);
 					} else {
 						startStopListenerDelegate.start(dlna);
-						output(output, "Content-Type: " + getRendererMimeType(dlna.mimeType(), mediaRenderer));
+						output(output, "Content-Type: " + getRendererMimeType(dlna.mimeType(), mediaRenderer, dlna.getMedia()));
 
 						if (dlna.getMedia() != null && !configuration.isDisableSubtitles()) {
 							// Some renderers (like Samsung devices) allow a custom header for a subtitle URL
@@ -877,8 +877,8 @@ public class Request extends HTTPResource {
 	 * Returns the string value that is enclosed by the left and right tag in a content string.
 	 * Only the first match of each tag is used to determine positions. If either of the tags
 	 * cannot be found, null is returned.
-	 * @param content The entire {@link String} that needs to be searched for the left and right tag. 
-	 * @param leftTag The {@link String} determining the match for the left tag. 
+	 * @param content The entire {@link String} that needs to be searched for the left and right tag.
+	 * @param leftTag The {@link String} determining the match for the left tag.
 	 * @param rightTag The {@link String} determining the match for the right tag.
 	 * @return The {@link String} that was enclosed by the left and right tag.
 	 */

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -423,7 +423,7 @@ public class RequestV2 extends HTTPResource {
 						startStopListenerDelegate.start(dlna);
 
 						// Try to determine the content type of the file
-						String rendererMimeType = getRendererMimeType(dlna.mimeType(), mediaRenderer);
+						String rendererMimeType = getRendererMimeType(dlna.mimeType(), mediaRenderer, dlna.getMedia());
 
 						if (rendererMimeType != null && !"".equals(rendererMimeType)) {
 							output.headers().set(HttpHeaders.Names.CONTENT_TYPE, rendererMimeType);
@@ -975,8 +975,8 @@ public class RequestV2 extends HTTPResource {
 	 * Returns the string value that is enclosed by the left and right tag in a content string.
 	 * Only the first match of each tag is used to determine positions. If either of the tags
 	 * cannot be found, null is returned.
-	 * @param content The entire {@link String} that needs to be searched for the left and right tag. 
-	 * @param leftTag The {@link String} determining the match for the left tag. 
+	 * @param content The entire {@link String} that needs to be searched for the left and right tag.
+	 * @param leftTag The {@link String} determining the match for the left tag.
 	 * @param rightTag The {@link String} determining the match for the right tag.
 	 * @return The {@link String} that was enclosed by the left and right tag.
 	 */

--- a/src/main/java/net/pms/remote/RemoteMediaHandler.java
+++ b/src/main/java/net/pms/remote/RemoteMediaHandler.java
@@ -71,7 +71,7 @@ public class RemoteMediaHandler implements HttpHandler {
 			throw new IOException("Bad code");
 		}
 		DLNAMediaSubtitle sid = null;
-		String mime = root.getDefaultRenderer().getMimeType(dlna.mimeType());
+		String mime = root.getDefaultRenderer().getMimeType(dlna.mimeType(), dlna.getMedia());
 		//DLNAResource dlna = res.get(0);
 		WebRender render = (WebRender) r;
 		DLNAMediaInfo m = dlna.getMedia();

--- a/src/main/java/net/pms/remote/RemotePlayHandler.java
+++ b/src/main/java/net/pms/remote/RemotePlayHandler.java
@@ -114,7 +114,7 @@ public class RemotePlayHandler implements HttpHandler {
 		root.getDefaultRenderer().setRootFolder(root);
 		String id1 = URLEncoder.encode(id, "UTF-8");
 		String name = StringEscapeUtils.escapeHtml(r.resumeName());
-		String mime = root.getDefaultRenderer().getMimeType(r.mimeType());
+		String mime = root.getDefaultRenderer().getMimeType(r.mimeType(), r.getMedia());
 		String mediaType = isVideo ? "video" : isAudio ? "audio" : isImage ? "image" : "";
 		String auto = "autoplay";
 		@SuppressWarnings("unused")

--- a/src/main/java/net/pms/remote/RemoteRawHandler.java
+++ b/src/main/java/net/pms/remote/RemoteRawHandler.java
@@ -51,7 +51,7 @@ public class RemoteRawHandler implements HttpHandler {
 			// For web resources actual length may be unknown until we open the stream
 			len = dlna.length();
 		}
-		String mime = root.getDefaultRenderer().getMimeType(dlna.mimeType());
+		String mime = root.getDefaultRenderer().getMimeType(dlna.mimeType(), dlna.getMedia());
 		Headers hdr = t.getResponseHeaders();
 		LOGGER.debug("dumping media " + mime + " " + dlna);
 		hdr.add("Content-Type", mime);

--- a/src/main/java/net/pms/util/ProcessUtil.java
+++ b/src/main/java/net/pms/util/ProcessUtil.java
@@ -217,8 +217,13 @@ public class ProcessUtil {
 	// Whitewash any arguments not suitable to display in dbg messages
 	// and make one single printable string
 	public static String dbgWashCmds(String[] cmd) {
-		for(int i=0; i < cmd.length; i++) {
-			if(cmd[i].contains("headers")) {
+		for (int i=0; i < cmd.length; i++) {
+			// Wrap arguments with spaces in double quotes to make them runnable if copy-pasted
+			if (cmd[i].contains(" ")) {
+				cmd[i] = "\"" + cmd[i] + "\"";
+			}
+			// Hide sensitive information from the log
+			if (cmd[i].contains("headers")) {
 				cmd[i+1]= cmd[i+1].replaceAll("Authorization: [^\n]+\n", "Authorization: ****\n");
 				i++;
 				continue;


### PR DESCRIPTION
@UniversalMediaServer/developers @SubJunk 
As described in #588 there's a pitch/sample frequency bug when transcoding audio to LPCM. This fixes this, although because of the messy nature of the involved code I'm not sure if I've broken anything else. I don't know if these changes touches anything video at all, but if not I think it should be reasonably safe. Is LPCM used for video at all?

In my opinion this is merely a band-aid, there's so much mess here that should be cleaned up. I have a hard time to see what role the ```AudioProperties``` class plays, it seems to me like a half clone of ```DLNAMediaAudio```. It doesn't seem to be finished either, and defaulting to 48 KHz for audio sample frequency is simply wrong and begging for bugs. If something is unknown, treat it like an unknown imo.

I also feel that the whole "resample audio" function is outdated and wrong. It caters specifically to the PS3 (where you can choose between 44.1 and 48 KHz sample rates only), and doesn't make much sense for any other renderers. Being "universal" this logics should somehow be moved to the renderer configuration and not be a part of the base configuration.

If anyone can shed some more light on any of these issues, please do so, so I don't plan a future refactoring with vital missing pieces of the picture.

Back to this PR, please inspect and comment on the changes if you see anything wrong/dangerour. Also, please let me know if you think this is safe to merge.