### PR TITLE
Update LG-WebOS.conf

### DIFF
--- a/src/main/external-resources/renderers/LG-WebOS.conf
+++ b/src/main/external-resources/renderers/LG-WebOS.conf
@@ -15,7 +15,7 @@ RendererIcon = lg-lb6500.png
 # ============================================================================
 #
 
-UserAgentSearch = LGE WebOS TV|LG WebOSTV
+UserAgentSearch = LG. (w|W)ebOS TV|LG (W|w)ebOSTV
 LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AAC
@@ -25,15 +25,26 @@ AutoExifRotate = true
 MediaInfo = true
 
 # Supported video formats:
-Supported = f:mp4      v:h264|mp4   a:aac   m:video/mp4
-Supported = f:mpegts   v:h264       a:aac   m:video/mpeg
-Supported = f:wmv      v:wmv|vc1    a:wma   m:video/x-ms-wmv
+#Supported = f:3g2|3gp     v:h264|mp4                        a:aac|aac-he                            m:video/3gpp
+Supported = f:avi         v:h264|mjpeg|mp4|xvid             a:aac|aac-he|ac3|dts|mp3|mpa            m:video/avi
+Supported = f:mkv         v:h264|h265|mp4|mpeg2|vp8|vp9     a:aac|aac-he|ac3|dts|mp3|mpa|vorbis     m:video/x-matroska
+Supported = f:mov         v:h264|h265|mp4                   a:aac|aac-he                            m:video/quicktime
+Supported = f:mp4|m4v     v:h264|mp4                        a:aac|aac-he                            m:video/mp4
+Supported = f:mpegps      v:mpeg1|mpeg2                     a:ac3|lpcm|mpa                          m:video/mpeg
+Supported = f:mpegts      v:h264|mpeg2                      a:aac|aac-he|ac3|dts|eac3               m:video/mpeg
+Supported = f:wmv|asf     v:wmv|vc1                         a:wma                                   m:video/x-ms-wmv
 
 # Supported audio formats:
 Supported = f:mp3   m:audio/mpeg
+Supported = f:ogg   m:audio/ogg
+Supported = f:wav   m:audio/L16
 Supported = f:wma   m:audio/x-ms-wma
 
 # Supported image formats:
+Supported = f:bmp    m:audio/bmp
 Supported = f:gif    m:image/gif
 Supported = f:jpg    m:image/jpeg
 Supported = f:png    m:image/png
+
+# Supported subtitles formats:
+SupportedExternalSubtitlesFormats = WEBVTT


### PR DESCRIPTION
Reported there by uxb : http://www.universalmediaserver.com/forum/viewtopic.php?p=29322#p29322
http://www.uxb.net/ums_dbg.zip (log)
> User-Agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 WebAppManager

> "[LG] webOS TV UH6030" with dlna details: {friendlyName=[LG] webOS TV UH6030, address=192.168.0.100, udn=uuid:eb2c68b6-6888-70ba-699f-3dad77002832, manufacturer=LG Electronics, modelName=LG Smart TV, modelNumber=55UH6030-UC, modelDescription=, manufacturerURL=http://www.lge.com, modelURL=http://www.lge.com}