### PR TITLE
OGG MIME type issue

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1371,6 +1371,9 @@ public class DLNAMediaInfo implements Cloneable {
 				case "mov":
 					mimeType = HTTPResource.MOV_TYPEMIME;
 					break;
+				case "ogg":
+					mimeType = HTTPResource.AUDIO_OGG_TYPEMIME;
+					break;	
 			}
 		}
 
@@ -1398,8 +1401,6 @@ public class DLNAMediaInfo implements Cloneable {
 					mimeType = HTTPResource.AUDIO_MP4_TYPEMIME;
 				} else if (codecA.contains("flac")) {
 					mimeType = HTTPResource.AUDIO_FLAC_TYPEMIME;
-				} else if (codecA.contains("vorbis")) {
-					mimeType = HTTPResource.AUDIO_OGG_TYPEMIME;
 				} else if (codecA.contains("asf") || codecA.startsWith("wm")) {
 					mimeType = HTTPResource.AUDIO_WMA_TYPEMIME;
 				} else if (codecA.contains("pcm") || codecA.contains("wav") || codecA.contains("dts")) {


### PR DESCRIPTION
Related to this issue: https://github.com/UniversalMediaServer/UniversalMediaServer/issues/1074

https://wiki.xiph.org/MIME_Types_and_File_Extensions

> .**ogg - audio/ogg**
>     Ogg Vorbis I Profile
>     .ogg applies now for Vorbis I files only
>     .ogg has more recently also been used for Ogg FLAC and for Theora, too — these uses are deprecated now in favor of .oga and .ogv respectively

**EDIT**: Tested.
> TRACE 2016-10-31 03:16:05.015 [Library Scanner] Parsing results for file "old_flac_in_ogg_flac_1_0_4.ogg": **container: ogg**, bitrate: 897704, size: 7621280, audio tracks: 1, video codec: und, duration: 00:01:07.00, width: 0, height: 0, frame rate: null, **mime type: audio/x-ogg** Audio track id: 0, lang: und, **audio codec: flac**, sample frequency:44100, number of channels: 2, bits per sample: 16

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1076)

<!-- Reviewable:end -->
