### PR TITLE
Bugfix: LanguageSelection trying to open in headless mode.

### DIFF
--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -406,7 +406,11 @@ public class PMS {
 	 */
 	private boolean init() throws Exception {
 		// Show the language selection dialog before displayBanner();
-		if (configuration.getLanguageRawString() == null || !Languages.isValid(configuration.getLanguageRawString())) {
+		if (
+			!isHeadless() &&
+			(configuration.getLanguageRawString() == null ||
+			!Languages.isValid(configuration.getLanguageRawString()))
+		) {
 			LanguageSelection languageDialog = new LanguageSelection(null, PMS.getLocale(), false);
 			if (languageDialog != null) {
 				languageDialog.show();


### PR DESCRIPTION
I forgot to do the headless check before spawning the language selection window :blush: 

If a graphical environment is available it will show even if UMS is run headless. If that's not available, UMS will crash during initialization. This PR fixes this.

Source: http://www.universalmediaserver.com/forum/viewtopic.php?p=28558#p28558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1057)
<!-- Reviewable:end -->
