### PR TITLE
WAV and BMP MIME types support

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1403,7 +1403,7 @@ public class DLNAMediaInfo implements Cloneable {
 					mimeType = HTTPResource.AVI_TYPEMIME;
 					break;
 				case "wav":
-                			mimeType = HTTPResource.WAV_TYPEMIME;
+                			mimeType = HTTPResource.AUDIO_WAV_TYPEMIME;
                 			break;
 				case "asf":
 				case "wmv":

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -910,6 +910,8 @@ public class DLNAMediaInfo implements Cloneable {
 						codecV = "gif";
 					} else if (formatName.startsWith("TIF")) {
 						codecV = "tiff";
+					} else if (formatName.startsWith("BMP")) {
+						codecV = "bmp";
 					}
 
 					container = codecV;
@@ -1400,6 +1402,9 @@ public class DLNAMediaInfo implements Cloneable {
 				case "avi":
 					mimeType = HTTPResource.AVI_TYPEMIME;
 					break;
+				case "wav":
+                			mimeType = HTTPResource.WAV_TYPEMIME;
+                			break;
 				case "asf":
 				case "wmv":
 					mimeType = HTTPResource.WMV_TYPEMIME;
@@ -1430,6 +1435,8 @@ public class DLNAMediaInfo implements Cloneable {
 					mimeType = HTTPResource.GIF_TYPEMIME;
 				} else if ("tiff".equals(codecV) || "tiff".equals(container)) {
 					mimeType = HTTPResource.TIFF_TYPEMIME;
+				} else if ("bmp".equals(codecV) || "bmp".equals(container)) {
+					mimeType = HTTPResource.BMP_TYPEMIME;
 				} else if (codecV.startsWith("h264") || codecV.equals("h263") || codecV.toLowerCase().equals("mpeg4") || codecV.toLowerCase().equals("mp4")) {
 					mimeType = HTTPResource.MP4_TYPEMIME;
 				} else if (codecV.contains("mpeg") || codecV.contains("mpg")) {
@@ -1446,8 +1453,6 @@ public class DLNAMediaInfo implements Cloneable {
 					mimeType = HTTPResource.AUDIO_OGG_TYPEMIME;
 				} else if (codecA.contains("asf") || codecA.startsWith("wm")) {
 					mimeType = HTTPResource.AUDIO_WMA_TYPEMIME;
-				} else if (codecA.contains("pcm") || codecA.contains("wav")) {
-					mimeType = HTTPResource.AUDIO_WAV_TYPEMIME;
 				}
 			}
 


### PR DESCRIPTION
Fix some missing that was giving incorrect parsing MIME type, WAV and BMP, in the LOG.

**EDIT** : and correct my mistake as well ;)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/916)
<!-- Reviewable:end -->
