### PR TITLE
Revert "Removed unused repository from POM"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,14 @@
 		 -->
 		<makensis-bin>${project.external-resources}/third-party/nsis/makensis.exe</makensis-bin>
 	</properties>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>ossrh</id>
+			<name>Sonatype OSS Repository</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<layout>default</layout>
+		</pluginRepository>
+	</pluginRepositories>
 	<repositories>
 		<!-- GSON -->
 		<repository>


### PR DESCRIPTION
It seems that this wasn't in fact unused - as seen in #724. I'm eager to remove slow repositories from the POM as they slow down the build (every dependency is resolved for every repository), but I was a bit over-eager this time..

We still need to resolve the situation in #724 though, we're depending on a SNAPSHOT that can be changed or disappear without warning.

The reason I didn't see that it was in use was that I used Travis to verify that the build worked without this repository. The problem is only that Travis doesn't build for Windows, and this plugin is only used when building for Windows.