### PR TITLE
Fix 9bcba891a3299f498c00aed3b5abc2d966bd66ff and then some

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -776,10 +776,14 @@ autoload_external_subtitles =
 
 # Color
 # -----
-# The integer value for the subtitles colour. GUI offers a palette to choose
-# from that will generate a number. Default is empty, causing UMS to pick
-# white.
-# Default: ""
+# The 0xRRGGBBAA or 0xRRGGBB value for the subtitles text colour. The value is
+# specified in hexadecimal starting with 0x. The value must consist of either
+# 6 or 8 hexadecimal digits (0-9, A-F). For the alpha value, 0 is fully 
+# transparent and 0xFF is opaque.
+#
+# The GUI offers a palette to 
+# choose from that will generate a value. The default is white.
+# Default: "0xFFFFFFFF"
 subtitles_color =
 
 # Force external subtitles

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -47,6 +47,7 @@ import net.pms.util.FileUtil.FileLocation;
 import net.pms.util.FullyPlayedAction;
 import net.pms.util.Languages;
 import net.pms.util.PropertiesUtil;
+import net.pms.util.SubtitleColor;
 import net.pms.util.UMSUtils;
 import net.pms.util.WindowsRegistry;
 import org.apache.commons.configuration.Configuration;
@@ -2807,12 +2808,27 @@ public class PmsConfiguration extends RendererConfiguration {
 		configuration.setProperty(KEY_CHAPTER_INTERVAL, value);
 	}
 
-	public String getSubsColor() {
-		return getString(KEY_SUBS_COLOR, "0xffffffff").substring(2);
+	public SubtitleColor getSubsColor() {
+		String colorString = getString(KEY_SUBS_COLOR, null);
+		if (StringUtils.isNotBlank(colorString)) {
+			SubtitleColor result = SubtitleColor.toSubtitleColor(colorString);
+			if (result != null) {
+				return result;
+			}
+		}
+		return new SubtitleColor(0xFF, 0xFF, 0xFF, 0xFF);
 	}
 
-	public void setSubsColor(String value) {
-		configuration.setProperty(KEY_SUBS_COLOR, "0x" + value);
+	public void setSubsColor(Color color) {
+		setSubsColor(new SubtitleColor(color));
+	}
+
+	public void setSubsColor(SubtitleColor color) {
+		if (color.getAlpha() != 0xFF) {
+			configuration.setProperty(KEY_SUBS_COLOR, color.get0xRRGGBBAA());
+		} else {
+			configuration.setProperty(KEY_SUBS_COLOR, color.get0xRRGGBB());
+		}
 	}
 
 	public boolean isFix25FPSAvMismatch() {

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.net.InetAddress;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1836,8 +1837,11 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		if (PMS.getConfiguration().isAutomaticMaximumBitrate()) {
 			try {
 				return calculatedSpeed();
-			} catch (Exception e) {
-				// ignore this
+			} catch (InterruptedException e) {
+				return "0";
+			} catch (ExecutionException e) {
+				LOGGER.debug("Automatic maximum bitrate calculation failed with: {}", e.getCause().getMessage());
+				LOGGER.trace("", e.getCause());
 			}
 		}
 		return getString(MAX_VIDEO_BITRATE, "0");
@@ -1867,13 +1871,20 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		int defaultMaxBitrates[] = getVideoBitrateConfig(PMS.getConfiguration().getMaximumBitrate());
 		int rendererMaxBitrates[] = new int[2];
 
-		if (StringUtils.isNotEmpty(getMaxVideoBitrate())) {
-			rendererMaxBitrates = getVideoBitrateConfig(getMaxVideoBitrate());
+		String maxVideoBitrate = getMaxVideoBitrate();
+		if (StringUtils.isNotEmpty(maxVideoBitrate)) {
+			rendererMaxBitrates = getVideoBitrateConfig(maxVideoBitrate);
 		}
 
 		// Give priority to the renderer's maximum bitrate setting over the user's setting
 		if (rendererMaxBitrates[0] > 0 && rendererMaxBitrates[0] < defaultMaxBitrates[0]) {
-			LOGGER.trace("Using the video bitrate limit from the renderer config (" + rendererMaxBitrates[0] + " Mb/s) which is lower than the one from the program settings (" + defaultMaxBitrates[0] + " Mb/s)");
+			LOGGER.trace(
+				"Using video bitrate limit from {} configuration ({} Mb/s) because " +
+				"it is lower than the general configuration bitrate limit ({} Mb/s)",
+				getRendererName(),
+				rendererMaxBitrates[0],
+				defaultMaxBitrates[0]
+			);
 			defaultMaxBitrates = rendererMaxBitrates;
 		}
 
@@ -2508,7 +2519,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		return getBoolean(IGNORE_TRANSCODE_BYTE_RANGE_REQUEST, false);
 	}
 
-	public String calculatedSpeed() throws Exception {
+	public String calculatedSpeed() throws InterruptedException, ExecutionException {
 		String max = getString(MAX_VIDEO_BITRATE, "");
 		for (InetAddress sa : addressAssociation.keySet()) {
 			if (addressAssociation.get(sa) == this) {

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -230,7 +230,7 @@ public class FFMpegVideo extends Player {
 
 						// XXX (valib) If the font size is not acceptable it could be calculated better taking in to account the original video size. Unfortunately I don't know how to do that.
 						subsFilter.append(",Fontsize=").append((int) 15 * Double.parseDouble(configuration.getAssScale()));
-						subsFilter.append(",PrimaryColour=").append(SubtitleUtils.convertColourToASSColourString(configuration.getSubsColor()));
+						subsFilter.append(",PrimaryColour=").append(configuration.getSubsColor().getASSv4StylesHexValue());
 						subsFilter.append(",Outline=").append(configuration.getAssOutline());
 						subsFilter.append(",Shadow=").append(configuration.getAssShadow());
 						subsFilter.append(",MarginV=").append(configuration.getAssMargin());
@@ -431,16 +431,17 @@ public class FFMpegVideo extends Player {
 
 		// Give priority to the renderer's maximum bitrate setting over the user's setting
 		if (rendererMaxBitrates[0] > 0 && rendererMaxBitrates[0] < defaultMaxBitrates[0]) {
-			defaultMaxBitrates = rendererMaxBitrates;
 			LOGGER.trace(
-				"Using the video bitrate limit from the renderer config ({} Mb/s) " +
-				"which is lower than the one from the program settings ({} Mb/s)",
+				"Using video bitrate limit from {} configuration ({} Mb/s) because " +
+				"it is lower than the general configuration bitrate limit ({} Mb/s)",
+				params.mediaRenderer.getRendererName(),
 				rendererMaxBitrates[0],
 				defaultMaxBitrates[0]
 			);
+			defaultMaxBitrates = rendererMaxBitrates;
 		} else {
 			LOGGER.trace(
-				"Using the video bitrate limit from the program settings ({} Mb/s)",
+				"Using video bitrate limit from the general configuration ({} Mb/s)",
 				defaultMaxBitrates[0]
 			);
 		}

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -51,7 +51,6 @@ import static net.pms.util.AudioUtils.getLPCMChannelMappingForMencoder;
 import static net.pms.util.StringUtil.quoteArg;
 import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.apache.commons.configuration.event.ConfigurationListener;
-import org.apache.commons.lang3.StringUtils;
 import static org.apache.commons.lang.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.*;
 import org.slf4j.Logger;
@@ -694,16 +693,17 @@ public class MEncoderVideo extends Player {
 
 		// Give priority to the renderer's maximum bitrate setting over the user's setting
 		if (rendererMaxBitrates[0] > 0 && rendererMaxBitrates[0] < defaultMaxBitrates[0]) {
-			defaultMaxBitrates = rendererMaxBitrates;
 			LOGGER.trace(
-				"Using the video bitrate limit from the renderer config ({} Mb/s) " +
-				"which is lower than the one from the program settings ({} Mb/s)",
+				"Using video bitrate limit from {} configuration ({} Mb/s) because " +
+				"it is lower than the general configuration bitrate limit ({} Mb/s)",
+				mediaRenderer.getRendererName(),
 				rendererMaxBitrates[0],
 				defaultMaxBitrates[0]
 			);
+			defaultMaxBitrates = rendererMaxBitrates;
 		} else {
 			LOGGER.trace(
-				"Using the video bitrate limit from the program settings ({} Mb/s)",
+				"Using video bitrate limit from the general configuration ({} Mb/s)",
 				defaultMaxBitrates[0]
 			);
 		}
@@ -1255,7 +1255,13 @@ public class MEncoderVideo extends Player {
 			}
 
 			if ((rendererMaxBitrates[0] > 0) && (rendererMaxBitrates[0] < defaultMaxBitrates[0])) {
-				LOGGER.trace("Using the video bitrate limit from the renderer config (" + rendererMaxBitrates[0] + " Mb/s) which is lower than the one from the program settings (" + defaultMaxBitrates[0] + " Mb/s)");
+				LOGGER.trace(
+					"Using video bitrate limit from {} configuration ({} Mb/s) because " +
+					"it is lower than the general configuration bitrate limit ({} Mb/s)",
+					params.mediaRenderer.getRendererName(),
+					rendererMaxBitrates[0],
+					defaultMaxBitrates[0]
+				);
 				defaultMaxBitrates = rendererMaxBitrates;
 			}
 
@@ -1420,14 +1426,7 @@ public class MEncoderVideo extends Player {
 					params.sid.getType() == SubtitleType.TX3G;
 
 				if (override_ass_style) {
-					String assSubColor = "ffffff00";
-					if (StringUtils.isNotBlank(configuration.getSubsColor())) {
-						assSubColor = configuration.getSubsColor();
-						if (assSubColor.length() > 2) {
-							assSubColor = assSubColor.substring(2) + "00";
-						}
-					}
-
+					String assSubColor = configuration.getSubsColor().getMEncoderHexValue();
 					sb.append("-ass-color ").append(assSubColor).append(" -ass-border-color 00000000 -ass-font-scale ").append(configuration.getAssScale());
 
 					// Set subtitles font

--- a/src/main/java/net/pms/encoders/VLCVideo.java
+++ b/src/main/java/net/pms/encoders/VLCVideo.java
@@ -310,7 +310,13 @@ public class VLCVideo extends Player {
 
 		// Give priority to the renderer's maximum bitrate setting over the user's setting
 		if (rendererMaxBitrates[0] > 0 && rendererMaxBitrates[0] < defaultMaxBitrates[0]) {
-			LOGGER.trace("Using the video bitrate limit from the renderer config (" + rendererMaxBitrates[0] + " Mb/s) which is lower than the one from the program settings (" + defaultMaxBitrates[0] + " Mb/s)");
+			LOGGER.trace(
+				"Using video bitrate limit from {} configuration ({} Mb/s) because " +
+				"it is lower than the general configuration bitrate limit ({} Mb/s)",
+				params.mediaRenderer.getRendererName(),
+				rendererMaxBitrates[0],
+				defaultMaxBitrates[0]
+			);
 			defaultMaxBitrates = rendererMaxBitrates;
 		}
 

--- a/src/main/java/net/pms/newgui/TranscodingTab.java
+++ b/src/main/java/net/pms/newgui/TranscodingTab.java
@@ -25,8 +25,8 @@ import com.jgoodies.forms.layout.FormLayout;
 import com.sun.jna.Platform;
 import java.awt.*;
 import java.awt.event.*;
-import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Locale;
 import javax.swing.*;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
@@ -1002,21 +1002,29 @@ public class TranscodingTab {
 
 		subColor = new JButton();
 		subColor.setText(Messages.getString("MEncoderVideo.31"));
-		subColor.setBackground(new Color(new BigInteger(configuration.getSubsColor(), 16).intValue()));
+		subColor.setBackground(configuration.getSubsColor());
 		subColor.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				Color newColor = JColorChooser.showDialog(
-					looksFrame,
-					Messages.getString("MEncoderVideo.125"),
-					subColor.getBackground()
-				);
+				final JColorChooser jColorChooser = new JColorChooser(subColor.getBackground());
+				Locale locale = PMS.getLocale();
+				jColorChooser.setLocale(locale);
+				jColorChooser.setComponentOrientation(ComponentOrientation.getOrientation(locale));
+				JDialog dialog = JColorChooser.createDialog(looksFrame, Messages.getString("MEncoderVideo.125"), true, jColorChooser, new ActionListener() {
 
-				if (newColor != null) {
-					subColor.setBackground(newColor);
-					configuration.setSubsColor(Integer.toHexString(newColor.getRGB()));
-					SubtitleUtils.deleteSubs(); // Color has been changed so all temporary subs will be deleted and make new
-				}
+					@Override
+					public void actionPerformed(ActionEvent e) {
+						Color newColor = jColorChooser.getColor();
+						if (newColor != null) {
+							subColor.setBackground(newColor);
+							configuration.setSubsColor(newColor);
+							// Subtitle color has been changed so all temporary subtitles must be deleted
+							SubtitleUtils.deleteSubs();
+						}
+					}
+				}, null);
+				dialog.setVisible(true);
+				dialog.dispose();
 			}
 		});
 		builder.add(subColor, FormLayoutUtil.flip(cc.xyw(13, 14, 3), colSpec, orientation));

--- a/src/main/java/net/pms/util/SubtitleColor.java
+++ b/src/main/java/net/pms/util/SubtitleColor.java
@@ -1,0 +1,475 @@
+package net.pms.util;
+
+import java.awt.Color;
+import java.awt.color.ColorSpace;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@SuppressWarnings("serial")
+public class SubtitleColor extends Color {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SubtitleColor.class);
+
+	protected static final Pattern hexPattern =
+		Pattern.compile("(?i)^\\s*(?:x'|%|#|0x|\\\\x|%x|\\$|h'|16#|16r|#x|#16r|&h|0h)([0-9a-f]{6}(?:[0-9a-f]{2})?)'?\\s*$");
+	protected static final Pattern decPattern =
+		Pattern.compile("^\\s*(-?\\d{1,10})\\s*$");
+	private static final Map<String, int[]> knownColors = new HashMap<>(140, 1f);
+
+	/**
+	 * @see Color#Color(int)
+	 */
+	public SubtitleColor(int rgb) {
+		super(rgb);
+	}
+
+	/**
+	 * @see Color#Color(int, boolean)
+	 */
+	public SubtitleColor(int rgba, boolean hasalpha) {
+		super(rgba, hasalpha);
+	}
+
+	/**
+	 * @see Color#Color(int, int, int)
+	 */
+	public SubtitleColor(int r, int g, int b) {
+		super(r, g, b);
+	}
+
+	/**
+	 * @see Color#Color(float, float, float)
+	 */
+	public SubtitleColor(float r, float g, float b) {
+		super(r, g, b);
+	}
+
+	/**
+	 * @see Color#Color(ColorSpace, float[], float)
+	 */
+	public SubtitleColor(ColorSpace cspace, float[] components, float alpha) {
+		super(cspace, components, alpha);
+	}
+
+	/**
+	 * @see Color#Color(int, int, int, int)
+	 */
+	public SubtitleColor(int r, int g, int b, int a) {
+		super(r, g, b, a);
+	}
+
+	/**
+	 * @see Color#Color(float, float, float, float)
+	 */
+	public SubtitleColor(float r, float g, float b, float a) {
+		super(r, g, b, a);
+	}
+
+	/**
+	 * Creates a {@link SubtitleColor} instance from a {@link Color} instance.
+	 *
+	 * @param color the {@link Color} to use for the new instance.
+	 */
+	public SubtitleColor(Color color) {
+		super(color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
+	}
+
+	/**
+	 * @return A formatted hexadecimal {@link String} with the current value
+	 *         from this {@link SubtitleColor} instance suitable as an argument
+	 *         for FFmpeg.
+	 */
+	public String getFFmpegHexValue() {
+		return getHexValue("0x", "AABBGGRR", null, true, false);
+	}
+
+	/**
+	 * @return A formatted hexadecimal {@link String} with the current value
+	 *         from this {@link SubtitleColor} instance suitable as a ASS v4+
+	 *         styles parameter.
+	 */
+	public String getASSv4StylesHexValue() {
+		return getHexValue("&H", "AABBGGRR", null, true, true);
+	}
+
+	/**
+	 * @return A formatted hexadecimal {@link String} with the current value
+	 *         from this {@link SubtitleColor} instance suitable as a SSA/ASS
+	 *         parameter.
+	 */
+	public String getSSAHexValue() {
+		return getHexValue("&H", "BBGGRR", "&", true, true);
+	}
+
+	/**
+	 * @return A formatted hexadecimal {@link String} with the current value
+	 *         from this {@link SubtitleColor} instance suitable as a SSA/ASS
+	 *         parameter.
+	 */
+	public String getSSAAlphaHexValue() {
+		return getHexValue("&H", "AA", "&", true, true);
+	}
+
+	/**
+	 * @return A formatted hexadecimal {@link String} with the current value
+	 *         from this {@link SubtitleColor} instance suitable as an argument
+	 *         for MEncoder.
+	 */
+	public String getMEncoderHexValue() {
+		return getHexValue(null, "RRGGBBAA", null, true, true);
+	}
+
+	/**
+	 * @return A formatted hexadecimal {@link String} in the form
+	 *         {@code 0xRRGGBBAA}.
+	 */
+	public String get0xRRGGBBAA() {
+		return getHexValue("0x", "RRGGBBAA", null, true, false);
+	}
+
+	/**
+	 * @return A formatted hexadecimal {@link String} in the form
+	 *         {@code 0xRRGGBB}.
+	 */
+	public String get0xRRGGBB() {
+		return getHexValue("0x", "RRGGBB", null, true, true);
+	}
+
+	/**
+	 * Returns a formatted hexadecimal {@link String} with the current value
+	 * from this {@link SubtitleColor} instance.
+	 *
+	 * @param prefix a prefix to add to the start of the resulting
+	 *            {@link String}. Can be {@code null}.
+	 * @param pattern the pattern consisting of any combinations of the codes
+	 *            {@code RR}, {@code R}, {@code GG}, {@code G}, {@code BB},
+	 *            {@code B}, {@code AA} and {@code A}. Any other characters are
+	 *            ignored.
+	 * @param suffix a suffix to add to the end of the resulting {@link String}.
+	 *            Can be {@code null}.
+	 * @param upperCase whether or not the resulting characters in the
+	 *            hexadecimal string should be upper- or lower case. Does not
+	 *            apply to {@code prefix} and {@code suffix}.
+	 * @param invertAlpha whether or not the alpha value should be inverted so
+	 *            that 0 is opaque instead of 0xFF.
+	 * @return The formatted hexadecimal {@link String}.
+	 */
+	public String getHexValue(String prefix, String pattern, String suffix, boolean upperCase, boolean invertAlpha) {
+		StringBuilder sb = new StringBuilder(prefix != null ? prefix : "");
+
+		String red = upperCase ?
+			Integer.toHexString(getRed()).toUpperCase(Locale.ROOT) :
+			Integer.toHexString(getRed());
+		String green = upperCase ?
+			Integer.toHexString(getGreen()).toUpperCase(Locale.ROOT) :
+			Integer.toHexString(getGreen());
+		String blue = upperCase ?
+			Integer.toHexString(getBlue()).toUpperCase(Locale.ROOT) :
+			Integer.toHexString(getBlue());
+		Integer a = invertAlpha ? 0xFF - getAlpha() : getAlpha();
+		String alpha = upperCase ?
+			Integer.toHexString(a).toUpperCase(Locale.ROOT) :
+			Integer.toHexString(a);
+
+		pattern = pattern.toUpperCase(Locale.ROOT);
+		for (int i = 0; i < pattern.length(); i++) {
+			if ("RR".equals(pattern.substring(i, i+2))) {
+				if (red.length() < 2) {
+					sb.append("0").append(red);
+				} else {
+					sb.append(red);
+				}
+				i++;
+			} else if ("R".equals(pattern.substring(i, i+1))) {
+				sb.append(red);
+			} else if ("GG".equals(pattern.substring(i, i+2))) {
+				if (green.length() < 2) {
+					sb.append("0").append(green);
+				} else {
+					sb.append(green);
+				}
+				i++;
+			} else if ("G".equals(pattern.substring(i, i+1))) {
+				sb.append(green);
+			} else if ("BB".equals(pattern.substring(i, i+2))) {
+				if (blue.length() < 2) {
+					sb.append("0").append(blue);
+				} else {
+					sb.append(blue);
+				}
+				i++;
+			} else if ("B".equals(pattern.substring(i, i+1))) {
+				sb.append(blue);
+			} else if ("AA".equals(pattern.substring(i, i+2))) {
+				if (alpha.length() < 2) {
+					sb.append("0").append(alpha);
+				} else {
+					sb.append(alpha);
+				}
+				i++;
+			} else if ("A".equals(pattern.substring(i, i+1))) {
+				sb.append(alpha);
+			}
+		}
+
+		if (suffix != null) {
+			sb.append(suffix);
+		}
+		return sb.toString();
+	}
+
+	@Override
+    public String toString() {
+        return
+        	getClass().getSimpleName() +
+        	"[r=" + getHexValue("0x", "RR", null, true, false) +
+        	", g=" + getHexValue("0x", "GG", null, true, false) +
+        	", b=" + getHexValue("0x", "BB", null, true, false) +
+        	", a=" + getHexValue("0x", "AA", null, true, false) +
+        	"]";
+    }
+
+	protected static String extractHexString(String s) {
+		Matcher matcher = hexPattern.matcher(s);
+		if (matcher.find()) {
+			return matcher.group(1).toUpperCase(Locale.ROOT);
+		} else {
+			return null;
+		}
+	}
+
+	protected static String extractDecString(String s) {
+		Matcher matcher = decPattern.matcher(s);
+		if (matcher.find()) {
+			return matcher.group(1);
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Try to create a {@link SubtitleColor} from {@code subtitleColor}. The
+	 * parsing will try 4 different parsing methods:
+	 *
+	 * <ul>
+	 * <li>First try to parse {@code subtitleColor} as a hexadecimal string.
+	 * Several different notations are supported and it can be with or without
+	 * alpha. Valid forms are RRGGBB or RRGGBBAA with one of the following
+	 * prefixes: "x'", "%", "#", "0x", "\x", "%x", "$", "h'", "16#", "16r",
+	 * "#x", "#16r", "&amp;h" or "0h".</li>
+	 * <li>If that fails, try to parse {@code subtitleColor} as a decimal string
+	 * without alpha.</li>
+	 * <li>If that also fails, try to parse {@code subtitleColor} as a color
+	 * name (Red, Yellow etc).</li>
+	 * <li>As a last attempt, try to parse {@code subtitleColor} as a system
+	 * property integer.</li>
+	 * </ul>
+	 * If the parsing fails, {@code null} is returned.
+	 *
+	 * @param subtitleColor the {@link String} to attempt to parse a
+	 *            {@link SubtitleColor} from.
+	 * @return A newly created {@link SubtitleColor} or {@code null} it the
+	 *         parsing fails.
+	 */
+	public static SubtitleColor toSubtitleColor(String subtitleColor) {
+		NumberFormatException ne = null;
+		String value = extractHexString(subtitleColor);
+		try {
+			if (value != null) {
+				int r = Integer.parseInt(value.substring(0, 2), 16);
+				int g = Integer.parseInt(value.substring(2, 4), 16);
+				int b = Integer.parseInt(value.substring(4, 6), 16);
+				int a = value.length() == 8 ? Integer.parseInt(value.substring(6, 8), 16) : 0xFF;
+				return new SubtitleColor(r, g, b, a);
+			}
+			value = extractDecString(subtitleColor);
+			if (value != null) {
+				return new SubtitleColor((int) Long.parseLong(value));
+			}
+		} catch (NumberFormatException e) {
+			ne = e;
+		}
+		int[] rgb = getNamedColorValues(subtitleColor);
+		if (rgb != null && rgb.length == 3) {
+			return new SubtitleColor(rgb[0], rgb[1], rgb[2]);
+		}
+		Color color = Color.getColor(subtitleColor);
+		if (color != null) {
+			return new SubtitleColor(color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
+		}
+		if (ne != null) {
+			LOGGER.warn("Could not parse subtitle color \"{}\": {}", subtitleColor, ne.getMessage());
+			LOGGER.trace("", ne);
+		} else {
+			LOGGER.warn("Could not parse subtitle color \"{}\"", subtitleColor);
+		}
+		return null;
+	}
+
+	/**
+	 * Returns an array of RGB integer values from a predefined list of color
+	 * names.
+	 *
+	 * @param colorName the name of the color which values to retrieve.
+	 * @return The integer array with RGB values or {@code null} if
+	 *         {@code colorName} isn't among the predefined color names.
+	 */
+	public static int[] getNamedColorValues(String colorName) {
+		colorName = colorName.toUpperCase(Locale.ROOT);
+		if (knownColors.containsKey(colorName)) {
+			return knownColors.get(colorName);
+		}
+		return null;
+	}
+
+	static {
+		// The color values are from http://ffmpeg.org/ffmpeg-utils.html#Color
+
+		knownColors.put("ALICEBLUE", new int[] {0xF0, 0xF8, 0xFF});
+		knownColors.put("ANTIQUEWHITE", new int[] {0xFA, 0xEB, 0xD7});
+		knownColors.put("AQUA", new int[] {0x00, 0xFF, 0xFF});
+		knownColors.put("AQUAMARINE", new int[] {0x7F, 0xFF, 0xD4});
+		knownColors.put("AZURE", new int[] {0xF0, 0xFF, 0xFF});
+		knownColors.put("BEIGE", new int[] {0xF5, 0xF5, 0xDC});
+		knownColors.put("BISQUE", new int[] {0xFF, 0xE4, 0xC4});
+		knownColors.put("BLACK", new int[] {0x00, 0x00, 0x00});
+		knownColors.put("BLANCHEDALMOND", new int[] {0xFF, 0xEB, 0xCD});
+		knownColors.put("BLUE", new int[] {0x00, 0x00, 0xFF});
+		knownColors.put("BLUEVIOLET", new int[] {0x8A, 0x2B, 0xE2});
+		knownColors.put("BROWN", new int[] {0xA5, 0x2A, 0x2A});
+		knownColors.put("BURLYWOOD", new int[] {0xDE, 0xB8, 0x87});
+		knownColors.put("CADETBLUE", new int[] {0x5F, 0x9E, 0xA0});
+		knownColors.put("CHARTREUSE", new int[] {0x7F, 0xFF, 0x00});
+		knownColors.put("CHOCOLATE", new int[] {0xD2, 0x69, 0x1E});
+		knownColors.put("CORAL", new int[] {0xFF, 0x7F, 0x50});
+		knownColors.put("CORNFLOWERBLUE", new int[] {0x64, 0x95, 0xED});
+		knownColors.put("CORNSILK", new int[] {0xFF, 0xF8, 0xDC});
+		knownColors.put("CRIMSON", new int[] {0xDC, 0x14, 0x3C});
+		knownColors.put("CYAN", new int[] {0x00, 0xFF, 0xFF});
+		knownColors.put("DARKBLUE", new int[] {0x00, 0x00, 0x8B});
+		knownColors.put("DARKCYAN", new int[] {0x00, 0x8B, 0x8B});
+		knownColors.put("DARKGOLDENROD", new int[] {0xB8, 0x86, 0x0B});
+		knownColors.put("DARKGRAY", new int[] {0xA9, 0xA9, 0xA9});
+		knownColors.put("DARKGREEN", new int[] {0x00, 0x64, 0x00});
+		knownColors.put("DARKKHAKI", new int[] {0xBD, 0xB7, 0x6B});
+		knownColors.put("DARKMAGENTA", new int[] {0x8B, 0x00, 0x8B});
+		knownColors.put("DARKOLIVEGREEN", new int[] {0x55, 0x6B, 0x2F});
+		knownColors.put("DARKORANGE", new int[] {0xFF, 0x8C, 0x00});
+		knownColors.put("DARKORCHID", new int[] {0x99, 0x32, 0xCC});
+		knownColors.put("DARKRED", new int[] {0x8B, 0x00, 0x00});
+		knownColors.put("DARKSALMON", new int[] {0xE9, 0x96, 0x7A});
+		knownColors.put("DARKSEAGREEN", new int[] {0x8F, 0xBC, 0x8F});
+		knownColors.put("DARKSLATEBLUE", new int[] {0x48, 0x3D, 0x8B});
+		knownColors.put("DARKSLATEGRAY", new int[] {0x2F, 0x4F, 0x4F});
+		knownColors.put("DARKTURQUOISE", new int[] {0x00, 0xCE, 0xD1});
+		knownColors.put("DARKVIOLET", new int[] {0x94, 0x00, 0xD3});
+		knownColors.put("DEEPPINK", new int[] {0xFF, 0x14, 0x93});
+		knownColors.put("DEEPSKYBLUE", new int[] {0x00, 0xBF, 0xFF});
+		knownColors.put("DIMGRAY", new int[] {0x69, 0x69, 0x69});
+		knownColors.put("DODGERBLUE", new int[] {0x1E, 0x90, 0xFF});
+		knownColors.put("FIREBRICK", new int[] {0xB2, 0x22, 0x22});
+		knownColors.put("FLORALWHITE", new int[] {0xFF, 0xFA, 0xF0});
+		knownColors.put("FORESTGREEN", new int[] {0x22, 0x8B, 0x22});
+		knownColors.put("FUCHSIA", new int[] {0xFF, 0x00, 0xFF});
+		knownColors.put("GAINSBORO", new int[] {0xDC, 0xDC, 0xDC});
+		knownColors.put("GHOSTWHITE", new int[] {0xF8, 0xF8, 0xFF});
+		knownColors.put("GOLD", new int[] {0xFF, 0xD7, 0x00});
+		knownColors.put("GOLDENROD", new int[] {0xDA, 0xA5, 0x20});
+		knownColors.put("GRAY", new int[] {0x80, 0x80, 0x80});
+		knownColors.put("GREEN", new int[] {0x00, 0x80, 0x00});
+		knownColors.put("GREENYELLOW", new int[] {0xAD, 0xFF, 0x2F});
+		knownColors.put("HONEYDEW", new int[] {0xF0, 0xFF, 0xF0});
+		knownColors.put("HOTPINK", new int[] {0xFF, 0x69, 0xB4});
+		knownColors.put("INDIANRED", new int[] {0xCD, 0x5C, 0x5C});
+		knownColors.put("INDIGO", new int[] {0x4B, 0x00, 0x82});
+		knownColors.put("IVORY", new int[] {0xFF, 0xFF, 0xF0});
+		knownColors.put("KHAKI", new int[] {0xF0, 0xE6, 0x8C});
+		knownColors.put("LAVENDER", new int[] {0xE6, 0xE6, 0xFA});
+		knownColors.put("LAVENDERBLUSH", new int[] {0xFF, 0xF0, 0xF5});
+		knownColors.put("LAWNGREEN", new int[] {0x7C, 0xFC, 0x00});
+		knownColors.put("LEMONCHIFFON", new int[] {0xFF, 0xFA, 0xCD});
+		knownColors.put("LIGHTBLUE", new int[] {0xAD, 0xD8, 0xE6});
+		knownColors.put("LIGHTCORAL", new int[] {0xF0, 0x80, 0x80});
+		knownColors.put("LIGHTCYAN", new int[] {0xE0, 0xFF, 0xFF});
+		knownColors.put("LIGHTGOLDENRODYELLOW", new int[] {0xFA, 0xFA, 0xD2});
+		knownColors.put("LIGHTGRAY", new int[] {0xD3, 0xD3, 0xD3});
+		knownColors.put("LIGHTGREEN", new int[] {0x90, 0xEE, 0x90});
+		knownColors.put("LIGHTPINK", new int[] {0xFF, 0xB6, 0xC1});
+		knownColors.put("LIGHTSALMON", new int[] {0xFF, 0xA0, 0x7A});
+		knownColors.put("LIGHTSEAGREEN", new int[] {0x20, 0xB2, 0xAA});
+		knownColors.put("LIGHTSKYBLUE", new int[] {0x87, 0xCE, 0xFA});
+		knownColors.put("LIGHTSLATEGRAY", new int[] {0x77, 0x88, 0x99});
+		knownColors.put("LIGHTSTEELBLUE", new int[] {0xB0, 0xC4, 0xDE});
+		knownColors.put("LIGHTYELLOW", new int[] {0xFF, 0xFF, 0xE0});
+		knownColors.put("LIME", new int[] {0x00, 0xFF, 0x00});
+		knownColors.put("LIMEGREEN", new int[] {0x32, 0xCD, 0x32});
+		knownColors.put("LINEN", new int[] {0xFA, 0xF0, 0xE6});
+		knownColors.put("MAGENTA", new int[] {0xFF, 0x00, 0xFF});
+		knownColors.put("MAROON", new int[] {0x80, 0x00, 0x00});
+		knownColors.put("MEDIUMAQUAMARINE", new int[] {0x66, 0xCD, 0xAA});
+		knownColors.put("MEDIUMBLUE", new int[] {0x00, 0x00, 0xCD});
+		knownColors.put("MEDIUMORCHID", new int[] {0xBA, 0x55, 0xD3});
+		knownColors.put("MEDIUMPURPLE", new int[] {0x93, 0x70, 0xDB});
+		knownColors.put("MEDIUMSEAGREEN", new int[] {0x3C, 0xB3, 0x71});
+		knownColors.put("MEDIUMSLATEBLUE", new int[] {0x7B, 0x68, 0xEE});
+		knownColors.put("MEDIUMSPRINGGREEN", new int[] {0x00, 0xFA, 0x9A});
+		knownColors.put("MEDIUMTURQUOISE", new int[] {0x48, 0xD1, 0xCC});
+		knownColors.put("MEDIUMVIOLETRED", new int[] {0xC7, 0x15, 0x85});
+		knownColors.put("MIDNIGHTBLUE", new int[] {0x19, 0x19, 0x70});
+		knownColors.put("MINTCREAM", new int[] {0xF5, 0xFF, 0xFA});
+		knownColors.put("MISTYROSE", new int[] {0xFF, 0xE4, 0xE1});
+		knownColors.put("MOCCASIN", new int[] {0xFF, 0xE4, 0xB5});
+		knownColors.put("NAVAJOWHITE", new int[] {0xFF, 0xDE, 0xAD});
+		knownColors.put("NAVY", new int[] {0x00, 0x00, 0x80});
+		knownColors.put("OLDLACE", new int[] {0xFD, 0xF5, 0xE6});
+		knownColors.put("OLIVE", new int[] {0x80, 0x80, 0x00});
+		knownColors.put("OLIVEDRAB", new int[] {0x6B, 0x8E, 0x23});
+		knownColors.put("ORANGE", new int[] {0xFF, 0xA5, 0x00});
+		knownColors.put("ORANGERED", new int[] {0xFF, 0x45, 0x00});
+		knownColors.put("ORCHID", new int[] {0xDA, 0x70, 0xD6});
+		knownColors.put("PALEGOLDENROD", new int[] {0xEE, 0xE8, 0xAA});
+		knownColors.put("PALEGREEN", new int[] {0x98, 0xFB, 0x98});
+		knownColors.put("PALETURQUOISE", new int[] {0xAF, 0xEE, 0xEE});
+		knownColors.put("PALEVIOLETRED", new int[] {0xDB, 0x70, 0x93});
+		knownColors.put("PAPAYAWHIP", new int[] {0xFF, 0xEF, 0xD5});
+		knownColors.put("PEACHPUFF", new int[] {0xFF, 0xDA, 0xB9});
+		knownColors.put("PERU", new int[] {0xCD, 0x85, 0x3F});
+		knownColors.put("PINK", new int[] {0xFF, 0xC0, 0xCB});
+		knownColors.put("PLUM", new int[] {0xDD, 0xA0, 0xDD});
+		knownColors.put("POWDERBLUE", new int[] {0xB0, 0xE0, 0xE6});
+		knownColors.put("PURPLE", new int[] {0x80, 0x00, 0x80});
+		knownColors.put("RED", new int[] {0xFF, 0x00, 0x00});
+		knownColors.put("ROSYBROWN", new int[] {0xBC, 0x8F, 0x8F});
+		knownColors.put("ROYALBLUE", new int[] {0x41, 0x69, 0xE1});
+		knownColors.put("SADDLEBROWN", new int[] {0x8B, 0x45, 0x13});
+		knownColors.put("SALMON", new int[] {0xFA, 0x80, 0x72});
+		knownColors.put("SANDYBROWN", new int[] {0xF4, 0xA4, 0x60});
+		knownColors.put("SEAGREEN", new int[] {0x2E, 0x8B, 0x57});
+		knownColors.put("SEASHELL", new int[] {0xFF, 0xF5, 0xEE});
+		knownColors.put("SIENNA", new int[] {0xA0, 0x52, 0x2D});
+		knownColors.put("SILVER", new int[] {0xC0, 0xC0, 0xC0});
+		knownColors.put("SKYBLUE", new int[] {0x87, 0xCE, 0xEB});
+		knownColors.put("SLATEBLUE", new int[] {0x6A, 0x5A, 0xCD});
+		knownColors.put("SLATEGRAY", new int[] {0x70, 0x80, 0x90});
+		knownColors.put("SNOW", new int[] {0xFF, 0xFA, 0xFA});
+		knownColors.put("SPRINGGREEN", new int[] {0x00, 0xFF, 0x7F});
+		knownColors.put("STEELBLUE", new int[] {0x46, 0x82, 0xB4});
+		knownColors.put("TAN", new int[] {0xD2, 0xB4, 0x8C});
+		knownColors.put("TEAL", new int[] {0x00, 0x80, 0x80});
+		knownColors.put("THISTLE", new int[] {0xD8, 0xBF, 0xD8});
+		knownColors.put("TOMATO", new int[] {0xFF, 0x63, 0x47});
+		knownColors.put("TURQUOISE", new int[] {0x40, 0xE0, 0xD0});
+		knownColors.put("VIOLET", new int[] {0xEE, 0x82, 0xEE});
+		knownColors.put("WHEAT", new int[] {0xF5, 0xDE, 0xB3});
+		knownColors.put("WHITE", new int[] {0xFF, 0xFF, 0xFF});
+		knownColors.put("WHITESMOKE", new int[] {0xF5, 0xF5, 0xF5});
+		knownColors.put("YELLOW", new int[] {0xFF, 0xFF, 0x00});
+		knownColors.put("YELLOWGREEN", new int[] {0x9A, 0xCD, 0x32});
+	}
+}

--- a/src/main/java/net/pms/util/SubtitleUtils.java
+++ b/src/main/java/net/pms/util/SubtitleUtils.java
@@ -440,7 +440,7 @@ public class SubtitleUtils {
 
 								break;
 							case "PrimaryColour":
-								params[i] = convertColourToASSColourString(configuration.getSubsColor());
+								params[i] = configuration.getSubsColor().getASSv4StylesHexValue();
 								break;
 							case "Outline":
 								params[i] = configuration.getAssOutline();
@@ -525,7 +525,7 @@ public class SubtitleUtils {
 				fontScaleY = Double.toString(100 * Double.parseDouble(configuration.getAssScale()));
 			}
 
-			String primaryColour = convertColourToASSColourString(configuration.getSubsColor());
+			String primaryColour = configuration.getSubsColor().getASSv4StylesHexValue();
 			String outline = configuration.getAssOutline();
 			String shadow = configuration.getAssShadow();
 			outputString.append("Style: Default,Arial,").append("15").append(',').append(primaryColour).append(",&H000000FF,&H00000000,&H00000000,0,0,0,0,").append(fontScaleX).append(',').append(fontScaleY).append(",0,0,1,").append(outline).append(',').append(shadow);
@@ -611,19 +611,6 @@ public class SubtitleUtils {
 
 	public static void deleteSubs() {
 		FileUtils.deleteQuietly(new File(configuration.getDataFile(SUB_DIR)));
-	}
-
-	/**
-	 * Converts the standard Colour RGB integer presentation to the SSA/ASS string format which
-	 * is formatted as BGR (really stupid SSA/ASS implementation)
-	 *
-	 * @param colour the RGB color in the integer format
-	 * @return Converted color string in the ASS format
-	 */
-	public static String convertColourToASSColourString(String colour) {
-		StringBuilder outputString = new StringBuilder();
-		outputString.append("&H").append(colour.substring(6, 8)).append(colour.substring(4, 6)).append(colour.substring(2, 4));
-		return outputString.toString();
 	}
 
 	/**


### PR DESCRIPTION
This partially reverts 9bcba891a3299f498c00aed3b5abc2d966bd66ff. In addition I've made what I think is a more robust and versatile solution for subtitle colors in the new class ```SubtitleColor```.

@Sami32 Can you test if UMS will start for you with this PR?

@valib Do you think this is an ok solution? I haven't tested if the color parameters are correct for FFmpeg, Mencoder and ASS - I've just used what I found of documentation.

I've assumed that MEncoder use 0 as opaque while FFmpeg and ASS use 0xFF as opaque. If that is wrong, this needs some adjustments.

I'd appreciate if some of you would test this, as I'm not that into how to actually use this.
