### PR TITLE
Making Philips PFL renderer more general

### DIFF
--- a/src/main/external-resources/renderers/Philips-PFL.conf
+++ b/src/main/external-resources/renderers/Philips-PFL.conf
@@ -128,14 +128,9 @@
 # wav with dts
 # wav with mp3
 # ----------------------------------------------------------------------------
-# .aac audio files into "adts" container play correctly with usb on the 40pfl8605h_12
-# and windows media player 12 can stream these files.
-# Unfortunately the logfile gives the next error when browsing into it
-# [New I/O server worker #1-4] INFO 23:46:50.055 The file W:\Muziek\Audio Data
-# Transport Stream.aac was badly parsed. It will be hidden.
-# Because of this I wasn't able to test next line:
-# Supported = f:adts a:aac s:48000 m:audio/vnd.dlna.adts
+# If some sound issue is met while transcoding, set the AC3 bitrate to 448 Kbps in the transcoding tab.
 # ----------------------------------------------------------------------------
+
 RendererName = Philips TV
 RendererIcon = philips-pfl.png
 
@@ -146,8 +141,8 @@ RendererIcon = philips-pfl.png
 # ============================================================================
 #
 
-UserAgentSearch = PhilipsIntelSDK
-UpnpDetailsSearch = Philips , NMR
+UserAgentSearch = PhilipsIntelSDK/1.4|Streamium/1.0
+UpnpDetailsSearch = Philips TV
 
 TranscodeAudio = WAV
 MimeTypesChanges = audio/x-m4a = audio/mp4
@@ -176,28 +171,23 @@ MediaInfo = true
 # MKV with VC-1, MPEG-2, MPEG-4 or DivX is not supported.
 
 # Supported video formats:
-Supported = f:mpegps   v:mpeg1   a:mpa|mp3            m:video/mpeg
-Supported = f:mpegps   v:mpeg2   a:mpa|mp3|ac3|lpcm   m:video/mpeg
-Supported = f:mpegts   v:mpeg2   a:mpa|ac3|lpcm       m:video/vnd.dlna.mpeg-tts
-Supported = f:avi      v:mp4     a:ac3|mp3|mpa        m:video/x-msvideo
-Supported = f:avi      v:divx    a:ac3|mp3|mpa        m:video/x-msvideo           qpel:no
-Supported = f:divx     v:divx    a:ac3|mp3|mpa        m:video/x-msvideo
-Supported = f:mp4      v:h264    a:aac|ac3|mp3|mpa    m:video/h264                          b:4528690
-Supported = f:mp4      v:mp4     a:aac|ac3|mp3|mpa    m:video/h264
-Supported = f:wmv      v:vc1     a:wma                m:video/x-ms-wmv                                  n:2 s:48000
-Supported = f:mkv      v:h264    a:aac|ac3|mp3|mpa    m:video/x-matroska
+Supported = f:mpegps   v:mpeg1       a:mpa|mp3                          m:video/mpeg
+Supported = f:mpegps   v:mpeg2       a:ac3|lpcm|mp3|mpa                 m:video/mpeg
+Supported = f:mpegts   v:mpeg2       a:mpa|ac3|lpcm                     m:video/vnd.dlna.mpeg-tts
+Supported = f:avi      v:mp4         a:ac3|mp3|mpa                      m:video/x-msvideo
+Supported = f:avi      v:divx        a:ac3|mp3|mpa                      m:video/x-msvideo               qpel:no
+Supported = f:divx     v:divx        a:ac3|mp3|mpa                      m:video/x-msvideo
+Supported = f:mp4      v:h264        a:aac|he-aac|ac3|mp3|mpa           m:video/h264                    b:4528690
+Supported = f:mp4      v:mp4         a:aac|he-aac|ac3|mp3|mpa           m:video/h264
+Supported = f:wmv      v:vc1         a:wma                              m:video/x-ms-wmv                n:2          s:48000
+Supported = f:mkv      v:h264        a:aac|he-aac|ac3|mp3|mpa           m:video/x-matroska
 
 # Supported audio formats:
-Supported = f:mpa|mp3    n:2            s:48000   b:327680    m:audio/mpeg
-Supported = f:wma        n:2   a:wma    s:48000   b:348160    m:audio/x-ms-wma
+Supported = f:adts       n:2   a:aac    s:48000               m:audio/vnd.dlna.adts
+Supported = f:aiff|wav   n:2   a:lpcm   s:44100   b:1445069   m:audio/L16
+Supported = f:mp3|mpa    n:2            s:48000   b:327680    m:audio/mpeg
 Supported = f:mp4        n:6   a:aac    s:48000   b:327680    m:audio/mp4
-Supported = f:aiff|wav   n:1   a:lpcm   s:44100   b:1445069   m:audio/L16;rate=44100;channels=1
-Supported = f:aiff|wav   n:2   a:lpcm   s:44100   b:1445069   m:audio/L16;rate=44100;channels=2
-Supported = f:aiff|wav   n:1   a:lpcm   s:48000   b:1445069   m:audio/L16;rate=48000;channels=1
-Supported = f:aiff|wav   n:2   a:lpcm   s:48000   b:1445069   m:audio/L16;rate=48000;channels=2
+Supported = f:wma        n:2   a:wma    s:48000   b:348160    m:audio/x-ms-wma
 
 # Supported image formats:
 Supported = f:jpg    m:image/jpeg
-# tiff is not supported. This line is added so that the 40pfl8605h_12 recognizes tiff
-# as an unsupported format.
-Supported = f:tiff   m:image/tiff

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -100,6 +100,7 @@ public class RendererConfigurationTest {
 
 		// PhilipsPFL:
 		testHeaders("Philips TV", "User-Agent: Windows2000/0.0 UPnP/1.0 PhilipsIntelSDK/1.4 DLNADOC/1.50");
+		testHeaders("Philips TV", "User-Agent: Streamium/1.0");
 
 		// Realtek:
 		// FIXME: Actual conflict here! Popcorn Hour is returned...


### PR DESCRIPTION
Philips PFL7605H/12 and all the PFL7[456].5[CH] models
http://download.p4c.philips.com/files/3/37pfl7605h_12/37pfl7605h_12_dfu_eng.pdf

```
"Philips TV"
USER-AGENT: Windows2000/0.0 UPnP/1.0 PhilipsIntelSDK/1.4 DLNADOC/1.50
User-Agent: Streamium/1.0
```

> DEBUG 2017-01-22 15:14:19.264 [New I/O worker #11] net.pms.configuration.RendererConfiguration Marking renderer "Philips TV" at /192.168.0.14 as unrecognized

LOG ==> http://www.universalmediaserver.com/forum/download/file.php?id=3624

> Specifications (p.67)
> Supported DLNA audio/video files
> WMV (*.wmv): 
> video: WMV9/VC1
> MPEG (*.mp2, *.mp3, *.mpg, *.mpeg, *.vob): 
> audio: MPEG-1 Layer 2, MPEG-1 Layer 3, 
> LPCM, AC3
> MPEG-4  (*.mp4): 
> video: MPEG-4 AVC (H.264, L2-CIF), 
> MPEG-4 AVC (H.264, L4-HD)
> audio: AAC-LC, HE-AAC
> MKV (*.mkv):
> video: H.264
> audio: HE-ACC, AC3

More detailed codecs specifications:
http://www.supportforum.philips.com/en/attachment.php?attachmentid=163&d=1298024519
http://www.supportforum.philips.com/en/attachment.php?attachmentid=925&d=1331632340