### PR TITLE
Fixed Panasonic TV UPnP detection (#918)

### DIFF
--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -9,6 +9,7 @@ import java.util.*;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import net.pms.PMS;
+import static net.pms.network.UPNPHelper.sleep;
 import net.pms.util.BasicPlayer;
 import net.pms.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
@@ -273,7 +274,6 @@ public class UPNPControl {
 	}
 
 	public void init() {
-
 		try {
 			db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 			UMSHeaders = new UpnpHeaders();
@@ -321,16 +321,56 @@ public class UPNPControl {
 			};
 
 			upnpService = new UpnpServiceImpl(sc, rl);
-
-			// find all media renderers on the network
-			for (DeviceType t : mediaRendererTypes) {
-				upnpService.getControlPoint().search(new DeviceTypeHeader(t));
-			}
+			search();
 
 			LOGGER.debug("UPNP Services are online, listening for media renderers");
 		} catch (Exception ex) {
 			LOGGER.debug("UPNP startup Error", ex);
 		}
+	}
+
+	private static int search_delay = 10000;
+	private static Thread searchThread;
+
+	/**
+	 * Find all media renderers on the network
+	 */
+	public void search() {
+		Runnable rSearch = new Runnable() {
+			@Override
+			public void run() {
+				while (true) {
+					sleep(search_delay);
+					for (DeviceType t : mediaRendererTypes) {
+						upnpService.getControlPoint().search(new DeviceTypeHeader(t));
+					}
+					LOGGER.trace("Searching for renderers with Cling...");
+
+					/**
+					 * The first delay for sending a search message is 10 seconds,
+					 * the second delay is for 20 seconds. From then on, all other
+					 * delays are 30 seconds.
+					 */
+					switch (search_delay) {
+						case 10000:
+							search_delay = 20000;
+							break;
+						case 20000:
+							if (PMS.get().getFoundRenderers().size() > 0) {
+								search_delay = 30000;
+							} else {
+								search_delay = 10000;
+							}
+							break;
+						default:
+							break;
+					}
+				}
+			}
+		};
+
+		searchThread = new Thread(rSearch, "UPNP-Search");
+		searchThread.start();
 	}
 
 	public void shutdown() {
@@ -340,6 +380,9 @@ public class UPNPControl {
 				if (upnpService != null) {
 					LOGGER.debug("Stopping UPNP Services...");
 					upnpService.shutdown();
+				}
+				if (searchThread != null) {
+					searchThread.interrupt();
 				}
 			}
 		}).start();

--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -340,11 +340,11 @@ public class UPNPControl {
 			@Override
 			public void run() {
 				while (true) {
-					sleep(search_delay);
 					for (DeviceType t : mediaRendererTypes) {
 						upnpService.getControlPoint().search(new DeviceTypeHeader(t));
 					}
 					LOGGER.trace("Searching for renderers with Cling...");
+					sleep(search_delay);
 
 					/**
 					 * The first delay for sending a search message is 10 seconds,

--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -194,7 +194,7 @@ public class UPNPControl {
 				public void run() {
 					String id = data.get("InstanceID");
 					while (active && !"STOPPED".equals(data.get("TransportState"))) {
-						UPNPHelper.sleep(1000);
+						sleep(1000);
 //						if (DEBUG) LOGGER.debug("InstanceID: " + id);
 						for (ActionArgumentValue o : getPositionInfo(d, id)) {
 							data.put(o.getArgument().getName(), o.toString());
@@ -202,7 +202,7 @@ public class UPNPControl {
 						}
 						alert();
 					}
-					if (! active) {
+					if (!active) {
 						data.put("TransportState", "STOPPED");
 						alert();
 					}
@@ -321,7 +321,7 @@ public class UPNPControl {
 			};
 
 			upnpService = new UpnpServiceImpl(sc, rl);
-			search();
+			initializeSearcher();
 
 			LOGGER.debug("UPNP Services are online, listening for media renderers");
 		} catch (Exception ex) {
@@ -333,9 +333,9 @@ public class UPNPControl {
 	private static Thread searchThread;
 
 	/**
-	 * Find all media renderers on the network
+	 * Runs a Cling search every 10/20/30 seconds to discover new renderers.
 	 */
-	public void search() {
+	public void initializeSearcher() {
 		Runnable rSearch = new Runnable() {
 			@Override
 			public void run() {

--- a/src/main/java/net/pms/network/UPNPHelper.java
+++ b/src/main/java/net/pms/network/UPNPHelper.java
@@ -369,8 +369,8 @@ public class UPNPHelper extends UPNPControl {
 					/**
 					 * The first delay for sending an ALIVE message is 10 seconds,
 					 * the second delay is for 20 seconds. From then on, all other
-					 * delays are standard for 180 seconds. It can be customized
-					 * with the ALIVE_delay user configuration setting.
+					 * delays are 30 seconds. It can be customized with the
+					 * ALIVE_delay user configuration setting.
 					 */
 					switch (ALIVE_delay) {
 						case 10000:


### PR DESCRIPTION
Basically we were only doing this on startup which is why Panasonic TVs would only be properly identified on startup.

Not sure if this may cause other consequences ( @skeptical ?) but I did brief testing and found it causes my TV to be detected correctly at all times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/920)
<!-- Reviewable:end -->
