### PR TITLE
Tweaks to Web interface tweaks (#807)

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -822,13 +822,20 @@ public class PmsConfiguration extends RendererConfiguration {
 		configuration.setProperty(KEY_SERVER_HOSTNAME, value);
 	}
 
+	public String getServerDisplayName() {
+		if (isAppendProfileName()) {
+			return String.format("%s [%s]", getString(KEY_SERVER_NAME, PMS.NAME), getProfileName());
+		} else {
+			return getString(KEY_SERVER_NAME, PMS.NAME);
+		}
+	}
 	/**
 	 * The name of the server.
 	 *
 	 * @return The name of the server.
 	 */
 	public String getServerName() {
-		return getString(KEY_SERVER_NAME, "Universal Media Server");
+		return getString(KEY_SERVER_NAME, PMS.NAME);
 	}
 
 	/**

--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -451,12 +451,6 @@ public class Request extends HTTPResource {
 			output(output, "Expires: " + getFUTUREDATE() + " GMT");
 			inputStream = getResourceInputStream(argument);
 		} else if ((method.equals("GET") || method.equals("HEAD")) && (argument.equals("description/fetch") || argument.endsWith("1.0.xml"))) {
-			String profileName = "";
-			if (configuration.isAppendProfileName()) {
-				profileName = " [" + configuration.getProfileName() + "]";
-			}
-
-			String serverName = configuration.getServerName();
 			output(output, CONTENT_TYPE);
 			output(output, "Cache-Control: no-cache");
 			output(output, "Expires: 0");
@@ -477,7 +471,7 @@ public class Request extends HTTPResource {
 
 				if (xbox360) {
 					LOGGER.debug("DLNA changes for Xbox 360");
-					s = s.replace("Universal Media Server", serverName + profileName + " : Windows Media Connect");
+					s = s.replace("Universal Media Server", configuration.getServerDisplayName() + " : Windows Media Connect");
 					s = s.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
 					s = s.replace("<serviceList>", "<serviceList>" + CRLF + "<service>" + CRLF +
 						"<serviceType>urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1</serviceType>" + CRLF +
@@ -486,7 +480,7 @@ public class Request extends HTTPResource {
 						"<controlURL>/upnp/mrr/control</controlURL>" + CRLF +
 						"</service>" + CRLF);
 				} else {
-					s = s.replace("Universal Media Server", serverName + profileName);
+					s = s.replace("Universal Media Server", configuration.getServerDisplayName());
 				}
 
 				inputStream = new ByteArrayInputStream(s.getBytes());

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -512,13 +512,6 @@ public class RequestV2 extends HTTPResource {
 				String s = new String(b);
 				s = s.replace("[uuid]", PMS.get().usn()); //.substring(0, PMS.get().usn().length()-2));
 
-				String profileName = "";
-				if (configuration.isAppendProfileName()) {
-					profileName = " [" + configuration.getProfileName() + "]";
-				}
-
-				String serverName = configuration.getServerName();
-
 				if (PMS.get().getServer().getHost() != null) {
 					s = s.replace("[host]", PMS.get().getServer().getHost());
 					s = s.replace("[port]", "" + PMS.get().getServer().getPort());
@@ -526,7 +519,7 @@ public class RequestV2 extends HTTPResource {
 
 				if (xbox360) {
 					LOGGER.debug("DLNA changes for Xbox 360");
-					s = s.replace("Universal Media Server", serverName + profileName + " : Windows Media Connect");
+					s = s.replace("Universal Media Server", configuration.getServerDisplayName() + " : Windows Media Connect");
 					s = s.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
 					s = s.replace("<serviceList>", "<serviceList>" + CRLF + "<service>" + CRLF +
 						"<serviceType>urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1</serviceType>" + CRLF +
@@ -535,7 +528,7 @@ public class RequestV2 extends HTTPResource {
 						"<controlURL>/upnp/mrr/control</controlURL>" + CRLF +
 						"</service>" + CRLF);
 				} else {
-					s = s.replace("Universal Media Server", serverName + profileName);
+					s = s.replace("Universal Media Server", configuration.getServerDisplayName());
 				}
 
 				response.append(s);

--- a/src/main/java/net/pms/remote/RemoteBrowseHandler.java
+++ b/src/main/java/net/pms/remote/RemoteBrowseHandler.java
@@ -192,7 +192,7 @@ public class RemoteBrowseHandler implements HttpHandler {
 		}
 
 		HashMap<String, Object> vars = new HashMap<>();
-		vars.put("name", id.equals("0") ? configuration.getServerName() :
+		vars.put("name", id.equals("0") ? configuration.getServerDisplayName() :
 			StringEscapeUtils.escapeHtml(root.getDLNAResource(id, null).getDisplayName()));
 		vars.put("hasFile", hasFile);
 		vars.put("noFoldersCSS", showFolders ? "" : " class=\"noFolders\"");

--- a/src/main/java/net/pms/remote/RemotePlayHandler.java
+++ b/src/main/java/net/pms/remote/RemotePlayHandler.java
@@ -70,7 +70,7 @@ public class RemotePlayHandler implements HttpHandler {
 
 	private String mkPage(String id, HttpExchange t) throws IOException {
 		HashMap<String, Object> vars = new HashMap<>();
-		vars.put("serverName", configuration.getServerName());
+		vars.put("serverName", configuration.getServerDisplayName());
 
 		LOGGER.debug("make play page " + id);
 		RootFolder root = parent.getRoot(RemoteUtil.userName(t), t);

--- a/src/main/java/net/pms/remote/RemoteWeb.java
+++ b/src/main/java/net/pms/remote/RemoteWeb.java
@@ -423,8 +423,7 @@ public class RemoteWeb {
 			}
 
 			HashMap<String, Object> vars = new HashMap<>();
-			vars.put("serverName", configuration.getServerName());
-			vars.put("profileName", configuration.getProfileName());
+			vars.put("serverName", configuration.getServerDisplayName());
 
 			String response = parent.getResources().getTemplate("start.html").execute(vars);
 			RemoteUtil.respond(t, response, 200, "text/html");


### PR DESCRIPTION
I saw that there was great inconsistancy in the use of server name, so I made a new method ```PmsConfiguration.getServerDisplayName()``` and put it to use all relevant places.

This also fixes it on the ```start.html``` page.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/808)
<!-- Reviewable:end -->
