### PR TITLE
Store the subs color in UMS.conf as the hexa string

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -2807,12 +2807,12 @@ public class PmsConfiguration extends RendererConfiguration {
 		configuration.setProperty(KEY_CHAPTER_INTERVAL, value);
 	}
 
-	public int getSubsColor() {
-		return getInt(KEY_SUBS_COLOR, 0xffffffff);
+	public String getSubsColor() {
+		return getString(KEY_SUBS_COLOR, "0xffffffff").substring(2);
 	}
 
-	public void setSubsColor(int value) {
-		configuration.setProperty(KEY_SUBS_COLOR, value);
+	public void setSubsColor(String value) {
+		configuration.setProperty(KEY_SUBS_COLOR, "0x" + value);
 	}
 
 	public boolean isFix25FPSAvMismatch() {

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -1877,6 +1877,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 
 		// Give priority to the renderer's maximum bitrate setting over the user's setting
 		if (rendererMaxBitrates[0] > 0 && rendererMaxBitrates[0] < defaultMaxBitrates[0]) {
+			LOGGER.trace("Using the video bitrate limit from the renderer config (" + rendererMaxBitrates[0] + " Mb/s) which is lower than the one from the program settings (" + defaultMaxBitrates[0] + " Mb/s)");
 			defaultMaxBitrates = rendererMaxBitrates;
 		}
 

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -431,8 +431,8 @@ public class FFMpegVideo extends Player {
 
 		// Give priority to the renderer's maximum bitrate setting over the user's setting
 		if (rendererMaxBitrates[0] > 0 && rendererMaxBitrates[0] < defaultMaxBitrates[0]) {
-			defaultMaxBitrates = rendererMaxBitrates;
 			LOGGER.trace("Using the video bitrate limit from the renderer config (" + rendererMaxBitrates[0] + "Mb/s) which is lower than the one from the program settings (" + defaultMaxBitrates[0] + ")");
+			defaultMaxBitrates = rendererMaxBitrates;
 		} else {
 			LOGGER.trace("Using the video bitrate limit from the program settings (" + defaultMaxBitrates[0] + "Mb/s)");
 		}

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -51,6 +51,7 @@ import static net.pms.util.AudioUtils.getLPCMChannelMappingForMencoder;
 import static net.pms.util.StringUtil.quoteArg;
 import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.apache.commons.configuration.event.ConfigurationListener;
+import org.apache.commons.lang3.StringUtils;
 import static org.apache.commons.lang.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.*;
 import org.slf4j.Logger;
@@ -693,8 +694,8 @@ public class MEncoderVideo extends Player {
 
 		// Give priority to the renderer's maximum bitrate setting over the user's setting
 		if (rendererMaxBitrates[0] > 0 && rendererMaxBitrates[0] < defaultMaxBitrates[0]) {
-			defaultMaxBitrates = rendererMaxBitrates;
 			LOGGER.trace("Using the video bitrate limit from the renderer config (" + rendererMaxBitrates[0] + "Mb/s) which is lower than the one from the program settings (" + defaultMaxBitrates[0] + ")");
+			defaultMaxBitrates = rendererMaxBitrates;
 		} else {
 			LOGGER.trace("Using the video bitrate limit from the program settings (" + defaultMaxBitrates[0] + "Mb/s)");
 		}
@@ -1243,6 +1244,7 @@ public class MEncoderVideo extends Player {
 			}
 
 			if ((rendererMaxBitrates[0] > 0) && (rendererMaxBitrates[0] < defaultMaxBitrates[0])) {
+				LOGGER.trace("Using the video bitrate limit from the renderer config (" + rendererMaxBitrates[0] + " Mb/s) which is lower than the one from the program settings (" + defaultMaxBitrates[0] + " Mb/s)");
 				defaultMaxBitrates = rendererMaxBitrates;
 			}
 
@@ -1408,8 +1410,8 @@ public class MEncoderVideo extends Player {
 
 				if (override_ass_style) {
 					String assSubColor = "ffffff00";
-					if (configuration.getSubsColor() != 0) {
-						assSubColor = Integer.toHexString(configuration.getSubsColor());
+					if (StringUtils.isNotBlank(configuration.getSubsColor())) {
+						assSubColor = configuration.getSubsColor();
 						if (assSubColor.length() > 2) {
 							assSubColor = assSubColor.substring(2) + "00";
 						}

--- a/src/main/java/net/pms/encoders/VLCVideo.java
+++ b/src/main/java/net/pms/encoders/VLCVideo.java
@@ -310,6 +310,7 @@ public class VLCVideo extends Player {
 
 		// Give priority to the renderer's maximum bitrate setting over the user's setting
 		if (rendererMaxBitrates[0] > 0 && rendererMaxBitrates[0] < defaultMaxBitrates[0]) {
+			LOGGER.trace("Using the video bitrate limit from the renderer config (" + rendererMaxBitrates[0] + " Mb/s) which is lower than the one from the program settings (" + defaultMaxBitrates[0] + " Mb/s)");
 			defaultMaxBitrates = rendererMaxBitrates;
 		}
 

--- a/src/main/java/net/pms/newgui/TranscodingTab.java
+++ b/src/main/java/net/pms/newgui/TranscodingTab.java
@@ -25,6 +25,7 @@ import com.jgoodies.forms.layout.FormLayout;
 import com.sun.jna.Platform;
 import java.awt.*;
 import java.awt.event.*;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import javax.swing.*;
 import javax.swing.event.TreeSelectionEvent;
@@ -1001,7 +1002,7 @@ public class TranscodingTab {
 
 		subColor = new JButton();
 		subColor.setText(Messages.getString("MEncoderVideo.31"));
-		subColor.setBackground(new Color(configuration.getSubsColor()));
+		subColor.setBackground(new Color(new BigInteger(configuration.getSubsColor(), 16).intValue()));
 		subColor.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -1013,7 +1014,7 @@ public class TranscodingTab {
 
 				if (newColor != null) {
 					subColor.setBackground(newColor);
-					configuration.setSubsColor(newColor.getRGB());
+					configuration.setSubsColor(Integer.toHexString(newColor.getRGB()));
 					SubtitleUtils.deleteSubs(); // Color has been changed so all temporary subs will be deleted and make new
 				}
 			}

--- a/src/main/java/net/pms/util/SubtitleUtils.java
+++ b/src/main/java/net/pms/util/SubtitleUtils.java
@@ -620,10 +620,9 @@ public class SubtitleUtils {
 	 * @param colour the RGB color in the integer format
 	 * @return Converted color string in the ASS format
 	 */
-	public static String convertColourToASSColourString(int colour) {
-		String colourString = Integer.toHexString(colour);
+	public static String convertColourToASSColourString(String colour) {
 		StringBuilder outputString = new StringBuilder();
-		outputString.append("&H").append(colourString.substring(6, 8)).append(colourString.substring(4, 6)).append(colourString.substring(2, 4));
+		outputString.append("&H").append(colour.substring(6, 8)).append(colour.substring(4, 6)).append(colour.substring(2, 4));
 		return outputString.toString();
 	}
 


### PR DESCRIPTION
+ fix the logging when the renderer's maximum bitrate setting has the
priority over the user's setting

This fix issues #1149 and #1150