### PR TITLE
Preventwindowsfromsleep fix

### DIFF
--- a/src/main/java/net/pms/io/WinUtils.java
+++ b/src/main/java/net/pms/io/WinUtils.java
@@ -31,7 +31,6 @@ import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Contains the Windows specific native functionality. Do not try to instantiate on Linux/MacOS X !

--- a/src/main/java/net/pms/io/WinUtils.java
+++ b/src/main/java/net/pms/io/WinUtils.java
@@ -74,20 +74,19 @@ public class WinUtils extends BasicSystemUtils {
 	private boolean kerio;
 	private String avsPluginsDir;
 	private String kLiteFiltersDir;
-        private AtomicInteger OpenRequests = new AtomicInteger(0);
 
 	/* (non-Javadoc)
 	 * @see net.pms.io.SystemUtils#disableGoToSleep()
 	 */
 	@Override
 	public void disableGoToSleep() {
-		// Disable go to sleep (probably the lastDontSleepCall check is not needed)
-       		LOGGER.debug("Called disableGoToSleep (cnt: " + OpenRequests.toString() + ")");
-                if (configuration.isPreventsSleep() && (OpenRequests.getAndIncrement() == 0)) {
+		// Disable go to sleep
+       		LOGGER.debug("Called disableGoToSleep");
+                if (configuration.isPreventsSleep()) {
                         // stay always on
 			LOGGER.debug("Calling SetThreadExecutionState ES_SYSTEM_REQUIRED|ES_CONTINUOUS");
                         Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_SYSTEM_REQUIRED | Kernel32.ES_CONTINUOUS);
-		}
+            }
 
 	}
 
@@ -96,15 +95,15 @@ public class WinUtils extends BasicSystemUtils {
 	 */
 	@Override
 	public void reenableGoToSleep() {
-		LOGGER.debug("Called reenableGoToSleep (cnt: " + OpenRequests.toString() + ")");
-                if (configuration.isPreventsSleep() && (OpenRequests.decrementAndGet() == 0)) {
+		LOGGER.debug("Called reenableGoToSleep");
+                if (configuration.isPreventsSleep()) {
                     // disable the "permanent on"
                     LOGGER.debug("Calling SetThreadExecutionState ES_CONTINUOUS");
                     Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_CONTINUOUS);
-                    // retrigger the normal idle timer
+                    // retrigger the normal idle timer (is this done automatically?)
                     LOGGER.trace("Calling SetThreadExecutionState ES_SYSTEM_REQUIRED");
                     Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_SYSTEM_REQUIRED);
-                }
+            }
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/net/pms/io/WinUtils.java
+++ b/src/main/java/net/pms/io/WinUtils.java
@@ -81,12 +81,14 @@ public class WinUtils extends BasicSystemUtils {
 	 */
 	@Override
 	public void disableGoToSleep() {
-		// Disable go to sleep (every 40s)
+		// Disable go to sleep (probably the lastDontSleepCall check is not needed)
+       		LOGGER.debug("Called disableGoToSleep");
 		if (configuration.isPreventsSleep() && System.currentTimeMillis() - lastDontSleepCall > 40000) {
-			LOGGER.trace("Calling SetThreadExecutionState ES_SYSTEM_REQUIRED");
-			Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_SYSTEM_REQUIRED | Kernel32.ES_CONTINUOUS);
+			LOGGER.debug("Calling SetThreadExecutionState ES_SYSTEM_REQUIRED");
+			Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_SYSTEM_REQUIRED);
 			lastDontSleepCall = System.currentTimeMillis();
 		}
+
 	}
 
 	/* (non-Javadoc)
@@ -94,12 +96,11 @@ public class WinUtils extends BasicSystemUtils {
 	 */
 	@Override
 	public void reenableGoToSleep() {
-		// Reenable go to sleep
-		if (configuration.isPreventsSleep() && System.currentTimeMillis() - lastGoToSleepCall > 40000) {
-			LOGGER.trace("Calling SetThreadExecutionState ES_CONTINUOUS");
-			Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_CONTINUOUS);
-			lastGoToSleepCall = System.currentTimeMillis();
-		}
+            	// not needed anymore
+		LOGGER.debug("Called reenableGoToSleep");
+                // lastGoToSleepCall is here just for the case that is is needed elsewhere
+                // (probably not needed)
+        	lastGoToSleepCall = System.currentTimeMillis();
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/net/pms/network/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/RequestHandlerV2.java
@@ -103,6 +103,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 
 		LOGGER.trace("Opened request handler on socket " + remoteAddress);
 		PMS.get().getRegistry().disableGoToSleep();
+            try {
 		request = new RequestV2(nettyRequest.getMethod().getName(), nettyRequest.getUri().substring(1));
 		LOGGER.trace("Request: " + nettyRequest.getProtocolVersion().getText() + " : " + request.getMethod() + " : " + request.getArgument());
 
@@ -254,6 +255,10 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 		LOGGER.trace("HTTP: " + request.getArgument() + " / " + request.getLowRange() + "-" + request.getHighRange());
 
 		writeResponse(ctx, e, request, ia);
+            } finally {
+                PMS.get().getRegistry().reenableGoToSleep();
+            }
+
 	}
 
 	/**

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -909,7 +909,7 @@ public class RequestV2 extends HTTPResource {
 					@Override
 					public void operationComplete(ChannelFuture future) {
 						try {
-							PMS.get().getRegistry().reenableGoToSleep();
+							//PMS.get().getRegistry().reenableGoToSleep();
 							inputStream.close();
 						} catch (IOException e) {
 							LOGGER.debug("Caught exception", e);
@@ -924,7 +924,7 @@ public class RequestV2 extends HTTPResource {
 			} else {
 				// HEAD method is being used, so simply clean up after the response was sent.
 				try {
-					PMS.get().getRegistry().reenableGoToSleep();
+					//PMS.get().getRegistry().reenableGoToSleep();
 					inputStream.close();
 				} catch (IOException ioe) {
 					LOGGER.debug("Caught exception", ioe);


### PR DESCRIPTION
This lets Windows count how often sleep is disabled and reenabled. You can check the effect by counting the lines with " ES_CONTINUOUS" and "|ES_CONTINUOUS" in the debug log:

grep "|ES_CONTINUOUS" debug.log|wc
grep " ES_CONTINUOUS" debug.log|wc

(should be the same when all network requests are finished)

and by looking at the outputs of 
powercfg -requests 
(run this as admin on Windows command line)
(there must be no "java" behind "SYSTEM")

One issue is still not solved:
Streaming of large content seems to run in a parallel thread (for instance I see ffmpeg in the log) which is not between a disable and a reenable! There is still work needed to avoid sleep during streaming!

This is not a final solution!