### PR TITLE
Change tool tip delay and margin

### DIFF
--- a/src/main/java/net/pms/newgui/LooksFrame.java
+++ b/src/main/java/net/pms/newgui/LooksFrame.java
@@ -316,13 +316,14 @@ public class LooksFrame extends JFrame implements IFrame, Observer {
 
 		// Customize the colors used in tooltips
 		UIManager.put("ToolTip.background", new ColorUIResource(PMS.getConfiguration().getToolTipBackgroundColor()));
-		Border border = BorderFactory.createLineBorder(PMS.getConfiguration().getToolTipBackgroundColor());
+		Border border = BorderFactory.createLineBorder(PMS.getConfiguration().getToolTipBackgroundColor(),4);
 		UIManager.put("ToolTip.border", border);
 		UIManager.put("ToolTip.foreground", new ColorUIResource(PMS.getConfiguration().getToolTipForegroundColor()));
 
 		// Display tooltips immediately and for a long time
-		ToolTipManager.sharedInstance().setInitialDelay(0);
+		ToolTipManager.sharedInstance().setInitialDelay(400);
 		ToolTipManager.sharedInstance().setDismissDelay(60000);
+		ToolTipManager.sharedInstance().setReshowDelay(400);
 
 		setResizable(true);
 		Dimension paneSize = getSize();
@@ -399,7 +400,7 @@ public class LooksFrame extends JFrame implements IFrame, Observer {
 		tt = new TracesTab(configuration, this);
 		gt = new GeneralTab(configuration, this);
 		pt = new PluginTab(configuration, this);
-		nt = new NavigationShareTab(configuration, this);		
+		nt = new NavigationShareTab(configuration, this);
 		tr = new TranscodingTab(configuration, this);
 		ht = new HelpTab();
 


### PR DESCRIPTION
@UniversalMediaServer/developers @SubJunk 
I made this a long time ago. My plan was to also look at other "misbehaviour" of the tooltip like that it's close to impossible to actually click the hyperlinks used in some tooltips and that the size sometimes is wrong, that the shadow sometimes doesn't render and that it places itself on top of the parent control in some instances.

I did quite a lot of digging as far as I can remember, but didn't actually get anywhere. I've always planned to return to this and dig some more, but I think we should merge the very simple changes I already did. What it does is to add a little bit more padding around the text making it slightly more readable, and most important: Adds a delay of 400 ms before a tooltip is shown.

That small delay will, according to my judgement, mean that all but the slowest users will have time to actually click the control before the tooptip appears, helping to remedy [problems like this] (http://www.universalmediaserver.com/forum/viewtopic.php?f=9&t=5773). As it is now, there's actually no way to use controls places closed to the screen edge.