### PR TITLE
Partially revert d7cdac34af11626623f428865847b4bc5714445c

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
 											maven-antrun-plugin
 										</artifactId>
 										<versionRange>
-											[1.8,)
+											[1.7,)
 										</versionRange>
 										<goals>
 											<goal>run</goal>


### PR DESCRIPTION
This is incorrect, it tells Eclipse what Java version is allowed. As long as we're on Java 7 we shouldn't limit Eclipse to Java 8.
