### PR TITLE
Bump allowed OS X Java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1225,7 +1225,7 @@
 								<configuration>
 									<rules>
 										<requireJavaVersion>
-											<version>[1.7.0-80,1.7.0-100]</version>
+											<version>[1.7.0-80,1.7.0-200]</version>
 										</requireJavaVersion>
 									</rules>
 								</configuration>
@@ -1403,7 +1403,7 @@
 								<configuration>
 									<rules>
 										<requireJavaVersion>
-											<version>[1.8.0-51,1.8.0-100]</version>
+											<version>[1.8.0-51,1.8.0-200]</version>
 										</requireJavaVersion>
 									</rules>
 								</configuration>


### PR DESCRIPTION
UMS won't build on OS X with the lastest Java 8 (121). I guess someone just wrote ```100``` at a time as an arbitrary number and that bumping it has no consequence. I've done a testbuild and didn't see any problems.
