### PR TITLE
Expanded SQL helper methods

### DIFF
--- a/src/main/java/net/pms/database/TableCoverArtArchive.java
+++ b/src/main/java/net/pms/database/TableCoverArtArchive.java
@@ -19,7 +19,6 @@
  */
 package net.pms.database;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -29,6 +28,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * This class is responsible for managing the Cover Art Archive table. It
@@ -83,7 +83,7 @@ public final class TableCoverArtArchive extends Tables{
 	}
 
 	private static String contructMBIDWhere(final String mBID) {
-		return " WHERE MBID" + nullIfBlank(mBID);
+		return " WHERE MBID" + sqlNullIfBlank(mBID, true, false);
 	}
 
 	/**

--- a/src/main/java/net/pms/database/TableMusicBrainzReleases.java
+++ b/src/main/java/net/pms/database/TableMusicBrainzReleases.java
@@ -19,7 +19,6 @@
  */
 package net.pms.database;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -32,6 +31,7 @@ import net.pms.util.StringUtil;
 import org.jaudiotagger.tag.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * This class is responsible for managing the MusicBrainz releases table. It
@@ -90,25 +90,25 @@ public final class TableMusicBrainzReleases extends Tables{
 
 	private static String constructTagWhere(final CoverArtArchiveTagInfo tagInfo, final boolean includeAll) {
 		StringBuilder where = new StringBuilder(" WHERE ");
-		final String AND = "AND ";
+		final String AND = " AND ";
 		boolean added = false;
 
 		if (includeAll || StringUtil.hasValue(tagInfo.album)) {
-			where.append("ALBUM").append(nullIfBlank(tagInfo.album));
+			where.append("ALBUM").append(sqlNullIfBlank(tagInfo.album, true, false));
 			added = true;
 		}
 		if (includeAll || StringUtil.hasValue(tagInfo.artistId)) {
 			if (added) {
 				where.append(AND);
 			}
-			where.append("ARTIST_ID").append(nullIfBlank(tagInfo.artistId));
+			where.append("ARTIST_ID").append(sqlNullIfBlank(tagInfo.artistId, true, false));
 			added = true;
 		}
 		if (includeAll || (!StringUtil.hasValue(tagInfo.artistId) && StringUtil.hasValue(tagInfo.artist))) {
 			if (added) {
 				where.append(AND);
 			}
-			where.append("ARTIST").append(nullIfBlank(tagInfo.artist));
+			where.append("ARTIST").append(sqlNullIfBlank(tagInfo.artist, true, false));
 			added = true;
 		}
 
@@ -125,7 +125,7 @@ public final class TableMusicBrainzReleases extends Tables{
 			if (added) {
 				where.append(AND);
 			}
-			 where.append("TRACK_ID").append(nullIfBlank(tagInfo.trackId));
+			 where.append("TRACK_ID").append(sqlNullIfBlank(tagInfo.trackId, true, false));
 			 added = true;
 		}
 		if (
@@ -143,7 +143,7 @@ public final class TableMusicBrainzReleases extends Tables{
 			if (added) {
 				where.append(AND);
 			}
-			where.append("TITLE").append(nullIfBlank(tagInfo.title));
+			where.append("TITLE").append(sqlNullIfBlank(tagInfo.title, true, false));
 			added = true;
 		}
 
@@ -151,7 +151,7 @@ public final class TableMusicBrainzReleases extends Tables{
 			if (added) {
 				where.append(AND);
 			}
-			where.append("YEAR").append(nullIfBlank(tagInfo.year));
+			where.append("YEAR").append(sqlNullIfBlank(tagInfo.year, true, false));
 			added = true;
 		}
 

--- a/src/main/java/net/pms/database/Tables.java
+++ b/src/main/java/net/pms/database/Tables.java
@@ -41,9 +41,10 @@ import org.slf4j.LoggerFactory;
  */
 public class Tables {
 	private static final Logger LOGGER = LoggerFactory.getLogger(Tables.class);
-	private final static Object checkTablesLock = new Object();
-	protected final static DLNAMediaDatabase database = PMS.get().getDatabase();
+	private static final Object checkTablesLock = new Object();
+	protected static final DLNAMediaDatabase database = PMS.get().getDatabase();
 	private static boolean tablesChecked = false;
+	private static final String EscapeCharacter = "\\";
 
 	// No instantiation
 	protected Tables() {
@@ -226,15 +227,56 @@ public class Tables {
 	 * thus <code>=</code> is illegal for <code>null</code>.
 	 * Instead, <code>IS NULL</code> must be used.
 	 *
-	 * @param s the {@link String} to compare to
-	 * @return The SQL formatted string including the <code>=</code> or
-	 * <code>IS</code> operator.
+	 * Please note that the like-escaping is not applied, as that must be done
+	 * before any wildcards are added.
+	 *
+	 * @param s the {@link String} to compare to.
+	 * @param quote whether the result should be single quoted for use as a SQL
+	 *        string or not.
+	 * @param like whether <code>LIKE</code> should be used instead of <code>=</code>. This implies quote.
+	 * @return The SQL formatted string including the <code>=</code>,
+	 * <code>LIKE</code> or <code>IS</code> operator.
 	 */
-	protected final static String nullIfBlank(String s) {
+	public final static String sqlNullIfBlank(final String s, boolean quote, boolean like) {
 		if (s == null || s.trim().isEmpty()) {
 			return " IS NULL ";
+		} else if (like) {
+			return " LIKE " + sqlQuote(s);
+		} else if (quote) {
+			return " = " + sqlQuote(s);
 		} else {
-			return " = '" + s.replaceAll("'", "''") + "' ";
+			return " = " + s;
 		}
+	}
+
+	/**
+	 * Surrounds the argument with single quotes {@link String} and escapes any
+	 * existing single quotes.
+	 *
+	 * @param s the {@link String} to quote.
+	 * @return The quoted {@link String}.
+	 */
+	public final static String sqlQuote(final String s) {
+		return s == null ? null : "'" + s.replace("'", "''") + "'";
+	}
+
+	/**
+	 * Escapes the argument with the default H2 escape character for the
+	 * escape character itself and the two wildcard characters <code>%</code>
+	 * and <code>_<code>. This escaping is only valid when using,
+	 *  <code>LIKE</code>, not when using <code>=</code>.
+	 *
+	 * TODO: Escaping should be generalized so that any escape character could
+	 *       be used and that the class would set the correct escape character
+	 *       when opening the database.
+	 *
+	 * @param the {@link String} to be SQL escaped.
+	 * @return The escaped {@link String}.
+	 */
+	public final static String sqlLikeEscape(final String s) {
+		return s == null ? null : s.
+			replace(EscapeCharacter, EscapeCharacter + EscapeCharacter).
+			replace("%", EscapeCharacter + "%").
+			replace("_", EscapeCharacter + "_");
 	}
 }


### PR DESCRIPTION
Expanded SQL helper methods in `Tables`
- `nullIfBlank()` renamed to `sqlNullIfBlank()` and additional options added (quoted or not, `LIKE` or `=` operator)
- Added `sqlQuote()` for easy quoting and quote-escaping of strings
- Added `sqlLikeEscape()` for easy escaping of strings used with the LIKE operator

This should be easy to review, I've tested the renamed/modified method and found no issues (the actual changes are minimal). The two other methods are not used by now, so any testing would have to be done once they are called from somewhere. They can't cause a bug as long as they are unused.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1075)

<!-- Reviewable:end -->
