### PR TITLE
Don't force the usage of discret GPU on Mac with dual GPUs

### DIFF
--- a/src/main/external-resources/osx/Info.plist-template.xml
+++ b/src/main/external-resources/osx/Info.plist-template.xml
@@ -36,6 +36,8 @@
 		</dict>
 		<key>NSHighResolutionCapable</key>
 		<true/>
+		<key>NSSupportsAutomaticGraphicsSwitching</key>
+		<true/>
 		<key>LSApplicationCategoryType</key>
 		<string>public.app-category.entertainment</string>
 	</dict>


### PR DESCRIPTION
Following the search and test done by @onon765trb this request: https://github.com/UniversalMediaServer/UniversalMediaServer/issues/1183#issuecomment-280897278