### PR TITLE
Add the renderer config option to transcode to FLV

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -239,6 +239,7 @@ CreateDLNATreeFaster =
 #
 #    Profile            Video           Audio   Container   Notes
 #    ------------------------------------------------------------
+#    FLV-H264-AAC       H.264           AAC     FLV
 #    MPEGPS-MPEG2-AC3   MPEG-2          AC-3    MPEG-PS     VLC only outputs 2-channel AC-3 audio
 #    MPEGTS-MPEG2-AC3   MPEG-2          AC-3    MPEG-TS     VLC only outputs 2-channel AC-3 audio
 #    MPEGTS-H264-AC3    H.264 (AVC)     AC-3    MPEG-TS     VLC only outputs 2-channel AC-3 audio

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -113,6 +113,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String DEPRECATED_H264TSAC3 = "H264TSAC3";
 
 	// Current video transcoding options
+	protected static final String FLVH264AAC = "FLV-H264-AAC";
 	protected static final String MPEGTSH264AAC = "MPEGTS-H264-AAC";
 	protected static final String MPEGTSH264AC3 = "MPEGTS-H264-AC3";
 	protected static final String MPEGTSH265AAC = "MPEGTS-H265-AAC";
@@ -1179,6 +1180,10 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		return getVideoTranscode().equals(MPEGTSH264AAC);
 	}
 
+	public boolean isTranscodeToFLVH264AAC() {
+		return getVideoTranscode().equals(FLVH264AAC);
+	}
+
 	public boolean isTranscodeToMPEGTSH265AAC() {
 		return getVideoTranscode().equals(MPEGTSH265AAC);
 	}
@@ -1198,14 +1203,14 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 * @return whether to use the AAC audio codec for transcoded video
 	 */
 	public boolean isTranscodeToAAC() {
-		return isTranscodeToMPEGTSH264AAC() || isTranscodeToMPEGTSH265AAC();
+		return isTranscodeToMPEGTSH264AAC() || isTranscodeToMPEGTSH265AAC() || isTranscodeToFLVH264AAC();
 	}
 
 	/**
 	 * @return whether to use the H.264 video codec for transcoded video
 	 */
 	public boolean isTranscodeToH264() {
-		return isTranscodeToMPEGTSH264AAC() || isTranscodeToMPEGTSH264AC3();
+		return isTranscodeToMPEGTSH264AAC() || isTranscodeToMPEGTSH264AC3() || isTranscodeToFLVH264AAC();
 	}
 
 	/**

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -400,6 +400,8 @@ public class FFMpegVideo extends Player {
 					transcodeOptions.add("mpeg2video");
 				} else if (renderer.isTranscodeToMPEGTS()) {
 					transcodeOptions.add("mpegts");
+				} else if (renderer.isTranscodeToFLVH264AAC()) {
+					transcodeOptions.add("flv");
 				} else {
 					transcodeOptions.add("vob");
 				}

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -111,6 +111,7 @@ public class MEncoderVideo extends Player {
 	protected boolean pcm;
 	protected boolean ovccopy;
 	protected boolean ac3Remux;
+	protected boolean isTranscodeToFLV;
 	protected boolean isTranscodeToMPEGTS;
 	protected boolean isTranscodeToH264;
 	protected boolean isTranscodeToAAC;
@@ -555,7 +556,7 @@ public class MEncoderVideo extends Player {
 		}
 
 		defaultArgsList.add("-of");
-		if (wmv || isTranscodeToMPEGTS) {
+		if (wmv || isTranscodeToMPEGTS || isTranscodeToFLV) {
 			defaultArgsList.add("lavf");
 		} else if (pcm && avisynth()) {
 			defaultArgsList.add("avi");
@@ -571,6 +572,9 @@ public class MEncoderVideo extends Player {
 		} else if (isTranscodeToMPEGTS) {
 			defaultArgsList.add("-lavfopts");
 			defaultArgsList.add("format=mpegts");
+		} else if (isTranscodeToFLV) {
+			defaultArgsList.add("-lavfopts");
+			defaultArgsList.add("format=flv");
 		}
 
 		defaultArgsList.add("-mpegopts");
@@ -985,6 +989,7 @@ public class MEncoderVideo extends Player {
 		isTranscodeToMPEGTS = params.mediaRenderer.isTranscodeToMPEGTS();
 		isTranscodeToH264   = params.mediaRenderer.isTranscodeToH264() || params.mediaRenderer.isTranscodeToH265();
 		isTranscodeToAAC    = params.mediaRenderer.isTranscodeToAAC();
+		isTranscodeToFLV    = params.mediaRenderer.isTranscodeToFLVH264AAC();
 
 		final boolean isXboxOneWebVideo = params.mediaRenderer.isXboxOne() && purpose() == VIDEO_WEBSTREAM_PLAYER;
 

--- a/src/main/java/net/pms/encoders/VLCVideo.java
+++ b/src/main/java/net/pms/encoders/VLCVideo.java
@@ -164,8 +164,14 @@ public class VLCVideo extends Player {
 			}
 
 			if (renderer.isTranscodeToAC3()) {
+				codecConfig.container = "ts";
 				codecConfig.audioCodec = "a52";
+			} else if (renderer.isTranscodeToFLVH264AAC()) {
+				LOGGER.debug("Using H.264 and AAC with FLV container");
+				codecConfig.container = "flv";
+				codecConfig.audioCodec = "mp4a";
 			} else {
+				codecConfig.container = "ts";
 				codecConfig.audioCodec = "mp4a";
 			}
 


### PR DESCRIPTION
This is a test to see if we can support transcoding to devices that we don't currently support, like Roku. It doesn't officially support FLV but maybe we can trick it into thinking it's MP4, like we do with Xbox 360 by telling it our MPEG-TS is WMV.