### PR TITLE
Update Google-Android-Chromecast.conf

### DIFF
--- a/src/main/external-resources/renderers/Google-Android-Chromecast.conf
+++ b/src/main/external-resources/renderers/Google-Android-Chromecast.conf
@@ -24,7 +24,7 @@ RendererIcon = chromecast.png
 # User-Agent: Android/4.2.1 UPnP/1.0 Cling/2.0
 # User-Agent: Apache-HttpClient/UNAVAILABLE (java 1.4)
 # ============================================================================
-#
+# https://developers.google.com/cast/docs/media
 
 UserAgentSearch = Android|CrKey
 
@@ -40,13 +40,23 @@ CustomFFmpegOptions = -async 1 -fflags +genpts -c:a libmp3lame -ac 2 -b:v 35000k
 MediaInfo = true
 
 # Supported video formats:
-Supported = f:mp4     v:mp4|h264   a:aac-lc|he-aac|mp3   n:2   m:video/mp4
+Supported = f:mp4    v:mp4|h264    a:aac-lc|he-aac|mp3                 n:2       m:video/mp4
+Supported = f:mkv    v:mp4|h264    a:aac-lc|he-aac|mp3|opus|vorbis     n:2       m:video/webm
 
 # Supported audio formats:
-Supported = f:aac         n:2      m:audio/aac       a:aac-lc|he-aac
-Supported = f:mp3         n:2      m:audio/mp3
-Supported = f:m4a|mp4     n:2      m:audio/mp4       a:aac-lc|he-aac
+Supported = f:flac        n:2      m:audio/x-flac                                s:96000
+Supported = f:mp3|mpa     n:2      m:audio/mp3
+Supported = f:m4a         n:2      m:audio/mp4       a:aac-lc|he-aac|mp3
+Supported = f:ogg         n:2      m:audio/ogg       a:flac|opus|vorbis
 Supported = f:wav         n:2      m:audio/x-wav     a:lpcm
+Supported = f:weba        n:2      m:audio/webm      a:opus|vorbis
+
+# Supported images formats:
+Supported = f:bmp         m:image/bmp        w:1280     h:720
+Supported = f:gif         m:image/gif        w:1280     h:720
+Supported = f:jpg         m:image/jpeg       w:1280     h:720
+Supported = f:png         m:image/png        w:1280     h:720
+#Supported = f:webp        m:image/webp       w:1280     h:720
 
 # Supported subtitles formats:
 SupportedExternalSubtitlesFormats = WEBVTT

--- a/src/main/external-resources/renderers/Google-ChromecastUltra.conf
+++ b/src/main/external-resources/renderers/Google-ChromecastUltra.conf
@@ -35,12 +35,11 @@ Supported = f:mpegts|mp4|mkv          v:mp4|h264|h265        a:aac-lc|he-aac|mp3
 Supported = f:webm                    v:vp8|vp9              a:opus|vorbis         n:2   m:video/webm
 
 # Supported audio formats:
-Supported = f:aac            n:2      a:aac-lc|he-aac       m:audio/aac
 Supported = f:flac           n:2                            m:audio/flac
 Supported = f:mp3            n:2                            m:audio/mp3
-Supported = f:m4a|mp4        n:2      a:aac-lc|he-aac       m:audio/mp4
+Supported = f:m4a            n:2      a:aac-lc|he-aac|mp3   m:audio/mp4
 Supported = f:wav            n:2      a:lpcm                m:audio/x-wav
-Supported = f:webm           n:2      a:opus|vorbis         m:audio/webm
+Supported = f:weba           n:2      a:opus|vorbis         m:audio/webm
 
 # Supported image formats:
 Supported = f:bmp                     m:image/bmp


### PR DESCRIPTION
Need to be tested on latest _Chromecast_ firmware or latest Chromecast device.

The _Chromecast Audio_ can now stream up to 96KHz/24bit lossless audio, but since some features could be limited to them, maybe create a different renderer file will be more appropriate.
A test will answer that, meaning that we depend on _Chromecast_'s users ;-)
http://162.243.219.67