### PR TITLE
Set the codecA and codecV always to lover case

### DIFF
--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -2435,7 +2435,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 				if (subtitle.getType().toString().equals(supportedSub.trim().toUpperCase())) {
 					if (supportedFormats != null) {
 						for (String supportedFormat : supportedFormats) {
-							if (media.getCodecV() != null && media.getCodecV().equals(supportedFormat.trim().toLowerCase())) {
+							if (media.getCodecV() != null && media.getCodecV().equals(supportedFormat.trim())) {
 								return true;
 							}
 						}

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -145,21 +145,21 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 * @return True if the audio codec is AC-3.
 	 */
 	public boolean isAC3() {
-		return getCodecA() != null && (getCodecA().equalsIgnoreCase("ac3") || getCodecA().equalsIgnoreCase("a52") || getCodecA().equalsIgnoreCase("liba52"));
+		return getCodecA() != null && ("ac3".equals(getCodecA()) || "a52".equals(getCodecA()) || "liba52".equals(getCodecA()));
 	}
 
 	/**
 	 * @return True if the audio codec is TrueHD.
 	 */
 	public boolean isTrueHD() {
-		return getCodecA() != null && getCodecA().equalsIgnoreCase("truehd");
+		return getCodecA() != null && "truehd".equals(getCodecA());
 	}
 
 	/**
 	 * @return True if the audio codec is DTS.
 	 */
 	public boolean isDTS() {
-		return getCodecA() != null && (getCodecA().startsWith("dts") || getCodecA().equalsIgnoreCase("dca") || getCodecA().equalsIgnoreCase("dca (dts)"));
+		return getCodecA() != null && (getCodecA().startsWith("dts") || "dca".equals(getCodecA()) || "dca (dts)".equals(getCodecA()));
 	}
 
 	/**
@@ -173,21 +173,21 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 * @return True if the audio codec is MP3.
 	 */
 	public boolean isMP3() {
-		return getCodecA() != null && getCodecA().equalsIgnoreCase(FormatConfiguration.MP3);
+		return getCodecA() != null && FormatConfiguration.MP3.equals(getCodecA());
 	}
 
 	/**
 	 * @return True if the audio codec is AAC.
 	 */
 	public boolean isAAC() {
-		return getCodecA() != null && getCodecA().equalsIgnoreCase(FormatConfiguration.AAC);
+		return getCodecA() != null && FormatConfiguration.AAC.equals(getCodecA());
 	}
 
 	/**
 	 * @return True if the audio codec is Ogg Vorbis.
 	 */
 	public boolean isVorbis() {
-		return getCodecA() != null && getCodecA().equalsIgnoreCase(FormatConfiguration.VORBIS);
+		return getCodecA() != null && FormatConfiguration.VORBIS.equals(getCodecA());
 	}
 
 	/**
@@ -201,14 +201,14 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 * @return True if the audio codec is MPEG-2.
 	 */
 	public boolean isMpegAudio() {
-		return getCodecA() != null && getCodecA().equalsIgnoreCase("mp2");
+		return getCodecA() != null && "mp2".equals(getCodecA());
 	}
 
 	/**
 	 * @return True if the audio codec is PCM.
 	 */
 	public boolean isPCM() {
-		return getCodecA() != null && (getCodecA().startsWith("pcm") || getCodecA().equals("LPCM"));
+		return getCodecA() != null && (getCodecA().startsWith("pcm") || "lpcm".equals(getCodecA()));
 	}
 
 	/**
@@ -222,7 +222,7 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 * @return True if the audio codec is lossless.
 	 */
 	public boolean isLossless() {
-		return getCodecA() != null && (isPCM() || getCodecA().startsWith("fla") || getCodecA().equals("mlp") || getCodecA().equals("wv") || getCodecA().equals("alac"));
+		return getCodecA() != null && (isPCM() || getCodecA().startsWith("fla") || "mlp".equals(getCodecA()) || "wv".equals(getCodecA()) || "alac".equals(getCodecA()));
 	}
 
 	/**
@@ -412,7 +412,7 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 * @since 1.50
 	 */
 	public void setCodecA(String codecA) {
-		this.codecA = codecA;
+		this.codecA = codecA.toLowerCase();
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -145,7 +145,7 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 * @return True if the audio codec is AC-3.
 	 */
 	public boolean isAC3() {
-		return getCodecA() != null && ("ac3".equals(getCodecA()) || "a52".equals(getCodecA()) || "liba52".equals(getCodecA()));
+		return getCodecA() != null && ("ac3".equals(getCodecA()) || getCodecA().contains("a52"));
 	}
 
 	/**
@@ -159,7 +159,7 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 * @return True if the audio codec is DTS.
 	 */
 	public boolean isDTS() {
-		return getCodecA() != null && (getCodecA().startsWith("dts") || "dca".equals(getCodecA()) || "dca (dts)".equals(getCodecA()));
+		return getCodecA() != null && (getCodecA().contains("dts") || getCodecA().contains("dca"));
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -786,7 +786,7 @@ public class DLNAMediaInfo implements Cloneable {
 								}
 							}
 
-							audio.setCodecA(ah.getEncodingType().toLowerCase());
+							audio.setCodecA(ah.getEncodingType());
 
 							if (audio.getCodecA().contains("(windows media")) {
 								audio.setCodecA(audio.getCodecA().substring(0, audio.getCodecA().indexOf("(windows media")).trim());
@@ -1386,7 +1386,7 @@ public class DLNAMediaInfo implements Cloneable {
 					mimeType = HTTPResource.TIFF_TYPEMIME;
 				} else if ("bmp".equals(codecV) || "bmp".equals(container)) {
 					mimeType = HTTPResource.BMP_TYPEMIME;
-				} else if (codecV.startsWith("h264") || codecV.equals("h263") || codecV.toLowerCase().equals("mpeg4") || codecV.toLowerCase().equals("mp4")) {
+				} else if (codecV.startsWith("h264") || codecV.equals("h263") || codecV.equals("mpeg4") || codecV.equals("mp4")) {
 					mimeType = HTTPResource.MP4_TYPEMIME;
 				} else if (codecV.contains("mpeg") || codecV.contains("mpg")) {
 					mimeType = HTTPResource.MPEG_TYPEMIME;
@@ -1940,7 +1940,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * @since 1.50.0
 	 */
 	public void setCodecV(String codecV) {
-		this.codecV = codecV;
+		this.codecV = codecV.toLowerCase();
 	}
 
 	/**


### PR DESCRIPTION
This change is made to avoid using containsIgnoreCase() and equalsIgnoreCase(). This could speed up the code.