### PR TITLE
Enable database debug logging

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
@@ -88,7 +88,7 @@ public class DLNAMediaDatabase implements Runnable {
 		dbName = name;
 		File profileDirectory = new File(configuration.getProfileDirectory());
 		dbDir = new File(profileDirectory.isDirectory() ? configuration.getProfileDirectory() : null, "database").getAbsolutePath();
-		url = Constants.START_URL + dbDir + File.separator + dbName;
+		url = Constants.START_URL + dbDir + File.separator + dbName + ";TRACE_LEVEL_FILE=3;TRACE_LEVEL_SYSTEM_OUT=3";
 		LOGGER.debug("Using database URL: " + url);
 		LOGGER.info("Using database located at: " + dbDir);
 


### PR DESCRIPTION
This is **not** a PR to be merged, it's for investigating database behaviour. 

This enabled debug logging for the database both to a separate "trace.db" file and in the regular UMS log file. Logging in the regular UMS log file is very useful at it shows when the database events take place in relation to what happens in UMS.
- [ ] Do not merge!
