### PR TITLE
StreamGobbler updates

### DIFF
--- a/src/main/java/net/pms/dlna/RootFolder.java
+++ b/src/main/java/net/pms/dlna/RootFolder.java
@@ -1116,7 +1116,7 @@ public class RootFolder extends DLNAResource {
 										pb.redirectErrorStream(true);
 										Process pid = pb.start();
 										// consume the error and output process streams
-										new StreamGobbler(pid.getInputStream()).start();
+										StreamGobbler.consume(pid.getInputStream());
 										pid.waitFor();
 									} catch (IOException | InterruptedException e) {
 									}

--- a/src/main/java/net/pms/encoders/AviDemuxerInputStream.java
+++ b/src/main/java/net/pms/encoders/AviDemuxerInputStream.java
@@ -130,12 +130,12 @@ public class AviDemuxerInputStream extends InputStream {
 
 					String[] cmd = new String[]{ts.executable(), f.getAbsolutePath(), tsPipe.getInputPipe()};
 					ProcessBuilder pb = new ProcessBuilder(cmd);
+					pb.redirectErrorStream(true);
 					process = pb.start();
 					ProcessWrapper pwi = new ProcessWrapperLiteImpl(process);
 					attachedProcesses.add(pwi);
 					// consume the error and output process streams
-					new StreamGobbler(process.getErrorStream(), true).start();
-					new StreamGobbler(process.getInputStream(), true).start();
+					StreamGobbler.consume(process.getInputStream(), true);
 
 					realIS = tsPipe.getInputStream();
 					ProcessUtil.waitFor(process);

--- a/src/main/java/net/pms/io/StreamGobbler.java
+++ b/src/main/java/net/pms/io/StreamGobbler.java
@@ -26,13 +26,21 @@ import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Use one of the constructors to create a thread (non-blocking) that will
+ * consume an {@link InputStream} and then die.
+ *
+ * Use the static methods to consume an {@link InputStream} in a blocking
+ * manner in the calling thread's context.
+ */
 public class StreamGobbler extends Thread {
 	private static final Logger LOGGER = LoggerFactory.getLogger(StreamGobbler.class);
 	BufferedReader in;
 	private boolean logging;
 
 	/**
-	 * The stream consumer that reads and discards the stream
+	 * Create a new thread that when started will read and discard the {@link InputStream}.
+	 * Use this when the stream has to be consumed in a non-blocking fashion.
 	 *
 	 * @param in the {@link InputStream} to be consumed
 	 * @param enableLogging true if the stream content should be logged to TRACE level
@@ -43,7 +51,8 @@ public class StreamGobbler extends Thread {
 	}
 
 	/**
-	 * The stream consumer that reads and discards the stream
+	 * Create a new thread that when started will read and discard the {@link InputStream}.
+	 * Use this when the stream has to be consumed in a non-blocking fashion.
 	 *
 	 * @param in the {@link InputStream} to be consumed
 	 */
@@ -53,18 +62,75 @@ public class StreamGobbler extends Thread {
 
 	@Override
 	public void run() {
-		String line = null;
 		try {
-			while ((line = in.readLine()) != null) {
-				if (logging && !line.startsWith("100")) {
-					LOGGER.trace(line);
-				}
-			}
-			in.close();
+			doGobble(in, logging);
 		} catch (IOException e) {
 			LOGGER.debug("Caught exception while gobbling stream: {}", e.getMessage());
 			LOGGER.trace("", e);
 		}
 
+	}
+
+	/**
+	 * Read and discard the {@link InputStream} in the caller's context
+	 * (blocking). Use this when you want to wait for the stream to be consumed.
+	 * Note that you cannot handle more than one stream at a time with this,
+	 * and thus any process output to be gobbled should be created with
+	 * {@link ProcessBuilder} and it's error stream redirected.
+	 *
+	 * @param in the {@link InputStream} to be consumed
+	 * @param enableLogging true if the stream content should be logged to TRACE level
+	 *
+	 * @throws IOException if any problems occur while consuming the stream
+	 */
+	public static void consumeThrow(InputStream in, boolean enableLogging) throws IOException {
+		BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+		doGobble(reader, enableLogging);
+	}
+
+	/**
+	 * Read and discard the {@link InputStream} in the caller's context
+	 * (blocking). Use this when you want to wait for the stream to be consumed.
+	 * Note that you cannot handle more than one stream at a time with this,
+	 * and thus any process output to be gobbled should be created with
+	 * {@link ProcessBuilder} and it's error stream redirected.
+	 *
+	 * @param in the {@link InputStream} to be consumed
+	 * @param enableLogging true if the stream content should be logged to TRACE level
+	 */
+	public static void consume(InputStream in, boolean enableLogging) {
+		BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+		try {
+			doGobble(reader, enableLogging);
+		} catch (IOException e) {
+			LOGGER.debug("Caught exception while gobbling stream: {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+
+	/**
+	 * Read and discard the {@link InputStream} in the caller's context
+	 * (blocking). Use this when you want to wait for the stream to be consumed.
+	 * Note that you cannot handle more than one stream at a time with this,
+	 * and thus any process output to be gobbled should be created with
+	 * {@link ProcessBuilder} and it's error stream redirected.
+	 *
+	 * @param in the {@link InputStream} to be consumed
+	 */
+	public static void consume(InputStream in) {
+		consume(in, false);
+	}
+
+	private static void doGobble(BufferedReader reader, boolean enableLogging) throws IOException {
+		String line = null;
+		try {
+			while ((line = reader.readLine()) != null) {
+				if (enableLogging && !line.startsWith("100")) {
+					LOGGER.trace(line);
+				}
+			}
+		} finally {
+			reader.close();
+		}
 	}
 }

--- a/src/main/java/net/pms/util/ProcessUtil.java
+++ b/src/main/java/net/pms/util/ProcessUtil.java
@@ -114,10 +114,11 @@ public class ProcessUtil {
 		boolean killed = false;
 		LOGGER.warn("Sending kill -" + signal + " to the Unix process: " + pid);
 		try {
-			Process process = Runtime.getRuntime().exec("kill -" + signal + " " + pid);
+			ProcessBuilder processBuilder = new ProcessBuilder("kill", "-" + signal, Integer.toString(pid));
+			processBuilder.redirectErrorStream(true);
+			Process process = processBuilder.start();
 			// consume the error and output process streams
-			new StreamGobbler(process.getErrorStream(), true).start();
-			new StreamGobbler(process.getInputStream(), true).start();
+			StreamGobbler.consume(process.getInputStream(), true);
 			int exit = waitFor(process);
 			if (exit == 0) {
 				killed = true;


### PR DESCRIPTION
@UniversalMediaServer/developers @SubJunk 

Following the discussions in db92c2a179fd260c7946a66b0b4cdcb798ab511e and 737936d3743f7f1bf555a42c80b1bea4d5f31670 and in particular the comment from @skeptical I decided to do a little optimization. Seeing that ```Runtime.getRuntime().exec()``` internally calls ```ProcessBuilder``` there's no performance loss in using ```ProcessBuilder``` directly instead, thus giving us the chance to merge the input(output?) and error streams for the process. This again means that we don't have to spawn threads to do the consuming, which is expensive.

Even though none of the current calls to ```StreamGobbler``` do this, I've kept the possibility to spawn threads in the event that the code don't want to wait/block until the stream is consumed, but I've added static methods to consume the stream in the callers thread. 

As a side note, I still haven't figured out why we read the input and not the output stream, but I see that it's the input stream that's used everywhere. Could it be so stupid that they named them from the Java POV, so that they exchanged the two? Any enlightenment is appreciated.

Here's the changelog:
* Expanded StreamGobbler to be able to do both blocking and non-blocking stream consumption
* Updated the callers to use blocking mode where it thread will wait for the stream to be consumed anyway.

What do you guys think? Is this a better way?