### PR TITLE
LG-UFxxxV renderer configuration

### DIFF
--- a/src/main/external-resources/renderers/LG-UFxxxV.conf
+++ b/src/main/external-resources/renderers/LG-UFxxxV.conf
@@ -1,0 +1,64 @@
+#----------------------------------------------------------------------------
+# Profile for LG TVs.
+# See DefaultRenderer.conf for descriptions of all the available options.
+#
+
+RendererName = LG xxUFxxxV
+RendererIcon = lg-lb6500.png
+
+# ============================================================================
+# This renderer has sent the following string/s:
+#
+# User-Agent: Linux/3.10.23-p.21.biscayne.lm15u... UPnP/1.0 LGE WebOS TV LGE_DLNA_SDK/1.6.0/04...... DLNADOC/1.50 
+# friendlyName=Living room 65UF850V
+# uuid:b92fa3c7-03d3-40b5-84ef-1372d5fed6e7
+# manufacturer=LG Electronics.
+# modelName=LG TV
+# modelNumber=1.0
+# modelDescription=
+# manufacturerURL : http://www.lge.com
+# ============================================================================
+#
+
+UserAgentSearch = \d{2}UF\d{3}V
+UpnpDetailsSearch = \d{2}UF\d{3}V
+LoadingPriority = 2
+
+TranscodeVideo = MPEGTS-H264-AC3
+TranscodeAudio = WAV
+#H264Level41Limited = false
+TranscodedVideoFileSize = -1
+MaxVideoWidth = 3840
+MaxVideoHeight = 2160
+AutoExifRotate = true
+MediaInfo = true
+
+# Supported video formats: H263 could be add depending of the TV model used
+Supported = f:3gp|3g2  v:h264|mp4                                     a:aac|aac-he                            m:video/3gpp
+Supported = f:avi|divx v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp8|xvid a:aac|aac-he|ac3|adpcm|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-divx
+Supported = f:mkv      v:divx|h264|h265|mp4|mpeg1|mpeg2|vc1|vp8|xvid  a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-matroska
+Supported = f:mov      v:h264|mp4|mpeg1|mpeg2|vc1                     a:aac|ac3|dts|mpa|mp3|wma               m:video/quicktime
+Supported = f:mp4|m4v  v:h264|h265|mp4                                a:aac|aac-he|ac3|dts|eac3|lpcm|mp3      m:video/mp4
+Supported = f:mpegps   v:mpeg1|mpeg2                                  a:aac|aac-he|ac3|mp3|mpa                m:video/mpeg
+Supported = f:mpegts   v:h264|h265|mpeg2                              a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa  m:video/mpeg
+#Supported = f:webm     v:vp8|vp9                                      a:vorbis                                m:video/webm
+Supported = f:wmv      v:wmv|vc1|asf                                  a:wma                                   m:video/x-ms-wmv
+
+# Supported audio formats:
+Supported = f:aac|m4a        m:audio/x-m4a
+Supported = f:cook|ralf      m:audio/vnd.rn-realaudio
+#Supported = f:flac           m:audio/flac
+Supported = f:mp3            m:audio/mpeg
+Supported = f:ogg            m:image/x-ogg
+Supported = f:wav            m:audio/x-wav
+Supported = f:wma            m:audio/x-ms-wma
+
+# Supported image formats:
+Supported = f:bmp       m:image/bmp
+#Supported = f:gif       m:image/gif
+Supported = f:jpg       m:image/jpeg
+Supported = f:png       m:image/png
+
+# Supported subtitles formats:
+#SupportedExternalSubtitlesFormats = SUBRIP,TEXT,MICRODVD,ASS,SAMI
+#SupportedInternalSubtitlesFormats = DIVX

--- a/src/main/external-resources/renderers/LG-WebOS4K.conf
+++ b/src/main/external-resources/renderers/LG-WebOS4K.conf
@@ -32,11 +32,11 @@ MaxVideoHeight = 2160
 AutoExifRotate = true
 MediaInfo = true
 
-# Supported video formats:
+# Supported video formats: H263 and VP9 could be add if necessary
 Supported = f:3gp|3g2  v:h264|mp4                                     a:aac|aac-he                            m:video/3gpp
 Supported = f:avi|divx v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp8|xvid a:aac|aac-he|ac3|adpcm|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-divx
 Supported = f:mkv      v:divx|h264|h265|mp4|mpeg1|mpeg2|vc1|vp8|xvid  a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-matroska
-Supported = f:mov      v:h264|mp4|mpeg1|mpeg2|vc1                     a:aac|ac3|dts|mpa|mp3|wma                m:video/quicktime
+Supported = f:mov      v:h264|mp4|mpeg1|mpeg2|vc1                     a:aac|ac3|dts|mpa|mp3|wma               m:video/quicktime
 Supported = f:mp4|m4v  v:h264|h265|mp4                                a:aac|aac-he|ac3|dts|eac3|lpcm|mp3      m:video/mp4
 Supported = f:mpegps   v:mpeg1|mpeg2                                  a:aac|aac-he|ac3|mp3|mpa                m:video/mpeg
 Supported = f:mpegts   v:h264|h265|mpeg2                              a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa  m:video/mpeg
@@ -45,6 +45,8 @@ Supported = f:wmv      v:wmv|vc1|asf                                  a:wma     
 
 # Supported audio formats:
 Supported = f:aac|m4a        m:audio/x-m4a
+#Supported = f:cook|ralf      m:audio/vnd.rn-realaudio
+#Supported = f:flac           m:audio/flac
 Supported = f:mp3            m:audio/mpeg
 Supported = f:ogg            m:image/x-ogg
 Supported = f:wav            m:audio/x-wav

--- a/src/main/external-resources/renderers/LG-WebOS4K.conf
+++ b/src/main/external-resources/renderers/LG-WebOS4K.conf
@@ -21,7 +21,7 @@ RendererIcon = lg-lb6500.png
 #
 
 UserAgentSearch = lgtv
-LoadingPriority = 1
+LoadingPriority = 2
 
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3

--- a/src/main/external-resources/renderers/LG-WebOS4K.conf
+++ b/src/main/external-resources/renderers/LG-WebOS4K.conf
@@ -1,0 +1,61 @@
+#----------------------------------------------------------------------------
+# Profile for LG WebOS TVs.
+# See DefaultRenderer.conf for descriptions of all the available options.
+#
+
+RendererName = LG WebOS TV 4K
+RendererIcon = lg-lb6500.png
+
+# ============================================================================
+# This renderer has sent the following string/s:
+#
+# User-Agent: Linux/3.10.............. UPnP/1.0 LGE WebOS TV LGE_DLNA_SDK/1.6.0/04...... DLNADOC/1.50 
+# friendlyName=lgtv
+# uuid:ae6c4d60-a44f-45fa-a651-10377728a487
+# manufacturer=LG Electronics.
+# modelName=LG TV
+# modelNumber=1.0
+# modelDescription=LG WebOSTV DMRplus
+# manufacturerURL : http://www.lge.com
+# ============================================================================
+#
+
+UserAgentSearch = lgtv
+LoadingPriority = 1
+
+TranscodeVideo = MPEGTS-H264-AC3
+TranscodeAudio = MP3
+#H264Level41Limited = false
+TranscodedVideoFileSize = -1
+MaxVideoWidth = 3840
+MaxVideoHeight = 2160
+AutoExifRotate = true
+MediaInfo = true
+
+# Supported video formats:
+Supported = f:3gp|3g2  v:h264|mp4                                     a:aac|aac-he                            m:video/3gpp
+Supported = f:avi|divx v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp8|xvid a:aac|aac-he|ac3|adpcm|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-divx
+Supported = f:mkv      v:divx|h264|h265|mp4|mpeg1|mpeg2|vc1|vp8|xvid  a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-matroska
+Supported = f:mov      v:h264|mp4|mpeg1|mpeg2|vc1                     a:aac|ac3|dts|mpa|mp3|wma                m:video/quicktime
+Supported = f:mp4|m4v  v:h264|h265|mp4                                a:aac|aac-he|ac3|dts|eac3|lpcm|mp3      m:video/mp4
+Supported = f:mpegps   v:mpeg1|mpeg2                                  a:aac|aac-he|ac3|mp3|mpa                m:video/mpeg
+Supported = f:mpegts   v:h264|h265|mpeg2                              a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa  m:video/mpeg
+Supported = f:webm     v:vp8                                          a:vorbis                                m:video/webm
+Supported = f:wmv      v:wmv|vc1|asf                                  a:wma                                   m:video/x-ms-wmv
+
+# Supported audio formats:
+Supported = f:aac|m4a        m:audio/x-m4a
+Supported = f:mp3            m:audio/mpeg
+Supported = f:ogg            m:image/x-ogg
+Supported = f:wav            m:audio/x-wav
+Supported = f:wma            m:audio/x-ms-wma
+
+# Supported image formats:
+Supported = f:bmp       m:image/bmp
+Supported = f:gif       m:image/gif
+Supported = f:jpg       m:image/jpeg
+Supported = f:png       m:image/png
+
+# Supported subtitles formats:
+SupportedExternalSubtitlesFormats = SUBRIP,TEXT,MICRODVD,ASS,SAMI
+SupportedInternalSubtitlesFormats = DIVX

--- a/src/main/external-resources/renderers/LG-WebOS4K.conf
+++ b/src/main/external-resources/renderers/LG-WebOS4K.conf
@@ -32,7 +32,7 @@ MaxVideoHeight = 2160
 AutoExifRotate = true
 MediaInfo = true
 
-# Supported video formats: H263 and VP9 could be add depending of the TV model
+# Supported video formats: H263 could be add depending of the TV model used
 Supported = f:3gp|3g2  v:h264|mp4                                     a:aac|aac-he                            m:video/3gpp
 Supported = f:avi|divx v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp8|xvid a:aac|aac-he|ac3|adpcm|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-divx
 Supported = f:mkv      v:divx|h264|h265|mp4|mpeg1|mpeg2|vc1|vp8|xvid  a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-matroska
@@ -40,7 +40,7 @@ Supported = f:mov      v:h264|mp4|mpeg1|mpeg2|vc1                     a:aac|ac3|
 Supported = f:mp4|m4v  v:h264|h265|mp4                                a:aac|aac-he|ac3|dts|eac3|lpcm|mp3      m:video/mp4
 Supported = f:mpegps   v:mpeg1|mpeg2                                  a:aac|aac-he|ac3|mp3|mpa                m:video/mpeg
 Supported = f:mpegts   v:h264|h265|mpeg2                              a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa  m:video/mpeg
-#Supported = f:webm     v:vp8                                          a:vorbis                                m:video/webm
+#Supported = f:webm     v:vp8|vp9                                      a:vorbis                                m:video/webm
 Supported = f:wmv      v:wmv|vc1|asf                                  a:wma                                   m:video/x-ms-wmv
 
 # Supported audio formats:

--- a/src/main/external-resources/renderers/LG-WebOS4K.conf
+++ b/src/main/external-resources/renderers/LG-WebOS4K.conf
@@ -9,7 +9,7 @@ RendererIcon = lg-lb6500.png
 # ============================================================================
 # This renderer has sent the following string/s:
 #
-# User-Agent: Linux/3.10.............. UPnP/1.0 LGE WebOS TV LGE_DLNA_SDK/1.6.0/04...... DLNADOC/1.50 
+# User-Agent: Linux/3.10.23-p.21.biscayne.lm15u... UPnP/1.0 LGE WebOS TV LGE_DLNA_SDK/1.6.0/04...... DLNADOC/1.50 
 # friendlyName=lgtv
 # uuid:ae6c4d60-a44f-45fa-a651-10377728a487
 # manufacturer=LG Electronics.
@@ -21,7 +21,7 @@ RendererIcon = lg-lb6500.png
 #
 
 UserAgentSearch = lgtv
-LoadingPriority = 2
+LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3

--- a/src/main/external-resources/renderers/LG-WebOS4K.conf
+++ b/src/main/external-resources/renderers/LG-WebOS4K.conf
@@ -32,7 +32,7 @@ MaxVideoHeight = 2160
 AutoExifRotate = true
 MediaInfo = true
 
-# Supported video formats: H263 and VP9 could be add if necessary
+# Supported video formats: H263 and VP9 could be add depending of the TV model
 Supported = f:3gp|3g2  v:h264|mp4                                     a:aac|aac-he                            m:video/3gpp
 Supported = f:avi|divx v:divx|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp8|xvid a:aac|aac-he|ac3|adpcm|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-divx
 Supported = f:mkv      v:divx|h264|h265|mp4|mpeg1|mpeg2|vc1|vp8|xvid  a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa|wma  m:video/x-matroska
@@ -54,7 +54,7 @@ Supported = f:wma            m:audio/x-ms-wma
 
 # Supported image formats:
 Supported = f:bmp       m:image/bmp
-Supported = f:gif       m:image/gif
+#Supported = f:gif       m:image/gif
 Supported = f:jpg       m:image/jpeg
 Supported = f:png       m:image/png
 

--- a/src/main/external-resources/renderers/LG-WebOS4K.conf
+++ b/src/main/external-resources/renderers/LG-WebOS4K.conf
@@ -40,12 +40,12 @@ Supported = f:mov      v:h264|mp4|mpeg1|mpeg2|vc1                     a:aac|ac3|
 Supported = f:mp4|m4v  v:h264|h265|mp4                                a:aac|aac-he|ac3|dts|eac3|lpcm|mp3      m:video/mp4
 Supported = f:mpegps   v:mpeg1|mpeg2                                  a:aac|aac-he|ac3|mp3|mpa                m:video/mpeg
 Supported = f:mpegts   v:h264|h265|mpeg2                              a:aac|aac-he|ac3|dts|eac3|lpcm|mp3|mpa  m:video/mpeg
-Supported = f:webm     v:vp8                                          a:vorbis                                m:video/webm
+#Supported = f:webm     v:vp8                                          a:vorbis                                m:video/webm
 Supported = f:wmv      v:wmv|vc1|asf                                  a:wma                                   m:video/x-ms-wmv
 
 # Supported audio formats:
 Supported = f:aac|m4a        m:audio/x-m4a
-#Supported = f:cook|ralf      m:audio/vnd.rn-realaudio
+Supported = f:cook|ralf      m:audio/vnd.rn-realaudio
 #Supported = f:flac           m:audio/flac
 Supported = f:mp3            m:audio/mpeg
 Supported = f:ogg            m:image/x-ogg
@@ -59,5 +59,5 @@ Supported = f:jpg       m:image/jpeg
 Supported = f:png       m:image/png
 
 # Supported subtitles formats:
-SupportedExternalSubtitlesFormats = SUBRIP,TEXT,MICRODVD,ASS,SAMI
-SupportedInternalSubtitlesFormats = DIVX
+#SupportedExternalSubtitlesFormats = SUBRIP,TEXT,MICRODVD,ASS,SAMI
+#SupportedInternalSubtitlesFormats = DIVX

--- a/src/main/external-resourcesrenderersLG-WebOS4K.conf
+++ b/src/main/external-resourcesrenderersLG-WebOS4K.conf
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-# Profile for LG WebOS TVs.
+# Profile for LG TVs.
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 
@@ -22,7 +22,7 @@ RendererIcon = lg-lb6500.png
 
 UserAgentSearch = \d{2}UF\d{3}V
 UpnpDetailsSearch = \d{2}UF\d{3}V
-LoadingPriority = 1
+LoadingPriority = 2
 
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3

--- a/src/main/external-resourcesrenderersLG-WebOS4K.conf
+++ b/src/main/external-resourcesrenderersLG-WebOS4K.conf
@@ -25,7 +25,7 @@ UpnpDetailsSearch = \d{2}UF\d{3}V
 LoadingPriority = 2
 
 TranscodeVideo = MPEGTS-H264-AC3
-TranscodeAudio = MP3
+TranscodeAudio = WAV
 #H264Level41Limited = false
 TranscodedVideoFileSize = -1
 MaxVideoWidth = 3840

--- a/src/main/external-resourcesrenderersLG-WebOS4K.conf
+++ b/src/main/external-resourcesrenderersLG-WebOS4K.conf
@@ -3,24 +3,25 @@
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 
-RendererName = LG WebOS TV 4K
+RendererName = LG UF 4K
 RendererIcon = lg-lb6500.png
 
 # ============================================================================
 # This renderer has sent the following string/s:
 #
 # User-Agent: Linux/3.10.23-p.21.biscayne.lm15u... UPnP/1.0 LGE WebOS TV LGE_DLNA_SDK/1.6.0/04...... DLNADOC/1.50 
-# friendlyName=lgtv
-# uuid:ae6c4d60-a44f-45fa-a651-10377728a487
+# friendlyName=Living room 65UF850V
+# uuid:b92fa3c7-03d3-40b5-84ef-1372d5fed6e7
 # manufacturer=LG Electronics.
 # modelName=LG TV
 # modelNumber=1.0
-# modelDescription=LG WebOSTV DMRplus
+# modelDescription=
 # manufacturerURL : http://www.lge.com
 # ============================================================================
 #
 
-UserAgentSearch = lgtv
+UserAgentSearch = \d{2}UF\d{3}V
+UpnpDetailsSearch = \d{2}UF\d{3}V
 LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AC3

--- a/src/main/external-resourcesrenderersLG-WebOS4K.conf
+++ b/src/main/external-resourcesrenderersLG-WebOS4K.conf
@@ -3,7 +3,7 @@
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 
-RendererName = LG UF 4K
+RendererName = LG xxUFxxxV
 RendererIcon = lg-lb6500.png
 
 # ============================================================================


### PR DESCRIPTION
New renderer conf, stricly theorical because i don't have any LG for test it.
Because i saw #738 and other threads in the forum.

EDIT: i have done it using LG 65UF850V datas as reference and adjusted it with LG 49UF770V datas.
It's look like, at minima, it will do all ..UF...V serie, but user's computers need to be powerfull to transcode in 4K, so l'm not sure leaving this definition will be advised ? These renderers having integrated upscaler maybe it will be more safe to # them.
The hell is paved with good intention ;-)

**P.S.** It's a copy of #953 but i corrected the name.conf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/971)
<!-- Reviewable:end -->
