### PR TITLE
Updated Travis builds to use multiple JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: java
+
 addons:
   apt:
     packages:
     - mediainfo 
+
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+
 install: mvn external:install 
+
 script: mvn install -Dmaven.javadoc.skip=true -B -V


### PR DESCRIPTION
This lets us test both Java 7 and Java 8. Unfortunately OpenJDK 8 isn't available: travis-ci/travis-ci#6483