### PR TITLE
Fix bitrate logging unit info omission

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -509,7 +509,7 @@ public class FFMpegVideo extends Player {
 					defaultMaxBitrates[0] = 3000;
 				}
 
-				LOGGER.trace("Adjusting the video bitrate limit to " + defaultMaxBitrates[0] + " to make room for audio");
+				LOGGER.trace("Adjusting the video bitrate limit to " + defaultMaxBitrates[0] + "kb/s to make room for audio");
 			}
 
 			videoBitrateOptions.add("-bufsize");

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -768,7 +768,7 @@ public class MEncoderVideo extends Player {
 				// Round down to the nearest Mb
 				defaultMaxBitrates[0] = defaultMaxBitrates[0] / 1000 * 1000;
 
-				LOGGER.trace("Adjusting the video bitrate limit to " + defaultMaxBitrates[0] + " to make room for audio");
+				LOGGER.trace("Adjusting the video bitrate limit to " + defaultMaxBitrates[0] + "kb/s to make room for audio");
 			}
 
 			encodeSettings += ":vrc_maxrate=" + defaultMaxBitrates[0] + ":vrc_buf_size=" + bufSize;


### PR DESCRIPTION
Bitrate unit was omited in that commit https://github.com/UniversalMediaServer/UniversalMediaServer/commit/078c3055869a1ddb215386c2f31accb29978822d