### PR TITLE
link update

### DIFF
--- a/src/main/java/net/pms/util/ProcessUtil.java
+++ b/src/main/java/net/pms/util/ProcessUtil.java
@@ -49,7 +49,7 @@ public class ProcessUtil {
 	private static final int ALRM_TIMEOUT = 2000;
 
 	// work around a Java bug
-	// see: http://kylecartmell.com/?p=9
+	// see: http://www.cnblogs.com/abnercai/archive/2012/12/27/2836008.html
 	public static int waitFor(Process p) {
 		int exit = -1;
 


### PR DESCRIPTION
That's said since Java 6 issues related in the reference link, the things could have changed:
http://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#exec
http://docs.oracle.com/javase/8/docs/api/java/lang/ProcessBuilder.html