### PR TITLE
Updated/Created new renderer profile for Kodi

### DIFF
--- a/src/main/external-resources/renderers/Kodi.conf
+++ b/src/main/external-resources/renderers/Kodi.conf
@@ -16,9 +16,65 @@ RendererIcon =
 
 UserAgentSearch = Kodi
 UpnpDetailsSearch = Kodi
+
+DefaultVBVBufSize = true
+H264Level41Limited = false
+MediaInfo = true
+MuxDTSToMpeg = true
 RemoveTagsFromSRTSubtitles = false
+StreamSubsForTranscodedVideo = true
+SubtitleHttpHeader = CaptionInfo.sec
+TranscodeAudio = WAV
+TranscodeFastStart = true
 
-# Include all settings from this parent configuration:
-# Note: this must come last for the overrides above to maintain priority
-include = XBMC.conf
+Supported = f:3gp             v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac|aac-he|ac3|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma        m:video/3gpp
+Supported = f:avi             v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac|aac-he|ac3|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma        m:video/avi
+Supported = f:flv                                                                                                                                  m:video/flv
+Supported = f:mjpeg																									                               m:video/mjpeg
+Supported = f:mkv             v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac|aac-he|ac3|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma        m:video/x-matroska
+Supported = f:mov             v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac|aac-he|ac3|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma        m:video/quicktime
+Supported = f:mp4             v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac|aac-he|ac3|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma        m:video/mp4
+Supported = f:mpegps|mpegts   v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac|aac-he|ac3|adts|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma   m:video/mpeg
+Supported = f:theora          v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac|aac-he|ac3|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma        m:video/mp4
+Supported = f:webm            v:vp6|vp7|vp8|vp9                                          a:opus                                                    m:video/webm
+Supported = f:wmv             v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac|aac-he|ac3|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma        m:video/x-ms-wmv
 
+
+# Supported audio formats:
+Supported = f:aac|aac-he              m:audio/x-m4a
+Supported = f:ac3                     m:audio/ac3
+Supported = f:acdpm                   m:audio/x-adpcm
+Supported = f:adts      a:aac         m:audio/aac
+Supported = f:aiff                    m:audio/aiff
+Supported = f:amr                     m:audio/amr
+Supported = f:ape                     m:audio/ape
+Supported = f:atmos                   m:audio/atmos
+Supported = f:atrac                   m:audio/x-oma
+Supported = f:cook                    m:audio/cook
+Supported = f:eac3                    m:audio/eac3
+Supported = f:flac                    m:audio/flac
+Supported = f:lpcm                    m:audio/L16
+Supported = f:m4a       a:alac        m:audio/x-m4a
+Supported = f:m4a|3gp   a:aac|aac-he  m:audio/x-m4a
+Supported = f:mlp                     m:audio/mlp
+Supported = f:mp3                     m:audio/mpeg
+Supported = f:mpa                     m:audio/mpa
+Supported = f:ogg                     m:audio/ogg
+Supported = f:opus                    m:audio/opus
+Supported = f:ralf                    m:audio/ralf
+Supported = f:truehd                  m:audio/truehd
+Supported = f:tta                     m:audio/tta
+Supported = f:wav                     m:audio/wav
+Supported = f:wavpack                 m:audio/x-wavpack
+Supported = f:wma                     m:audio/x-ms-wma
+
+# Supported image formats:
+Supported = f:bmp   m:image/bmp
+Supported = f:gif   m:image/gif
+Supported = f:jpg   m:image/jpeg
+Supported = f:png   m:image/png
+Supported = f:tiff  m:image/tiff
+
+# Supported subtitles formats:
+SupportedExternalSubtitlesFormats = ASS,MICRODVD,PGS,SAMI,SUBRIP,TEXT,UFS,VOBSUB,WEBVTT
+SupportedInternalSubtitlesFormats = ASS,MICRODVD,PGS,SAMI,SUBRIP,TEXT,UFS,VOBSUB,WEBVTT


### PR DESCRIPTION
This isn't perfect, trying to configure ```Supported``` lines correctly looking up file format and codec combinations and how they are interpreted by UMS makes me loose the will to live, so I'm simply uploading it as it is now. It's certainly a whole lot better than the current Kodi profile, which to be honest, doesn't work very well at all.

Kodi is brilliant for testing in my opinion, but the severely lacking renderer profiles always drive me crazy and introduces issues whenever I am to do that. This will remedy that situation a lot I'd think.

I've tested this on quite a few audio and video formats, most seem to work well. I haven't tested all the subtitle formats since I don't have test files for them, and there are some problems with a few of the audio formats (some M4A files aren't correctly recognized, but that is a UMS bug that's been there a long time). Generally it will play most audio well. 

When it comes to images I haven't really managed to get it to show JPG at all - it just displays a black screen. I don't quite understand how that could be UMS' fault so I'm assuming that is a bug with Kodi and haven't pursued it any further.

Feel free to make corrections to this PR if you see anything that could be improved, and I hope this can be merged relatively quickly so that all the issues I have when testing other stuff can be a little less frustrating.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1094)
<!-- Reviewable:end -->
