### PR TITLE
Update LG-WebOS.conf

### DIFF
--- a/src/main/external-resources/renderers/LG-WebOS.conf
+++ b/src/main/external-resources/renderers/LG-WebOS.conf
@@ -13,7 +13,7 @@ RendererIcon = lg-lb6500.png
 # ============================================================================
 #
 
-UserAgentSearch = LGE WebOS TV
+UserAgentSearch = WebOS TV
 LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AAC


### PR DESCRIPTION
If i believe this log https://gist.github.com/porst17/ad84e0061795bb5b71de coming from #738
DEBUG 2015-11-23 11:47:57.264 [cling-14] New renderer found: "[LG] webOS TV" with dlna details: {friendlyName=[LG] webOS TV, address=192.168.178.34, udn=uuid:6b0c000b-135c-5900-e48e-3f397708c652, manufacturer=LG Electronics., modelName=LG TV, modelNumber=1.0, modelDescription=LG WebOSTV DMRplus, manufacturerURL=http://www.lge.com, modelURL=}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/951)
<!-- Reviewable:end -->
