### PR TITLE
Global id debug

### DIFF
--- a/src/main/java/net/pms/dlna/GlobalIdRepo.java
+++ b/src/main/java/net/pms/dlna/GlobalIdRepo.java
@@ -31,23 +31,31 @@ public class GlobalIdRepo {
 	public void add(DLNAResource dlnaResource) {
 		lock.writeLock().lock();
 		try {
-			String id = dlnaResource.getId();
-			if (id != null) {
-				remove(id);
-			}
-			ids.add(new ID(dlnaResource, curGlobalId++));
+			boolean isUniqueResource = true;
+			String resourcePath = dlnaResource.getSystemName();
+//			String id = dlnaResource.getId();
+//			if (id != null) {
+//				remove(id);
+//			}
 
 			LOGGER.info("---------------------------------------------------------------------------------");
 			LOGGER.info("------------------------------- Global ID dump ----------------------------------");
 			LOGGER.info("---------------------------------------------------------------------------------");
 			for (ID element : ids) {
+				if ("RealFile".equals(element.dlnaResource.getClass().getSimpleName()) && resourcePath.equals(element.dlnaResource.getSystemName())) {
+					dlnaResource.setId(element.dlnaResource.getId());
+					isUniqueResource = false;
+				}
 				LOGGER.info(
-					"Id: {}, Name: {}, Class: {}, DisplayName: {}",
-					element.dlnaResource.getId(), element.dlnaResource.getName(), element.dlnaResource.getClass().getSimpleName(), element.dlnaResource.getDisplayName()
+					"Id: {}, Name: {}, Class: {}, DisplayName: {}, Path: {}",
+					element.dlnaResource.getId(), element.dlnaResource.getName(), element.dlnaResource.getClass().getSimpleName(), element.dlnaResource.getDisplayName(), element.dlnaResource.getSystemName()
 				);
 			}
 			LOGGER.info("---------------------------------------------------------------------------------");
 			LOGGER.info("");
+			if (isUniqueResource) {
+				ids.add(new ID(dlnaResource, curGlobalId++));
+			}
 		} finally {
 			lock.writeLock().unlock();
 		}

--- a/src/main/java/net/pms/dlna/GlobalIdRepo.java
+++ b/src/main/java/net/pms/dlna/GlobalIdRepo.java
@@ -53,8 +53,9 @@ public class GlobalIdRepo {
 //					isUniqueResource = false;
 //				}
 				LOGGER.info(
-					"Id: {}, Name: {}, Class: {}, DisplayName: {}, Path: {}",
-					element.dlnaResource.getId(), element.dlnaResource.getName(), element.dlnaResource.getClass().getSimpleName(), element.dlnaResource.getDisplayName(), element.dlnaResource.getSystemName()
+					"Instance: {}, Id: {}, Name: {}, Class: {}, DisplayName: {}, Path: {}",
+					System.identityHashCode(element.dlnaResource), element.dlnaResource.getId(), element.dlnaResource.getName(),
+					element.dlnaResource.getClass().getSimpleName(), element.dlnaResource.getDisplayName(), element.dlnaResource.getSystemName()
 				);
 			}
 			LOGGER.info("---------------------------------------------------------------------------------");

--- a/src/main/java/net/pms/dlna/GlobalIdRepo.java
+++ b/src/main/java/net/pms/dlna/GlobalIdRepo.java
@@ -32,17 +32,23 @@ public class GlobalIdRepo {
 		lock.writeLock().lock();
 		try {
 			boolean isUniqueResource = true;
-			String resourcePath = dlnaResource.getSystemName();
-//			String id = dlnaResource.getId();
-//			if (id != null) {
-//				remove(id);
-//			}
+			String incomingResourcePath = dlnaResource.getSystemName();
+			String incomingClass = dlnaResource.getClass().getSimpleName();
+			String id = dlnaResource.getId();
+			if (id != null) {
+				remove(id);
+			}
+			LOGGER.info(
+				"Incoming Id: {}, Name: {}, Class: {}, DisplayName: {}, Path: {}",
+				dlnaResource.getId(), dlnaResource.getName(), dlnaResource.getClass().getSimpleName(), dlnaResource.getDisplayName(), dlnaResource.getSystemName()
+			);
 
 			LOGGER.info("---------------------------------------------------------------------------------");
 			LOGGER.info("------------------------------- Global ID dump ----------------------------------");
 			LOGGER.info("---------------------------------------------------------------------------------");
 			for (ID element : ids) {
-				if ("RealFile".equals(element.dlnaResource.getClass().getSimpleName()) && resourcePath.equals(element.dlnaResource.getSystemName())) {
+				if (incomingClass.equals(element.dlnaResource.getClass().getSimpleName()) && incomingResourcePath.equals(element.dlnaResource.getSystemName())) {
+					LOGGER.info("already exists, setting id to " + element.dlnaResource.getId());
 					dlnaResource.setId(element.dlnaResource.getId());
 					isUniqueResource = false;
 				}
@@ -54,6 +60,7 @@ public class GlobalIdRepo {
 			LOGGER.info("---------------------------------------------------------------------------------");
 			LOGGER.info("");
 			if (isUniqueResource) {
+				LOGGER.info("adding");
 				ids.add(new ID(dlnaResource, curGlobalId++));
 			}
 		} finally {

--- a/src/main/java/net/pms/dlna/GlobalIdRepo.java
+++ b/src/main/java/net/pms/dlna/GlobalIdRepo.java
@@ -31,9 +31,9 @@ public class GlobalIdRepo {
 	public void add(DLNAResource dlnaResource) {
 		lock.writeLock().lock();
 		try {
-			boolean isUniqueResource = true;
-			String incomingResourcePath = dlnaResource.getSystemName();
-			String incomingClass = dlnaResource.getClass().getSimpleName();
+//			boolean isUniqueResource = true;
+//			String incomingResourcePath = dlnaResource.getSystemName();
+//			String incomingClass = dlnaResource.getClass().getSimpleName();
 			String id = dlnaResource.getId();
 			if (id != null) {
 				remove(id);
@@ -47,11 +47,11 @@ public class GlobalIdRepo {
 			LOGGER.info("------------------------------- Global ID dump ----------------------------------");
 			LOGGER.info("---------------------------------------------------------------------------------");
 			for (ID element : ids) {
-				if (incomingClass.equals(element.dlnaResource.getClass().getSimpleName()) && incomingResourcePath.equals(element.dlnaResource.getSystemName())) {
-					LOGGER.info("already exists, setting id to " + element.dlnaResource.getId());
-					dlnaResource.setId(element.dlnaResource.getId());
-					isUniqueResource = false;
-				}
+//				if (incomingClass.equals(element.dlnaResource.getClass().getSimpleName()) && incomingResourcePath.equals(element.dlnaResource.getSystemName())) {
+//					LOGGER.info("already exists, setting id to " + element.dlnaResource.getId());
+//					dlnaResource.setId(element.dlnaResource.getId());
+//					isUniqueResource = false;
+//				}
 				LOGGER.info(
 					"Id: {}, Name: {}, Class: {}, DisplayName: {}, Path: {}",
 					element.dlnaResource.getId(), element.dlnaResource.getName(), element.dlnaResource.getClass().getSimpleName(), element.dlnaResource.getDisplayName(), element.dlnaResource.getSystemName()
@@ -59,10 +59,10 @@ public class GlobalIdRepo {
 			}
 			LOGGER.info("---------------------------------------------------------------------------------");
 			LOGGER.info("");
-			if (isUniqueResource) {
-				LOGGER.info("adding");
+//			if (isUniqueResource) {
+//				LOGGER.info("adding");
 				ids.add(new ID(dlnaResource, curGlobalId++));
-			}
+//			}
 		} finally {
 			lock.writeLock().unlock();
 		}

--- a/src/main/java/net/pms/dlna/GlobalIdRepo.java
+++ b/src/main/java/net/pms/dlna/GlobalIdRepo.java
@@ -36,9 +36,22 @@ public class GlobalIdRepo {
 				remove(id);
 			}
 			ids.add(new ID(dlnaResource, curGlobalId++));
+
+			LOGGER.info("---------------------------------------------------------------------------------");
+			LOGGER.info("------------------------------- Global ID dump ----------------------------------");
+			LOGGER.info("---------------------------------------------------------------------------------");
+			for (ID element : ids) {
+				LOGGER.info(
+					"Id: {}, Name: {}, Class: {}, DisplayName: {}",
+					element.dlnaResource.getId(), element.dlnaResource.getName(), element.dlnaResource.getClass().getSimpleName(), element.dlnaResource.getDisplayName()
+				);
+			}
+			LOGGER.info("---------------------------------------------------------------------------------");
+			LOGGER.info("");
 		} finally {
 			lock.writeLock().unlock();
 		}
+
 	}
 
 	public DLNAResource get(String id) {


### PR DESCRIPTION
This isn't meant to be merged - it's just for debugging. Hands of the ```Merge``` button (@Sami32) 😛 

@SubJunk This is a little "tool" I made to debug #1185. Set logging level to "INFO" and you'll get mostly this output. It will dump the global id's with their ```DLNAResources``` every time one is added. 

I see that every time a folder is scanned, new entries are added. There are multiple entires for each resource. However, it's new ```DLNAResource``` instances. To me that indicates that neither ff11febbe088199f6d27b9cefafa723cae8c08ce nor 7ddcda093e01ac2efa5a30f8a50119f3c77bacd8 is the culprit, they simply expose the underlying problem.

The problem as I see it is simply that when resources are being scanned new instances are being created for the same media file/stream. I've never quite understood how existing resources are supposed to be recycled, but apparantly they aren't. 

I fear that this won't be an easy fix. One one side it partly explains why there aren't more threading issues with the extremely thread-unsafe code in DLNAResource. Every time a new renderer enters a folder, the folder is "scanned" and new resources are generated. That means that two renderers don't actually share the same instance even though they refer to the same underlying media file. The problem is that fixing this also means unleashing a world of pain with all the thread-safety flaws.

As I see it, "fixing" DLNAResource is a daunting task - I'm not even sure if it's doable. I've been thinking about it, and come to the conclution that is might be easier to rewrite it from scratch than to try to untangle everything that goes wrong there. But, I might be wrong, one really don't know before one tries. The problem is that objects are being shared without any regard for concurrency and immutability or synchronization is virtually unheard of. It's not just ```DLNAResource``` itself, it's all the instances it holds. They all need to be either immutable or synchronized. It isn't just to add synchronization either, you generally don't want to hold too many locks at the same time (or, if you hold multiple locks you have to make sure that they are ALWAYS aquired in the same order - which can be very difficult). 

I'm not actually sure how to tackle this, it might be easier to dispose of them after use. That would mean forgetting all about caching them and redoing the global cache. It won't be very efficient, but it might actually be achievable.

