### PR TITLE
BMP add to WebRender

### DIFF
--- a/src/main/java/net/pms/configuration/WebRender.java
+++ b/src/main/java/net/pms/configuration/WebRender.java
@@ -66,6 +66,7 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 	private static final Format[] supportedFormats = {
 		new GIF(),
 		new JPG(),
+		new BMP(),
 		new MP3(),
 		new PNG()
 	};
@@ -112,6 +113,7 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 //		configuration.addProperty(SUPPORTED, "f:wav n:2 m:audio/wav");
 		configuration.addProperty(SUPPORTED, "f:jpg m:image/jpeg");
 		configuration.addProperty(SUPPORTED, "f:png m:image/png");
+		configuration.addProperty(SUPPORTED, "f:bmp m:image/bmp");
 		configuration.addProperty(SUPPORTED, "f:gif m:image/gif");
 		configuration.addProperty(SUPPORTED, "f:tiff m:image/tiff");
 		configuration.addProperty(TRANSCODE_AUDIO, MP3);


### PR DESCRIPTION
I tried only with Firefox and Opera.

For people wanting TIFF support they can add it, but they will need, except for lucky Safari's users,  to add something like that
http://www.alternatiff.com/
https://chrome.google.com/webstore/detail/docs-pdfpowerpoint-viewer/nnbmlagghjjcbdhgmkedmbmedengocbn?hl=en

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/940)
<!-- Reviewable:end -->
