### PR TITLE
Fixed regression in a4f837958f623c178d0132c3d24509e54f87c371

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -18,6 +18,7 @@
  */
 package net.pms.dlna;
 
+import java.util.Locale;
 import net.pms.configuration.FormatConfiguration;
 import net.pms.formats.v2.AudioProperties;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -412,7 +413,7 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 * @since 1.50
 	 */
 	public void setCodecA(String codecA) {
-		this.codecA = codecA.toLowerCase();
+		this.codecA = codecA != null ? codecA.toLowerCase(Locale.ROOT) : null;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -865,7 +865,7 @@ public class DLNAMediaInfo implements Cloneable {
 						ffmpeg_parsing = true;
 					}
 				}
-				
+
 				if (configuration.getImageThumbnailsEnabled() && thumbOnly) {
 					LOGGER.trace("Creating (temporary) thumbnail: {}", file.getName());
 
@@ -1368,7 +1368,7 @@ public class DLNAMediaInfo implements Cloneable {
 			if (codecV != null) {
 				if ("matroska".equals(container) || "mkv".equals(container)) {
 					mimeType = HTTPResource.MATROSKA_TYPEMIME;
-				} else if ("ogg".equals(container)) { 
+				} else if ("ogg".equals(container)) {
 					mimeType = HTTPResource.OGG_TYPEMIME;
 				} else if ("3gp".equals(container)) {
 					mimeType = HTTPResource.THREEGPP_TYPEMIME;
@@ -1398,7 +1398,7 @@ public class DLNAMediaInfo implements Cloneable {
 					mimeType = HTTPResource.AUDIO_THREEGPPA_TYPEMIME;
 				} else if ("3g2".equals(container)) {
 					mimeType = HTTPResource.AUDIO_THREEGPP2A_TYPEMIME;
-				} else if ("adts".equals(container)) {	
+				} else if ("adts".equals(container)) {
 					mimeType = HTTPResource.AUDIO_ADTS_TYPEMIME;
 				} else if ("matroska".equals(container) || "mkv".equals(container)) {
 					mimeType = HTTPResource.AUDIO_MATROSKA_TYPEMIME;
@@ -1940,7 +1940,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * @since 1.50.0
 	 */
 	public void setCodecV(String codecV) {
-		this.codecV = codecV.toLowerCase();
+		this.codecV = codecV != null ? codecV.toLowerCase(Locale.ROOT) : null ;
 	}
 
 	/**


### PR DESCRIPTION
This is a bit urgent, we should maybe consider to do a release soon because of this. I can't believe we haven't gotten more reports about this, but maybe we have?

Basicly, setting ```codecA``` or ```codecV``` to ```null``` causes a NPE after a4f837958f623c178d0132c3d24509e54f87c371.

This is the [source](http://www.universalmediaserver.com/forum/viewtopic.php?f=10&t=9086).
