### PR TITLE
Prefer FrameRate_Original over FrameRate from MediaInfo (#1210)

### DIFF
--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -139,6 +139,13 @@ public class LibMediaInfoParser {
 							media.setAspectRatioContainer(MI.Get(video, i, "DisplayAspectRatio/String"));
 							media.setAspectRatioVideoTrack(MI.Get(video, i, "DisplayAspectRatio_Original/String"));
 							media.setFrameRate(getFPSValue(MI.Get(video, i, "FrameRate")));
+							// Prefer "FrameRate_Original over FrameRate if it's there because it is more accurate
+							// https://github.com/UniversalMediaServer/UniversalMediaServer/issues/1210
+							value = MI.Get(video, i, "FrameRate_Original");
+							if (isBlank(value)) {
+								value = MI.Get(video, i, "FrameRate");
+							}
+							media.setFrameRate(getFPSValue(value));
 							media.setFrameRateOriginal(MI.Get(video, i, "FrameRate_Original"));
 							media.setFrameRateMode(getFrameRateModeValue(MI.Get(video, i, "FrameRate_Mode")));
 							media.setFrameRateModeRaw(MI.Get(video, i, "FrameRate_Mode"));


### PR DESCRIPTION
This is an implementation of the suggested fix to MEncoder sync issues in #1210. I haven't tested it. Please test and give feedback.

Thanks to @owlhuang for doing all the work and presenting it in a very easy-to-understand way 👍
