### PR TITLE
Fixed bug in RendererConfiguration.setStringList() #1045

### DIFF
--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -354,7 +354,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		if (result.toString().equals("")) {
 			result.append("None");
 		}
-		configuration.setProperty(key, result);
+		configuration.setProperty(key, result.toString());
 	}
 
 	public Color getColor(String key, String defaultValue) {


### PR DESCRIPTION
A little oversight by me, soz :blush: 

It was always meant to be stored as a String, but I must have forgotten to include that little .toString(). The reason it has slipped detection for so long is that the file is actually saved correctly (by pure luck), so if the file is re-read it will be read as a String. When just read from memory however, it is returned as a StringBuilder instead of String, causing:
```
ConversionException: 'selected_renderers' doesn't map to a String object
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1050)
<!-- Reviewable:end -->
