### PR TITLE
Make sure the JNA version from our JAR is used

### DIFF
--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -1093,6 +1093,8 @@ public class PMS {
 		boolean denyHeadless = false;
 		File profilePath = null;
 		CacheLogger.startCaching();
+		// Make sure that no other versions of JNA found on the system is used
+		System.setProperty("jna.nosys", "true");
 
 		// Set headless options if given as a system property when launching the JVM
 		if (System.getProperty(CONSOLE, "").equalsIgnoreCase(Boolean.toString(true))) {


### PR DESCRIPTION
@UniversalMediaServer/developers 
This is based on [this thread] (http://www.universalmediaserver.com/forum/viewtopic.php?f=9&t=6053). I scratched my head for a while there because I couldn't imagine that JNA's behaviour was as strange as it seems to be.

In short, it seems that by detault (java-native-access/jna#399) JNA uses whatever JNA version it finds in the host OS by searching the ```path``` and possibly other to me unknown locations instead of the one in our own JAR. This is supposedly to save time unpacking from the JAR file, but it opens the possibility for all kind of bugs introduced by other installed software that use another version of JNA than we do. If it can't find an existing version it will unpack from the JAR and use "our" version, which is what I suppose happens in most cases.

That's not always the case though, as this support case has shown. The remedy is to disable this recless behaviour and this is what this PR does by setting a system property before JNA is first called.

It's hard to see what side effects this could have, but since JNA has a history of being extra tricky I'm posting this as a PR so we can all discuss this. The user posting the support thread confirms that this solves the case for him.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/819)
<!-- Reviewable:end -->
