### PR TITLE
Maven debugging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -647,6 +647,7 @@
 					<target>1.7</target>
 					<testSource>1.7</testSource>
 					<testTarget>1.7</testTarget>
+					<compilerArgument>${compilerArgument}</compilerArgument>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
So we can pass arguments, like `-Xlint`, to the compiler from the command line.