### PR TITLE
Remove unused repository from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,14 +100,6 @@
 		 -->
 		<makensis-bin>${project.external-resources}/third-party/nsis/makensis.exe</makensis-bin>
 	</properties>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>ossrh</id>
-			<name>Sonatype OSS Repository</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-			<layout>default</layout>
-		</pluginRepository>
-	</pluginRepositories>
 	<repositories>
 		<!-- GSON -->
 		<repository>


### PR DESCRIPTION
When looking at the travis builds, I noticed that Sonatype OSS repository was there. That's mostly for snapshots and where things are placed before being pushed to central. We have nothing that uses this currently in our POM, and every artifact is checked against every repository so this could save some build time.
