### PR TITLE
Support external Blu-ray subtitles (.sup)

### DIFF
--- a/src/main/java/net/pms/formats/v2/SubtitleType.java
+++ b/src/main/java/net/pms/formats/v2/SubtitleType.java
@@ -45,7 +45,7 @@ public enum SubtitleType {
 	BMP         (9,  "BMP",                         list(),             list("S_IMAGE/BMP"),                                              type.PICTURE),
 	DIVX        (10, "DIVX subtitles",              list(),             list("DXSB"),                                                     type.PICTURE),
 	TX3G        (11, "Timed text (TX3G)",           list(),             list("tx3g"),                                                     type.TEXT),
-	PGS         (12, "Blu-ray subtitles",           list(),             list("S_HDMV/PGS", "PGS", "144"),                                 type.PICTURE),
+	PGS         (12, "Blu-ray subtitles",           list("sup"),        list("S_HDMV/PGS", "PGS", "144"),                                 type.PICTURE),
 	WEBVTT      (13, "WebVTT",                      list("vtt"),        list("WebVTT"),                                                   type.TEXT);
 
 	public enum type {TEXT, PICTURE, UNDEF}

--- a/src/test/java/net/pms/formats/v2/SubtitleTypeTest.java
+++ b/src/test/java/net/pms/formats/v2/SubtitleTypeTest.java
@@ -36,6 +36,7 @@ public class SubtitleTypeTest {
 		assertThat(valueOfFileExtension("ass")).isEqualTo(ASS);
 		assertThat(valueOfFileExtension("idx")).isEqualTo(VOBSUB);
 		assertThat(valueOfFileExtension("vtt")).isEqualTo(WEBVTT);
+		assertThat(valueOfFileExtension("sup")).isEqualTo(PGS);
 	}
 
 	@Test
@@ -92,6 +93,7 @@ public class SubtitleTypeTest {
 		assertThat(VOBSUB.getExtension()).isEqualTo("idx");
 		assertThat(UNSUPPORTED.getExtension()).isEqualTo("");
 		assertThat(WEBVTT.getExtension()).isEqualTo("vtt");
+		assertThat(PGS.getExtension()).isEqualTo("sup");
 	}
 
 	@Test
@@ -143,7 +145,7 @@ public class SubtitleTypeTest {
 
 	@Test
 	public void getSupportedFileExtensions() {
-		Set<String> expectedExtensionsSet = new HashSet<>(Arrays.asList("srt", "txt", "sub", "smi", "ssa", "ass", "idx", "vtt"));
+		Set<String> expectedExtensionsSet = new HashSet<>(Arrays.asList("srt", "txt", "sub", "smi", "ssa", "ass", "idx", "vtt", "sup"));
 		assertThat(SubtitleType.getSupportedFileExtensions()).isEqualTo(expectedExtensionsSet);
 	}
 


### PR DESCRIPTION
MEncoder and FFmpeg don't seem to support transcoding this format when it's external (they both do it when it's internal, though) so we should convert the PGS to a supported format like VOBSUB before we pass it to the transcoder. It should be very fast since no extraction is needed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/828)

<!-- Reviewable:end -->
