### PR TITLE
Small audio related fixes

### DIFF
--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -29,6 +29,7 @@ import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.InputFile;
 import net.pms.dlna.LibMediaInfoParser;
 import net.pms.formats.Format;
+import net.pms.formats.Format.Identifier;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,8 +37,6 @@ import org.slf4j.LoggerFactory;
 public class FormatConfiguration {
 	private static final Logger LOGGER = LoggerFactory.getLogger(FormatConfiguration.class);
 	private ArrayList<SupportSpec> supportSpecs;
-	// Use old parser for JPEG files (MediaInfo does not support EXIF)
-	private static final String[] PARSER_V1_EXTENSIONS = new String[]{".jpg", ".jpe", ".jpeg"};
 	public static final String THREEGPP = "3gp";
 	public static final String THREEGPP2 = "3g2";
 	public static final String THREEGA = "3ga";
@@ -366,7 +365,12 @@ public class FormatConfiguration {
 	 */
 	public void parse(DLNAMediaInfo media, InputFile file, Format ext, int type, RendererConfiguration renderer) {
 		if (file.getFile() != null) {
-			if (renderer.isUseMediaInfo()) {
+			// MediaInfo can't correctly parse ADPCM or DSD
+			if (
+				renderer.isUseMediaInfo() &&
+				ext.getIdentifier() != Identifier.ADPCM &&
+				ext.getIdentifier() != Identifier.DSD
+			) {
 				LibMediaInfoParser.parse(media, file, type, renderer);
 			} else {
 				media.parse(file, ext, type, false, false, renderer);

--- a/src/main/java/net/pms/database/TableMusicBrainzReleases.java
+++ b/src/main/java/net/pms/database/TableMusicBrainzReleases.java
@@ -224,7 +224,7 @@ public final class TableMusicBrainzReleases extends Tables{
 							result.updateString("TITLE", tagInfo.title);
 						}
 						if (StringUtil.hasValue(tagInfo.year)) {
-							result.updateString("YEAR", tagInfo.year);
+							result.updateString("YEAR", tagInfo.year.substring(0, Math.min(4, tagInfo.year.length())));
 						}
 						if (StringUtil.hasValue(tagInfo.artistId)) {
 							result.updateString("ARTIST_ID", tagInfo.artistId);

--- a/src/main/java/net/pms/util/CoverArtArchiveUtil.java
+++ b/src/main/java/net/pms/util/CoverArtArchiveUtil.java
@@ -728,7 +728,7 @@ public class CoverArtArchiveUtil extends CoverUtil {
 				}
 
 				if (query != null) {
-					final String url = "http://musicbrainz.org/ws/2/" + query;
+					final String url = "http://musicbrainz.org/ws/2/" + query + "&fmt=xml";
 					if (LOGGER.isTraceEnabled()) {
 						LOGGER.trace("Performing release MBID lookup at musicbrainz: \"{}\"", url);
 					}
@@ -749,6 +749,8 @@ public class CoverArtArchiveUtil extends CoverUtil {
 							LOGGER.error("Failed to parse XML for \"{}\": {}", url, e.getMessage());
 							LOGGER.trace("", e);
 							return null;
+						} finally {
+							connection.getInputStream().close();
 						}
 
 						ArrayList<ReleaseRecord> releaseList;


### PR DESCRIPTION
This is a bit of a mixed PR, but I just couldn't let those musicbranz issues be when I found them. The main purpose was to avoid parsing ADPCM and DSD with MediaInfo as they aren't supported and the parsing fails. Their ```container``` and ```audio codec``` will be set based on ```Format``` which is in reality simply based on file extension, so this is far from ideal - but still better than nothing.

MusicBranz has made a couple of changes since the implementation, so I've done a couple of small fixes to make the parsing succeed:
* The field ```year``` used to contain 4 digits with the year only, but now if suddenly contains a full date. I've simply concenated the string to keep the first 4 as they seem containt the "year" part of the date.
* Even though the API documentation doesn't say so, it looks like they've changed the default format from XML to JSON. We use an XML parser, which fails horribly when fed JSON so I've added an extra parameter to explicitly request XML.
