### PR TITLE
FrameAppender synchronization

### DIFF
--- a/src/main/external-resources/logback.headless.xml
+++ b/src/main/external-resources/logback.headless.xml
@@ -50,9 +50,9 @@
 		Appender for the default logfile that will roll the logfile after 10 MBytes
 		and will keep a maximum of 5 old and compressed logs.
 	-->
+	<!--
 	<appender name="default.log.10MB" class="ch.qos.logback.core.rolling.RollingFileAppender">
-		<!-- No threshold filtering, log everything the root logger allows -->
-		<file>${logFilePath}${file.separator}${logFileName}</file>
+		<file>${logFilePath}${file.separator}${logFileName}.rolling</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
 			<fileNamePattern>${logFilePath}${logFileName}.%i.zip</fileNamePattern>
 			<minIndex>1</minIndex>
@@ -66,6 +66,7 @@
 			<pattern>%-5level %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %msg%n</pattern>
 		</encoder>
 	</appender>
+	-->
 
 	<!--
 		For debugging purposes it can be handy to define custom levels for

--- a/src/main/external-resources/logback.xml
+++ b/src/main/external-resources/logback.xml
@@ -59,8 +59,8 @@
 		Appender for the default logfile that will roll the logfile after 10 MBytes
 		and will keep a maximum of 5 old and compressed logs.
 	-->
+	<!--
 	<appender name="default.log.10MB" class="ch.qos.logback.core.rolling.RollingFileAppender">
-		<!-- No threshold filtering, log everything the root logger allows -->
 		<file>${logFilePath}${file.separator}${logFileName}</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
 			<fileNamePattern>${logFilePath}${logFileName}.%i.zip</fileNamePattern>
@@ -75,6 +75,7 @@
 			<pattern>%-5level %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %msg%n</pattern>
 		</encoder>
 	</appender>
+	-->
 
 	<!--
 		For debugging purposes it can be handy to define custom levels for

--- a/src/main/java/net/pms/newgui/LooksFrame.java
+++ b/src/main/java/net/pms/newgui/LooksFrame.java
@@ -520,7 +520,13 @@ public class LooksFrame extends JFrame implements IFrame, Observer {
 
 	@Override
 	public void append(final String msg) {
-		tt.append(msg);
+		SwingUtilities.invokeLater(new Runnable() {
+
+			@Override
+			public void run() {
+				tt.append(msg);
+			}
+		});
 	}
 
 	@Override


### PR DESCRIPTION
I forgot to shut down UMS last night, and when I woke up today there were a lot of stalled threads that had thrown exceptions like this:
```logtalk
INFO  15:42:40.369 [Thread-460] Exception in thread "Thread-226" Exception in thread "Thread-332" Exception in thread "Thread-372" Exception in thread "Thread-172" Exception in thread "Thread-460" Exception in thread "Thread-299" Exception in thread "Thread-224" Exception in thread "Thread-241" Exception in thread "Thread-173" Exception in thread "Thread-606" Exception in thread "Thread-442" Exception in thread "Thread-443" Exception in thread "Thread-552" Exception in thread "Thread-192" Exception in thread "Thread-659" Exception in thread "Thread-227" Exception in thread "Thread-298" Exception in thread "Thread-281" Exception in thread "Thread-583" Exception in thread "Thread-461" Exception in thread "Thread-533" Exception in thread "Thread-390" Exception in thread "Thread-205" java.lang.Error: Interrupted attempt to aquire write lock
INFO  15:42:40.371 [Thread-460] 	at javax.swing.text.AbstractDocument.writeLock(AbstractDocument.java:1349)
INFO  15:42:40.375 [Thread-460] 	at javax.swing.text.AbstractDocument.insertString(AbstractDocument.java:702)
INFO  15:42:40.391 [Thread-460] 	at javax.swing.text.PlainDocument.insertString(PlainDocument.java:130)
INFO  15:42:40.398 [Thread-460] 	at javax.swing.JTextArea.append(JTextArea.java:477)
INFO  15:42:40.404 [Thread-460] 	at net.pms.newgui.TracesTab.append(TracesTab.java:186)
INFO  15:42:40.412 [Thread-460] 	at net.pms.newgui.LooksFrame.append(LooksFrame.java:523)
INFO  15:42:40.419 [Thread-460] 	at net.pms.logging.FrameAppender.append(FrameAppender.java:109)
INFO  15:42:40.425 [Thread-460] 	at ch.qos.logback.core.UnsynchronizedAppenderBase.doAppend(UnsynchronizedAppenderBase.java:84)
INFO  15:42:40.430 [Thread-460] 	at ch.qos.logback.core.spi.AppenderAttachableImpl.appendLoopOnAppenders(AppenderAttachableImpl.java:48)
INFO  15:42:40.432 [Thread-460] 	at ch.qos.logback.classic.Logger.appendLoopOnAppenders(Logger.java:270)
INFO  15:42:40.742 [Thread-460] 	at ch.qos.logback.classic.Logger.callAppenders(Logger.java:257)
INFO  15:42:40.746 [Thread-460] 	at ch.qos.logback.classic.Logger.buildLoggingEventAndAppend(Logger.java:421)
INFO  15:42:40.759 [Thread-460] 	at ch.qos.logback.classic.Logger.filterAndLog_0_Or3Plus(Logger.java:383)
INFO  15:42:40.762 [Thread-460] 	at ch.qos.logback.classic.Logger.debug(Logger.java:482)
INFO  15:42:40.765 [Thread-460] 	at net.pms.io.PipeIPCProcess.run(PipeIPCProcess.java:86)
```

After a quick peek I discovered that FrameAppender's call to update the GUI is run from whatever thread makes the logging call. Since Swing isn't multithreaded that isn't allowed and every update of the GUI must be done via the event dispatcher thread. I see this as the likely cause of the issue, and corrected that.

Ideally I'd like for the "separation" between other threads and Swing to be outside the "GUI classes" (net.pms.newgui.*) since I think that's the logical place to do the separation and because any GUI component can safely call such a method without queuing the event dispatcher as they already run in the event dispatcher thread. That isn't feasable here because of the IFrame construct though (because when running headless there *is* no event dispatcher thread), so I had to put the change in LooksFrame even though I dislike it.

I've also commented out the rolling file appender configuration from the logback configuration files since some upgrade of logback has started throwing errors because it was configured with the same file name as the non-rolling file appender. Commenting it out should have no practical effect since the rolling file appender isn't used by default and only serves as a configuration example for anyone that want to configure it differently. Coming up with a separate name for the rolling file name would require changes in several classes and further complicating the configuration file with another setting, so I found it easiest to simply comment out the example configuration. This takse care of the errors thrown by logback during LogBack configuration when UMS starts.

I've attached the logfile containing both errors (It's compressed as it is too big to attach uncompressed):
[debug.zip](https://github.com/UniversalMediaServer/UniversalMediaServer/files/518409/debug.zip)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1037)
<!-- Reviewable:end -->
