### PR TITLE
DLNA standard

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2292,7 +2292,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 *            Media Renderer for which to represent this information. Useful
 	 *            for some hacks.
 	 * @return String representing the item. An example would start like this:
-	 *         {@code <container id="0$1" childCount="1" parentID="0" restricted="true">}
+	 *         {@code <container id="0$1" childCount="1" parentID="0" restricted="1">}
 	 */
 	public final String getDidlString(RendererConfiguration mediaRenderer) {
 		// Use device-specific pms conf, if any
@@ -2349,7 +2349,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		}
 
 		addAttribute(sb, "parentID", id);
-		addAttribute(sb, "restricted", "true");
+		addAttribute(sb, "restricted", "1");
 		endTag(sb);
 		StringBuilder wireshark = new StringBuilder();
 		final DLNAMediaAudio firstAudioTrack = media != null ? media.getFirstAudioTrack() : null;


### PR DESCRIPTION
## cf. _upnp-av-contentdirectory-v3-service.pdf_
**For UPnP Device Architecture defined boolean data types**, it is **strongly RECOMMENDED to use the value “0” for false, and the value “1” for true**. However, when used as input arguments, the values “false”, “no”, “true”, “yes” may also be encountered and MUST be accepted. Nevertheless, it is strongly RECOMMENDED that all boolean state variables and output arguments be represented as “0” and “1”. 
**For XML Schema defined Boolean data types**, it is **strongly RECOMMENDED to use the value “0” for false, and the value “1” for true**. However, when used as input properties, the values “false”, “true” may also be encountered and MUST be accepted. Nevertheless, it is strongly RECOMMENDED that all Boolean properties be represented as “0” and “1”.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/936)
<!-- Reviewable:end -->
