### PR TITLE
Additional memory and CPU logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
 		<!-- Skip 4.65-1.05-RC because it doesn't work, author is working on fixing it -->
 		<sevenzip-version>4.65-1.04-RC</sevenzip-version>
-		
+
 		<twelvemonkeys-imageio-version>3.3.2</twelvemonkeys-imageio-version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -87,8 +87,25 @@
 		<maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
 		<git-commit-id-plugin-version>2.2.2</git-commit-id-plugin-version>
 		<maven-assembly-plugin-version>3.0.0</maven-assembly-plugin-version>
+
+		<!--
+			org.slf4j:slf4j-api is shared with
+				- su.litvak.chromecast:api-v2
+				- fm.last:coverartarchive-api
+				- com.github.oshi:oshi-core
+
+			Check the org.slf4j:slf4j-api version of the other libraries before upgrading
+		-->
 		<logback-version>1.2.3</logback-version>
 		<surefire-version>2.20</surefire-version>
+
+		<!--
+			net.java.dev.jna:jna-platform is shared with
+				- com.github.oshi:oshi-core
+
+			Check the net.java.dev.jna:jna-platform version of the other library before upgrading
+		-->
+		<jna-version>4.4.0</jna-version>
 
 		<!--
 			 use the Windows makensis.exe for Windows builds unless
@@ -133,26 +150,35 @@
 		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
+			<!--
+				commons-logging:commons-logging is shared with
+					- commons-httpclient:commons-httpclient
+					- com.github.junrar:junrar
+					- fm.last:coverartarchive-api
+
+				Check the commons-logging:commons-logging version of the other libraries before upgrading
+			-->
 			<version>1.10</version>
-			<exclusions>
-				<!--  no need for commons-logging, as jcl-over-slf4j provides the impl -->
-				<exclusion>
-					<artifactId>commons-logging</artifactId>
-					<groupId>commons-logging</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-httpclient</groupId>
 			<artifactId>commons-httpclient</artifactId> <!-- TODO this should be changed to org.apache.httpcomponents which is the follower. -->
 			<version>3.1</version>
 			<exclusions>
-				<!--  no need for commons-logging, as jcl-over-slf4j provides the impl -->
 				<exclusion>
+					<!--
+						commons-logging:commons-logging is shared with
+							- commons-configuration:commons-configuration
+							- com.github.junrar:junrar
+							- fm.last:coverartarchive-api
+
+						The other libraries use a much newer version since commons-httpclient is ancient and abandoned
+					-->
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
 				<exclusion>
+					<!-- fm.last:coverartarchive-api uses a much newer version since commons-httpclient is ancient and abandoned -->
 					<groupId>commons-codec</groupId>
 					<artifactId>commons-codec</artifactId>
 				</exclusion>
@@ -161,6 +187,12 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
+			<!--
+				commons-io:commons-io is shared with
+					- fm.last:coverartarchive-api
+
+				Check the commons-io:commons-io version of the library before upgrading
+			-->
 			<version>2.5</version>
 		</dependency>
 		<dependency>
@@ -211,8 +243,8 @@
 			<artifactId>thumbnailator</artifactId>
 			<version>[0.4, 0.5)</version>
 		</dependency>
-		
-		<!-- 
+
+		<!--
 			If any ImageIO plugins are added or removed, corresponding changes
 		 	must be made in src/main/external-resources/META-INF/services
 		 -->
@@ -290,7 +322,7 @@
 			<groupId>com.drewnoakes</groupId>
 			<artifactId>metadata-extractor</artifactId>
 			<version>2.10.1</version>
-		</dependency>		
+		</dependency>
 		<dependency>
 			<groupId>net.jthink</groupId>
 			<artifactId>jaudiotagger</artifactId>
@@ -309,6 +341,14 @@
 		<dependency>
 			<groupId>com.github.junrar</groupId>
 			<artifactId>junrar</artifactId>
+			<!--
+				commons-logging:commons-logging is shared with
+					- commons-configuration:commons-configuration
+					- commons-httpclient:commons-httpclient
+					- fm.last:coverartarchive-api
+
+				Check the commons-logging:commons-logging version of the other libraries before upgrading
+			-->
 			<version>0.7</version>
 		</dependency>
 
@@ -355,12 +395,12 @@
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>
 			<artifactId>jna</artifactId>
-			<version>4.4.0</version>
+			<version>${jna-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>
 			<artifactId>jna-platform</artifactId>
-			<version>4.4.0</version>
+			<version>${jna-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.fourthline.cling</groupId>
@@ -395,6 +435,14 @@
 		<dependency>
 			<groupId>su.litvak.chromecast</groupId>
 			<artifactId>api-v2</artifactId>
+			<!--
+				org.slf4j:slf4j-api is shared with
+					- ch.qos.logback:logback-classic
+					- fm.last:coverartarchive-api
+					- com.github.oshi:oshi-core
+
+				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
+			-->
 			<version>0.10.0</version>
 		</dependency>
 		<dependency>
@@ -410,8 +458,29 @@
 		<dependency>
 			<groupId>fm.last</groupId>
 			<artifactId>coverartarchive-api</artifactId>
+			<!--
+				org.slf4j:slf4j-api is shared with
+					- ch.qos.logback:logback-classic
+					- su.litvak.chromecast
+					- com.github.oshi:oshi-core
+
+				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
+
+				commons-logging:commons-logging is shared with
+					- commons-configuration:commons-configuration
+					- commons-httpclient:commons-httpclient
+					- com.github.junrar:junrar
+
+				Check the commons-logging:commons-logging version of the other libraries before upgrading
+
+				commons-io:commons-io is shared with
+					- net.pms:ums
+
+				Check the commons-io:commons-io version before upgrading
+			-->
 			<version>2.1.0</version>
 			<exclusions>
+				<!-- This should never have been a dependency in the first place -->
 				<exclusion>
 					<groupId>com.google.code.findbugs</groupId>
 					<artifactId>jsr305</artifactId>
@@ -425,6 +494,19 @@
 		<dependency>
 			<groupId>com.github.oshi</groupId>
 			<artifactId>oshi-core</artifactId>
+			<!--
+				org.slf4j:slf4j-api is shared with
+					- ch.qos.logback:logback-classic
+					- su.litvak.chromecast
+					- fm.last:coverartarchive-api
+
+				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
+
+				net.java.dev.jna:jna-platform is shared with
+					- net.pms:ums
+
+				Check the net.java.dev.jna:jna-platform version before upgrading
+			-->
 			<version>3.4.2</version>
 			<exclusions>
 				<exclusion>
@@ -539,9 +621,9 @@
 					<version>${surefire-version}</version>
 				</plugin>
 
-				<!-- 
+				<!--
 					This plugin's configuration is used to run crowdin plugin from the command line,
-					it has no influence on the Maven build itself. 
+					it has no influence on the Maven build itself.
 				-->
 				<plugin>
 					<groupId>com.universalmediaserver</groupId>
@@ -618,7 +700,7 @@
 										</artifactId>
 										<versionRange>
 											[0.1,)
-										</versionRange>										
+										</versionRange>
 										<goals>
 											<goal>clean</goal>
 											<goal>deploy</goal>
@@ -1418,7 +1500,7 @@
 								</configuration>
 							</execution>
 							<!--
-								Assemble the UMS files in the right place before 
+								Assemble the UMS files in the right place before
 								moving them to the app Bundle.
 							-->
 							<execution>
@@ -1595,7 +1677,7 @@
 								</configuration>
 							</execution>
 							<!--
-								Assemble the UMS files in the right place before 
+								Assemble the UMS files in the right place before
 								moving them to the app Bundle.
 							-->
 							<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,17 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>com.github.oshi</groupId>
+			<artifactId>oshi-core</artifactId>
+			<version>3.4.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>assembly:assembly</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,10 @@
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-api</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>net.java.dev.jna</groupId>
+					<artifactId>jna-platform</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 	</dependencies>

--- a/src/main/external-resources/logback.headless.xml
+++ b/src/main/external-resources/logback.headless.xml
@@ -81,6 +81,7 @@
 	<logger name="org.apache" level="WARN" />
 	<logger name="httpclient.wire" level="WARN" />
 	<logger name="fm.last.musicbrainz.coverart" level="WARN" />
+	<logger name="oshi" level="WARN" />
 
 	<!-- Root logger defines the minimum log level for all loggers -->
 	<root level="${rootLevel}">

--- a/src/main/external-resources/logback.xml
+++ b/src/main/external-resources/logback.xml
@@ -90,6 +90,7 @@
 	<logger name="org.apache" level="WARN" />
 	<logger name="httpclient.wire" level="WARN" />
 	<logger name="fm.last.musicbrainz.coverart" level="WARN" />
+	<logger name="oshi" level="WARN" />
 
 	<!-- Root logger defines the minimum log level for all loggers -->
 	<root level="${rootLevel}">

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -69,6 +69,10 @@ import net.pms.newgui.*;
 import net.pms.remote.RemoteWeb;
 import net.pms.update.AutoUpdater;
 import net.pms.util.*;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.apache.commons.configuration.event.ConfigurationListener;
@@ -1414,12 +1418,17 @@ public class PMS {
 	 */
 	private void logSystemInfo() {
 		long memoryInMB = Runtime.getRuntime().maxMemory() / 1048576;
+		HardwareAbstractionLayer hal = new SystemInfo().getHardware();
+		CentralProcessor processor = hal.getProcessor();
+		GlobalMemory memory = hal.getMemory();
 
 		LOGGER.info("Java: " + System.getProperty("java.vm.name") + " " + System.getProperty("java.version") + " " + System.getProperty("sun.arch.data.model") + "-bit" + " by " + System.getProperty("java.vendor"));
 		LOGGER.info("OS: " + System.getProperty("os.name") + " " + getOSBitness() + "-bit " + System.getProperty("os.version"));
-		LOGGER.info("Encoding: " + System.getProperty("file.encoding"));
-		LOGGER.info("Memory: {} MB", memoryInMB);
+		LOGGER.info("Physical memory available: {} MB", memory.getAvailable() / 1048576);
+		LOGGER.info("Memory accessible by Java: {} MB", memoryInMB);
+		LOGGER.info("CPU: " + processor.getName());
 		LOGGER.info("Language: " + WordUtils.capitalize(PMS.getLocale().getDisplayName(Locale.ENGLISH)));
+		LOGGER.info("Encoding: " + System.getProperty("file.encoding"));
 		LOGGER.info("");
 
 		if (Platform.isMac()) {

--- a/src/main/java/net/pms/util/StringUtil.java
+++ b/src/main/java/net/pms/util/StringUtil.java
@@ -64,6 +64,18 @@ public class StringUtil {
 	public static final String SEC_TIME_FORMAT = "%02d:%02d:%02.0f";
 	public static final String DURATION_TIME_FORMAT = "%02d:%02d:%05.2f";
 	public static final String NEWLINE_CHARACTER = System.getProperty("line.separator");
+	public static final long KIBI = 1L << 10;
+	public static final long MEBI = 1L << 20;
+	public static final long GIBI = 1L << 30;
+	public static final long TEBI = 1L << 40;
+	public static final long PEBI = 1L << 50;
+	public static final long EXBI = 1L << 60;
+	public static final long KILO = 1000L;
+	public static final long MEGA = 1000000L;
+	public static final long GIGA = 1000000000L;
+	public static final long TERA = 1000000000000L;
+	public static final long PETA = 1000000000000000L;
+	public static final long EXA  = 1000000000000000000L;
 
 	/**
 	 * Appends "&lt;<u>tag</u> " to the StringBuilder. This is a typical HTML/DIDL/XML tag opening.
@@ -358,7 +370,7 @@ public class StringUtil {
 		Pattern pattern = Pattern.compile("<body>(.*)</body>", Pattern.CASE_INSENSITIVE + Pattern.DOTALL);
 		Matcher matcher = pattern.matcher(html);
 		if (matcher.find()) {
-			return matcher.group(1).replaceAll("\n    ", "").trim().replaceAll("(?i)<br>", "\n").replaceAll("<.*?>","");
+			return matcher.group(1).replaceAll("\n    ", "").trim().replaceAll("(?i)<br>", "\n").replaceAll("<.*?>", "");
 		}
 		throw new IllegalArgumentException("HTML text not as expected, must have <body> section");
 	}
@@ -375,10 +387,10 @@ public class StringUtil {
 	}
 
 	/**
-	 * Escapes {@link org.apache.lucene} special characters with backslash
+	 * Escapes {@link org.apache.lucene} special characters with backslash.
 	 *
-	 * @param s the {@link String} to evaluate
-	 * @return The converted String
+	 * @param s the {@link String} to evaluate.
+	 * @return The converted String.
 	 */
 	@SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
 	public static String luceneEscape(final String s) {
@@ -415,10 +427,10 @@ public class StringUtil {
 	}
 
 	/**
-	 * Escapes special characters with backslashes for FFmpeg subtitles
+	 * Escapes special characters with backslashes for FFmpeg subtitles.
 	 *
-	 * @param s the {@link String} to evaluate
-	 * @return The converted String
+	 * @param s the {@link String} to evaluate.
+	 * @return The converted String.
 	 */
 	public static String ffmpegEscape(String s) {
 		StringBuilder sb = new StringBuilder();
@@ -447,7 +459,21 @@ public class StringUtil {
 		return sb.toString();
 	}
 
-	public static String prettifyXML(String xml, int indentWidth) throws SAXException, ParserConfigurationException, XPathExpressionException, TransformerException {
+	/**
+	 * Formats a XML string to be easier to read with newlines and indentations.
+	 *
+	 * @param xml the {@link String} to "prettify".
+	 * @param indentWidth the width of one indentation in number of characters.
+	 * @return The "prettified" {@link String}.
+	 * @throws SAXException If a parsing error occurs.
+	 * @throws ParserConfigurationException If a parsing error occurs.
+	 * @throws XPathExpressionException If a parsing error occurs.
+	 * @throws TransformerException If a parsing error occurs.
+	 */
+	public static String prettifyXML(
+		String xml,
+		int indentWidth
+	) throws SAXException, ParserConfigurationException, XPathExpressionException, TransformerException {
 		try {
 			// Turn XML string into a document
 			Document xmlDocument =
@@ -576,5 +602,60 @@ public class StringUtil {
 			sb.append(strings[i]);
 		}
 		return sb.toString();
+	}
+
+	/**
+	 * Formats bytes into a rounded {@link String} representation in either
+	 * binary/power of 2 or SI notation using {@link Locale#ROOT}.
+	 *
+	 * @param bytes the value to format.
+	 * @param binary whether the representation should be binary/power of 2 or
+	 *            SI/metric.
+	 * @return The formatted byte value and unit.
+	 */
+	public static String formatBytes(long bytes, boolean binary) {
+		return formatBytes(bytes, binary, Locale.ROOT);
+	}
+
+	/**
+	 * Formats bytes into a rounded {@link String} representation in either
+	 * binary/power of 2 or SI notation.
+	 *
+	 * @param bytes the value to format.
+	 * @param binary whether the representation should be binary/power of 2 or
+	 *            SI/metric.
+	 * @param locale the {@link Locale} to use when formatting.
+	 * @return The formatted byte value and unit.
+	 */
+	public static String formatBytes(long bytes, boolean binary, Locale locale) {
+		if ((binary && bytes < 1L << 10) || bytes < KILO) {
+			return String.format("%d %s", bytes, bytes == 1L ? "byte" : "bytes");
+		}
+
+		long divisor;
+		String unit;
+		if ((binary && bytes < MEBI) || bytes < MEGA) { // kibi/kilo
+			divisor = binary ? KIBI : KILO;
+			unit = binary ? "KiB" : "kB";
+		} else if ((binary && bytes < GIBI) || bytes < GIGA) { // mebi/mega
+			divisor = binary ? MEBI : MEGA;
+			unit = binary ? "MiB" : "MB";
+		} else if ((binary && bytes < TEBI) || bytes < TERA) { // gibi/giga
+			divisor = binary ? GIBI : GIGA;
+			unit = binary ? "GiB" : "GB";
+		} else if ((binary && bytes < PEBI) || bytes < PETA) { // tebi/tera
+			divisor = binary ? TEBI : TERA;
+			unit = binary ? "TiB" : "TB";
+		} else if ((binary && bytes < EXBI) || bytes < EXA) { // pebi/peta
+			divisor = binary ? PEBI : PETA;
+			unit = binary ? "PiB" : "PB";
+		} else { // exbi/exa
+			divisor = binary ? EXBI : EXA;
+			unit = binary ? "EiB" : "EB";
+		}
+		if (bytes % divisor == 0) {
+			return String.format(locale, "%d %s", bytes / divisor, unit);
+		}
+		return String.format(locale, "%.1f %s", (double) bytes / divisor, unit);
 	}
 }


### PR DESCRIPTION
My mistake in #1123 made me think that we should have more info available for debugging. I recalled that @valib had done something like that, and cherry-picked 7a84789419eb3316bd082eccde18061b96524236 from #979/#1091.

I've further modified the logging, and added ```StringUtil.formatBytes()``` to easily format byte values for output.