### PR TITLE
Add Mimetype for WAV DTS files

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1441,7 +1441,7 @@ public class DLNAMediaInfo implements Cloneable {
 					mimeType = HTTPResource.AUDIO_OGG_TYPEMIME;
 				} else if (codecA.contains("asf") || codecA.startsWith("wm")) {
 					mimeType = HTTPResource.AUDIO_WMA_TYPEMIME;
-				} else if (codecA.contains("pcm") || codecA.contains("wav")) {
+				} else if (codecA.contains("pcm") || codecA.contains("wav") || codecA.contains("dts")) {
 					mimeType = HTTPResource.AUDIO_WAV_TYPEMIME;
 				}
 			}


### PR DESCRIPTION
> Parsing results for file "SURROUNDTEST_DTS-6ch**.wav**": container: wav, bitrate: 1411204, size: 22347820, audio tracks: 1, video codec: und, duration: 00:02:06.00, width: 0, height: 0, frame rate: null, **mime type: audio/mpeg** Audio track id: 0, lang: und, **audio codec: DTS**, sample frequency:44100, number of channels: 6, bits per sample: 24

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/957)
<!-- Reviewable:end -->
