### PR TITLE
Making J6200 more general

### DIFF
--- a/src/main/external-resources/renderers/Samsung-J6200.conf
+++ b/src/main/external-resources/renderers/Samsung-J6200.conf
@@ -13,7 +13,8 @@ RendererIcon = Samsung-H6400.png
 # modelName=UA40J6200
 # ============================================================================
 
-UserAgentSearch = UA\d{2}J6200
+UserAgentSearch = U.\\d{2}(J|JS)6200
+UpnpDetailsSearch = U.\\d{2}(J|JS)6200
 
 LoadingPriority = 1
 


### PR DESCRIPTION
Based on the log of that user:
http://www.universalmediaserver.com/forum/posting.php?mode=reply&f=9&t=9261#pr30011
```logtalk
based on headers {ACCEPT-LANGUAGE=en-us, Connection=Keep-Alive, Content-Length=0, HOST=192.168.1.211:5001, USER-AGENT=DLNADOC/1.50 SEC_HHP_[TV] UA55JS7200/1.0 UPnP/1.0}
```
Though i extrapolate to this renderer, i didn't included J(S)7200 as it's an 4K HDR, but if you think i should just tell it.