### PR TITLE
Log video bit depth color and fix frameRateMode bug

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -509,40 +509,52 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	@Override
 	public String toString() {
 		StringBuilder result = new StringBuilder();
-		result.append("id: ");
-		result.append(getId());
-		result.append(", lang: ");
-		result.append(getLang());
+		if (!getLang().equals("und")) {
+			result.append("Id: ").append(getId());
+			result.append(", Language Code: ").append(getLang());
+		}
 
 		if (isNotBlank(getAudioTrackTitleFromMetadata())) {
-			result.append(", audio track title from metadata: ");
-			result.append(getAudioTrackTitleFromMetadata());
+			if (result.length() > 0) {
+				result.append(", ");
+			}
+			result.append("Audio Track Title From Metadata: ").append(getAudioTrackTitleFromMetadata());
 		}
 
-		result.append(", audio codec: ");
-		result.append(getAudioCodec());
-		result.append(", sample frequency:");
-		result.append(getSampleFrequency());
-
-		if (getAudioProperties() != null && getAudioProperties().getNumberOfChannels() != 0) {
-			result.append(", number of channels: ");
-			result.append(getAudioProperties().getNumberOfChannels());
+		if (result.length() > 0) {
+			result.append(", ");
 		}
+		result.append("Audio Codec: ").append(getAudioCodec());
 
-		result.append(", bits per sample: ");
-		result.append(getBitsperSample());
+		result.append(", Bitrate: ").append(getBitRate());
+		if (getBitsperSample() != 16) {
+			result.append(", Bits per Sample: ").append(getBitsperSample());
+		}
+		if (getAudioProperties() != null) {
+			result.append(", ").append(getAudioProperties());
+		}
 
 		if (isNotBlank(getArtist())) {
-			result.append(", artist: ");
-			result.append(getArtist());
-			result.append(", album: ");
-			result.append(getAlbum());
-			result.append(", song name: ");
-			result.append(getSongname());
-			result.append(", year: ");
-			result.append(getYear());
-			result.append(", track: ");
-			result.append(getTrack());
+			result.append(", Artist: ").append(getArtist());
+		}
+		if (isNotBlank(getAlbum())) {
+			result.append(", Album: ").append(getAlbum());
+		}
+		if (isNotBlank(getSongname())) {
+			result.append(", Track Name: ").append(getSongname());
+		}
+		if (getYear() != 0) {
+			result.append(", Year: ").append(getYear());
+		}
+		if (getTrack() != 0) {
+			result.append(", Track: ").append(getTrack());
+		}
+		if (isNotBlank(getGenre())) {
+			result.append(", Genre: ").append(getGenre());
+		}
+
+		if (isNotBlank(getMuxingModeAudio())) {
+			result.append(", Muxing Mode: ").append(getMuxingModeAudio());
 		}
 
 		return result.toString();

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -900,7 +900,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 					LOGGER.trace(prependTraceReason + "the bitrate ({} b/s) is too high ({} b/s).", getName(), media.getBitrate(), maxBandwidth);
 				} else if (!renderer.isVideoBitDepthSupported(media.getVideoBitDepth())) {
 					isIncompatible = true;
-					LOGGER.trace(prependTraceReason + "the bit depth ({}) is not supported.", getName(), media.getVideoBitDepth());
+					LOGGER.trace(prependTraceReason + "the video bit depth ({}) is not supported.", getName(), media.getVideoBitDepth());
 				} else if (renderer.isH264Level41Limited() && media.isH264()) {
 					if (media.getAvcLevel() != null) {
 						double h264Level = 4.1;

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -117,7 +117,9 @@ public class LibMediaInfoParser {
 							media.setAspectRatioContainer(MI.Get(video, i, "DisplayAspectRatio/String"));
 							media.setAspectRatioVideoTrack(MI.Get(video, i, "DisplayAspectRatio_Original/String"));
 							media.setFrameRate(getFPSValue(MI.Get(video, i, "FrameRate")));
-							media.setFrameRateMode(getFrameRateModeValue(MI.Get(video, i, "FrameRateMode")));
+							media.setFrameRateOriginal(MI.Get(video, i, "FrameRate_Original"));
+							media.setFrameRateMode(getFrameRateModeValue(MI.Get(video, i, "FrameRate_Mode")));
+							media.setFrameRateModeRaw(MI.Get(video, i, "FrameRate_Mode"));
 							media.setReferenceFrameCount(getReferenceFrameCount(MI.Get(video, i, "Format_Settings_RefFrames/String")));
 							media.setVideoTrackTitleFromMetadata(MI.Get(video, i, "Title"));
 							value = MI.Get(video, i, "Format_Settings_QPel");

--- a/src/main/java/net/pms/formats/v2/AudioProperties.java
+++ b/src/main/java/net/pms/formats/v2/AudioProperties.java
@@ -219,4 +219,16 @@ public class AudioProperties {
 			return result;
 		}
 	}
+
+	@Override
+	public String toString() {
+		StringBuilder result = new StringBuilder();
+		result.append("Channel(s): ").append(getNumberOfChannels());
+		result.append(", Sample Frequency: ").append(getSampleFrequency()).append(" Hz");
+		if (getAudioDelay() != 0) {
+			result.append(", Delay: ").append(getAudioDelay());
+		}
+
+		return result.toString();
+	}
 }


### PR DESCRIPTION
- [x] Fix an old `frameRateMode` bug ([<2009](https://sourceforge.net/p/mediainfo/discussion/297610/thread/cd4f521f/?SetFreedomCookie)) that could have caused desynchronization issues.
- [x] Log `videoBitDepth` and `frameRateModeRaw`
For  a more easy debugging, as many desynchronization or transcoding issues are reported, and asking MediaInfo log from users could be hazardous and time consuming.
- [x] Refactoring the parsing logger; thanks to @Nadahar advices.