### PR TITLE
Renderer hot-swapping fixes

### DIFF
--- a/src/main/java/net/pms/configuration/DeviceConfiguration.java
+++ b/src/main/java/net/pms/configuration/DeviceConfiguration.java
@@ -87,7 +87,7 @@ public class DeviceConfiguration extends PmsConfiguration {
 		// Initialize our internal RendererConfiguration vars
 		renderCache = new HashMap<>();
 		sortedHeaderMatcher = ref.sortedHeaderMatcher;
-		// Note: intentionally omitting 'player = null' so as to preserve player state when reloading
+		// Note: intentionally omitting 'player = null' so as to preserve player state when reloading/replacing
 		loaded = true;
 		this.ref = ref;
 

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -1534,6 +1534,18 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		return player;
 	}
 
+	public void resetPlayer() {
+		// Replace the player if already existing and transfer its state
+		if (player != null) {
+			BasicPlayer old = player;
+			player = null;
+			getPlayer().replace(old);
+			LOGGER.debug("{}: swapped data from {} to {}", getRendererName(), StringUtils.substringAfterLast(old.getClass().getName(), "."), StringUtils.substringAfterLast(player.getClass().getName(), "."));
+		} else {
+			getPlayer();
+		}
+	}
+
 	/**
 	 * Sets the UPnP player.
 	 *
@@ -2569,6 +2581,10 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 					state.playback = PLAYING;
 					while (res == renderer.getPlayingRes()) {
 						long elapsed = System.currentTimeMillis() - res.getStartTime();
+						if (state == null) {
+							// We've been disabled
+							return;
+						}
 						state.position = (duration == 0 || elapsed < duration + 500) ?
 							// Position is valid as far as we can tell
 							DurationFormatUtils.formatDuration(elapsed, "HH:mm:ss") :

--- a/src/main/java/net/pms/configuration/WebRender.java
+++ b/src/main/java/net/pms/configuration/WebRender.java
@@ -619,6 +619,10 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 		}
 
 		public void setData(String jsonData) {
+			if (state == null) {
+				// We've been disabled
+				return;
+			}
 			data = gson.fromJson(jsonData, data.getClass());
 			String s = data.get("playback");
 			state.playback = "STOPPED".equals(s) ? STOPPED :

--- a/src/main/java/net/pms/network/ChromecastPlayer.java
+++ b/src/main/java/net/pms/network/ChromecastPlayer.java
@@ -118,6 +118,10 @@ public class ChromecastPlayer extends BasicPlayer.Logical {
 				for(;;) {
 					try {
 						Thread.sleep(1000);
+						if (state == null) {
+							// We've been disabled
+							return;
+						}
 						Status s1 = api.getStatus();
 						if (!s1.isAppRunning(MediaPlayer)) {
 							continue;

--- a/src/main/java/net/pms/network/PlayerControlHandler.java
+++ b/src/main/java/net/pms/network/PlayerControlHandler.java
@@ -166,6 +166,11 @@ public class PlayerControlHandler implements HttpHandler {
 
 	public Logical getPlayer(String uuid) {
 		Logical player = players.get(uuid);
+		if (player != null && player.getState() == null) {
+			// Player was disabled
+			players.remove(uuid);
+			player = null;
+		}
 		if (player == null) {
 			try {
 				RendererConfiguration r = RendererConfiguration.getRendererConfigurationByUUID(uuid);

--- a/src/main/java/net/pms/network/UPNPHelper.java
+++ b/src/main/java/net/pms/network/UPNPHelper.java
@@ -707,7 +707,7 @@ public class UPNPHelper extends UPNPControl {
 	protected void rendererReady(String uuid) {
 		RendererConfiguration r = RendererConfiguration.getRendererConfigurationByUUID(uuid);
 		if(r != null) {
-			r.getPlayer();
+			r.resetPlayer();
 		}
 	}
 
@@ -805,6 +805,10 @@ public class UPNPHelper extends UPNPControl {
 		}
 
 		public void refresh() {
+			if (state == null) {
+				// We've been disabled
+				return;
+			}
 			String s = data.get("TransportState");
 			state.playback = "STOPPED".equals(s) ? STOPPED :
 				"PLAYING".equals(s) ? PLAYING :

--- a/src/main/java/net/pms/newgui/PlayerControlPanel.java
+++ b/src/main/java/net/pms/newgui/PlayerControlPanel.java
@@ -318,6 +318,9 @@ public class PlayerControlPanel extends JPanel implements ActionListener {
 	}
 
 	public void refresh(BasicPlayer.State state) {
+		if (state == null) {
+			return;
+		}
 		if (playControl) {
 			playing = state.playback != BasicPlayer.STOPPED;
 			// update playback status

--- a/src/main/java/net/pms/util/BasicPlayer.java
+++ b/src/main/java/net/pms/util/BasicPlayer.java
@@ -84,6 +84,8 @@ public interface BasicPlayer extends ActionListener {
 
 	public void close();
 
+	public void replace(BasicPlayer other);
+
 	// An empty implementation with some basic funtionalities defined
 
 	public static class Minimal implements BasicPlayer {
@@ -223,6 +225,17 @@ public interface BasicPlayer extends ActionListener {
 
 		@Override
 		public void actionPerformed(final ActionEvent e) {
+		}
+
+		@Override
+		public void replace(BasicPlayer other) {
+			if (other instanceof Minimal) {
+				Minimal o = (Minimal)other;
+				state = o.state;
+				o.state = null;
+				listeners = o.listeners;
+				o.listeners = null;
+			}
 		}
 	}
 
@@ -375,6 +388,19 @@ public interface BasicPlayer extends ActionListener {
 			}
 		}
 
+		@Override
+		public void replace(BasicPlayer other) {
+			super.replace(other);
+			if (other instanceof Logical) {
+				Logical o = (Logical)other;
+				playlist = o.playlist;
+				o.playlist = null;
+				playlist.setPlayer(this);
+				forceStop = o.forceStop;
+				lastPlayback = o.lastPlayback;
+			}
+		}
+
 		public void clear() {
 			playlist.removeAllElements();
 		}
@@ -426,7 +452,12 @@ public interface BasicPlayer extends ActionListener {
 			Logical player;
 
 			public Playlist(Logical p) {
+				setPlayer(p);
+			}
+
+			public void setPlayer(Logical p) {
 				player = p;
+				validate();
 			}
 
 			public Item get(String uri) {


### PR DESCRIPTION
This came up indirectly as a result of #754, where the renderer conf is switched during playback because it takes 15 minutes or so before we see the renderer via cling.  In this particular case there were no dire consequences specifically related to this hot-swapping afaict (due to dumb-luck mostly :-), but it wasn't a scenario I'd actually contemplated before and made me go back and reconsider.  What wasn't happening after the renderer switch was that the renderer's playback "controller" wasn't being upgraded from a passive playback timer to a upnp control, so this pr is a quick take on making that happen smoothly and avoid some possible pitfalls.

The main thing to be sure of is that there aren't any weird side effects in the normal case, i.e. for the vast majority of renderers where this doesn't happen, so if people would just run it for a while during normal use and confirm that all is well (or not, as the case may be) I'd appreciate it.

The second thing to test is the actual efficacy, which I've been simulating by hacking upnp service startup to be delayed until we're in the midst of playback, using the patch below and so far it seems to do the job vis internals and gui, but please try to trip it up if you feel the urge and bring any defects to light.

[upnp-hotswap-test.diff.txt](https://github.com/UniversalMediaServer/UniversalMediaServer/files/67645/upnp-hotswap-test.diff.txt)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/761)

<!-- Reviewable:end -->
