### PR TITLE
Automatically rescan shared folders if there is a change in a monitored folder

### DIFF
--- a/src/main/java/net/pms/dlna/RootFolder.java
+++ b/src/main/java/net/pms/dlna/RootFolder.java
@@ -150,6 +150,13 @@ public class RootFolder extends DLNAResource {
 			addChild(r);
 		}
 
+		/**
+		 * Changes to monitored folders trigger a rescan
+		 */
+		for (DLNAResource r : getConfiguredFolders(tags)) {
+			FileWatcher.add(new FileWatcher.Watch(r.getSystemName(), LIBRARY_RESCANNER));
+		}
+
 		for (DLNAResource r : getVirtualFolders(tags)) {
 			addChild(r);
 		}
@@ -279,8 +286,12 @@ public class RootFolder extends DLNAResource {
 	}
 
 	private List<RealFile> getConfiguredFolders(ArrayList<String> tags) {
+		return getConfiguredFolders(tags, false);
+	}
+
+	private List<RealFile> getConfiguredFolders(ArrayList<String> tags, boolean monitored) {
 		List<RealFile> res = new ArrayList<>();
-		File[] files = PMS.get().getSharedFoldersArray(false, tags, configuration);
+		File[] files = PMS.get().getSharedFoldersArray(monitored, tags, configuration);
 		String s = configuration.getFoldersIgnored(tags);
 		String[] skips = null;
 
@@ -1440,6 +1451,22 @@ public class RootFolder extends DLNAResource {
 			if (r != null) {
 				if (watch.flag == RELOAD_WEB_CONF) {
 					r.loadWebConf();
+				}
+			}
+		}
+	};
+
+	/**
+	 * Rescans the media library when a change is made to relevant file or folder.
+	 */
+	public static final FileWatcher.Listener LIBRARY_RESCANNER = new FileWatcher.Listener() {
+		@Override
+		public void notify(String filename, String event, FileWatcher.Watch watch, boolean isDir) {
+			if (PMS.getConfiguration().getUseCache()) {
+				DLNAMediaDatabase database = PMS.get().getDatabase();
+
+				if (database != null && !database.isScanLibraryRunning()) {
+					database.scanLibrary();
 				}
 			}
 		}

--- a/src/main/java/net/pms/dlna/RootFolder.java
+++ b/src/main/java/net/pms/dlna/RootFolder.java
@@ -153,8 +153,10 @@ public class RootFolder extends DLNAResource {
 		/**
 		 * Changes to monitored folders trigger a rescan
 		 */
-		for (DLNAResource r : getConfiguredFolders(tags)) {
-			FileWatcher.add(new FileWatcher.Watch(r.getSystemName(), LIBRARY_RESCANNER));
+		if (PMS.getConfiguration().getUseCache()) {
+			for (DLNAResource r : getConfiguredFolders(tags, true)) {
+				FileWatcher.add(new FileWatcher.Watch(r.getSystemName(), LIBRARY_RESCANNER));
+			}
 		}
 
 		for (DLNAResource r : getVirtualFolders(tags)) {


### PR DESCRIPTION
In my opinion this feature is an important part of keeping the program up to date with the functionality of our competitors, and it especially makes sense given the changes in 7.0.0.

The only real change to this I can think of is to make a config variable to be able to disable it, but then I think it makes sense to include it in the functionality of "monitor" which we already have.
