### PR TITLE
Fixed some bugs already solved in #1061

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -548,9 +548,9 @@ public class DLNAMediaInfo implements Cloneable {
 
 		args[1] = "-ss";
 		if (resume) {
-			args[2] = "" + (int) getDurationInSeconds();
+			args[2] = Integer.toString((int) getDurationInSeconds());
 		} else {
-			args[2] = "" + configuration.getThumbnailSeekPos();
+			args[2] = Integer.toString((int) Math.min(configuration.getThumbnailSeekPos(), getDurationInSeconds()));
 		}
 
 		args[3] = "-i";
@@ -892,10 +892,11 @@ public class DLNAMediaInfo implements Cloneable {
 						// Make sure the image fits in the renderer's bounds
 						boolean isFullyPlayedThumbnail = FullyPlayed.isFullyPlayedThumbnail(file);
 						thumb = UMSUtils.scaleImage(Files.readAllBytes(file.toPath()), thumbnailWidth, thumbnailHeight, isFullyPlayedThumbnail, renderer);
-
+						thumbready = true;
 						if (isFullyPlayedThumbnail) {
 							thumb = FullyPlayed.addFullyPlayedOverlay(thumb, MediaType.IMAGE);
 						}
+
 					} catch (IOException e) {
 						LOGGER.debug("Error generating thumbnail for \"{}\": {}", file.getName(), e.getMessage());
 						LOGGER.trace("", e);
@@ -904,7 +905,7 @@ public class DLNAMediaInfo implements Cloneable {
 			}
 
 			if (ffmpeg_parsing) {
-				if (!thumbOnly || !configuration.isUseMplayerForVideoThumbs()) {
+				if (!thumbOnly || (type == Format.VIDEO && !configuration.isUseMplayerForVideoThumbs())) {
 					pw = getFFmpegThumbnail(inputFile, resume, renderer);
 				}
 
@@ -956,6 +957,7 @@ public class DLNAMediaInfo implements Cloneable {
 								if (sz > 0) {
 									thumb = new byte[sz];
 									is.read(thumb);
+									thumbready = true;
 								}
 							}
 
@@ -984,6 +986,7 @@ public class DLNAMediaInfo implements Cloneable {
 								if (sz > 0) {
 									thumb = new byte[sz];
 									is.read(thumb);
+									thumbready = true;
 								}
 							}
 						} finally {

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -946,7 +946,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				LOGGER.trace("Final verdict: \"{}\" will be streamed", getName());
 			}
 		} else {
-			LOGGER.trace("Final verdict: \"{}\" will be streamed because no compatible player was found");
+			LOGGER.trace("Final verdict: \"{}\" will be streamed because no compatible player was found", getName());
 		}
 		return resolvedPlayer;
 	}


### PR DESCRIPTION
- Fixed a bug in getFFmpegThumbnail() where thumbnail position could be after EOF
- Fixed some missing "thumbready = true"
- Fixed a bug where FFmpeg thumbnail generation would be attempted for non-video content
- Fixed missing media name for the TRACE log when resolving player