### PR TITLE
Implement OSHI to obtain CPU and memory info (#979)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,6 +407,16 @@
     		<artifactId>oshi-core</artifactId>
     		<version>2.6-m-java7</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<version>1.8.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.googlecode.json-simple</groupId>
+			<artifactId>json-simple</artifactId>
+			<version>1.1.1</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>assembly:assembly</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -402,6 +402,11 @@
 			<artifactId>coverartarchive-api</artifactId>
 			<version>2.1.0</version>
 		</dependency>
+		<dependency>
+    		<groupId>com.github.dblock</groupId>
+    		<artifactId>oshi-core</artifactId>
+    		<version>2.6-m-java7</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>assembly:assembly</defaultGoal>

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -67,6 +67,10 @@ import net.pms.newgui.*;
 import net.pms.remote.RemoteWeb;
 import net.pms.update.AutoUpdater;
 import net.pms.util.*;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.apache.commons.configuration.event.ConfigurationListener;
@@ -1387,12 +1391,17 @@ public class PMS {
 	 */
 	private void logSystemInfo() {
 		long memoryInMB = Runtime.getRuntime().maxMemory() / 1048576;
+		HardwareAbstractionLayer hal = new SystemInfo().getHardware();
+        CentralProcessor processor = hal.getProcessor();
+        GlobalMemory memory = hal.getMemory();
 
 		LOGGER.info("Java: " + System.getProperty("java.vm.name") + " " + System.getProperty("java.version") + " " + System.getProperty("sun.arch.data.model") + "-bit" + " by " + System.getProperty("java.vendor"));
 		LOGGER.info("OS: " + System.getProperty("os.name") + " " + getOSBitness() + "-bit " + System.getProperty("os.version"));
-		LOGGER.info("Encoding: " + System.getProperty("file.encoding"));
-		LOGGER.info("Memory: {} MB", memoryInMB);
+		LOGGER.info("Physical memory available: {} MB", memory.getAvailable() / 1048576);
+		LOGGER.info("Memory accessible by Java: {} MB", memoryInMB);
+		LOGGER.info("CPU: " + processor.getName());
 		LOGGER.info("Language: " + WordUtils.capitalize(PMS.getLocale().getDisplayName(Locale.ENGLISH)));
+		LOGGER.info("Encoding: " + System.getProperty("file.encoding"));
 		LOGGER.info("");
 
 		if (Platform.isMac()) {

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -1404,28 +1404,15 @@ public class PMS {
 	 */
 	private void logSystemInfo() {
 		long memoryInMB = Runtime.getRuntime().maxMemory() / 1048576;
-		HardwareAbstractionLayer hal = new SystemInfo().getHardware();
-        CentralProcessor processor = hal.getProcessor();
-        GlobalMemory memory = hal.getMemory();
-        String name = processor.getName();
-        String result = CbmAPI.getCpuByName(name);
-        String score = "not available";
-        if (result.contains("Score")) {
-        	score = result.substring(result.indexOf("Score") + 8, result.indexOf(",") - 1);
-        	try {
-        		cpuScore = Integer.parseInt(score);
-        	} catch (NumberFormatException e) {
-                LOGGER.error("Can't parse the CPU score result: " + e);
-            }
-
-        }
+        GlobalMemory memory = new SystemInfo().getHardware().getMemory();
+        configuration.parseCpuInfo();
 
 		LOGGER.info("Java: " + System.getProperty("java.vm.name") + " " + System.getProperty("java.version") + " " + System.getProperty("sun.arch.data.model") + "-bit" + " by " + System.getProperty("java.vendor"));
 		LOGGER.info("OS: " + System.getProperty("os.name") + " " + getOSBitness() + "-bit " + System.getProperty("os.version"));
 		LOGGER.info("Physical memory: {} MB", memory.getTotal() / 1048576);
 		LOGGER.info("Available physical memory : {} MB", memory.getAvailable() / 1048576);
 		LOGGER.info("Memory accessible by Java: {} MB", memoryInMB);
-		LOGGER.info("CPU: " + name + ", Benchmark score: " + score);
+		LOGGER.info("CPU: " + configuration.getCpuName() + ", Benchmark score: " + configuration.getCpuScore());
 		LOGGER.info("Language: " + WordUtils.capitalize(PMS.getLocale().getDisplayName(Locale.ENGLISH)));
 		LOGGER.info("Encoding: " + System.getProperty("file.encoding"));
 		LOGGER.info("");

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -40,10 +40,15 @@ import net.pms.PMS;
 import net.pms.dlna.CodeEnter;
 import net.pms.formats.Format;
 import net.pms.io.SystemUtils;
+import net.pms.util.CbmAPI;
 import net.pms.util.CoverSupplier;
 import net.pms.util.FilePermissions;
 import net.pms.util.FileUtil;
 import net.pms.util.FileUtil.FileLocation;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
 import net.pms.util.FullyPlayedAction;
 import net.pms.util.Languages;
 import net.pms.util.PropertiesUtil;
@@ -127,6 +132,8 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_CODE_THUMBS = "code_show_thumbs_no_code";
 	protected static final String KEY_CODE_TMO = "code_valid_timeout";
 	protected static final String KEY_CODE_USE = "code_enable";
+	protected static final String KEY_CPU_NAME = "cpu_name";
+	protected static final String KEY_CPU_SCORE = "cpu_score";
 	protected static final String KEY_DISABLE_FAKESIZE = "disable_fakesize";
 	public    static final String KEY_DISABLE_SUBTITLES = "disable_subtitles";
 	protected static final String KEY_DISABLE_TRANSCODE_FOR_EXTENSIONS = "disable_transcode_for_extensions";
@@ -3863,5 +3870,39 @@ public class PmsConfiguration extends RendererConfiguration {
 
 	public int getAliveDelay() {
 		return getInt(KEY_ALIVE_DELAY, 0);
+	}
+
+	public void setCpuName(String value) {
+		configuration.setProperty(KEY_CPU_NAME, value);
+	}
+
+	public String getCpuName() {
+		return getString(KEY_CPU_NAME, "");
+	}
+
+	public void setCpuScore(String value) {
+		configuration.setProperty(KEY_CPU_SCORE, value);
+	}
+
+	public String getCpuScore() {
+		return getString(KEY_CPU_SCORE, "");
+	}
+
+	public void parseCpuInfo() {
+		String name = new SystemInfo().getHardware().getProcessor().getName();
+		boolean cpuChanged = false;
+		if (getCpuName().isEmpty() || !getCpuName().equals(name)) {
+			setCpuName(name);
+			cpuChanged = true;
+		}
+
+		if ((getCpuScore().isEmpty() || cpuChanged) && !getCpuName().isEmpty()) {
+			String result = CbmAPI.getCpuByName(getCpuName());
+			if (result.contains("Score")) {
+				setCpuScore(result.substring(result.indexOf("Score") + 8, result.indexOf(",") - 1));
+			} else {
+				setCpuScore("not available");
+			}
+		}
 	}
 }

--- a/src/main/java/net/pms/util/CbmAPI.java
+++ b/src/main/java/net/pms/util/CbmAPI.java
@@ -9,6 +9,9 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.pms.PMS;
 
 /*
 Copyright (c) 2015 yakka34
@@ -38,6 +41,8 @@ THE SOFTWARE.
  * @author yakka34
  */
 public class CbmAPI {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CbmAPI.class);
 
     //Folowing 3 methods are the only ones that can be called outside of the class.
     //getCpuByUrl takes a complete cpubenchmark.net url and passes it forward as it is.
@@ -118,8 +123,17 @@ public class CbmAPI {
         Element table = html.select("table.desc").first();
         //<span> containing the name is clearly labeled as cpuname.
         String cpuName = table.select("span.cpuname").text();
-        //Score is the last one to use <span> tag and will be parsed to int.
-        int cpuScore = Integer.parseInt(table.select("span").last().text());
+        //Score is the last but one to use <span> tag and will be parsed to int.
+        int cpuScoreTagPosition = table.select("span").size() - 2;
+        int cpuScore = 0;
+        String cpuScoreString = null;
+        try {
+        	cpuScoreString = table.select("span").get(cpuScoreTagPosition).text();
+        	cpuScore = Integer.parseInt(cpuScoreString);
+        } catch (NumberFormatException e) {
+			LOGGER.debug("Retrieved CPU score format '{}' is wrong.", cpuScoreString);
+		}
+
         //There are 2 <em> tags containing information. First one has description and second one has "Other names" eg.alternative name.
         String description = table.select("em").first().text();
         String altName = table.select("em").last().text();

--- a/src/main/java/net/pms/util/CbmAPI.java
+++ b/src/main/java/net/pms/util/CbmAPI.java
@@ -11,7 +11,6 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import net.pms.PMS;
 
 /*
 Copyright (c) 2015 yakka34

--- a/src/main/java/net/pms/util/CbmAPI.java
+++ b/src/main/java/net/pms/util/CbmAPI.java
@@ -1,0 +1,162 @@
+package net.pms.util;
+
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import static java.net.URLEncoder.encode;
+import org.json.simple.JSONObject;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/*
+Copyright (c) 2015 yakka34
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+/*
+ * Unofficial cpubenchmark.net API
+ *
+ * @version 1.0.2.1
+ * @author yakka34
+ */
+public class CbmAPI {
+
+    //Folowing 3 methods are the only ones that can be called outside of the class.
+    //getCpuByUrl takes a complete cpubenchmark.net url and passes it forward as it is.
+    public static String getCpuByUrl(String url) {
+        String jsonString = getCpuInfo(url);
+        return jsonString;
+    }
+
+    //getCpuById uses cpubenchmark.net individually assigned cpu id.
+    public static String getCpuById(int id) {
+        String jsonString = getCpuInfo("https://www.cpubenchmark.net/cpu.php?id=" + id);
+        return jsonString;
+    }
+
+    //Names must be complete and intel cpus has to have "@ clockspeed" in them. Examples: Intel Core i7-5960X @ 3.00GHz or AMD FX-8350 Eight-Core
+    public static String getCpuByName(String cpuName) {
+        String encodedUrl = encodeToUrl(cpuName);
+        String jsonString = getCpuInfo("https://www.cpubenchmark.net/cpu.php?cpu=" + encodedUrl);
+        return jsonString;
+    }
+
+    //Uses cpubenchmark.net's zoom zearch and returns cpu's benhmark/information url.
+    public static String searchCpuByName(String cpuName) {
+        String encodedName = encodeToUrl(cpuName);
+        Document html = null;
+        String url = null;
+        try {
+            //Connects to zoom's search engine and looks for given cpu from benhmarks section.
+            html = Jsoup.connect("https://www.passmark.com/search/zoomsearch.php?zoom_sort=0&zoom_query=" + encodedName + "&zoom_cat%5B%5D=5").get();
+        } catch (IOException e) {
+            System.out.println("Connection throws an exception: " + e);
+        }
+        
+        //Regex check is used to validate correct search result.
+        if (html != null) {
+            Elements links = html.select("div.results");
+            links = links.select("a[href~=^(https?:\\/\\/www.cpubenchmark.net/cpu.php\\?)]");
+            url = links.attr("href");
+            if(url.isEmpty()){
+                return "No results found for: " + cpuName;
+            }
+        } //message for connection issues.
+        else {
+            return "Connection to the search engine failed.";
+        }
+        return url;
+    }
+
+    //getCpuInfo calls various methods to construct a complete Json formated string from given url.
+    private static String getCpuInfo(String url) {
+        Document html = null;
+        String infoString;
+        String jsonString;
+        String infoArray[];
+        try {
+            html = Jsoup.connect(url).get();
+        } catch (IOException e) {
+            System.out.println("Connection to: " + url + " ,throws an exception: " + e);
+        }
+
+        if (html != null) {
+            //Attributes in the infoString are seperated by commas and data by semicolons.
+            infoString = parseHtmlForInfo(html);
+            //infoString needs to be split into array for further processing.
+            infoArray = parseStringToArray(infoString);
+            //Array is used to create JSONString.
+            jsonString = convertArrayToJsonString(infoArray);
+        } else {
+            System.out.println("No html value assigned returning null!");
+            return null;
+        }
+        return jsonString;
+    }
+
+    //Parses given html file. Data parsing is hardcoded because lack of id tagging on cpubenchmark.net behalf.
+    private static String parseHtmlForInfo(Document html) {
+        //Instead of parsing the the whole html page everytime, only useful table section is used.
+        Element table = html.select("table.desc").first();
+        //<span> containing the name is clearly labeled as cpuname.
+        String cpuName = table.select("span.cpuname").text();
+        //Score is the last one to use <span> tag and will be parsed to int.
+        int cpuScore = Integer.parseInt(table.select("span").last().text());
+        //There are 2 <em> tags containing information. First one has description and second one has "Other names" eg.alternative name.
+        String description = table.select("em").first().text();
+        String altName = table.select("em").last().text();
+        //Name -> Score -> possible description -> AltName.
+        String infoString = cpuName + ",Score:" + cpuScore + "," + description + ",AltName:" + altName;
+        return infoString;
+    }
+
+    //Splits the infoString into array by using regex split.
+    private static String[] parseStringToArray(String infoString) {
+        //Splits the String everytime it founds comma or semicolon.
+        String[] infoArray = infoString.split("[,:]");
+        return infoArray;
+    }
+
+    //Data from array is read and placed into json object which will be parsed into String.
+    private static String convertArrayToJsonString(String[] infoArray) {
+        //Depending on prefered formating, use of temp is not necessary.
+        JSONObject temp = new JSONObject();
+        JSONObject jObj = new JSONObject();
+        int length = infoArray.length;
+        for (int i = 1; i < length - 1; i += 2) {
+            int y = i + 1;
+            temp.put(infoArray[i].trim(), infoArray[y].trim());
+        }
+        //Name of the cpu is always located first in the array.
+        jObj.put(infoArray[0], temp);
+        return jObj.toString();
+    }
+
+    private static String encodeToUrl(String string) {
+        String encodedUrl = null;
+        try {
+            encodedUrl = encode(string, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            System.out.println("Encoding not supported: " + e);
+        }
+        return encodedUrl;
+    }
+}


### PR DESCRIPTION
I just learned that if you force push while a PR is closed, the PR is invalidated and can't be reopened for some strange reason.

This is therefore the continuation of #979. That doesn't mean that I think it should be merged - I actually dislike several aspects of this. In addition to my reservation regarding catering just to those with spare CPU capacity and bad networks:
* I think storing the CPU information in the configuration file defeats all purpose of this. That means that whenever someone moves UMS from one computer to another (or upgrades their hardware) UMS will still use the information from the previous hardware. That won't make sense to the users, that I'm sure of.
* This doesn't actually measure the speed of the computer in any way, but tries to get a "CPU score" from a benchmarking website. The average reported benchmark score of a CPU can not be translated to "how much CPU resources we have available in the current enironment".
* The lookup is based on a text string of the CPU name. This will only work as long as everything is kept updated, and is bound to fail for more rare cases or when some of the involved libraries are abandoned.
* Retrieving the results is done by scraping [cpubenchmark.net](http://www.cpubenchmark.net). Scraping is bad in so many ways I don't know where to begin. It's slow, it WILL break and it's often against the will of the host. In addition the current scraping code is very "lazily" written and doesn't handle when things doesn't go as planned. One basic example is that if UMS doesn't have internet connection, it fails to start. This also breaks with UMS' "use external network" permission, it will contact the internet regardless.

@valib I had to do a lot of rebasing work to get this branch to compile at all. I don't know what had happened, but there were some serious git corruptions in this branch. I think I managed to figure it all out. In addition I've squashed simple spell correction or white space commits, removed the commit that was reversed and it's reversal and removed the merge commits. The result is that this shrunk from 12 to 3 commits!

For me, this is a major reason why I takes a long time for me to review a PR - when there is so much "mess" with the commits, I need a long time to figure it out before I can actually review the changes. It took me almost 3 hours to get this to a state where I could actually get an overview. You should really start using rebasing to clean up all your "work in progress" commits, and at the very least use ```amend```.

One further issue is that the ```Oshi``` is Java 8 only. I've told you a long time ago that you should configure Eclipse to use JDK 7 as long as we're working with Java 7, you would have detected it right away. So, I had to revert the version back to the last Java 7 release ```2.6-m-java7```. 

Then I could finally figure out the ```low``` error. The error is simple enough, it is on line 122 in ```CbmAPI```: 
```java
        int cpuScore = Integer.parseInt(table.select("span").last().text());
```

The reason it fails is because it is a scraper and a lousy one as such. It expects that element to be the cpu score, while it's actually the word "low". The reason is bound to be because they have done some slight adjustment to the web page. In addition the code is so terribly lazy that it doesn't check for a ```NumberFormatException``` when parsing scraped data! I can't fix it because I don't know what to do when the score can't be found. That could happen even if I updated the scraper to find the (currently) correct element. It's also guaranteed to send CPU strings that [cpubenchmark.net](http://www.cpubenchmark.net) can't parse and the scraper would probably fail even worse.

A better approach (although I still consider it wrong to assume that UMS can "spend" all available CPU resources to save network bandwidth) would be to run a short CPU intensive code or external program and then time it. That would give an indication of speed that is a much better approximation. @Sami32 would probably have to look at the splash image for quite some time though :stuck_out_tongue:
