### PR TITLE
Updates to RemoteWeb

### DIFF
--- a/src/main/java/net/pms/remote/RemoteWeb.java
+++ b/src/main/java/net/pms/remote/RemoteWeb.java
@@ -79,10 +79,12 @@ public class RemoteWeb {
 			} catch (IOException e) {
 				LOGGER.error("Failed to start WEB interface on HTTPS: {}", e.getMessage());
 				LOGGER.trace("", e);
+				if (e.getMessage().contains("UMS.jks")) {
+					LOGGER.info("To enable HTTPS please generate a self-signed keystore file called \"UMS.jks\" using the java 'keytool' commandline utility.");
+				}
 			} catch (GeneralSecurityException e) {
 				LOGGER.error("Failed to start WEB interface on HTTPS due to a security error: {}", e.getMessage());
 				LOGGER.trace("", e);
-				LOGGER.info("To enable HTTPS please generate a self-signed keystore file called 'UMS.jks' using the java 'keytool' commandline utility.");
 			}
 		} else {
 			server = HttpServer.create(address, 0);


### PR DESCRIPTION
@UniversalMediaServer/developers 
I wanted to find a better solution to the NPE avoided in ec6131aca7152ae69b7fbc0e4e66ff4860df7747. I ended up changing quite a lot of the ```Exception``` handling and fixing all FindBugs bugs and thread unsafe access to a ```HashMap```:

* Reorganized ```Exception``` handling
- Fixed synchronization for ```roots``` map
- Made ```ResourceManager``` creation run inside ```doPrivileged()```
- Made sure ```UMS.jks``` is closed after read
- Updated unused method ```associate()``` to avoid potential ```ClassCastException``` should it ever be used
- Made reading of credentials use ```UTF-8``` and closing the file in case of an ```Exception```
- Removed unused variable ```p``` in ```handle()```

The ```Exception``` handling is the only thing that's actually changed, everything else should be bug fixes with no behaviour change. The contructor now throws ```IOException``` into ```PMS.init()``` where it's called, and I believe that is the correct way to do it since ```PMS.init()``` need to handle if the creation of the web interface fails. It doesn't handle it very gracefully at the moment (but no worse than several other ```Exceptions```), but I'm working on another branch improving ```Exception``` handling during startup that will improve this if I ever find the time to finish it.

What do you think?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/805)
<!-- Reviewable:end -->
