### PR TITLE
Mark all as played

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2813,7 +2813,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 *
 	 * @return The system time when the resource was last (re)started
 	 */
-	public double getLastStartSystemTime() {
+	public long getLastStartSystemTime() {
 		return lastStartSystemTime;
 	}
 

--- a/src/main/java/net/pms/dlna/MediaMonitor.java
+++ b/src/main/java/net/pms/dlna/MediaMonitor.java
@@ -16,12 +16,11 @@ import net.pms.util.FileUtil;
 import net.pms.util.FreedesktopTrash;
 import net.pms.util.FullyPlayedAction;
 import org.apache.commons.lang.StringUtils;
-import org.fest.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MediaMonitor extends VirtualFolder {
-	private static Set<String> fullyPlayedEntries;
+	private static Set<String> fullyPlayedEntries = new HashSet<>();
 	private File[] dirs;
 	private PmsConfiguration config;
 
@@ -29,8 +28,12 @@ public class MediaMonitor extends VirtualFolder {
 
 	public MediaMonitor(File[] dirs) {
 		super(Messages.getString("VirtualFolder.2"), "images/thumbnail-folder-256.png");
-		this.dirs = dirs;
-		fullyPlayedEntries = new HashSet<>();
+		if (dirs == null) {
+			this.dirs = null;
+		} else {
+			this.dirs = new File[dirs.length];
+			System.arraycopy(dirs, 0, this.dirs, 0, dirs.length);
+		}
 		config = PMS.getConfiguration();
 		parseMonitorFile();
 	}
@@ -74,35 +77,41 @@ public class MediaMonitor extends VirtualFolder {
 		}
 	}
 
-	public void scanDir(File[] files, final DLNAResource res) {
+	public void scanDir(File[] files, final DLNAResource resource) {
 		if (files != null) {
-			final DLNAResource mm = this;
-			res.addChild(new VirtualVideoAction(Messages.getString("PMS.150"), true) {
-				@Override
-				public boolean enable() {
-					for (DLNAResource r : res.getChildren()) {
-						if (!(r instanceof RealFile)) {
-							continue;
+			if (resource.getChildren().isEmpty()) {
+				// Only add "Mark all as played" it there are no children here
+				// already to prevent one entry per monitored folder
+				final MediaMonitor mediaMonitor = this;
+				resource.addChild(new VirtualVideoAction(Messages.getString("PMS.150"), true) {
+					@Override
+					public boolean enable() {
+						for (DLNAResource r : resource.getChildren()) {
+							if (!(r instanceof RealFile)) {
+								continue;
+							}
+							RealFile rf = (RealFile) r;
+							fullyPlayedEntries.add(rf.getFile().getAbsolutePath());
 						}
-						RealFile rf = (RealFile) r;
-						fullyPlayedEntries.add(rf.getFile().getAbsolutePath());
+						mediaMonitor.setDiscovered(false);
+						mediaMonitor.getChildren().clear();
+						try {
+							dumpFile();
+						} catch (IOException e) {
+							LOGGER.error("Error dumping media monitor: {}", e.getMessage());
+							LOGGER.trace("", e);
+						}
+						return true;
 					}
-					mm.setDiscovered(false);
-					mm.getChildren().clear();
-					try {
-						dumpFile();
-					} catch (IOException e) {
-					}
-					return true;
-				}
-			});
+				});
+			}
 
 			for (File f : files) {
 				if (f.isFile()) {
 					if (isFullyPlayed(f.getAbsolutePath())) {
 						continue;
 					}
-					res.addChild(new RealFile(f));
+					resource.addChild(new RealFile(f));
 				}
 				if (f.isDirectory()) {
 					boolean add = true;
@@ -110,7 +119,7 @@ public class MediaMonitor extends VirtualFolder {
 						add = FileUtil.isFolderRelevant(f, config, fullyPlayedEntries);
 					}
 					if (add) {
-						res.addChild(new MonitorEntry(f, this));
+						resource.addChild(new MonitorEntry(f, this));
 					}
 				}
 			}
@@ -149,7 +158,7 @@ public class MediaMonitor extends VirtualFolder {
 		 * This is not a great way to get this value because if the
 		 * video is paused, it will no longer be accurate.
 		 */
-		double elapsed;
+		long elapsed;
 		if (res.getLastStartPosition() == 0) {
 			elapsed = (System.currentTimeMillis() - res.getStartTime()) / 1000;
 		} else {
@@ -241,7 +250,7 @@ public class MediaMonitor extends VirtualFolder {
 							if (Platform.isLinux()) {
 								FreedesktopTrash.moveToTrash(playedFile);
 							} else {
-								FileUtils.getInstance().moveToTrash(Arrays.array(playedFile));
+								FileUtils.getInstance().moveToTrash(new File[] {playedFile});
 							}
 						} catch (IOException | FileUtil.InvalidFileSystemException e) {
 							LOGGER.warn("Failed to move file \"{}\" to recycler/trash after it has been fully played: {}", playedFile.getAbsoluteFile(), e.getMessage());


### PR DESCRIPTION
@UniversalMediaServer/developers 
The `VirtualVideoAction` "Mark all as played" does not work as reported [here](http://www.universalmediaserver.com/forum/viewtopic.php?f=9&t=5883). With the new fully played functionality this has become even more of an issue, every upgrade of UMS will end up erasing all fully played information. Even though it's far from perfect, using this would atleast allow marking all media currently shared as fully played, so only new media won't be. 

I actually think this should be completely redone in such a way that a version upgrade doesn't affect what's considered fully played as it almost renders the whole fully played function useless.

Even so, "Mark all as played" is better than nothing, and it still should work if it's there. I've not been able to solve this. I've spent some time on it, and I don't know what broke this but I can see that there's issues with other `VirtualVideoAction`s as well, so I think the problem might lie outside this specific implementation. From what I can see, the code is never actually called.

I've done some changes in while trying to solve it, so I'm posting these here:
- Made MediaMonitor make one instead of multiple (One per shared folder) "Mark all as played" folder(s)
- Multiple bugfixes in MediaMonitor
- A bugfix in DLNAResource

I have to many other things to tend to, so I can't dig any deeper into this now. I'd really wish some of you would see if you could find out why the code isn't called and push to this PR.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/806)

<!-- Reviewable:end -->
