### PR TITLE
Search for subtitles in alternative folder even when a subtitle was already found

### DIFF
--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -808,7 +808,7 @@ public class FileUtil {
 			}
 
 			if (subFolder.exists()) {
-				found = found || browseFolderForSubtitles(subFolder, file, media, usecache);
+				found = browseFolderForSubtitles(subFolder, file, media, usecache) || found;
 			}
 		}
 


### PR DESCRIPTION
The original code does not search for subtitles in alternative subtitles folder if a subtitle is already found, because of `[short-circuiting evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation)`.