### PR TITLE
Viera AVT and related fixes

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -283,6 +283,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_TRANSCODE_FOLDER_NAME = "transcode_folder_name";
 	protected static final String KEY_TRANSCODE_KEEP_FIRST_CONNECTION = "transcode_keep_first_connection";
 	protected static final String KEY_TSMUXER_FORCEFPS = "tsmuxer_forcefps";
+	protected static final String KEY_UPNP_DEBUG = "upnp_debug";
 	protected static final String KEY_UPNP_ENABLED = "upnp_enable";
 	protected static final String KEY_UPNP_PORT = "upnp_port";
 	protected static final String KEY_USE_CACHE = "use_cache";
@@ -3810,6 +3811,10 @@ public class PmsConfiguration extends RendererConfiguration {
 	 */
 	public void setAutoSave() {
 		((PropertiesConfiguration) configuration).setAutoSave(true);
+	}
+
+	public boolean isUpnpDebug() {
+		return getBoolean(KEY_UPNP_DEBUG, false);
 	}
 
 	public boolean isUpnpEnabled() {

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -141,6 +141,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String DLNA_TREE_HACK = "CreateDLNATreeFaster";
 	protected static final String EMBEDDED_SUBS_SUPPORTED = "InternalSubtitlesSupported";
 	protected static final String FORCE_JPG_THUMBNAILS = "ForceJPGThumbnails"; // Sony devices require JPG thumbnails
+	protected static final String FORCE_PLAYBACKTIMER = "ForcePlaybackTimer";
 	protected static final String H264_L41_LIMITED = "H264Level41Limited";
 	protected static final String IGNORE_TRANSCODE_BYTE_RANGE_REQUEST = "IgnoreTranscodeByteRangeRequests";
 	protected static final String IMAGE = "Image";
@@ -1555,14 +1556,34 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	}
 
 	/**
-	 * Returns a UPnP player for this renderer if UPnP control is supported.
+	 * Returns whether to force a playback timer regardless of whether UPnP or
+	 * other control mechanisms are supported.
 	 *
-	 * @return a player or null.
+	 * @return Whether to force a playback timer.
+	 */
+	public boolean isForcePlaybackTimer() {
+		return getBoolean(FORCE_PLAYBACKTIMER, false);
+	}
+
+	/**
+	 * Returns a UPnP player for this renderer if UPnP control is supported,
+	 * or a simple playback timer if not.
+	 *
+	 * @return a player.
+	 */
+	public BasicPlayer createPlayer() {
+		return isUpnpControllable() ? new UPNPHelper.Player((DeviceConfiguration) this) :
+			new PlaybackTimer((DeviceConfiguration) this);
+	}
+
+	/**
+	 * Gets or creates the player.
+	 *
+	 * @return a player.
 	 */
 	public BasicPlayer getPlayer() {
 		if (player == null) {
-			player = isUpnpControllable() ? new UPNPHelper.Player((DeviceConfiguration) this) :
-				new PlaybackTimer((DeviceConfiguration) this);
+			player = isForcePlaybackTimer() ? new PlaybackTimer((DeviceConfiguration) this) : createPlayer();
 		}
 		return player;
 	}
@@ -1573,7 +1594,9 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 * @param player
 	 */
 	public void setPlayer(UPNPHelper.Player player) {
-		this.player = player;
+		if (!isForcePlaybackTimer()) {
+			this.player = player;
+		}
 	}
 
 	@Override

--- a/src/main/java/net/pms/configuration/WebRender.java
+++ b/src/main/java/net/pms/configuration/WebRender.java
@@ -496,11 +496,8 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 	}
 
 	@Override
-	public BasicPlayer getPlayer() {
-		if (player == null) {
-			player = new WebPlayer(this);
-		}
-		return player;
+	public BasicPlayer createPlayer() {
+		return new WebPlayer(this);
 	}
 
 	@Override

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -47,6 +47,7 @@ import net.pms.io.OutputParams;
 import net.pms.io.ProcessWrapper;
 import net.pms.io.SizeLimitInputStream;
 import net.pms.network.HTTPResource;
+import net.pms.network.HTTPXMLHelper;
 import net.pms.util.*;
 import static net.pms.util.StringUtil.*;
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -2282,11 +2283,20 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 *         {@code <container id="0$1" childCount="1" parentID="0" restricted="true">}
 	 */
 	public final String getDidlString(RendererConfiguration mediaRenderer) {
+		return getDidlString(mediaRenderer, false);
+	}
+
+	public final String getDidlString(RendererConfiguration mediaRenderer, boolean useHeader) {
 		// Use device-specific pms conf, if any
 		PmsConfiguration configuration = PMS.getConfiguration(mediaRenderer);
 		StringBuilder sb = new StringBuilder();
 		boolean subsAreValidForStreaming = false;
 		boolean xbox360 = mediaRenderer.isXbox360();
+
+		if (useHeader) {
+			sb.append(HTTPXMLHelper.DIDL_HEADER);
+		}
+
 		if (!isFolder()) {
 			if (format != null && format.isVideo()) {
 				if (
@@ -2611,6 +2621,10 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			closeTag(sb, "container");
 		} else {
 			closeTag(sb, "item");
+		}
+
+		if (useHeader) {
+			sb.append(HTTPXMLHelper.DIDL_FOOTER);
 		}
 
 		return sb.toString();

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2215,6 +2215,8 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 							}
 						}
 					}
+				} else if (mime.equals(MATROSKA_TYPEMIME)) {
+					dlnaOrgPnFlags = "DLNA.ORG_PN=MKV";
 				} else if (mime.equals("video/vnd.dlna.mpeg-tts")) {
 					// patters - on Sony BDP m2ts clips aren't listed without this
 					dlnaOrgPnFlags = "DLNA.ORG_PN=" + getMPEG_TS_EULocalizedValue(localizationValue, media.isHDVideo());

--- a/src/main/java/net/pms/network/ChromecastMgr.java
+++ b/src/main/java/net/pms/network/ChromecastMgr.java
@@ -105,12 +105,10 @@ public class ChromecastMgr implements ServiceListener {
 		}
 
 		@Override
-		public BasicPlayer getPlayer() {
-			if (player == null) {
-				player = new ChromecastPlayer(this, api);
-				((ChromecastPlayer)player).startPoll();
-			}
-			return player;
+		public BasicPlayer createPlayer() {
+			ChromecastPlayer p = new ChromecastPlayer(this, api);
+			p.startPoll();
+			return p;
 		}
 
 		@Override

--- a/src/main/java/net/pms/network/HTTPXMLHelper.java
+++ b/src/main/java/net/pms/network/HTTPXMLHelper.java
@@ -18,28 +18,28 @@
  */
 package net.pms.network;
 
-class HTTPXMLHelper {
+public class HTTPXMLHelper {
 	private final static String CRLF = "\r\n";
-	static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"utf-8\"?>";
-	static final String SOAP_ENCODING_HEADER = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">" + CRLF + "<s:Body>";
-	static final String SOAP_ENCODING_FOOTER = "</s:Body>" + CRLF + "</s:Envelope>";
-	static final String GETSYSTEMUPDATEID_HEADER = "<u:GetSystemUpdateIDResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\">";
-	static final String GETSYSTEMUPDATEID_FOOTER = "</u:GetSystemUpdateIDResponse>";
-	static final String BROWSERESPONSE_HEADER = "<u:BrowseResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\">";
-	static final String BROWSERESPONSE_FOOTER = "</u:BrowseResponse>";
-	static final String SEARCHRESPONSE_HEADER = "<u:SearchResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\">";
-	static final String SEARCHRESPONSE_FOOTER = "</u:SearchResponse>";
-	static final String SORTCAPS_RESPONSE = "<u:GetSortCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SortCaps></SortCaps></u:GetSortCapabilitiesResponse>";
-	static final String SEARCHCAPS_RESPONSE = "<u:GetSearchCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SearchCaps></SearchCaps></u:GetSearchCapabilitiesResponse>";
-	static final String PROTOCOLINFO_RESPONSE = "<u:GetProtocolInfoResponse xmlns:u=\"urn:schemas-upnp-org:service:ConnectionManager:1\"><Source>http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_SM,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_MED,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_LRG,http-get:*:audio/mpeg:DLNA.ORG_PN=MP3,http-get:*:audio/L16:DLNA.ORG_PN=LPCM,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_24_AC3_ISO;SONY.COM_PN=AVC_TS_HD_24_AC3_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_24_AC3;SONY.COM_PN=AVC_TS_HD_24_AC3,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_24_AC3_T;SONY.COM_PN=AVC_TS_HD_24_AC3_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_PS_PAL,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_PS_NTSC,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_50_L2_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_60_L2_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_EU_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_50_AC3_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_50_L2_ISO;SONY.COM_PN=HD2_50_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_60_AC3_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_60_L2_ISO;SONY.COM_PN=HD2_60_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_50_L2_T;SONY.COM_PN=HD2_50_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_60_L2_T;SONY.COM_PN=HD2_60_T,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_50_AC3_ISO;SONY.COM_PN=AVC_TS_HD_50_AC3_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_50_AC3;SONY.COM_PN=AVC_TS_HD_50_AC3,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_60_AC3_ISO;SONY.COM_PN=AVC_TS_HD_60_AC3_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_60_AC3;SONY.COM_PN=AVC_TS_HD_60_AC3,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_50_AC3_T;SONY.COM_PN=AVC_TS_HD_50_AC3_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_60_AC3_T;SONY.COM_PN=AVC_TS_HD_60_AC3_T,http-get:*:video/x-mp2t-mphl-188:*,http-get:*:*:*,http-get:*:video/*:*,http-get:*:audio/*:*,http-get:*:image/*:*</Source><Sink></Sink></u:GetProtocolInfoResponse>";
-	static final String RESULT_HEADER = "<Result>";
-	static final String RESULT_FOOTER = "</Result>";
-	static final String DIDL_HEADER = "&lt;DIDL-Lite xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\"&gt;";
-	static final String DIDL_FOOTER = "&lt;/DIDL-Lite&gt;";
-	static final String XBOX_360_1 = "<u:IsValidatedResponse xmlns:u=\"urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1\">" + CRLF + "<Result>1</Result>" + CRLF + "</u:IsValidatedResponse>";
-	static final String XBOX_360_2 = "<u:IsAuthorizedResponse xmlns:u=\"urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1\">" + CRLF + "<Result>1</Result>" + CRLF + "</u:IsAuthorizedResponse>";
-	static final String SAMSUNG_ERROR_RESPONSE = "<s:Fault><faultCode>s:Client</faultCode><faultString>UPnPError</faultString><detail><UPnPError xmlns=\"urn:schemas-upnp-org:control-1-0\"><errorCode>401</errorCode><errorDescription>Invalid Action</errorDescription></UPnPError></detail></s:Fault>";
-	static final String EVENT_FOOTER = "</e:propertyset>";
+	public static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"utf-8\"?>";
+	public static final String SOAP_ENCODING_HEADER = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">" + CRLF + "<s:Body>";
+	public static final String SOAP_ENCODING_FOOTER = "</s:Body>" + CRLF + "</s:Envelope>";
+	public static final String GETSYSTEMUPDATEID_HEADER = "<u:GetSystemUpdateIDResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\">";
+	public static final String GETSYSTEMUPDATEID_FOOTER = "</u:GetSystemUpdateIDResponse>";
+	public static final String BROWSERESPONSE_HEADER = "<u:BrowseResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\">";
+	public static final String BROWSERESPONSE_FOOTER = "</u:BrowseResponse>";
+	public static final String SEARCHRESPONSE_HEADER = "<u:SearchResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\">";
+	public static final String SEARCHRESPONSE_FOOTER = "</u:SearchResponse>";
+	public static final String SORTCAPS_RESPONSE = "<u:GetSortCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SortCaps></SortCaps></u:GetSortCapabilitiesResponse>";
+	public static final String SEARCHCAPS_RESPONSE = "<u:GetSearchCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SearchCaps></SearchCaps></u:GetSearchCapabilitiesResponse>";
+	public static final String PROTOCOLINFO_RESPONSE = "<u:GetProtocolInfoResponse xmlns:u=\"urn:schemas-upnp-org:service:ConnectionManager:1\"><Source>http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_SM,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_MED,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_LRG,http-get:*:audio/mpeg:DLNA.ORG_PN=MP3,http-get:*:audio/L16:DLNA.ORG_PN=LPCM,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_24_AC3_ISO;SONY.COM_PN=AVC_TS_HD_24_AC3_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_24_AC3;SONY.COM_PN=AVC_TS_HD_24_AC3,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_24_AC3_T;SONY.COM_PN=AVC_TS_HD_24_AC3_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_PS_PAL,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_PS_NTSC,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_50_L2_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_60_L2_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_EU_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_50_AC3_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_50_L2_ISO;SONY.COM_PN=HD2_50_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_60_AC3_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_60_L2_ISO;SONY.COM_PN=HD2_60_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_50_L2_T;SONY.COM_PN=HD2_50_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_60_L2_T;SONY.COM_PN=HD2_60_T,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_50_AC3_ISO;SONY.COM_PN=AVC_TS_HD_50_AC3_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_50_AC3;SONY.COM_PN=AVC_TS_HD_50_AC3,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_60_AC3_ISO;SONY.COM_PN=AVC_TS_HD_60_AC3_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_60_AC3;SONY.COM_PN=AVC_TS_HD_60_AC3,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_50_AC3_T;SONY.COM_PN=AVC_TS_HD_50_AC3_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_60_AC3_T;SONY.COM_PN=AVC_TS_HD_60_AC3_T,http-get:*:video/x-mp2t-mphl-188:*,http-get:*:*:*,http-get:*:video/*:*,http-get:*:audio/*:*,http-get:*:image/*:*</Source><Sink></Sink></u:GetProtocolInfoResponse>";
+	public static final String RESULT_HEADER = "<Result>";
+	public static final String RESULT_FOOTER = "</Result>";
+	public static final String DIDL_HEADER = "&lt;DIDL-Lite xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\"&gt;";
+	public static final String DIDL_FOOTER = "&lt;/DIDL-Lite&gt;";
+	public static final String XBOX_360_1 = "<u:IsValidatedResponse xmlns:u=\"urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1\">" + CRLF + "<Result>1</Result>" + CRLF + "</u:IsValidatedResponse>";
+	public static final String XBOX_360_2 = "<u:IsAuthorizedResponse xmlns:u=\"urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1\">" + CRLF + "<Result>1</Result>" + CRLF + "</u:IsAuthorizedResponse>";
+	public static final String SAMSUNG_ERROR_RESPONSE = "<s:Fault><faultCode>s:Client</faultCode><faultString>UPnPError</faultString><detail><UPnPError xmlns=\"urn:schemas-upnp-org:control-1-0\"><errorCode>401</errorCode><errorDescription>Invalid Action</errorDescription></UPnPError></detail></s:Fault>";
+	public static final String EVENT_FOOTER = "</e:propertyset>";
 
 	public static String eventProp(String prop) {
 		return eventProp(prop, "");

--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -367,8 +367,7 @@ public class UPNPControl {
 	}
 
 	public static boolean isUpnpControllable(String uuid) {
-		// Disable manually for Panasonic TVs since they lie
-		if (rendererMap.containsKey(uuid) && !getDeviceDetailsString(getDevice(uuid)).contains("VIERA")) {
+		if (rendererMap.containsKey(uuid)) {
 			return rendererMap.get(uuid, "0").controls != 0;
 		}
 		return false;

--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -20,6 +20,7 @@ import org.fourthline.cling.controlpoint.SubscriptionCallback;
 import org.fourthline.cling.model.ServerClientTokens;
 import org.fourthline.cling.model.action.*;
 import org.fourthline.cling.model.gena.*;
+import org.fourthline.cling.model.message.control.ActionRequestMessage;
 import org.fourthline.cling.model.message.UpnpHeaders;
 import org.fourthline.cling.model.message.UpnpResponse;
 import org.fourthline.cling.model.message.header.DeviceTypeHeader;
@@ -29,9 +30,12 @@ import org.fourthline.cling.model.types.DeviceType;
 import org.fourthline.cling.model.types.ServiceId;
 import org.fourthline.cling.model.types.UDADeviceType;
 import org.fourthline.cling.model.types.UDN;
+import org.fourthline.cling.model.UnsupportedDataException;
 import org.fourthline.cling.registry.DefaultRegistryListener;
 import org.fourthline.cling.registry.Registry;
 import org.fourthline.cling.registry.RegistryListener;
+import org.fourthline.cling.transport.impl.SOAPActionProcessorImpl;
+import org.fourthline.cling.transport.spi.SOAPActionProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -60,7 +64,7 @@ public class UPNPControl {
 	public static final int RC = BasicPlayer.VOLUMECONTROL;
 	public static final int ANY = 0xff;
 
-	private static final boolean DEBUG = true; // log upnp state vars
+	protected static boolean DEBUG = false; // log upnp state vars, avt soap data, etc
 
 	protected static Map<String, Renderer> socketMap = new HashMap<>();
 
@@ -194,10 +198,8 @@ public class UPNPControl {
 					String id = data.get("InstanceID");
 					while (active && !"STOPPED".equals(data.get("TransportState"))) {
 						UPNPHelper.sleep(1000);
-//						if (DEBUG) LOGGER.debug("InstanceID: " + id);
 						for (ActionArgumentValue o : getPositionInfo(d, id)) {
 							data.put(o.getArgument().getName(), o.toString());
-//							if (DEBUG) LOGGER.debug(o.getArgument().getName() + ": " + o.toString());
 						}
 						alert();
 					}
@@ -243,7 +245,6 @@ public class UPNPControl {
 			for (int i = 0; i < ids.getLength(); i++) {
 				NodeList c = ids.item(i).getChildNodes();
 				String id = ((Element) ids.item(i)).getAttribute("val");
-//				if (DEBUG) LOGGER.debug("InstanceID: " + id);
 				if (item == null) {
 					item = rendererMap.get(uuid, id);
 				}
@@ -283,6 +284,19 @@ public class UPNPControl {
 				@Override
 				public UpnpHeaders getDescriptorRetrievalHeaders(RemoteDeviceIdentity identity) {
 					return UMSHeaders;
+				}
+
+				@Override
+				protected SOAPActionProcessor createSOAPActionProcessor() {
+					return new SOAPActionProcessorImpl() {
+						@Override
+						public void writeBody(ActionRequestMessage requestMessage, ActionInvocation actionInvocation) throws UnsupportedDataException {
+							super.writeBody(requestMessage, actionInvocation);
+							if (DEBUG) {
+								LOGGER.trace("Sending SOAP action: {}", requestMessage.getBodyString().replaceAll("><", ">\n<"));
+							}
+						}
+					};
 				}
 			};
 
@@ -657,7 +671,7 @@ public class UPNPControl {
 		if (svc != null) {
 			Action x = svc.getAction(action);
 			String name = getFriendlyName(dev);
-			boolean log = !action.equals("GetPositionInfo");
+			boolean log = DEBUG || !action.equals("GetPositionInfo");
 			if (x != null) {
 				ActionInvocation a = new ActionInvocation(x);
 				a.setInput("InstanceID", instanceID);

--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionListener;
 import java.io.ByteArrayInputStream;
 import java.net.InetAddress;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.*;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -782,8 +783,21 @@ public class UPNPControl {
 	}
 
 	public static void setAVTransportURI(Device dev, String instanceID, String uri, String metaData) {
+		// Ensure uri is not url-encoded
+		uri = URLDecoder.decode(uri);
+		if (metaData != null) {
+			// Ensure metadata is plain xml and didl uri is not url-encoded
+			metaData = URLDecoder.decode(StringUtil.unEncodeXML(metaData));
+			// Ensure uri is same as didl uri
+			// Note: this assumes the first <res> item is guaranteed to be the media resource
+			String didlUri = StringUtils.substringAfterLast(StringUtils.substringBefore(metaData, "</res>"), ">");
+			if (StringUtils.isNotBlank(didlUri) && ! uri.equals(didlUri)) {
+				LOGGER.trace("using didl uri '{}' instead of '{}'", didlUri, uri);
+				uri = didlUri;
+			}
+		}
 		send(dev, instanceID, "AVTransport", "SetAVTransportURI", "CurrentURI", uri,
-			"CurrentURIMetaData", metaData != null ? StringUtil.unEncodeXML(metaData) : null);
+			"CurrentURIMetaData", metaData);
 	}
 
 	public static void setPlayMode(Device dev, String instanceID, String mode) {

--- a/src/main/java/net/pms/network/UPNPHelper.java
+++ b/src/main/java/net/pms/network/UPNPHelper.java
@@ -723,7 +723,7 @@ public class UPNPHelper extends UPNPControl {
 		if (d1 != null) {
 			Device dev = getDevice(r.getUUID());
 			String id = r.getInstanceID();
-			setAVTransportURI(dev, id, d1.getURL(""), r.isPushMetadata() ? d1.getDidlString(r) : null);
+			setAVTransportURI(dev, id, d1.getURL(""), r.isPushMetadata() ? d1.getDidlString(r, true) : null);
 			play(dev, id);
 		}
 	}

--- a/src/main/java/net/pms/network/UPNPHelper.java
+++ b/src/main/java/net/pms/network/UPNPHelper.java
@@ -87,6 +87,7 @@ public class UPNPHelper extends UPNPControl {
 	 */
 	private UPNPHelper() {
 		rendererMap = new DeviceMap<>(DeviceConfiguration.class);
+		DEBUG = configuration.isUpnpDebug();
 	}
 
 	public static UPNPHelper getInstance() {

--- a/src/main/java/net/pms/newgui/RendererPanel.java
+++ b/src/main/java/net/pms/newgui/RendererPanel.java
@@ -9,6 +9,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
+import net.pms.util.BasicPlayer;
 import java.util.List;
 import java.util.Map;
 import javax.swing.*;
@@ -61,13 +62,14 @@ public class RendererPanel extends JPanel {
 				builder, y);
 		}
 
-		if (renderer.isControllable()) {
+		BasicPlayer player = renderer.getPlayer();
+		if (player instanceof BasicPlayer.Logical) {
 			builder.appendRow(rspec);
 			builder.addLabel(" ", cc.xy(1, ++y));
 			builder.appendRow(rspec);
 			builder.addSeparator(Messages.getString("RendererPanel.1"), cc.xyw(1, ++y, 2));
 			builder.appendRow(rspec);
-			builder.add(new PlayerControlPanel(renderer.getPlayer()), cc.xyw(1, ++y, 2));
+			builder.add(new PlayerControlPanel(player), cc.xyw(1, ++y, 2));
 		}
 		return builder.getPanel();
 	}

--- a/src/main/java/net/pms/util/BasicPlayer.java
+++ b/src/main/java/net/pms/util/BasicPlayer.java
@@ -265,7 +265,7 @@ public interface BasicPlayer extends ActionListener {
 					// Note: here metadata (if any) is actually the resource name
 					DLNAResource d = DLNAResource.getValidResource(uri, metadata, renderer);
 					if (d != null) {
-						return new Playlist.Item(d.getURL("", true), d.getDisplayName(), d.getDidlString(renderer));
+						return new Playlist.Item(d.getURL("", true), d.getDisplayName(), d.getDidlString(renderer, true));
 					}
 				}
 			}


### PR DESCRIPTION
Parking this here in case @UniversalMediaServer/developers or others with Vieras want to jump in :-). The story so far:
- Contrary to previous reports the Viera's AVT service appears to work with UMS, at least over ethernet, as shown by @Sami32's results with the patches in #880 using `PushMetadata=false`.
- With `PushMetadata=true` he gets mixed results, possibly due to unrelated issues from running on XP. It would be good to pin this down by testing on newer Windows or other platforms.
- Per @valib's experiences  lack of UMS AVT functionality probably has to do with network topology rather than the Viera itself, so I've disabled @SubJunk's hard-coded Viera hack in 296a941, and substituted a generally equivalent renderer setting:

``` sh
ForcePlaybackTimer = true
```
- To enable extra upnp debug logging, add this to `UMS.conf`:

``` sh
upnp_debug = true
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/899)

<!-- Reviewable:end -->
