### PR TITLE
Further tooltip tweaks (#779)

### DIFF
--- a/src/main/java/net/pms/newgui/LooksFrame.java
+++ b/src/main/java/net/pms/newgui/LooksFrame.java
@@ -351,7 +351,7 @@ public class LooksFrame extends JFrame implements IFrame, Observer {
 
 		// Customize the colors used in tooltips
 		UIManager.put("ToolTip.background", new ColorUIResource(PMS.getConfiguration().getToolTipBackgroundColor()));
-		Border border = BorderFactory.createLineBorder(PMS.getConfiguration().getToolTipBackgroundColor(),4);
+		Border border = BorderFactory.createLineBorder(PMS.getConfiguration().getToolTipBackgroundColor(), 4);
 		UIManager.put("ToolTip.border", border);
 		UIManager.put("ToolTip.foreground", new ColorUIResource(PMS.getConfiguration().getToolTipForegroundColor()));
 

--- a/src/main/java/net/pms/newgui/components/HyperLinkToolTip.java
+++ b/src/main/java/net/pms/newgui/components/HyperLinkToolTip.java
@@ -2,13 +2,14 @@ package net.pms.newgui.components;
 
 import java.awt.BorderLayout;
 import java.awt.Desktop;
+import java.awt.Dimension;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.swing.*;
 import javax.swing.event.*;
 import javax.swing.plaf.ColorUIResource;
-import javax.swing.plaf.ToolTipUI;
+import javax.swing.text.html.StyleSheet;
 import net.pms.PMS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +21,19 @@ public class HyperLinkToolTip extends JToolTip {
 	private static final Logger LOGGER = LoggerFactory.getLogger(HyperLinkToolTip.class);
 	private static ColorUIResource fg = new ColorUIResource(PMS.getConfiguration().getToolTipForegroundColor());
 	private static ColorUIResource bg = new ColorUIResource(PMS.getConfiguration().getToolTipBackgroundColor());
+	private static CustomHTMLEditorKit editorKit;
+
+	/*
+	 * Creates a static, shared (between instances of this class only) instance
+	 * of a EditorKit that is applied to all HyperLinkToolTips. A blank
+	 * StyleSheet is also created and only hyperlinks are styled.
+	 */
+	static {
+		editorKit = new CustomHTMLEditorKit();
+		StyleSheet styleSheet = new StyleSheet();
+		styleSheet.addRule("a { color: #0000EE; text-decoration:underline; }");
+		editorKit.setStyleSheet(styleSheet);
+	}
 
 	private JEditorPane editorPane;
 
@@ -27,7 +41,7 @@ public class HyperLinkToolTip extends JToolTip {
 		setLayout(new BorderLayout());
 		editorPane = new JEditorPane();
 		editorPane.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, Boolean.TRUE);
-		editorPane.setContentType("text/html");
+		editorPane.setEditorKit(editorKit);
 		editorPane.setEditable(false);
 		editorPane.setForeground(fg);
 		editorPane.setBackground(bg);
@@ -39,7 +53,7 @@ public class HyperLinkToolTip extends JToolTip {
 					if (Desktop.isDesktopSupported()) {
 						try {
 							Desktop.getDesktop().browse(new URI(e.getDescription()));
-							closeToolTip();
+							hideToolTip();
 						} catch (IOException | URISyntaxException e1) {
 							LOGGER.error("Failed to open hyperlink", e1);
 						}
@@ -58,11 +72,14 @@ public class HyperLinkToolTip extends JToolTip {
 	}
 
 	@Override
-	public void updateUI() {
-		setUI(new ToolTipUI() { });
+	public Dimension getPreferredSize() {
+	    if (getLayout() != null) {
+	        return getLayout().preferredLayoutSize(this);
+	    }
+	    return super.getPreferredSize();
 	}
 
-	private void closeToolTip() {
+	private void hideToolTip() {
 		setVisible(false);
 	}
 }


### PR DESCRIPTION
What I've done: 
* Detached ```HyperLinkToolTip``` from the default Swing shared ```StyleSheet```. This means that the tooltip is no longer affected by changes to the default shared ```StyleSheet``` used in components using ```EditorKit```. This restores tooltip padding to normal.
* Changed ```ToolTipUI``` back to the inherited to preserve UI style. The ```ToolTipUI``` was overridden in this class probably because the default ```ToolTipUI``` wouldn't render the custom content. Overriding ```getPreferredSize()``` fixes the rendering, and thus using the inherited ```ToolTipUI``` better preserves LAF (like drawing a drop-shadow).

What I haven't done is address to two remaining issues I'm aware of regarding tooltips:
* ```ToolTipUI``` isn't properly rendering ```JComboBox```. This seems to be a Swing bug, but still looks ugly.
* Solving "clickability" on tooltip links. This should be done by either having a delay before the tooltip close (only if there's a link in it preferrably), or by positioning the tooltip so that it overlaps the component and it's possible to move the mouse there without it closing.

This should solve #779.