### PR TITLE
Some fixes in RendererConfiguration

### DIFF
--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -8,7 +8,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
@@ -33,7 +35,6 @@ import net.pms.util.StringUtil;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.WordUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -50,7 +51,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static RendererConfiguration defaultConf;
 	protected static final Map<InetAddress, RendererConfiguration> addressAssociation = new HashMap<>();
 
-	protected RootFolder rootFolder;
+	protected volatile RootFolder rootFolder;
 	protected File file;
 	protected Configuration configuration;
 	protected PmsConfiguration pmsConfiguration = _pmsConfiguration;
@@ -60,7 +61,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected Matcher sortedHeaderMatcher;
 	protected List<String> identifiers = null;
 
-	public StatusTab.RendererItem gui;
+	public volatile StatusTab.RendererItem gui;
 	public boolean loaded, fileless = false;
 	protected BasicPlayer player;
 
@@ -263,29 +264,31 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 				LOGGER.info("Loading renderer configurations from " + renderersDir.getAbsolutePath());
 
 				File[] confs = renderersDir.listFiles();
-				Arrays.sort(confs);
-				int rank = 1;
+				if (confs != null) {
+					Arrays.sort(confs);
+					int rank = 1;
 
-				List<String> selectedRenderers = pmsConf.getSelectedRenderers();
-				for (File f : confs) {
-					if (f.getName().endsWith(".conf")) {
-						try {
-							RendererConfiguration r = new RendererConfiguration(f);
-							r.rank = rank++;
-							String rendererName = r.getConfName();
-							allRenderersNames.add(rendererName);
-							String renderersGroup = null;
-							if (rendererName.indexOf(' ') > 0) {
-								renderersGroup = rendererName.substring(0, rendererName.indexOf(' '));
-							}
+					List<String> selectedRenderers = pmsConf.getSelectedRenderers();
+					for (File f : confs) {
+						if (f.getName().endsWith(".conf")) {
+							try {
+								RendererConfiguration r = new RendererConfiguration(f);
+								r.rank = rank++;
+								String rendererName = r.getConfName();
+								allRenderersNames.add(rendererName);
+								String renderersGroup = null;
+								if (rendererName.indexOf(' ') > 0) {
+									renderersGroup = rendererName.substring(0, rendererName.indexOf(' '));
+								}
 
-							if (selectedRenderers.contains(rendererName) || selectedRenderers.contains(renderersGroup) || selectedRenderers.contains(pmsConf.ALL_RENDERERS)) {
-								enabledRendererConfs.add(r);
-							} else {
-								LOGGER.debug("Ignored \"{}\" configuration", rendererName);
+								if (selectedRenderers.contains(rendererName) || selectedRenderers.contains(renderersGroup) || selectedRenderers.contains(pmsConf.ALL_RENDERERS)) {
+									enabledRendererConfs.add(r);
+								} else {
+									LOGGER.debug("Ignored \"{}\" configuration", rendererName);
+								}
+							} catch (ConfigurationException ce) {
+								LOGGER.info("Error in loading configuration of: " + f.getAbsolutePath());
 							}
-						} catch (ConfigurationException ce) {
-							LOGGER.info("Error in loading configuration of: " + f.getAbsolutePath());
 						}
 					}
 				}
@@ -394,7 +397,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 * @return The list of enabled renderers.
 	 */
 	public static ArrayList<RendererConfiguration> getEnabledRenderersConfigurations() {
-		return enabledRendererConfs != null ? new ArrayList(enabledRendererConfs) : null;
+		return enabledRendererConfs != null ? new ArrayList<RendererConfiguration>(enabledRendererConfs) : null;
 	}
 
 	/**
@@ -494,13 +497,13 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	}
 
 	public static void resetAllRenderers() {
-		for (RendererConfiguration r : getConnectedRenderersConfigurations()) {
-			r.rootFolder = null;
+		for (RendererConfiguration renderer : getConnectedRenderersConfigurations()) {
+			renderer.rootFolder = null;
 		}
 		// Resetting enabledRendererConfs isn't strictly speaking necessary any more, since
 		// these are now for reference only and never actually populate their root folders.
-		for (RendererConfiguration r : enabledRendererConfs) {
-			r.rootFolder = null;
+		for (RendererConfiguration renderer : enabledRendererConfs) {
+			renderer.rootFolder = null;
 		}
 	}
 
@@ -508,9 +511,9 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		if (rootFolder == null) {
 			ArrayList<String> tags = new ArrayList<>();
 			tags.add(getRendererName());
-			for (InetAddress sa : addressAssociation.keySet()) {
-				if (addressAssociation.get(sa) == this) {
-					tags.add(sa.getHostAddress());
+			for (Entry<InetAddress, RendererConfiguration> entry : addressAssociation.entrySet()) {
+				if (entry.getValue() == this) {
+					tags.add(entry.getKey().getHostAddress());
 				}
 			}
 
@@ -529,8 +532,8 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		}
 	}
 
-	public void setRootFolder(RootFolder r) {
-		rootFolder = r;
+	public void setRootFolder(RootFolder rootFolder) {
+		this.rootFolder = rootFolder;
 	}
 
 	/**
@@ -574,13 +577,13 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	}
 
 	public static void calculateAllSpeeds() {
-		for (InetAddress sa : addressAssociation.keySet()) {
-			if (sa.isLoopbackAddress() || sa.isAnyLocalAddress()) {
+		for (Entry<InetAddress, RendererConfiguration> entry : addressAssociation.entrySet()) {
+			if (entry.getKey().isLoopbackAddress() || entry.getKey().isAnyLocalAddress()) {
 				continue;
 			}
-			RendererConfiguration r = addressAssociation.get(sa);
-			if (!r.isOffline()) {
-				SpeedStats.getInstance().getSpeedInMBits(sa, r.getRendererName());
+			RendererConfiguration renderer = entry.getValue();
+			if (!renderer.isOffline()) {
+				SpeedStats.getInstance().getSpeedInMBits(entry.getKey(), renderer.getRendererName());
 			}
 		}
 	}
@@ -805,7 +808,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 					UPNP_DETAILS + "|" + USER_AGENT + "|" + USER_AGENT_ADDITIONAL_HEADER + "|" +
 					USER_AGENT_ADDITIONAL_SEARCH + ").*").matcher("");
 				boolean header = true;
-				for (String line : FileUtils.readLines(ref, Charsets.UTF_8)) {
+				for (String line : FileUtils.readLines(ref, StandardCharsets.UTF_8)) {
 					if (
 						skip.reset(line).matches() ||
 						(
@@ -1020,7 +1023,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 			boolean addWatch = file != f;
 			file = f;
 			if (addWatch) {
-				PMS.getFileWatcher().add(new FileWatcher.Watch(getFile().getPath(), reloader, this));
+				FileWatcher.add(new FileWatcher.Watch(getFile().getPath(), reloader, this));
 			}
 			return true;
 		}
@@ -1127,13 +1130,25 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 			loaded = false;
 			init(f);
 			// update gui
-			for (RendererConfiguration d : DeviceConfiguration.getInheritors(this)) {
-				PMS.get().updateRenderer(d);
+			for (RendererConfiguration device : DeviceConfiguration.getInheritors(this)) {
+				PMS.get().updateRenderer(device);
 			}
 		} catch (Exception e) {
-			LOGGER.debug("Error reloading renderer configuration {}: {}", f, e);
-			e.printStackTrace();
+			LOGGER.debug("Error reloading renderer configuration \"{}\": {}", f, e.getMessage());
+			LOGGER.trace("", e);
 		}
+	}
+
+	public void cleanup() {
+
+		PMS.get().getFoundRenderers().remove(this);
+		UPNPHelper.getInstance().removeRenderer(this);
+		InetAddress inetAddress = getAddress();
+		if (addressAssociation.get(inetAddress) == this) {
+			addressAssociation.remove(inetAddress);
+		}
+		gui = null;
+		rootFolder = null;
 	}
 
 	public String getDLNAPN(String old) {
@@ -1569,9 +1584,9 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 			}
 		}
 		// Otherwise check the address association
-		for (InetAddress sa : addressAssociation.keySet()) {
-			if (addressAssociation.get(sa) == this) {
-				return sa;
+		for (Entry<InetAddress, RendererConfiguration> entry : addressAssociation.entrySet()) {
+			if (entry.getValue() == this) {
+				return entry.getKey();
 			}
 		}
 		return null;
@@ -1620,30 +1635,24 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		delete(this, delay);
 	}
 
-	public static void delete(final RendererConfiguration r, int delay) {
-		r.setActive(false);
-		// Using javax.swing.Timer because of gui (this works in headless mode too).
-		javax.swing.Timer t = new javax.swing.Timer(delay, new ActionListener() {
+	public static void delete(final RendererConfiguration renderer, int delay) {
+		renderer.setActive(false);
+		// Using javax.swing.Timer because so it will run in the Swing event dispatcher thread (this works in headless mode too).
+		javax.swing.Timer timer = new javax.swing.Timer(delay, new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent event) {
 				// Make sure we haven't been reactivated while asleep
-				if (! r.isActive()) {
-					LOGGER.debug("Deleting renderer " + r);
-					if (r.gui != null) {
-						r.gui.delete();
+				if (!renderer.isActive()) {
+					LOGGER.debug("Deleting renderer \"{}\"", renderer);
+					if (renderer.gui != null) {
+						renderer.gui.delete();
 					}
-					PMS.get().getFoundRenderers().remove(r);
-					UPNPHelper.getInstance().removeRenderer(r);
-					InetAddress ia = r.getAddress();
-					if (addressAssociation.get(ia) == r) {
-						addressAssociation.remove(ia);
-					}
-					// TODO: actually delete rootfolder, etc.
+					renderer.cleanup();
 				}
 			}
 		});
-		t.setRepeats(false);
-		t.start();
+		timer.setRepeats(false);
+		timer.start();
 	}
 
 	public void setGuiComponents(StatusTab.RendererItem item) {
@@ -2383,9 +2392,9 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		}
 
 		// Substitute
-		for (String s : charMap.keySet()) {
-			String repl = charMap.get(s).replaceAll("###e", "");
-			name = name.replaceAll(s, repl);
+		for (Entry<String, String> entry : charMap.entrySet()) {
+			String repl = entry.getValue().replaceAll("###e", "");
+			name = name.replaceAll(entry.getKey(), repl);
 		}
 
 		return name;
@@ -2402,7 +2411,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 
 	public static int getIntAt(String s, String key, int fallback) {
 		try {
-			return Integer.valueOf((s + " ").split(key)[1].split("\\D")[0]);
+			return Integer.parseInt((s + " ").split(key)[1].split("\\D")[0]);
 		} catch (Exception e) {
 			return fallback;
 		}


### PR DESCRIPTION
I'm not sure if this should be merged or not. What happened was that I was dealing with something completely unrelated, and saw [this line](https://github.com/UniversalMediaServer/UniversalMediaServer/blob/7e347199cb9fcb83de40725eeb9e38445807bf77/src/main/java/net/pms/configuration/RendererConfiguration.java#L1623). With the memory issues (#1185) in the back of my mind I thought "maybe we can save some memory by freeing some references here". 

But, when I looked more at it, I'm not sure what the original author meant, how to "delete" rootfolder. All one can do in Java is to dereference it, unless he had some other cleanup procedure in mind. I guess dereferencing it is better than doing nothing, but this obviously has nothing to do with the "core" cause for #1185. Still, cleaning up as much as possible should be a good thing.

The reason I'm reluctant is that ```RendererConfiguration``` is fundamentally full of thread-unsafety. Different threads will be running these methods, and I'm simply afraid that doing anything extra can lead to new and mysterious bugs. The likelihood of this causing issues should still be marginal.

When I were at it, I fixed some of the other bugs FindBugs warned me about. Neither of these are revolutionary, there's some performance fixes, a NPE fix and some other minor stuff.