### PR TITLE
Disable transcoding #565

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -596,6 +596,15 @@ disable_transcode_for_extensions =
 # troubleshooting when you are not able to edit the renderer configuration.
 # Default: ""
 force_transcode_for_extensions =
+
+# Disable all transcoding
+# -----------------------
+# Do not transcode under any circumstances.
+# Warning: This will probably mean that your renderer will fail to play many
+# files or fail to show subtitles, but there are cases where this is still 
+# preferable.
+# Default: false
+disable_transcoding = 
  
 # ---< Audio settings tab >---------------------------------------------------
 

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -130,6 +130,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_DISABLE_FAKESIZE = "disable_fakesize";
 	public    static final String KEY_DISABLE_SUBTITLES = "disable_subtitles";
 	protected static final String KEY_DISABLE_TRANSCODE_FOR_EXTENSIONS = "disable_transcode_for_extensions";
+	protected static final String KEY_DISABLE_TRANSCODING = "disable_transcoding";
 	protected static final String KEY_DVDISO_THUMBNAILS = "dvd_isos_thumbnails";
 	protected static final String KEY_DYNAMIC_PLS = "dynamic_playlist";
 	protected static final String KEY_DYNAMIC_PLS_AUTO_SAVE = "dynamic_playlist_auto_save";
@@ -366,6 +367,7 @@ public class PmsConfiguration extends RendererConfiguration {
 			KEY_AUDIO_THUMBNAILS_METHOD,
 			KEY_CHAPTER_SUPPORT,
 			KEY_DISABLE_TRANSCODE_FOR_EXTENSIONS,
+			KEY_DISABLE_TRANSCODING,
 			KEY_ENGINES,
 			KEY_FOLDERS,
 			KEY_FORCE_TRANSCODE_FOR_EXTENSIONS,
@@ -2376,6 +2378,10 @@ public class PmsConfiguration extends RendererConfiguration {
 
 	public void setDisableTranscodeForExtensions(String value) {
 		configuration.setProperty(KEY_DISABLE_TRANSCODE_FOR_EXTENSIONS, value);
+	}
+
+	public boolean getDisableTranscoding() {
+		return getBoolean(KEY_DISABLE_TRANSCODING, false);
 	}
 
 	public String getForceTranscodeForExtensions() {

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -538,9 +538,8 @@ public class PmsConfiguration extends RendererConfiguration {
 	 * @param loadFile Set to true to attempt to load the PMS configuration
 	 *                 file from the profile path. Set to false to skip
 	 *                 loading.
-	 * @throws org.apache.commons.configuration.ConfigurationException
 	 */
-	public PmsConfiguration(boolean loadFile) throws ConfigurationException {
+	public PmsConfiguration(boolean loadFile) {
 		super(0);
 
 		if (loadFile) {

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -282,7 +282,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 							if (selectedRenderers.contains(rendererName) || selectedRenderers.contains(renderersGroup) || selectedRenderers.contains(pmsConf.ALL_RENDERERS)) {
 								enabledRendererConfs.add(r);
 							} else {
-								LOGGER.debug("Ignored " + rendererName + " configuration");
+								LOGGER.debug("Ignored \"{}\" configuration", rendererName);
 							}
 						} catch (ConfigurationException ce) {
 							LOGGER.info("Error in loading configuration of: " + f.getAbsolutePath());
@@ -2192,12 +2192,13 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	public boolean isCompatible(DLNAMediaInfo mediainfo, Format format) {
 
 		PmsConfiguration configuration = PMS.getConfiguration(this);
-		if (configuration == null) {
-			LOGGER.error("Can't find configuration in isCompatible()");
-			return false;
-		}
 
-		if (format != null && format.skip(configuration.getDisableTranscodeForExtensions())) {
+		if (
+			configuration != null &&
+			(configuration.getDisableTranscoding() ||
+			(format != null &&
+			format.skip(configuration.getDisableTranscodeForExtensions())))
+		) {
 			return true;
 		}
 

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -2190,25 +2190,24 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 * 				otherwise.
 	 */
 	public boolean isCompatible(DLNAMediaInfo mediainfo, Format format) {
+
+		PmsConfiguration configuration = PMS.getConfiguration(this);
+		if (configuration == null) {
+			LOGGER.error("Can't find configuration in isCompatible()");
+			return false;
+		}
+
+		if (format != null && format.skip(configuration.getDisableTranscodeForExtensions())) {
+			return true;
+		}
+
 		// Use the configured "Supported" lines in the renderer.conf
 		// to see if any of them match the MediaInfo library
 		if (isUseMediaInfo() && mediainfo != null && getFormatConfiguration().match(mediainfo) != null) {
 			return true;
 		}
 
-		if (format != null) {
-			String noTranscode = "";
-
-			if (PMS.getConfiguration(this) != null) {
-				noTranscode = PMS.getConfiguration(this).getDisableTranscodeForExtensions();
-			}
-
-			// Is the format among the ones to be streamed?
-			return format.skip(noTranscode, getStreamedExtensions());
-		} else {
-			// Not natively supported.
-			return false;
-		}
+		return format != null ? format.skip(getStreamedExtensions()) : false;
 	}
 
 	public int getAutoPlayTmo() {

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -2186,12 +2186,15 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 * @param mediainfo The {@link DLNAMediaInfo} information parsed from the
 	 * 				media file.
 	 * @param format The {@link Format} to test compatibility for.
+	 * @param configuration The {@link PmsConfiguration} to use while evaluating compatibility
 	 * @return True if the renderer natively supports the format, false
 	 * 				otherwise.
 	 */
-	public boolean isCompatible(DLNAMediaInfo mediainfo, Format format) {
+	public boolean isCompatible(DLNAMediaInfo mediainfo, Format format, PmsConfiguration configuration) {
 
-		PmsConfiguration configuration = PMS.getConfiguration(this);
+		if (configuration == null) {
+			configuration = PMS.getConfiguration(this);
+		}
 
 		if (
 			configuration != null &&
@@ -2209,6 +2212,22 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		}
 
 		return format != null ? format.skip(getStreamedExtensions()) : false;
+	}
+
+	/**
+	 * Returns whether or not the renderer can handle the given format
+	 * natively, based on its configuration in the renderer.conf. If it can
+	 * handle a format natively, content can be streamed to the renderer. If
+	 * not, content should be transcoded before sending it to the renderer.
+	 *
+	 * @param mediainfo The {@link DLNAMediaInfo} information parsed from the
+	 * 				media file.
+	 * @param format The {@link Format} to test compatibility for.
+	 * @return True if the renderer natively supports the format, false
+	 * 				otherwise.
+	 */
+	public boolean isCompatible(DLNAMediaInfo mediainfo, Format format) {
+		return isCompatible(mediainfo, format, null);
 	}
 
 	public int getAutoPlayTmo() {

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -794,6 +794,11 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			return resolvedPlayer;
 		}
 
+		if (configurationSpecificToRenderer.getDisableTranscoding()) {
+			LOGGER.trace("File \"{}\" will be streamed since transcoding is disabled", getName());
+			return null;
+		}
+
 		String configurationSkipExtensions = configurationSpecificToRenderer.getDisableTranscodeForExtensions();
 		String rendererSkipExtensions = renderer == null ? null : renderer.getStreamedExtensions();
 
@@ -802,7 +807,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		setSkipTranscode(skipTranscode); // Hard to see the point in doing this, but assuming some plugins rely on this information.
 
 		if (skipTranscode) {
-			LOGGER.trace("File \"{}\" will be forced to skip transcoding by configuration", getName());
+			LOGGER.trace("File \"{}\" will be forced to be streamed by configuration", getName());
 			return null;
 		}
 

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1598,6 +1598,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		}
 
 		if (
+			!configurationSpecificToRenderer.getDisableTranscoding() &&
 			hasExternalSubtitles() &&
 			!isNamedNoEncoding &&
 			media_audio == null &&

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -794,8 +794,50 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			return resolvedPlayer;
 		}
 
+		boolean hasSubsToTranscode = false;
+
+		boolean hasEmbeddedSubs = false;
+		for (DLNAMediaSubtitle s : media.getSubtitleTracksList()) {
+			hasEmbeddedSubs = (hasEmbeddedSubs || s.isEmbedded());
+		}
+
+		/**
+		 * At this stage, we know the media is compatible with the renderer based on its
+		 * "Supported" lines, and can therefore be streamed to the renderer without a
+		 * player. However, other details about the media can change this, such as
+		 * whether it has subtitles that match this user's language settings, so here we
+		 * perform those checks.
+		 */
+		if (format.isVideo() && !configurationSpecificToRenderer.isDisableSubtitles()) {
+			if (hasEmbeddedSubs || hasExternalSubtitles()) {
+				OutputParams params = new OutputParams(configurationSpecificToRenderer);
+				Player.setAudioAndSubs(getSystemName(), media, params); // set proper subtitles in accordance with user setting
+				if (params.sid != null) {
+					if (params.sid.isExternal()) {
+						if (renderer != null && renderer.isExternalSubtitlesFormatSupported(params.sid, media)) {
+							media_subtitle = params.sid;
+							media_subtitle.setSubsStreamable(true);
+							LOGGER.trace("This video has external subtitles that could be streamed");
+						} else {
+							hasSubsToTranscode = true;
+							LOGGER.trace("This video has external subtitles that should be transcoded");
+						}
+					} else if (params.sid.isEmbedded()) {
+						if (renderer != null && renderer.isEmbeddedSubtitlesFormatSupported(params.sid)) {
+							LOGGER.trace("This video has embedded subtitles that could be streamed");
+						} else {
+							hasSubsToTranscode = true;
+							LOGGER.trace("This video has embedded subtitles that should be transcoded");
+						}
+					}
+				}
+			} else {
+				LOGGER.trace("This video does not have subtitles");
+			}
+		}
+
 		if (configurationSpecificToRenderer.getDisableTranscoding()) {
-			LOGGER.trace("File \"{}\" will be streamed since transcoding is disabled", getName());
+			LOGGER.trace("Final verdict: \"{}\" will be streamed since transcoding is disabled", getName());
 			return null;
 		}
 
@@ -803,14 +845,12 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		String rendererSkipExtensions = renderer == null ? null : renderer.getStreamedExtensions();
 
 		// Should transcoding be skipped for this format?
-		boolean skipTranscode = format.skip(configurationSkipExtensions, rendererSkipExtensions);
-		setSkipTranscode(skipTranscode); // Hard to see the point in doing this, but assuming some plugins rely on this information.
+		skipTranscode = format.skip(configurationSkipExtensions, rendererSkipExtensions);
 
 		if (skipTranscode) {
-			LOGGER.trace("File \"{}\" will be forced to be streamed by configuration", getName());
+			LOGGER.trace("Final verdict: \"{}\" will be streamed since it is forced by configuration", getName());
 			return null;
 		}
-
 
 		// Try to match a player based on media information and format.
 		resolvedPlayer = PlayerFactory.getPlayer(this);
@@ -825,58 +865,13 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 
 			// Should transcoding be forced for this format?
 			boolean forceTranscode = format.skip(configurationForceExtensions, rendererForceExtensions);
-
-			if (forceTranscode) {
-				LOGGER.trace("File \"{}\" will be forced to be transcoded by configuration", getName());
-			}
-
-			boolean hasSubsToTranscode = false;
-
-			boolean hasEmbeddedSubs = false;
-			for (DLNAMediaSubtitle s : media.getSubtitleTracksList()) {
-				hasEmbeddedSubs = (hasEmbeddedSubs || s.isEmbedded());
-			}
-
-			/**
-			 * At this stage, we know the media is compatible with the renderer based on its
-			 * "Supported" lines, and can therefore be streamed to the renderer without a
-			 * player. However, other details about the media can change this, such as
-			 * whether it has subtitles that match this user's language settings, so here we
-			 * perform those checks.
-			 */
-			if (format.isVideo() && !configurationSpecificToRenderer.isDisableSubtitles()) {
-				if (hasEmbeddedSubs || hasExternalSubtitles()) {
-					OutputParams params = new OutputParams(configurationSpecificToRenderer);
-					Player.setAudioAndSubs(getSystemName(), media, params); // set proper subtitles in accordance with user setting
-					if (params.sid != null) {
-						if (params.sid.isExternal()) {
-							if (renderer != null && renderer.isExternalSubtitlesFormatSupported(params.sid, media)) {
-								media_subtitle = params.sid;
-								media_subtitle.setSubsStreamable(true);
-								LOGGER.trace("This video has external subtitles that should be streamed");
-							} else {
-								hasSubsToTranscode = true;
-								LOGGER.trace("This video has external subtitles that should be transcoded");
-							}
-						} else if (params.sid.isEmbedded()) {
-							if (renderer != null && renderer.isEmbeddedSubtitlesFormatSupported(params.sid)) {
-								LOGGER.trace("This video has embedded subtitles that should be streamed");
-							} else {
-								hasSubsToTranscode = true;
-								LOGGER.trace("This video has embedded subtitles that should be transcoded");
-							}
-						}
-					}
-				} else {
-					LOGGER.trace("This video does not have subtitles");
-				}
-			}
-
 			boolean isIncompatible = false;
 			String audioTracksList = getName() + media.getAudioTracksList().toString();
 
 			String prependTraceReason = "File \"{}\" will not be streamed because ";
-			if (!format.isCompatible(media, renderer)) {
+			if (forceTranscode) {
+				LOGGER.trace(prependTraceReason + "transcoding is forced by configuration", getName());
+			} else if (!format.isCompatible(media, renderer)) {
 				isIncompatible = true;
 				LOGGER.trace(prependTraceReason + "it is not supported by the renderer", getName());
 			} else if (
@@ -945,6 +940,8 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				resolvedPlayer = null;
 				LOGGER.trace("Final verdict: \"{}\" will be streamed", getName());
 			}
+		} else {
+			LOGGER.trace("Final verdict: \"{}\" will be streamed because no compatible player was found");
 		}
 		return resolvedPlayer;
 	}

--- a/src/main/java/net/pms/formats/Format.java
+++ b/src/main/java/net/pms/formats/Format.java
@@ -24,6 +24,7 @@ import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.InputFile;
 import net.pms.network.HTTPResource;
 import net.pms.util.FileUtil;
+import net.pms.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -280,42 +281,29 @@ public abstract class Format implements Cloneable {
 	 * the list of supplied extensions.
 	 *
 	 * @param extensions String of comma-separated extensions
-	 * @param moreExtensions String of comma-separated extensions
 	 *
 	 * @return True if this format matches an extension in the supplied lists,
 	 * false otherwise.
 	 *
 	 * @see #match(String)
 	 */
-	public boolean skip(String extensions, String moreExtensions) {
-		if ("*".equals(extensions)) {
-			return true;
-		}
+	public boolean skip(String... extensions) {
+		for (String extensionsString : extensions) {
+			if (extensionsString == null) {
+				continue;
+			}
 
-		if (extensions != null && extensions.length() > 0) {
-			StringTokenizer st = new StringTokenizer(extensions, ",");
+			if ("*".equals(extensionsString)) {
+				return true;
+			}
 
-			while (st.hasMoreTokens()) {
-				String id = st.nextToken().toLowerCase();
-
-				if (matchedExtension != null && matchedExtension.toLowerCase().equals(id)) {
+			String[] extensionsArray = extensionsString.split(",");
+			for (String extension : extensionsArray) {
+				if (StringUtil.hasValue(extension) && extension.equalsIgnoreCase(matchedExtension)) {
 					return true;
 				}
 			}
 		}
-
-		if (moreExtensions != null && moreExtensions.length() > 0) {
-			StringTokenizer st = new StringTokenizer(moreExtensions, ",");
-
-			while (st.hasMoreTokens()) {
-				String id = st.nextToken().toLowerCase();
-
-				if (matchedExtension != null && matchedExtension.toLowerCase().equals(id)) {
-					return true;
-				}
-			}
-		}
-
 		return false;
 	}
 

--- a/src/main/java/net/pms/newgui/LooksFrame.java
+++ b/src/main/java/net/pms/newgui/LooksFrame.java
@@ -448,7 +448,11 @@ public class LooksFrame extends JFrame implements IFrame, Observer {
 		tabbedPane.addTab(Messages.getString("LooksFrame.20"), gt.build());
 		tabbedPane.addTab(Messages.getString("LooksFrame.27"), pt.build());
 		tabbedPane.addTab(Messages.getString("LooksFrame.22"), nt.build());
-		tabbedPane.addTab(Messages.getString("LooksFrame.21"), tr.build());
+		if (!configuration.getDisableTranscoding()) {
+			tabbedPane.addTab(Messages.getString("LooksFrame.21"), tr.build());
+		} else {
+			tr.build();
+		}
 		tabbedPane.addTab(Messages.getString("LooksFrame.24"), new HelpTab().build());
 		tabbedPane.addTab(Messages.getString("LooksFrame.25"), new AboutTab().build());
 

--- a/src/test/java/net/pms/test/formats/FormatRecognitionTest.java
+++ b/src/test/java/net/pms/test/formats/FormatRecognitionTest.java
@@ -48,7 +48,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeTrue;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
@@ -56,22 +56,17 @@ import org.slf4j.LoggerFactory;
  * Test the recognition of formats.
  */
 public class FormatRecognitionTest {
-	private boolean mediaInfoParserIsValid;
+	private final static boolean mediaInfoParserIsValid = LibMediaInfoParser.isValid();
+	private final static PmsConfiguration configuration = new PmsConfiguration(false);
 
-	@Before
-	public void setUp() throws ConfigurationException {
+	@BeforeClass
+	public static void setUpBeforeClass() throws ConfigurationException {
 		// Silence all log messages from the PMS code that is being tested
 		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-        context.reset(); 
-
-		PmsConfiguration pmsConf = null;
-
-		pmsConf = new PmsConfiguration(false);
+        context.reset();
 
 		// Initialize the RendererConfiguration
-		RendererConfiguration.loadRendererConfigurations(pmsConf);
-
-		mediaInfoParserIsValid = LibMediaInfoParser.isValid();
+		RendererConfiguration.loadRendererConfigurations(configuration);
 	}
 
     /**
@@ -84,7 +79,7 @@ public class FormatRecognitionTest {
 		RendererConfiguration conf = RendererConfiguration.getRendererConfigurationByName("Playstation 3");
 		assertNotNull("Renderer named \"Playstation 3\" found.", conf);
 		assertEquals("With nothing provided isCompatible() should return false", false,
-				conf.isCompatible(null, null));
+				conf.isCompatible(null, null, configuration));
 	}
 
 	/**
@@ -104,7 +99,7 @@ public class FormatRecognitionTest {
 		Format format = new GIF();
 		format.match("test.gif");
 		assertEquals("PS3 is compatible with GIF", true,
-				conf.isCompatible(info, format));
+				conf.isCompatible(info, format, configuration));
 	}
 
 	/**
@@ -124,7 +119,7 @@ public class FormatRecognitionTest {
 		Format format = new PNG();
 		format.match("test.png");
 		assertEquals("PS3 is compatible with PNG", true,
-				conf.isCompatible(info, format));
+				conf.isCompatible(info, format, configuration));
 	}
 
 	/**
@@ -144,7 +139,7 @@ public class FormatRecognitionTest {
 		Format format = new TIF();
 		format.match("test.tiff");
 		assertEquals("PS3 is compatible with TIFF", true,
-				conf.isCompatible(info, format));
+				conf.isCompatible(info, format, configuration));
 	}
 
 	/**
@@ -170,12 +165,12 @@ public class FormatRecognitionTest {
 		Format format = new MP3();
 		format.match("test.mp3");
 		assertEquals("PS3 is compatible with MP3", true,
-				conf.isCompatible(info, format));
+				conf.isCompatible(info, format, configuration));
 
 		// Construct five channel MP3 that the PS3 does not support natively
 		audio.getAudioProperties().setNumberOfChannels(5);
 		assertEquals("PS3 is incompatible with five channel MP3", false,
-				conf.isCompatible(info, format));
+				conf.isCompatible(info, format, configuration));
 	}
 
 	/**
@@ -202,12 +197,12 @@ public class FormatRecognitionTest {
 		Format format = new MPG();
 		format.match("test.avi");
 		assertEquals("PS3 is compatible with MPG", true,
-				conf.isCompatible(info, format));
+				conf.isCompatible(info, format, configuration));
 
 		// Construct MPG with wmv codec that the PS3 does not support natively
 		info.setCodecV("wmv");
 		assertEquals("PS3 is incompatible with MPG with wmv codec", false,
-				conf.isCompatible(info, format));
+				conf.isCompatible(info, format, configuration));
 	}
 
 	/**
@@ -234,7 +229,7 @@ public class FormatRecognitionTest {
 		Format format = new MPG();
 		format.match("test.mkv");
 		assertEquals("PS3 is incompatible with MKV", false,
-				conf.isCompatible(info, format));
+				conf.isCompatible(info, format, configuration));
 	}
 
 	/**
@@ -259,7 +254,7 @@ public class FormatRecognitionTest {
 		Format format = new DVRMS();
 		format.match("test.dvr");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for DVRMS",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// ISO: false
 		info = new DLNAMediaInfo();
@@ -267,7 +262,7 @@ public class FormatRecognitionTest {
 		format = new ISO();
 		format.match("test.iso");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for ISO",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// JPG: true
 		info = new DLNAMediaInfo();
@@ -275,7 +270,7 @@ public class FormatRecognitionTest {
 		format = new JPG();
 		format.match("test.jpeg");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for JPG",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// M4A: false
 		info = new DLNAMediaInfo();
@@ -283,7 +278,7 @@ public class FormatRecognitionTest {
 		format = new M4A();
 		format.match("test.m4a");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for M4A",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// MKV: false
 		info = new DLNAMediaInfo();
@@ -291,7 +286,7 @@ public class FormatRecognitionTest {
 		format = new MKV();
 		format.match("test.mkv");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for MKV",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// MP3: true
 		info = new DLNAMediaInfo();
@@ -299,7 +294,7 @@ public class FormatRecognitionTest {
 		format = new MP3();
 		format.match("test.mp3");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for MP3",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// MPG: true
 		info = new DLNAMediaInfo();
@@ -307,7 +302,7 @@ public class FormatRecognitionTest {
 		format = new MPG();
 		format.match("test.mpg");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for MPG",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// OGG: false
 		info = new DLNAMediaInfo();
@@ -315,7 +310,7 @@ public class FormatRecognitionTest {
 		format = new OGG();
 		format.match("test.ogg");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for OGG",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// RAW: false
 		info = new DLNAMediaInfo();
@@ -323,7 +318,7 @@ public class FormatRecognitionTest {
 		format = new RAW();
 		format.match("test.arw");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for RAW",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// WAV: true
 		info = new DLNAMediaInfo();
@@ -331,7 +326,7 @@ public class FormatRecognitionTest {
 		format = new WAV();
 		format.match("test.wav");
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for WAV",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// WEB: type=IMAGE
 		info = new DLNAMediaInfo();
@@ -340,14 +335,14 @@ public class FormatRecognitionTest {
 		format.match("http://test.org/");
 		format.setType(Format.IMAGE);
 		assertEquals("isCompatible() give same outcome as ps3compatible() for WEB image",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 
 		// WEB: type=VIDEO
 		info = new DLNAMediaInfo();
 		info.setContainer("avi");
 		format.setType(Format.VIDEO);
 		assertEquals("isCompatible() gives same outcome as ps3compatible() for WEB video",
-				format.ps3compatible(),	conf.isCompatible(info, format));
+				format.ps3compatible(),	conf.isCompatible(info, format, configuration));
 	}
 
 	/**


### PR DESCRIPTION
This both fixes the existing option to disable transcoding for specific extensions and creates a new configuration option that disables transcoding completely. #565 #597 #1040 

For as long as I've been involved I've seen requests from people from time to time for the option to disable transcoding completely. Some people simply doesn't have a computer that can handle transcoding, other prefers that the file doesn't play if the renderer doesn't support it - or that the subtitle is ignored instead of transcoding the video.

When trying to fix "disable transcoding for specific extensions" it didn't cost much to add it. Regarding that feature, I don't think this can have been working properly for a very long time. As far as I can see this was broken way back in 43c0c12a7b417c69d5e5e7034f83c216c963c155 where basicly `skipTranscode` was set for the parent of the resource if was checked for (the parent would be a folder, and thus the information had no impact). There were other problems as well that has probably trickled in as time went by since the feature didn't work anyway.

I've done some testing and it seems to work for me, but since `DLNAResource` is, in my opinion, the worst mess in the whole codebase, it is extremely dangerous to change anything there as the side effects are very hard to predict. From what I can see the class variable `skipTranscode` isn't used for anything and could be removed, but since it's there I'm guessing some obscure plugin has used it once upon a time so I left it there. As a result I think we need to test this pretty thoroughly before a potential merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1053)
<!-- Reviewable:end -->
