### PR TITLE
H265 level implementation

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -313,6 +313,10 @@ MaxVideoHeight =
 # Default: true
 H264Level41Limited = 
 
+# Whether to transcode H.265 video if it exceeds level 4.1
+# Default: true
+H265Level41Limited = 
+
 # Whether to transcode linear PCM audio files at 44.1 kHz.
 # By default they are resampled at 48 kHz. Resampling occurs only if resample
 # function is enable. This makes LPCM audio files strictly DLNA compliant.

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -143,6 +143,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String FORCE_JPG_THUMBNAILS = "ForceJPGThumbnails"; // Sony devices require JPG thumbnails
 	protected static final String HALVE_BITRATE = "HalveBitrate";
 	protected static final String H264_L41_LIMITED = "H264Level41Limited";
+	protected static final String H265_L41_LIMITED = "H265Level41Limited";
 	protected static final String IGNORE_TRANSCODE_BYTE_RANGE_REQUEST = "IgnoreTranscodeByteRangeRequests";
 	protected static final String IMAGE = "Image";
 	protected static final String KEEP_ASPECT_RATIO = "KeepAspectRatio";
@@ -1269,6 +1270,10 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 */
 	public boolean isH264Level41Limited() {
 		return getBoolean(H264_L41_LIMITED, true);
+	}
+	
+	public boolean isH265Level41Limited() {
+		return getBoolean(H265_L41_LIMITED, true);
 	}
 
 	public boolean isTranscodeFastStart() {

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -509,10 +509,12 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	@Override
 	public String toString() {
 		StringBuilder result = new StringBuilder();
-		result.append("id: ");
-		result.append(getId());
-		result.append(", lang: ");
-		result.append(getLang());
+		if (isNotBlank(getLang())) {
+			result.append("id: ");
+			result.append(getId());
+			result.append(", lang: ");
+			result.append(getLang());
+		}
 
 		if (isNotBlank(getAudioTrackTitleFromMetadata())) {
 			result.append(", audio track title from metadata: ");
@@ -528,9 +530,11 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 			result.append(", number of channels: ");
 			result.append(getAudioProperties().getNumberOfChannels());
 		}
-
-		result.append(", bits per sample: ");
-		result.append(getBitsperSample());
+		
+		if (getBitsperSample() != 16) {
+			result.append(", bits per sample: ");
+			result.append(getBitsperSample());
+		}
 
 		if (isNotBlank(getArtist())) {
 			result.append(", artist: ");

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -509,44 +509,52 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	@Override
 	public String toString() {
 		StringBuilder result = new StringBuilder();
-		if (isNotBlank(getLang())) {
-			result.append("id: ");
-			result.append(getId());
-			result.append(", lang: ");
-			result.append(getLang());
+		if (!getLang().equals("und")) {
+			result.append("Id: ").append(getId());
+			result.append(", Language Code: ").append(getLang());
 		}
 
 		if (isNotBlank(getAudioTrackTitleFromMetadata())) {
-			result.append(", audio track title from metadata: ");
-			result.append(getAudioTrackTitleFromMetadata());
+			if (result.length() > 0) {
+				result.append(", ");
+			}
+			result.append("Audio Track Title From Metadata: ").append(getAudioTrackTitleFromMetadata());
 		}
 
-		result.append(", audio codec: ");
-		result.append(getAudioCodec());
-		result.append(", sample frequency:");
-		result.append(getSampleFrequency());
-
-		if (getAudioProperties() != null && getAudioProperties().getNumberOfChannels() != 0) {
-			result.append(", number of channels: ");
-			result.append(getAudioProperties().getNumberOfChannels());
+		if (result.length() > 0) {
+			result.append(", ");
 		}
-		
-		if (getBitsperSample() != 16) {
-			result.append(", bits per sample: ");
-			result.append(getBitsperSample());
+		result.append("Audio Codec: ").append(getAudioCodec());
+
+		result.append(", Bitrate: ").append(getBitRate());
+		if (getBitsperSample() != 16 ) {
+			result.append(", Bits per Sample: ").append(getBitsperSample());
+		}
+		if (getAudioProperties() != null) {
+			result.append(", ").append(getAudioProperties());
 		}
 
 		if (isNotBlank(getArtist())) {
-			result.append(", artist: ");
-			result.append(getArtist());
-			result.append(", album: ");
-			result.append(getAlbum());
-			result.append(", song name: ");
-			result.append(getSongname());
-			result.append(", year: ");
-			result.append(getYear());
-			result.append(", track: ");
-			result.append(getTrack());
+			result.append(", Artist: ").append(getArtist());
+			if (isNotBlank(getAlbum())) {
+				result.append(", Album: ").append(getAlbum());
+			}
+			if (isNotBlank(getSongname())) {
+				result.append(", Track Name: ").append(getSongname());
+			}
+			if (getYear() != 0) {
+				result.append(", Year: ").append(getYear());
+			}
+			if (getTrack() != 0) {
+				result.append(", Track: ").append(getTrack());
+			}
+			if (isNotBlank(getGenre())) {
+				result.append(", Genre: ").append(getGenre());
+			}
+		}
+
+		if (isNotBlank(getMuxingModeAudio())) {
+			result.append(", Muxing Mode: ").append(getMuxingModeAudio());
 		}
 
 		return result.toString();

--- a/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
@@ -69,6 +69,7 @@ public class DLNAMediaDatabase implements Runnable {
 	private final int SIZE_ASPECTRATIO_CONTAINER = 5;
 	private final int SIZE_ASPECTRATIO_VIDEOTRACK = 5;
 	private final int SIZE_AVC_LEVEL = 3;
+	private final int SIZE_HEVC_LEVEL = 3;
 	private final int SIZE_CONTAINER = 32;
 	private final int SIZE_MATRIX_COEFFICIENTS = 16;
 	private final int SIZE_MODEL = 128;
@@ -235,6 +236,7 @@ public class DLNAMediaDatabase implements Runnable {
 				sb.append(", ASPECTRATIOVIDEOTRACK   VARCHAR2(").append(SIZE_ASPECTRATIO_VIDEOTRACK).append(')');
 				sb.append(", REFRAMES                TINYINT");
 				sb.append(", AVCLEVEL                VARCHAR2(").append(SIZE_AVC_LEVEL).append(')');
+				sb.append(", HEVCLEVEL               VARCHAR2(").append(SIZE_HEVC_LEVEL).append(')');
 				sb.append(", BITSPERPIXEL            INT");
 				sb.append(", THUMB                   BINARY");
 				sb.append(", CONTAINER               VARCHAR2(").append(SIZE_CONTAINER).append(')');
@@ -373,6 +375,7 @@ public class DLNAMediaDatabase implements Runnable {
 				media.setAspectRatioVideoTrack(rs.getString("ASPECTRATIOVIDEOTRACK"));
 				media.setReferenceFrameCount(rs.getByte("REFRAMES"));
 				media.setAvcLevel(rs.getString("AVCLEVEL"));
+				media.setHevcLevel(rs.getString("HEVCLEVEL"));
 				media.setBitsPerPixel(rs.getInt("BITSPERPIXEL"));
 				media.setThumb(rs.getBytes("THUMB"));
 				media.setContainer(rs.getString("CONTAINER"));
@@ -461,7 +464,7 @@ public class DLNAMediaDatabase implements Runnable {
 			conn = getConnection();
 			ps = conn.prepareStatement(
 				"INSERT INTO FILES(FILENAME, MODIFIED, TYPE, DURATION, BITRATE, WIDTH, HEIGHT, SIZE, CODECV, "+
-				"FRAMERATE, ASPECT, ASPECTRATIOCONTAINER, ASPECTRATIOVIDEOTRACK, REFRAMES, AVCLEVEL, BITSPERPIXEL, "+
+				"FRAMERATE, ASPECT, ASPECTRATIOCONTAINER, ASPECTRATIOVIDEOTRACK, REFRAMES, AVCLEVEL, HEVCLEVEL, BITSPERPIXEL, "+
 				"THUMB, CONTAINER, MODEL, EXPOSURE, ORIENTATION, ISO, MUXINGMODE, FRAMERATEMODE, STEREOSCOPY, "+
 				"MATRIXCOEFFICIENTS, TITLECONTAINER, TITLEVIDEOTRACK, VIDEOTRACKCOUNT, IMAGECOUNT, BITDEPTH) VALUES "+
 				"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
@@ -494,26 +497,27 @@ public class DLNAMediaDatabase implements Runnable {
 				ps.setString(13, left(media.getAspectRatioVideoTrack(), SIZE_ASPECTRATIO_VIDEOTRACK));
 				ps.setByte(14, media.getReferenceFrameCount());
 				ps.setString(15, left(media.getAvcLevel(), SIZE_AVC_LEVEL));
-				ps.setInt(16, media.getBitsPerPixel());
-				ps.setBytes(17, media.getThumb());
-				ps.setString(18, left(media.getContainer(), SIZE_CONTAINER));
+				ps.setString(16, left(media.getHevcLevel(), SIZE_HEVC_LEVEL));
+				ps.setInt(17, media.getBitsPerPixel());
+				ps.setBytes(18, media.getThumb());
+				ps.setString(19, left(media.getContainer(), SIZE_CONTAINER));
 				if (media.getExtras() != null) {
-					ps.setString(19, left(media.getExtrasAsString(), SIZE_MODEL));
+					ps.setString(20, left(media.getExtrasAsString(), SIZE_MODEL));
 				} else {
-					ps.setString(19, left(media.getModel(), SIZE_MODEL));
+					ps.setString(20, left(media.getModel(), SIZE_MODEL));
 				}
-				ps.setInt(20, media.getExposure());
-				ps.setInt(21, media.getOrientation());
-				ps.setInt(22, media.getIso());
-				ps.setString(23, left(media.getMuxingModeAudio(), SIZE_MUXINGMODE));
-				ps.setString(24, left(media.getFrameRateMode(), SIZE_FRAMERATE_MODE));
-				ps.setString(25, left(media.getStereoscopy(), SIZE_STEREOSCOPY));
-				ps.setString(26, left(media.getMatrixCoefficients(), SIZE_MATRIX_COEFFICIENTS));
-				ps.setString(27, left(media.getFileTitleFromMetadata(), SIZE_TITLE));
-				ps.setString(28, left(media.getVideoTrackTitleFromMetadata(), SIZE_TITLE));
-				ps.setInt(29, media.getVideoTrackCount());
-				ps.setInt(30, media.getImageCount());
-				ps.setInt(31, media.getVideoBitDepth());
+				ps.setInt(21, media.getExposure());
+				ps.setInt(22, media.getOrientation());
+				ps.setInt(23, media.getIso());
+				ps.setString(24, left(media.getMuxingModeAudio(), SIZE_MUXINGMODE));
+				ps.setString(25, left(media.getFrameRateMode(), SIZE_FRAMERATE_MODE));
+				ps.setString(26, left(media.getStereoscopy(), SIZE_STEREOSCOPY));
+				ps.setString(27, left(media.getMatrixCoefficients(), SIZE_MATRIX_COEFFICIENTS));
+				ps.setString(28, left(media.getFileTitleFromMetadata(), SIZE_TITLE));
+				ps.setString(29, left(media.getVideoTrackTitleFromMetadata(), SIZE_TITLE));
+				ps.setInt(30, media.getVideoTrackCount());
+				ps.setInt(31, media.getImageCount());
+				ps.setInt(32, media.getVideoBitDepth());
 			} else {
 				ps.setString(4, null);
 				ps.setInt(5, 0);
@@ -527,22 +531,23 @@ public class DLNAMediaDatabase implements Runnable {
 				ps.setString(13, null);
 				ps.setByte(14, (byte) -1);
 				ps.setString(15, null);
-				ps.setInt(16, 0);
-				ps.setBytes(17, null);
-				ps.setString(18, null);
+				ps.setString(16, null);
+				ps.setInt(17, 0);
+				ps.setBytes(18, null);
 				ps.setString(19, null);
-				ps.setInt(20, 0);
+				ps.setString(20, null);
 				ps.setInt(21, 0);
 				ps.setInt(22, 0);
-				ps.setString(23, null);
+				ps.setInt(23, 0);
 				ps.setString(24, null);
 				ps.setString(25, null);
 				ps.setString(26, null);
 				ps.setString(27, null);
 				ps.setString(28, null);
-				ps.setInt(29, 0);
+				ps.setString(29, null);
 				ps.setInt(30, 0);
 				ps.setInt(31, 0);
+				ps.setInt(32, 0);
 			}
 			ps.executeUpdate();
 			int id;

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1312,6 +1312,15 @@ public class DLNAMediaInfo implements Cloneable {
 	public boolean isH264() {
 		return codecV != null && codecV.startsWith("h264");
 	}
+	
+	/**
+	 * Whether the file contains H.265 (HEVC) video.
+	 *
+	 * @return {boolean}
+	 */
+	public boolean isH265() {
+		return codecV != null && codecV.startsWith("hevc");
+	}
 
 	/**
 	 * Disable LPCM transcoding for MP4 container with non-H264 video as workaround for MEncoder's A/V sync bug
@@ -1701,9 +1710,9 @@ public class DLNAMediaInfo implements Cloneable {
 			if (isNotBlank(avcLevel)) {
 				result.append(", AVC Level: ").append(getAvcLevel());
 			}
-//			if (isNotBlank(getHevcLevel())) {
-//				result.append(", HEVC Level: ");
-//				result.append(getHevcLevel());
+			if (isNotBlank(getHevcLevel())) {
+				result.append(", HEVC Level: ");
+				result.append(getHevcLevel());
 			if (getVideoBitDepth() != 8) {
 				result.append(", Video Bit Depth: ").append(getVideoBitDepth());
 			}
@@ -2381,6 +2390,18 @@ public class DLNAMediaInfo implements Cloneable {
 			avcLevelLock.readLock().unlock();
 		}
 	}
+	
+	/**
+	 * @return HEVC level for video stream or {@code null} if not parsed.
+	 */
+	public String getHevcLevel() {
+		hevcLevelLock.readLock().lock();
+		try {
+			return hevcLevel;
+		} finally {
+			hevcLevelLock.readLock().unlock();
+		}
+	}
 
 	/**
 	 * Sets AVC level for video stream or {@code null} if not parsed.
@@ -2395,10 +2416,32 @@ public class DLNAMediaInfo implements Cloneable {
 			avcLevelLock.writeLock().unlock();
 		}
 	}
+	
+	/**
+	 * Sets HEVC level for video stream or {@code null} if not parsed.
+	 *
+	 * @param hevcLevel HEVC level.
+	 */
+	public void setHevcLevel(String hevcLevel) {
+		hevcLevelLock.writeLock().lock();
+		try {
+			this.hevcLevel = hevcLevel;
+		} finally {
+			hevcLevelLock.writeLock().unlock();
+		}
+	}
 
 	public int getAvcAsInt() {
 		try {
 			return Integer.parseInt(getAvcLevel().replaceAll("\\.", ""));
+		} catch (Exception e) {
+			return 0;
+		}
+	}
+	
+	public int getHevcAsInt() {
+		try {
+			return Integer.parseInt(getHevcLevel().replaceAll("\\.", ""));
 		} catch (Exception e) {
 			return 0;
 		}
@@ -2409,10 +2452,22 @@ public class DLNAMediaInfo implements Cloneable {
 			return h264Profile;
 		}
 	}
+	
+	public String getH265Profile() {
+		synchronized (h265ProfileLock) {
+			return h265Profile;
+		}
+	}
 
 	public void setH264Profile(String s) {
 		synchronized (h264ProfileLock) {
 			h264Profile = s;
+		}
+	}
+	
+	public void setH265Profile(String s) {
+		synchronized (h265ProfileLock) {
+			h265Profile = s;
 		}
 	}
 

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -126,6 +126,8 @@ public class DLNAMediaInfo implements Cloneable {
 	public String frameRate;
 
 	private String frameRateMode;
+	private String frameRateModeLog;
+	private String frameRateOriginal;
 
 	/**
 	 * @deprecated Use standard getter and setter to access this variable.
@@ -1663,78 +1665,106 @@ public class DLNAMediaInfo implements Cloneable {
 	public String toString() {
 		StringBuilder result = new StringBuilder();
 		result.append("container: ");
-		result.append(container);
-		result.append(", bitrate: ");
-		result.append(bitrate);
+		result.append(getContainer());
 		result.append(", size: ");
-		result.append(size);
-		if (videoTrackCount > 0) {
+		result.append(getSize());
+		if (isVideo()) {
+			result.append(", bitrate: ");
+			result.append(getBitrate());
 			result.append(", video tracks: ");
-			result.append(videoTrackCount);
-		}
-		if (getAudioTrackCount() > 0) {
+			result.append(getVideoTrackCount());
+			result.append(", video codec: ");
+			result.append(getCodecV());
+			result.append(", duration: ");
+			result.append(getDurationString());
+			result.append(", width: ");
+			result.append(getWidth());
+			result.append(", height: ");
+			result.append(getHeight());
+			if (isNotBlank(getFrameRate())) {
+			result.append(", frame rate: ");
+			result.append(getFrameRate());
+			}
+			if (isNotBlank(getFrameRateOriginal())) {
+			result.append(", original frame rate: ");
+			result.append(getFrameRateOriginal());
+			}
+			if (isNotBlank(getFrameRateModeLog())) {
+			result.append(", frame rate mode: ");
+			result.append(getFrameRateModeLog());
+			}
+			if (isNotBlank(getMuxingMode())) {
+				result.append(", muxing mode: ");
+				result.append(getMuxingMode());
+			}
+			if (isNotBlank(getMatrixCoefficients())) {
+				result.append(", matrix coefficients: ");
+				result.append(getMatrixCoefficients());
+			}
+			if (isNotBlank(getAvcLevel())) {
+				result.append(", avc level: ");
+				result.append(getAvcLevel());
+			}
+//			if (isNotBlank(getHevcLevel())) {
+//				result.append(", hevc level: ");
+//				result.append(getHevcLevel());
+			if (getVideoBitDepth() != 8) {
+				result.append(", video bit depth: ");
+				result.append(getVideoBitDepth());
+			}
+			if (hasSubtitles()) {
+				result.append(", subtitle tracks: ");
+				result.append(getSubTrackCount());
+			}
+			if (isNotBlank(getFileTitleFromMetadata())) {
+				result.append(", file title from metadata: ");
+				result.append(getFileTitleFromMetadata());
+			}
+			if (isNotBlank(getVideoTrackTitleFromMetadata())) {
+				result.append(", video track title from metadata: ");
+				result.append(getVideoTrackTitleFromMetadata());
+			}
 			result.append(", audio tracks: ");
 			result.append(getAudioTrackCount());
+			for (DLNAMediaAudio audio : audioTracks) {
+				result.append("\n\tAudio track ");
+				result.append(audio.toString());
+			}
+			for (DLNAMediaSubtitle sub : subtitleTracks) {
+				result.append("\n\tSubtitle track ");
+				result.append(sub.toString());
+			}
 		}
-		if (imageCount > 0) {
-			result.append(", images: ");
-			result.append(imageCount);
+		if (isAudio()) {
+			result.append(", bitrate: ");
+			result.append(getBitrate());
+			result.append(", audio tracks: ");
+			result.append(getAudioTrackCount());
+			result.append(", duration: ");
+			result.append(getDurationString());
+			for (DLNAMediaAudio audio : audioTracks) {
+				result.append("\n\tAudio track ");
+				result.append(audio.toString());
+			}
 		}
-		if (getSubTrackCount() > 0) {
-			result.append(", subtitle tracks: ");
-			result.append(getSubTrackCount());
+		if (isImage()) {
+			if (getImageCount() > 1) {
+				result.append(", images: ");
+				result.append(getImageCount());
+			}
+			result.append(", width: ");
+			result.append(getWidth());
+			result.append(", height: ");
+			result.append(getHeight());
 		}
-		result.append(", video codec: ");
-		result.append(codecV);
-		result.append(", duration: ");
-		result.append(getDurationString());
-		result.append(", width: ");
-		result.append(width);
-		result.append(", height: ");
-		result.append(height);
-		result.append(", frame rate: ");
-		result.append(frameRate);
-
-		if (thumb != null) {
+		
+		if (getThumb() != null) {
 			result.append(", thumb size: ");
-			result.append(thumb.length);
-		}
-		if (isNotBlank(muxingMode)) {
-			result.append(", muxing mode: ");
-			result.append(muxingMode);
+			result.append(getThumb().length);
 		}
 
 		result.append(", mime type: ");
-		result.append(mimeType);
-
-		if (isNotBlank(matrixCoefficients)) {
-			result.append(", matrix coefficients: ");
-			result.append(matrixCoefficients);
-		}
-
-		if (isNotBlank(avcLevel)) {
-			result.append(", avc level: ");
-			result.append(avcLevel);
-		}
-
-		if (isNotBlank(fileTitleFromMetadata)) {
-			result.append(", file title from metadata: ");
-			result.append(fileTitleFromMetadata);
-		}
-		if (isNotBlank(videoTrackTitleFromMetadata)) {
-			result.append(", video track title from metadata: ");
-			result.append(videoTrackTitleFromMetadata);
-		}
-
-		for (DLNAMediaAudio audio : audioTracks) {
-			result.append("\n\tAudio track ");
-			result.append(audio.toString());
-		}
-
-		for (DLNAMediaSubtitle sub : subtitleTracks) {
-			result.append("\n\tSubtitle track ");
-			result.append(sub.toString());
-		}
+		result.append(getMimeType());
 
 		return result.toString();
 	}
@@ -2069,6 +2099,20 @@ public class DLNAMediaInfo implements Cloneable {
 	public void setFrameRate(String frameRate) {
 		this.frameRate = frameRate;
 	}
+	
+	/**
+	 * @return the frameRateOriginal
+	 */
+	public String getFrameRateOriginal() {
+		return frameRateOriginal;
+	}
+	
+	/**
+	 * @param frameRateOriginal the frameRateOriginal to set
+	 */
+	public void setFrameRateOriginal(String frameRateOriginal) {
+		this.frameRateOriginal = frameRateOriginal;
+	}
 
 	/**
 	 * @return the frameRateMode
@@ -2084,6 +2128,20 @@ public class DLNAMediaInfo implements Cloneable {
 	 */
 	public void setFrameRateMode(String frameRateMode) {
 		this.frameRateMode = frameRateMode;
+	}
+	
+	/**
+	 * @return the frameRateModeLog
+	 */
+	public String getFrameRateModeLog() {
+		return frameRateModeLog;
+	}
+	
+	/**
+	 * @param frameRateModeLog the frameRateModeLog to set
+	 */
+	public void setFrameRateModeLog(String frameRateModeLog) {
+		this.frameRateModeLog = frameRateModeLog;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -126,7 +126,11 @@ public class DLNAMediaInfo implements Cloneable {
 	public String frameRate;
 
 	private String frameRateMode;
-	private String frameRateModeLog;
+
+	/**
+	 * The frame rate mode as read from the parser
+	 */
+	private String frameRateModeRaw;
 	private String frameRateOriginal;
 
 	/**
@@ -1664,109 +1668,100 @@ public class DLNAMediaInfo implements Cloneable {
 	@Override
 	public String toString() {
 		StringBuilder result = new StringBuilder();
-		result.append("container: ");
-		result.append(getContainer());
-		result.append(", size: ");
-		result.append(getSize());
+		result.append("Container: ").append(getContainer().toUpperCase(Locale.ROOT));
+		result.append(", Size: ").append(getSize());
 		if (isVideo()) {
-			result.append(", bitrate: ");
-			result.append(getBitrate());
-			result.append(", video tracks: ");
-			result.append(getVideoTrackCount());
-			result.append(", video codec: ");
-			result.append(getCodecV());
-			result.append(", duration: ");
-			result.append(getDurationString());
-			result.append(", width: ");
-			result.append(getWidth());
-			result.append(", height: ");
-			result.append(getHeight());
+			result.append(", Video Bitrate: ").append(getBitrate());
+			result.append(", Video Tracks: ").append(getVideoTrackCount());
+			result.append(", Video Codec: ").append(getCodecV());
+			result.append(", Duration: ").append(getDurationString());
+			result.append(", Video Resolution: ").append(getWidth()).append(" x ").append(getHeight());
 			if (isNotBlank(getFrameRate())) {
-			result.append(", frame rate: ");
-			result.append(getFrameRate());
+				result.append(", Frame Rate: ").append(getFrameRate());
 			}
 			if (isNotBlank(getFrameRateOriginal())) {
-			result.append(", original frame rate: ");
-			result.append(getFrameRateOriginal());
+				result.append(", Original Frame Rate: ").append(getFrameRateOriginal());
 			}
-			if (isNotBlank(getFrameRateModeLog())) {
-			result.append(", frame rate mode: ");
-			result.append(getFrameRateModeLog());
+			if (isNotBlank(getFrameRateMode())) {
+				result.append(", Frame Rate Mode: ");
+				result.append(getFrameRateModeRaw());
+				if (isNotBlank(getFrameRateModeRaw())) {
+					result.append(" (").append(getFrameRateModeRaw()).append(")");
+				}
+			} else if (isNotBlank(getFrameRateModeRaw())) {
+				result.append(", Frame Rate Mode Raw: ");
+				result.append(getFrameRateModeRaw());
 			}
 			if (isNotBlank(getMuxingMode())) {
-				result.append(", muxing mode: ");
-				result.append(getMuxingMode());
+				result.append(", Muxing Mode: ").append(getMuxingMode());
 			}
 			if (isNotBlank(getMatrixCoefficients())) {
-				result.append(", matrix coefficients: ");
-				result.append(getMatrixCoefficients());
+				result.append(", Matrix Coefficients: ").append(getMatrixCoefficients());
 			}
-			if (isNotBlank(getAvcLevel())) {
-				result.append(", avc level: ");
-				result.append(getAvcLevel());
+			if (isNotBlank(avcLevel)) {
+				result.append(", AVC Level: ").append(getAvcLevel());
 			}
 //			if (isNotBlank(getHevcLevel())) {
-//				result.append(", hevc level: ");
+//				result.append(", HEVC Level: ");
 //				result.append(getHevcLevel());
 			if (getVideoBitDepth() != 8) {
-				result.append(", video bit depth: ");
-				result.append(getVideoBitDepth());
-			}
-			if (hasSubtitles()) {
-				result.append(", subtitle tracks: ");
-				result.append(getSubTrackCount());
+				result.append(", Video Bit Depth: ").append(getVideoBitDepth());
 			}
 			if (isNotBlank(getFileTitleFromMetadata())) {
-				result.append(", file title from metadata: ");
-				result.append(getFileTitleFromMetadata());
+				result.append(", File Title from Metadata: ").append(getFileTitleFromMetadata());
 			}
 			if (isNotBlank(getVideoTrackTitleFromMetadata())) {
-				result.append(", video track title from metadata: ");
-				result.append(getVideoTrackTitleFromMetadata());
+				result.append(", Video Track Title from Metadata: ").append(getVideoTrackTitleFromMetadata());
 			}
-			result.append(", audio tracks: ");
-			result.append(getAudioTrackCount());
-			for (DLNAMediaAudio audio : audioTracks) {
-				result.append("\n\tAudio track ");
-				result.append(audio.toString());
+
+			if (getAudioTrackCount() > 0) {
+				appendAudioTracks(result);
 			}
-			for (DLNAMediaSubtitle sub : subtitleTracks) {
-				result.append("\n\tSubtitle track ");
-				result.append(sub.toString());
+
+			if (hasSubtitles()) {
+				appendSubtitleTracks(result);
 			}
+
+		} else if (getAudioTrackCount() > 0) {
+			result.append(", Bitrate: ").append(getBitrate());
+			result.append(", Duration: ").append(getDurationString());
+			appendAudioTracks(result);
 		}
-		if (isAudio()) {
-			result.append(", bitrate: ");
-			result.append(getBitrate());
-			result.append(", audio tracks: ");
-			result.append(getAudioTrackCount());
-			result.append(", duration: ");
-			result.append(getDurationString());
-			for (DLNAMediaAudio audio : audioTracks) {
-				result.append("\n\tAudio track ");
-				result.append(audio.toString());
-			}
-		}
-		if (isImage()) {
+		if (getImageCount() > 0) {
 			if (getImageCount() > 1) {
-				result.append(", images: ");
-				result.append(getImageCount());
+				result.append(", Images: ").append(getImageCount());
 			}
-			result.append(", width: ");
-			result.append(getWidth());
-			result.append(", height: ");
-			result.append(getHeight());
-		}
-		
-		if (getThumb() != null) {
-			result.append(", thumb size: ");
-			result.append(getThumb().length);
+			result.append(", Image Width: ").append(getWidth());
+			result.append(", Image Height: ").append(getHeight());
 		}
 
-		result.append(", mime type: ");
-		result.append(getMimeType());
+		if (getThumb() != null) {
+			result.append(", Thumb Size: ").append(getThumb().length);
+		}
+
+		result.append(", Mime Type: ").append(getMimeType());
 
 		return result.toString();
+	}
+
+	public void appendAudioTracks(StringBuilder sb) {
+		sb.append(", Audio Tracks: ").append(getAudioTrackCount());
+		for (DLNAMediaAudio audio : audioTracks) {
+			if (!audio.equals(audioTracks.get(0))) {
+				sb.append(",");
+			}
+			sb.append(" [").append(audio).append("]");
+		}
+	}
+
+	public void appendSubtitleTracks(StringBuilder sb) {
+		sb.append(", Subtitle Tracks: ").append(getSubTrackCount());
+		for (DLNAMediaSubtitle subtitleTrack : subtitleTracks) {
+			if (!subtitleTrack.equals(subtitleTracks.get(0))) {
+				sb.append(",");
+			}
+			sb.append(" [").append(subtitleTrack).append("]");
+		}
 	}
 
 	public InputStream getThumbnailInputStream() {
@@ -2099,14 +2094,14 @@ public class DLNAMediaInfo implements Cloneable {
 	public void setFrameRate(String frameRate) {
 		this.frameRate = frameRate;
 	}
-	
+
 	/**
 	 * @return the frameRateOriginal
 	 */
 	public String getFrameRateOriginal() {
 		return frameRateOriginal;
 	}
-	
+
 	/**
 	 * @param frameRateOriginal the frameRateOriginal to set
 	 */
@@ -2129,19 +2124,19 @@ public class DLNAMediaInfo implements Cloneable {
 	public void setFrameRateMode(String frameRateMode) {
 		this.frameRateMode = frameRateMode;
 	}
-	
+
 	/**
-	 * @return the frameRateModeLog
+	 * @return The unaltered frame rate mode
 	 */
-	public String getFrameRateModeLog() {
-		return frameRateModeLog;
+	public String getFrameRateModeRaw() {
+		return frameRateModeRaw;
 	}
-	
+
 	/**
-	 * @param frameRateModeLog the frameRateModeLog to set
+	 * @param frameRateModeRaw the unaltered frame rate mode to set
 	 */
-	public void setFrameRateModeLog(String frameRateModeLog) {
-		this.frameRateModeLog = frameRateModeLog;
+	public void setFrameRateModeRaw(String frameRateModeRaw) {
+		this.frameRateModeRaw = frameRateModeRaw;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -900,7 +900,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 					LOGGER.trace(prependTraceReason + "the bitrate ({} b/s) is too high ({} b/s).", getName(), media.getBitrate(), maxBandwidth);
 				} else if (!renderer.isVideoBitDepthSupported(media.getVideoBitDepth())) {
 					isIncompatible = true;
-					LOGGER.trace(prependTraceReason + "the bit depth ({}) is not supported.", getName(), media.getVideoBitDepth());
+					LOGGER.trace(prependTraceReason + "the video bit depth ({}) is not supported.", getName(), media.getVideoBitDepth());
 				} else if (renderer.isH264Level41Limited() && media.isH264()) {
 					if (media.getAvcLevel() != null) {
 						double h264Level = 4.1;

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -920,6 +920,25 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 						LOGGER.trace(prependTraceReason + "the H.264 level is unknown.", getName());
 					}
 				}
+				} else if (renderer.isH265Level41Limited() && media.isH265()) {
+					if (media.getHevcLevel() != null) {
+						double h265Level = 4.1;
+
+						try {
+							h265Level = Double.parseDouble(media.getHevcLevel());
+						} catch (NumberFormatException e) {
+							LOGGER.trace("Could not convert {} to double: {}", media.getHevcLevel(), e.getMessage());
+						}
+
+						if (h265Level > 4.1) {
+							isIncompatible = true;
+							LOGGER.trace(prependTraceReason + "the H.265 level ({}) is not supported.", getName(), h265Level);
+						}
+					} else {
+						isIncompatible = true;
+						LOGGER.trace(prependTraceReason + "the H.265 level is unknown.", getName());
+					}
+				}
 			}
 
 			// Prefer transcoding over streaming if:

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -117,7 +117,9 @@ public class LibMediaInfoParser {
 							media.setAspectRatioContainer(MI.Get(video, i, "DisplayAspectRatio/String"));
 							media.setAspectRatioVideoTrack(MI.Get(video, i, "DisplayAspectRatio_Original/String"));
 							media.setFrameRate(getFPSValue(MI.Get(video, i, "FrameRate")));
-							media.setFrameRateMode(getFrameRateModeValue(MI.Get(video, i, "FrameRateMode")));
+							media.setFrameRateOriginal(MI.Get(video, i, "FrameRate_Original"));
+							media.setFrameRateMode(getFrameRateModeValue(MI.Get(video, i, "FrameRate_Mode")));
+							media.setFrameRateModeLog(MI.Get(video, i, "FrameRate_Mode"));
 							media.setReferenceFrameCount(getReferenceFrameCount(MI.Get(video, i, "Format_Settings_RefFrames/String")));
 							media.setVideoTrackTitleFromMetadata(MI.Get(video, i, "Title"));
 							value = MI.Get(video, i, "Format_Settings_QPel");

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -119,7 +119,7 @@ public class LibMediaInfoParser {
 							media.setFrameRate(getFPSValue(MI.Get(video, i, "FrameRate")));
 							media.setFrameRateOriginal(MI.Get(video, i, "FrameRate_Original"));
 							media.setFrameRateMode(getFrameRateModeValue(MI.Get(video, i, "FrameRate_Mode")));
-							media.setFrameRateModeLog(MI.Get(video, i, "FrameRate_Mode"));
+							media.setFrameRateModeRaw(MI.Get(video, i, "FrameRate_Mode"));
 							media.setReferenceFrameCount(getReferenceFrameCount(MI.Get(video, i, "Format_Settings_RefFrames/String")));
 							media.setVideoTrackTitleFromMetadata(MI.Get(video, i, "Title"));
 							value = MI.Get(video, i, "Format_Settings_QPel");

--- a/src/main/java/net/pms/formats/v2/AudioProperties.java
+++ b/src/main/java/net/pms/formats/v2/AudioProperties.java
@@ -219,4 +219,16 @@ public class AudioProperties {
 			return result;
 		}
 	}
+
+	@Override
+	public String toString() {
+		StringBuilder result = new StringBuilder();
+		result.append("Channel(s): ").append(getNumberOfChannels());
+		result.append(", Sample Frequency: ").append(getSampleFrequency()).append(" Hz");
+		if (getAudioDelay() != 0) {
+			result.append(", Delay: ").append(getAudioDelay());
+		}
+
+		return result.toString();
+	}
 }


### PR DESCRIPTION
- [x] Implement the H.265 level renderer limitation
- [x] Correct a bug in the AVC level parsing
- [x] Log the HEVC level

The only purpose of that PR is to log this information, as some renderer, like Samsung 9 series, have a H.265 limitation as well, and that the video could be correctly triggered to transcoding if they need to be.

I leave the potential implementation in the video engines to some more skilled ones.