### PR TITLE
Improve English in docs -> introduction

### DIFF
--- a/src/main/external-resources/documentation/introduction.html
+++ b/src/main/external-resources/documentation/introduction.html
@@ -61,7 +61,7 @@
 	<h2>Alternatives</h2>
 
 	<p>There are several streaming servers available which can be used
-		to communicate with a your viewing device. Here is a small selection:</p>
+		to communicate with viewing devices. Here is a small selection:</p>
 	<ul>
 		<li><a
 			href="http://www.microsoft.com/windows/windowsmedia/player/11/default.aspx">Windows
@@ -120,15 +120,15 @@
 		for more information.
 	</p>
 
-	<p>The most stunning features of UMS are transcoding and muxing.</p>
+	<p>The most important features of UMS are transcoding and muxing.</p>
 
 
 	<h2>What are transcoding and muxing?</h2>
 
 	<p>
-		If the video codec is not supported UMS can convert the video stream
-		to a device compatible codec. For example the PS3 is compatible with
-		MPEG2. This procedure is called <a
+		If the video codec is not supported by your viewing device, UMS can convert
+		the video stream to a device-compatible codec. For example, the PS3 is
+		compatible with MPEG2. This procedure is called <a
 			href="http://en.wikipedia.org/wiki/Transcoding">transcoding</a> and
 		it costs a lot of CPU power.
 	</p>
@@ -152,19 +152,19 @@
 	<p>You can stream media files with quite old computers. If the
 		device does not recognize the video container format and UMS has to
 		remux you will need some additional CPU power. A 2 GHz CPU should be
-		sufficient. When transcoding a video on full HD resolution an up to
-		date dual core processor from Intel or AMD with at least 2,6 GHz is
+		sufficient. When transcoding a full HD resolution video, an up-to-date
+		dual core processor from Intel or AMD running at at least 2.6 GHz is
 		necessary.</p>
 
-	<p>It is also necessary to have enough network bandwidth available
-		when streaming HD videos. It is nearly impossible to stream a full HD
-		video via WLAN, even when restricting network bandwidth and setting
+	<p>You should also have enough network bandwidth available when streaming HD
+		videos. It is nearly impossible to stream a full HD video via
+		wireless LAN, even when restricting network bandwidth and setting
 		video quality very low.</p>
 
 	<p>You should also have enough free RAM, which means about 512 MB.
-		There is also some space needed on your systems hard drive for
-		buffering videos. 500 MB free disk space is enough. If you want to
-		stream media files from an external hard drive please consider that an
+		There is also some space needed on your hard drive for
+		buffering videos. 500 MB of free disk space is enough. If you want to
+		stream media files from an external hard drive please consider that a
 		USB 1.1 connection is too slow for videos.</p>
 
 


### PR DESCRIPTION
These docs should be reviewed for out-of-date references, e.g.

* USB 1.1
* no mention of Plex (instead the discontinued MediaTomb is mentioned)
* wireless LANs being unable to stream full-HD videos