### PR TITLE
Fix UPnP controls for Viera E6 series

### DIFF
--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -366,7 +366,7 @@ public class UPNPControl {
 
 	public static boolean isUpnpControllable(String uuid) {
 		// Disable manually for Panasonic TVs since they lie
-		if (rendererMap.containsKey(uuid) && !getDeviceDetailsString(getDevice(uuid)).contains("VIERA")) {
+		if (rendererMap.containsKey(uuid) && (getDeviceDetailsString(getDevice(uuid)).contains("VIERA E6") && getDeviceDetailsString(getDevice(uuid)).contains("VIERA"))) {
 			return rendererMap.get(uuid, "0").controls != 0;
 		}
 		return false;


### PR DESCRIPTION
I don't know if it's the way to go, in the mean that other Viera model could be unfairly concerned as well, so any comments are welcome...
Perhaps only "banned" the Viera that we are sure about ?