### PR TITLE
Implemented workaround for Java bug JDK-8034057

### DIFF
--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -300,7 +300,7 @@ public class PMS {
 		String cwd = new File("").getAbsolutePath();
 		LOGGER.info("Working directory: " + cwd);
 
-		LOGGER.info("Temp directory: " + configuration.getTempFolder());
+		LOGGER.info("Temporary directory: " + configuration.getTempFolder());
 
 		/**
 		 * Verify the java.io.tmpdir is writable; JNA requires it.
@@ -312,10 +312,10 @@ public class PMS {
 		if (!FileUtil.getFilePermissions(javaTmpdir).isWritable()) {
 			LOGGER.error("The Java temp directory \"" + javaTmpdir.getAbsolutePath() + "\" is not writable by UMS");
 			LOGGER.error("Please make sure the directory is writable for user \"" + System.getProperty("user.name") + "\"");
-			throw new IOException("Cannot write to Java temp directory");
+			throw new IOException("Cannot write to Java temp directory: " + javaTmpdir.getAbsolutePath());
 		}
 
-		LOGGER.info("Logging config file: " + LoggingConfig.getConfigFilePath());
+		LOGGER.info("Logging configuration file: " + LoggingConfig.getConfigFilePath());
 
 		HashMap<String, String> lfps = LoggingConfig.getLogFilePaths();
 

--- a/src/main/java/net/pms/configuration/TempFolder.java
+++ b/src/main/java/net/pms/configuration/TempFolder.java
@@ -86,7 +86,7 @@ class TempFolder {
 			throw new IOException("Temporary folder isn't browsable: " + folder.getAbsolutePath());
 		}
 		if (!permission.isWritable()) {
-			throw new IOException("Temporary folder isn't writable:" + folder.getAbsolutePath());
+			throw new IOException("Temporary folder isn't writable: " + folder.getAbsolutePath());
 		}
 	}
 }

--- a/src/main/java/net/pms/util/FilePermissions.java
+++ b/src/main/java/net/pms/util/FilePermissions.java
@@ -21,8 +21,15 @@ package net.pms.util;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AccessMode;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.sun.jna.Platform;
 
 /**
@@ -42,6 +49,8 @@ public class FilePermissions {
 	private Boolean write = null;
 	private Boolean execute = null;
 	private final boolean folder;
+	private String lastCause = null;
+	private static final Logger LOGGER = LoggerFactory.getLogger(FilePermissions.class);
 
 	public FilePermissions(File file) throws FileNotFoundException {
 		if (file == null) {
@@ -76,13 +85,74 @@ public class FilePermissions {
 	private void checkPermissions(boolean checkRead, boolean checkWrite, boolean checkExecute) {
 
 		if (read == null && checkRead) {
-			read = Boolean.valueOf(Files.isReadable(path));
+			try {
+				path.getFileSystem().provider().checkAccess(path, AccessMode.READ);
+				read = true;
+			} catch (AccessDeniedException e) {
+				if (path.toString().equals(e.getMessage())) {
+					lastCause = "Insufficient permission to read permissions";
+				} else if ("Permissions does not allow requested access".equals(e.getMessage())) {
+					lastCause = "Permissions don't allow read access";
+				} else {
+					lastCause = e.getMessage();
+				}
+				read = false;
+			} catch (IOException e) {
+				lastCause = e.getMessage();
+				read = false;
+			}
 		}
 		if (write == null && checkWrite) {
-			write = Boolean.valueOf(Files.isWritable(path));
+			try {
+				path.getFileSystem().provider().checkAccess(path, AccessMode.WRITE);
+				write = true;
+			} catch (AccessDeniedException e) {
+				if (e.getMessage().endsWith("Permissions does not allow requested access")) {
+					lastCause = "Permissions don't allow write access";
+				} else {
+					lastCause = e.getMessage();
+				}
+				write = false;
+			} catch (FileSystemException e) {
+				// A workaround for https://bugs.openjdk.java.net/browse/JDK-8034057
+				// and similar bugs, if we can't determine it the nio way, fall
+				// back to actually testing it.
+				LOGGER.trace(
+					"Couldn't determine write permissions for \"{}\", falling back to write testing. The error was: {}",
+					path.toString(),
+					e.getMessage()
+				);
+				if (folder) {
+					write = testFolderWritable();
+				} else {
+					write = testFileWritable(file);
+				}
+			} catch (IOException e) {
+				lastCause = e.getMessage();
+				write = false;
+			}
 		}
 		if (execute == null && checkExecute) {
-			execute = Boolean.valueOf(Files.isExecutable(path) || (Platform.isLinux() && FileUtil.isAdmin()));
+			// To conform to the fact that on Linux root always implicit
+			// execute permission regardless of explicit permissions
+			if (Platform.isLinux() && FileUtil.isAdmin()) {
+				execute = true;
+			} else {
+				try {
+					path.getFileSystem().provider().checkAccess(path, AccessMode.EXECUTE);
+					execute = true;
+				} catch (AccessDeniedException e) {
+					if (e.getMessage().endsWith("Permissions does not allow requested access")) {
+						lastCause = "Permissions don't allow execute access";
+					} else {
+						lastCause = e.getMessage();
+					}
+					execute = false;
+				} catch (IOException e) {
+					lastCause = e.getMessage();
+					execute = false;
+				}
+			}
 		}
 	}
 
@@ -152,6 +222,11 @@ public class FilePermissions {
 		read = null;
 		write = null;
 		execute = null;
+		lastCause = null;
+	}
+
+	public synchronized String getLastCause() {
+		return lastCause;
 	}
 
 	@Override
@@ -175,5 +250,74 @@ public class FilePermissions {
 			sb.append(execute.booleanValue() ? "x" : "-");
 		}
 		return sb.toString();
+	}
+
+	/**
+	 * Must always be called in a synchronized context
+	 */
+	private boolean testFolderWritable() {
+		if (!folder) {
+			throw new IllegalStateException("Can only be called on a folder");
+		}
+		boolean isWritable = false;
+
+		File file = new File(
+			this.file,
+			String.format(
+				"UMS_folder_write_test_%d_%d.tmp",
+				System.currentTimeMillis(),
+				Thread.currentThread().getId()
+			)
+		);
+
+		try {
+			if (file.createNewFile()) {
+				if (testFileWritable(file)) {
+					isWritable = true;
+				}
+
+				if (!file.delete()) {
+					LOGGER.warn("Can't delete temporary test file: {}", file.getAbsolutePath());
+				}
+			}
+		} catch (IOException e) {
+			lastCause = e.getMessage();
+		}
+
+		return isWritable;
+	}
+
+	/**
+	 * Must always be called in a synchronized context
+	 */
+	private boolean testFileWritable(File file) {
+		file = file.getAbsoluteFile();
+		if (file.isDirectory()) {
+			throw new IllegalStateException("Can't be called on a folder");
+		}
+
+		boolean isWritable = false;
+		boolean fileAlreadyExists = file.isFile(); // i.e. exists and is a File
+
+		if (fileAlreadyExists || !file.exists()) {
+			try {
+				// fileAlreadyExists: open for append: make sure the open
+				// doesn't clobber the file
+				new FileOutputStream(file, true).close();
+				isWritable = true;
+
+				if (!fileAlreadyExists) { // a new file has been "touched"; try to remove it
+					if (!file.delete()) {
+						LOGGER.warn("Can't delete temporary test file: {}", file.getAbsolutePath());
+					}
+				}
+			} catch (IOException e) {
+				lastCause = e.getMessage();
+			}
+		} else {
+			lastCause = file.getAbsolutePath() + " isn't a file";
+		}
+
+		return isWritable;
 	}
 }


### PR DESCRIPTION
Based on [this forum thread] (http://www.universalmediaserver.com/forum/viewtopic.php?f=9&t=5854).

[JDK-8034057] (https://bugs.openjdk.java.net/browse/JDK-8034057) is a rare bug, and I'm not sure if the exact bug that cased this issue, but it any case it's very closely related. The bug is fixed, but not for any released Java version so it seems we have to handle it for quite a while.

I found out after some testing that I got a particular exception, ```FileSystemException``` when this occurred if I made the call "one step deeper" into NIO. I've then brought back and slightly modified the "old" write tests that actually try to write to a file to determine write permission, and when this particular exception is thrown I fall back to trying to write to a file or folder.

It will make UMS run for anyone who's using the open source ImDisk RAM drive for Windows as their temp folder.

It shouldn't need much testing since the old, tested code is used. I have tested that it resolves the issue with ImDisk.

