### PR TITLE
Disable HTTPS/SSL validation when downloading external dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,9 +681,10 @@
 			<plugin>
 				<groupId>com.universalmediaserver</groupId>
 				<artifactId>external-maven-plugin</artifactId>
-				<version>0.1</version>
+				<version>0.2</version>
 				<inherited>false</inherited>
 				<configuration>
+					<disableSSLValidation>true</disableSSLValidation>
 					<stagingDirectory>${project.build.directory}/dependencies/</stagingDirectory>
 					<createChecksum>true</createChecksum>
 					<artifactItems>


### PR DESCRIPTION
I experienced the same problem as @taconaut [reported here](http://www.universalmediaserver.com/forum/viewtopic.php?f=14&t=4145#p29593) today. In short, running ```mvn external:install``` will on some installations fail with:
```powershell
[ERROR] Failed to execute goal com.universalmediaserver:external-maven-plugin:0.1:install (default-cli) on project ums: Failed to download artifact mediautil:mediautil:1.0:jar: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target -> [Help 1]
```

 After a little head-scratching I suddenly understood exactly what was going on. It's the exact same "error" that you get when trying to load a HTTPS URL where the server's certificate is expired or self-signed. It's about verifying that the remote host is in fact who it claims to be (its identity can't be confirmed). 

Certificate validation all boils down to trust relationships, and some "root" certificate authorities are defined as "trusted". It means that any certificate issues by them, or by another certificate authority "trusted" by them is "trused" - and any other certificate isn't. The problem is that who is trusted isn't decided by us, it has been decided for us. Typically the only "trusted" certificate authorities are commercial and will "rent" you a trusted certificate. I don't know what guarantees that give other than that whoever has this certificate has money, but that's beside the point here. When a certificate can't be verified it could either be because it's "fake" (not what it claims to be) or because the rent has not been paid. What is trusted and not changes constantly, and many "security updates" simply keeps updating what to "trust" and not. Because of this, our OS and browsers usually keeps more or less "up to date".

Java on the other hand has a fixed set of trusts distributed with the JRE/JDK. It will never be updated for this Java version, you have to install a new Java version to get an updated "trust" file (the file is actually ```<JDK/JRE folder>/lib/security/cacerts``` and can be manually copied between Java versions). Users can manually add trusts to this file by using Java's ```keytool``` like this:
```
keytool -exportcert -alias [host]-1 -keystore jssecacerts -storepass changeit -file [host].cer
```
This is very cryptic and too difficult for most people though, and you also have to save the certificate you wish to trust to a file first (can be done from browsers by visiting the URL in question).

What has happened in our case is that sourceforge (which hosts ```mediautil```) has switched from HTTP to HTTPS, and is automatically forwarding any HTTP requests to HTTPS. That means that our download link for ```mediautil```: 
http://downloads.sourceforge.net/project/mediachest/MediaUtil/Version%201.0/mediautil-1.zip
is "translated" into:
https://sourceforge.net/projects/mediachest/files/MediaUtil/Version 1.0/mediautil-1.zip

This change has happened at sourceforge, we've been unaware of the change - and since you only have to run ```mvn external:install``` once per installation, we don't do this regularly and thus doesn't notice. 

A lot of JDK/JRE versions doesn't "trust" sourceforge's certificate, and thus Java refuses to download the file.

I think it's unrealistic to expect anyone that want to build UMS to understand all this, or force them to use the "latest" JDK. We also do checksum verification for the downloaded artifacts, so it doesn't really matter if the host is who it claims to be: If the file is altered at all, the download will fail.

As a consequence, I think the best solution is to disable HTTPS/SSL validation when downloading external dependencies. It's no more unsafe than using HTTP (which is what we have done until now), and I really don't see the big problem.

I've released version [```0.2``` of ```external-maven-plugin```](https://github.com/UniversalMediaServer/external-maven-plugin/releases/tag/v0.2) and released it to Maven Central. This version has an optional parameter ```disableSSLValidation``` - which I have enabled in this PR.

The concrete changes in this PR are:
* Updated external-maven-plugin to 0.2
* Disabled HTTPS/SSL validation when downloading external dependencies

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1223)
<!-- Reviewable:end -->
