### PR TITLE
Fix not to be subtitles parsing twice

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -331,9 +331,8 @@ public class DLNAMediaInfo implements Cloneable {
 	}
 
 	/**
-	 * @return the number of subtitle tracks embedded in the media file.
+	 * @return true when there are subtitle tracks embedded in the media file.
 	 */
-
 	public boolean hasSubtitles() {
 		return subtitleTracks.size() > 0;
 	}
@@ -1402,8 +1401,17 @@ public class DLNAMediaInfo implements Cloneable {
 
 		// Check for external subs here
 		if (f.getFile() != null && type == Format.VIDEO && configuration.isAutoloadExternalSubtitles()) {
-			FileUtil.isSubtitlesExists(f.getFile(), this);
+			hasExternalSubs = FileUtil.isSubtitlesExists(f.getFile(), this);
 		}
+	}
+
+	private boolean hasExternalSubs;
+
+	/**
+	 * @return true when there are external subtitle tracks for the video file.
+	 */
+	public boolean hasExternalSubs() {
+		return hasExternalSubs;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1408,7 +1408,7 @@ public class DLNAMediaInfo implements Cloneable {
 	private boolean hasExternalSubs;
 
 	/**
-	 * @return true when there are external subtitle tracks for the video file.
+	 * @return true when there is an external subtitle file matching the renderer subtitles setting for the video file.
 	 */
 	public boolean hasExternalSubs() {
 		return hasExternalSubs;

--- a/src/main/java/net/pms/dlna/DLNAMediaSubtitle.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaSubtitle.java
@@ -188,6 +188,7 @@ public class DLNAMediaSubtitle extends DLNAMediaLang implements Cloneable {
 					LOGGER.debug("Set detected charset \"{}\" and language \"{}\" for {}", match.getName(), lang, externalFile.getAbsolutePath());
 				} else {
 					subsCharacterSet = null;
+					LOGGER.debug("No charset detected for {}", externalFile.getAbsolutePath());
 				}
 
 			} catch (IOException ex) {

--- a/src/main/java/net/pms/dlna/DLNAMediaSubtitle.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaSubtitle.java
@@ -185,12 +185,14 @@ public class DLNAMediaSubtitle extends DLNAMediaLang implements Cloneable {
 				if (match != null) {
 					subsCharacterSet = match.getName().toUpperCase(PMS.getLocale());
 					lang = match.getLanguage();
+					LOGGER.debug("Set detected charset \"{}\" and language \"{}\" for {}", match.getName(), lang, externalFile.getAbsolutePath());
 				} else {
 					subsCharacterSet = null;
 				}
+
 			} catch (IOException ex) {
 				subsCharacterSet = null;
-				LOGGER.warn("Exception during external file charset detection.", ex);
+				LOGGER.warn("Exception during external file charset detection: ", ex.getMessage());
 			}
 		}
 	}

--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -53,12 +53,8 @@ public class RealFile extends MapFile {
 	public boolean isValid() {
 		File file = this.getFile();
 		resolveFormat();
-		if (getType() == Format.VIDEO && file.exists() && configuration.isAutoloadExternalSubtitles() && file.getName().length() > 4) {
-			setHasExternalSubtitles(FileUtil.isSubtitlesExists(file, null));
-		}
-
+		boolean checkSubs = getType() == Format.VIDEO && configuration.isAutoloadExternalSubtitles() && file.getName().length() > 4; // TODO why should be file name longer than 4 chars?
 		boolean valid = file.exists() && (getFormat() != null || file.isDirectory());
-
 		if (valid && getParent().getDefaultRenderer() != null && getParent().getDefaultRenderer().isUseMediaInfo()) {
 			// we need to resolve the DLNA resource now
 			run();
@@ -83,6 +79,12 @@ public class RealFile extends MapFile {
 			if (getParent().getDefaultRenderer().isMediaInfoThumbnailGeneration()) {
 				checkThumbnail();
 			}
+
+			if (checkSubs) {
+				setHasExternalSubtitles(getMedia() != null && getMedia().hasExternalSubs());
+			}
+		} else if (checkSubs && valid && getParent().getDefaultRenderer() != null && !getParent().getDefaultRenderer().isUseMediaInfo()) {
+			setHasExternalSubtitles(FileUtil.isSubtitlesExists(file, null)); // TODO it is still parsing subs twice when FFmpeg is used for parsing the file
 		}
 
 		return valid;

--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -53,7 +53,7 @@ public class RealFile extends MapFile {
 	public boolean isValid() {
 		File file = this.getFile();
 		resolveFormat();
-		boolean checkSubs = getType() == Format.VIDEO && configuration.isAutoloadExternalSubtitles() && file.getName().length() > 4; // TODO why should be file name longer than 4 chars?
+		boolean checkSubs = getType() == Format.VIDEO && configuration.isAutoloadExternalSubtitles();
 		boolean valid = file.exists() && (getFormat() != null || file.isDirectory());
 		if (valid && getParent().getDefaultRenderer() != null && getParent().getDefaultRenderer().isUseMediaInfo()) {
 			// we need to resolve the DLNA resource now

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -846,12 +846,6 @@ public class FileUtil {
 			result = detector.detectAll()[0];
 		}
 
-		if (result != null) {
-			LOGGER.debug("Detected encoding for {} is {}.", file.getAbsolutePath(), result.getName());
-		} else {
-			LOGGER.debug("No encoding detected for {}.", file.getAbsolutePath());
-		}
-
 		return result;
 	}
 


### PR DESCRIPTION
It needs testing but it works for me. It works when the MediaInfo is used but it needs some improvement when FFmpeg is used for the media parsing. Any help is appreciated. :smile:

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/817)
<!-- Reviewable:end -->
