### PR TITLE
Renderer conf for LG-EG910V

### DIFF
--- a/src/main/external-resources/renderers/LG-EG910V.conf
+++ b/src/main/external-resources/renderers/LG-EG910V.conf
@@ -1,0 +1,50 @@
+#----------------------------------------------------------------------------
+# Profile for LG EG910V Smart TV.
+# See DefaultRenderer.conf for descriptions of all the available options.
+#
+
+RendererName = LG EG910V
+RendererIcon = lg-la644v.png
+UserAgentSearch = LGE WebOS TV LGE_DLNA_SDK
+# This maps the device correctly among LG devices
+UpnpDetailsSearch = webOS TV EG910V
+
+# Note: There are several similar LG profiles that use the same User-Agent.
+# Set loading priority to 1 to prefer this configuration over the others
+LoadingPriority = 1
+
+# Uncomment to disable serving images/audio for this renderer
+#Audio=false
+#Image=false
+
+# Not sure if these are needed - needs more testing
+H264Level41Limited = false
+DefaultVBVBufSize = true
+SeekByTime = true
+ChunkedTransfer = true
+MediaInfo = true
+
+# Supported video formats (might be off, but works for my media):
+Supported = f:3gp        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/3gpp
+Supported = f:avi|divx   v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/avi
+Supported = f:flv        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/x-flv
+Supported = f:mkv        v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv   a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/x-matroska
+Supported = f:mp4        v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv   a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/mp4
+Supported = f:mov        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/quicktime
+Supported = f:mpegps     v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/mpeg
+Supported = f:ts|mpegts     v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv   a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/mpeg
+Supported = f:webm       v:vp8                                                a:vorbis                                 m:video/webm
+Supported = f:wmv        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/x-ms-wmv
+
+# Supported audio formats (might be off, but works for me):
+Supported = f:aac    m:audio/x-m4a
+Supported = f:aiff   m:audio/L16
+Supported = f:flac   m:audio/flac
+Supported = f:mp3    m:audio/mpeg
+Supported = f:ogg    m:audio/x-ogg
+Supported = f:wma    m:audio/x-ms-wma
+Supported = f:wav    m:audio/wav
+
+# Having external subs trigger transcode for files that dont need it otherwise 
+# This resolves that issue for .srt - device might support other formats as well
+SupportedExternalSubtitlesFormats = SUBRIP

--- a/src/main/external-resources/renderers/LG-EG910V.conf
+++ b/src/main/external-resources/renderers/LG-EG910V.conf
@@ -25,16 +25,18 @@ ChunkedTransfer = true
 MediaInfo = true
 
 # Supported video formats (might be off, but works for my media):
-Supported = f:3gp        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/3gpp
 Supported = f:avi|divx   v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/avi
 Supported = f:flv        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/x-flv
 Supported = f:mkv        v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv   a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/x-matroska
-Supported = f:mp4        v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv   a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/mp4
+Supported = f:mp4        v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv   a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma|mpa   m:video/mp4
 Supported = f:mov        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/quicktime
-Supported = f:mpegps     v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/mpeg
-Supported = f:ts|mpegts     v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv   a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/mpeg
-Supported = f:webm       v:vp8                                                a:vorbis                                 m:video/webm
+Supported = f:ts|mpegts     v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv   a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma|mpa   m:video/mpeg
 Supported = f:wmv        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/x-ms-wmv
+#Supported = f:3gp        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/3gpp
+#Supported = f:mpegps     v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|wma   m:video/mpeg
+#Supported = f:webm       v:vp8                                                a:vorbis                                 m:video/webm
+
+
 
 # Supported audio formats (might be off, but works for me):
 Supported = f:aac    m:audio/x-m4a


### PR DESCRIPTION
Not everything might be perfect in the conf, but the tv seems to work nicely with pretty much any videofile I stream at it. Tested with different mkv, mp4, wmv, avi, flv, mov files. SupportedExternalSubtitlesFormats needs to be used so files don't get transcoded because of subtitles.

So far only one videofile has refused to play: a wmv that had a video with "Windows Media Video 8" codec, but I can live with that. Here's the part from mediainfo output:

Format                                   : WMV2
Codec ID                                 : WMV2
Codec ID/Info                            : Windows Media Video 8
Description of the codec                 : wmv2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/877)
<!-- Reviewable:end -->
