### PR TITLE
Legacy RealAudio parsing

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -42,7 +42,7 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 * @deprecated Use standard getter and setter to access this variable.
 	 */
 	@Deprecated
-	public int bitsperSample;
+	public int bitsperSample = 16;
 
 	private int bitRate;
 
@@ -117,13 +117,6 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 */
 	@Deprecated
 	public String muxingModeAudio;
-
-	/**
-	 * Constructor
-	 */
-	public DLNAMediaAudio() {
-		setBitsperSample(16);
-	}
 
 	/**
 	 * Returns the sample rate for this audio media.

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1476,6 +1476,13 @@ public class DLNAMediaInfo implements Cloneable {
 				case FormatConfiguration.RA:
 					mimeType = HTTPResource.AUDIO_RA_TYPEMIME;
 					break;
+				case FormatConfiguration.RM:
+					if (isAudio()) {
+						mimeType = HTTPResource.AUDIO_RA_TYPEMIME;
+					} else {
+						mimeType = HTTPResource.RM_TYPEMIME;
+					}
+					break;
 				case FormatConfiguration.SHORTEN:
 					mimeType = HTTPResource.AUDIO_SHN_TYPEMIME;
 					break;
@@ -1713,8 +1720,10 @@ public class DLNAMediaInfo implements Cloneable {
 	@Override
 	public String toString() {
 		StringBuilder result = new StringBuilder();
-		result.append("Container: ").append(getContainer().toUpperCase(Locale.ROOT));
-		result.append(", Size: ").append(getSize());
+		if (getContainer() != null) {
+			result.append("Container: ").append(getContainer().toUpperCase(Locale.ROOT)).append(", ");
+		}
+		result.append("Size: ").append(getSize());
 		if (isVideo()) {
 			result.append(", Video Bitrate: ").append(getBitrate());
 			result.append(", Video Tracks: ").append(getVideoTrackCount());

--- a/src/main/java/net/pms/formats/v2/AudioProperties.java
+++ b/src/main/java/net/pms/formats/v2/AudioProperties.java
@@ -223,7 +223,11 @@ public class AudioProperties {
 	@Override
 	public String toString() {
 		StringBuilder result = new StringBuilder();
-		result.append("Channel(s): ").append(getNumberOfChannels());
+		if (getNumberOfChannels() == 1) {
+			result.append("Channel: ").append(getNumberOfChannels());
+		} else {
+			result.append("Channels: ").append(getNumberOfChannels());
+		}
 		result.append(", Sample Frequency: ").append(getSampleFrequency()).append(" Hz");
 		if (getAudioDelay() != 0) {
 			result.append(", Delay: ").append(getAudioDelay());

--- a/src/main/java/net/pms/network/HTTPResource.java
+++ b/src/main/java/net/pms/network/HTTPResource.java
@@ -65,7 +65,8 @@ public class HTTPResource {
 	public static final String AUDIO_MPA_TYPEMIME = "audio/mpeg";
 	public static final String AUDIO_MPC_TYPEMIME = "audio/x-musepack";
 	public static final String AUDIO_OGG_TYPEMIME = "audio/ogg";
-	public static final String AUDIO_RA_TYPEMIME = "audio/x-realaudio";
+	public static final String AUDIO_RA_TYPEMIME = "audio/vnd.rn-realaudio";
+	public static final String AUDIO_RM_TYPEMIME = "audio/vnd.rn-realaudio";
 	public static final String AUDIO_SHN_TYPEMIME = "audio/x-shn";
 	public static final String AUDIO_THREEGPPA_TYPEMIME = "audio/3gpp";
 	public static final String AUDIO_THREEGPP2A_TYPEMIME = "audio/3gpp2";
@@ -87,6 +88,7 @@ public class HTTPResource {
 	public static final String MP4_TYPEMIME = "video/mp4";
 	public static final String MPEG_TYPEMIME = "video/mpeg";
 	public static final String PNG_TYPEMIME = "image/png";
+	public static final String RM_TYPEMIME = "application/vnd.rn-realmedia";
 	public static final String THREEGPP_TYPEMIME = "video/3gpp";
 	public static final String THREEGPP2_TYPEMIME = "video/3gpp2";
 	public static final String TIFF_TYPEMIME = "image/tiff";

--- a/src/main/java/net/pms/util/AudioUtils.java
+++ b/src/main/java/net/pms/util/AudioUtils.java
@@ -19,22 +19,42 @@
  */
 package net.pms.util;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Locale;
+import net.pms.PMS;
+import net.pms.configuration.FormatConfiguration;
 import net.pms.dlna.DLNAMediaAudio;
+import net.pms.dlna.DLNAMediaInfo;
+import net.pms.dlna.DLNAThumbnail;
+import net.pms.image.ImageFormat;
+import net.pms.image.ImagesUtil.ScaleType;
+import org.apache.commons.lang3.StringUtils;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.Tag;
+import org.jaudiotagger.tag.id3.ID3v1Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * This is a utility class for audio related methods
+ * This is a utility class for audio related methods.
  */
 
-public class AudioUtils {
+public final class AudioUtils {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AudioUtils.class);
 
 	// No instantiation
 	private AudioUtils() {
 	}
 
 	/**
-	 * Checks if a given {@link Tag} supports a given {@link FieldKey}
+	 * Checks if a given {@link Tag} supports a given {@link FieldKey}.
 	 *
 	 * @param tag the {@link Tag} to check for support
 	 * @param key the {@link FieldKey} to check for support for
@@ -101,10 +121,254 @@ public class AudioUtils {
 			// remap and leave 7.1
 			// inputs to PCM encoder are FL:0 FR:1 RL:2 RR:3 FC:4 LFE:5 SL:6 SR:7
 			mixer = "channels=8:8:0:0:1:4:2:7:3:5:4:1:5:3:6:6:7:2";
-		} else if (numberOfInputChannels == 2) { // 2.0
-			// do nothing for stereo tracks
-		}
+		} // do nothing for stereo tracks
 
 		return mixer;
+	}
+
+	/**
+	 * Parses the old RealAudio 1.0 and 2.0 formats that's not supported by
+	 * neither {@link org.jaudiotagger} nor MediaInfo. Returns {@code false} if
+	 * {@code channel} isn't one of these formats or the parsing fails.
+	 * <p>
+	 * Primary references:
+	 * <ul>
+	 * <li><a href="https://wiki.multimedia.cx/index.php/RealMedia">RealAudio on
+	 * MultimediaWiki</a></li>
+	 * <li><a
+	 * href="https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/rmdec.c"
+	 * >FFmpeg rmdec.c</a></li>
+	 * </ul>
+	 *
+	 * @param channel the {@link Channel} containing the input. Size will only
+	 *            be parsed if {@code channel} is a {@link FileChannel}
+	 *            instance.
+	 * @param media the {@link DLNAMediaInfo} instance to write the parsing
+	 *            results to.
+	 * @return {@code true} if the {@code channel} input is in RealAudio 1.0 or
+	 *         2.0 format and the parsing succeeds; false otherwise
+	 */
+	public static boolean parseRealAudio(ReadableByteChannel channel, DLNAMediaInfo media) {
+		final byte[] magicBytes = {0x2E, 0x72, 0x61, (byte) 0xFD};
+		ByteBuffer buffer = ByteBuffer.allocate(8);
+		buffer.order(ByteOrder.BIG_ENDIAN);
+		DLNAMediaAudio audio = new DLNAMediaAudio();
+		try {
+			int count = channel.read(buffer);
+			if (count < 4) {
+				LOGGER.trace("Input is too short to be RealAudio");
+				return false;
+			}
+			buffer.flip();
+			byte[] signature = new byte[4];
+			buffer.get(signature);
+			if (!Arrays.equals(magicBytes, signature)) {
+				if (LOGGER.isTraceEnabled()) {
+					LOGGER.trace(
+						"Input signature ({}) mismatches RealAudio version 1.0 or 2.0",
+						new String(signature, StandardCharsets.US_ASCII)
+					);
+				}
+				return false;
+			}
+			media.setContainer(FormatConfiguration.RA);
+			short version = buffer.getShort();
+			int reportedHeaderSize = 0;
+			int reportedDataSize = 0;
+			if (version == 3) {
+				audio.setCodecA("RealAudio 14.4");
+				audio.getAudioProperties().setNumberOfChannels(1);
+				audio.getAudioProperties().setSampleFrequency(8000);
+				short headerSize = buffer.getShort();
+
+				buffer = ByteBuffer.allocate(headerSize);
+				channel.read(buffer);
+				buffer.flip();
+				buffer.position(8);
+				int bytesPerMinute = buffer.getShort() & 0xFFFF;
+				reportedDataSize = buffer.getInt();
+				byte b = buffer.get();
+				if (b != 0) {
+					byte[] title = new byte[b & 0xFF];
+					buffer.get(title);
+					String titleString = new String(title, StandardCharsets.US_ASCII);
+					audio.setSongname(titleString);
+					audio.setAudioTrackTitleFromMetadata(titleString);
+				}
+				b = buffer.get();
+				if (b != 0) {
+					byte[] artist = new byte[b & 0xFF];
+					buffer.get(artist);
+					audio.setArtist(new String(artist, StandardCharsets.US_ASCII));
+				}
+				audio.setBitRate(bytesPerMinute * 8 / 60);
+				media.setBitrate(bytesPerMinute * 8 / 60);
+			} else if (version == 4 || version == 5) {
+				buffer = ByteBuffer.allocate(14);
+				channel.read(buffer);
+				buffer.flip();
+				buffer.get(signature);
+				if (!".ra4".equals(new String(signature, StandardCharsets.US_ASCII))) {
+					LOGGER.debug("Invalid RealAudio 2.0 signature \"{}\"", new String(signature, StandardCharsets.US_ASCII));
+					return false;
+				}
+				reportedDataSize = buffer.getInt();
+				buffer.getShort(); //skip version repeated
+				reportedHeaderSize = buffer.getInt();
+
+				buffer = ByteBuffer.allocate(reportedHeaderSize);
+				channel.read(buffer);
+				buffer.flip();
+				buffer.getShort(); // skip codec flavor
+				buffer.getInt(); // skip coded frame size
+				buffer.getInt(); // skip unknown
+				long bytesPerMinute = buffer.getInt() & 0xFFFFFFFFL;
+				buffer.getInt(); // skip unknown
+				buffer.getShort(); // skip sub packet
+				buffer.getShort(); // skip frame size
+				buffer.getShort(); // skip sub packet size
+				buffer.getShort(); // skip unknown
+				if (version == 5) {
+					buffer.position(buffer.position() + 6); // skip unknown
+				}
+				short sampleRate = buffer.getShort();
+				buffer.getShort(); // skip unknown
+				short sampleSize = buffer.getShort();
+				short nrChannels = buffer.getShort();
+				byte[] fourCC;
+				if (version == 4) {
+					buffer.position(buffer.get() + buffer.position()); // skip interleaver id
+					fourCC = new byte[buffer.get()];
+					buffer.get(fourCC);
+				} else {
+					buffer.getFloat(); // skip deinterlace id
+					fourCC = new byte[4];
+					buffer.get(fourCC);
+				}
+				String fourCCString = new String(fourCC, StandardCharsets.US_ASCII).toLowerCase(Locale.ROOT);
+				switch (fourCCString) {
+					case "lpcJ":
+						audio.setCodecA("RealAudio 14.4");
+						break;
+					case "28_8":
+						audio.setCodecA("RealAudio 28.8");
+						break;
+					case "dnet":
+						audio.setCodecA(FormatConfiguration.AC3);
+						break;
+					case "sipr":
+						audio.setCodecA("Sipro");
+						break;
+					case "cook":
+						audio.setCodecA(FormatConfiguration.COOK);
+					case "atrc":
+						audio.setCodecA(FormatConfiguration.ATRAC);
+					case "ralf":
+						audio.setCodecA(FormatConfiguration.REALAUDIO_LOSSLESS);
+					case "raac":
+						audio.setCodecA(FormatConfiguration.AAC);
+					case "racp":
+						audio.setCodecA(FormatConfiguration.AAC_HE);
+					default:
+						LOGGER.debug("Unknown RealMedia codec FourCC \"{}\" - parsing failed", fourCCString);
+						return false;
+				}
+
+				if (buffer.hasRemaining()) {
+					parseRealAudioMetaData(buffer, audio, version);
+				}
+
+				audio.setBitRate((int) (bytesPerMinute * 8 / 60));
+				media.setBitrate((int) (bytesPerMinute * 8 / 60));
+				audio.setBitsperSample(sampleSize);
+				audio.getAudioProperties().setNumberOfChannels(nrChannels);
+				audio.getAudioProperties().setSampleFrequency(sampleRate);
+			} else {
+				LOGGER.error("Could not parse RealAudio format - unknown format version {}", version);
+				return false;
+			}
+
+			media.getAudioTracksList().add(audio);
+			long fileSize = 0;
+			if (channel instanceof FileChannel) {
+				fileSize = ((FileChannel) channel).size();
+				media.setSize(fileSize);
+			}
+			// Duration is estimated based on bitrate and might not be accurate
+			if (audio.getBitRate() > 0) {
+				int dataSize;
+				if (fileSize > 0 && reportedHeaderSize > 0) {
+					int fullHeaderSize = reportedHeaderSize + (version == 3 ? 8 : 16);
+					if (reportedDataSize > 0) {
+						dataSize = (int) Math.min(reportedDataSize, fileSize - fullHeaderSize);
+					} else {
+						dataSize = (int) (fileSize - fullHeaderSize);
+					}
+				} else {
+					dataSize = reportedDataSize;
+				}
+				media.setDuration((double) dataSize / audio.getBitRate() * 8);
+			}
+
+		} catch (IOException e) {
+			LOGGER.debug("Error while trying to parse RealAudio version 1 or 2: {}", e.getMessage());
+			LOGGER.trace("", e);
+			return false;
+		}
+		if (
+			PMS.getConfiguration() != null &&
+			!PMS.getConfiguration().getAudioThumbnailMethod().equals(CoverSupplier.NONE) &&
+			(
+				StringUtils.isNotBlank(media.getFirstAudioTrack().getSongname()) ||
+				StringUtils.isNotBlank(media.getFirstAudioTrack().getArtist())
+			)
+		) {
+			ID3v1Tag tag = new ID3v1Tag();
+			if (StringUtils.isNotBlank(media.getFirstAudioTrack().getSongname())) {
+				tag.setTitle(media.getFirstAudioTrack().getSongname());
+			}
+			if (StringUtils.isNotBlank(media.getFirstAudioTrack().getArtist())) {
+				tag.setArtist(media.getFirstAudioTrack().getArtist());
+			}
+			try {
+				media.setThumb(DLNAThumbnail.toThumbnail(
+					CoverUtil.get().getThumbnail(tag),
+					640,
+					480,
+					ScaleType.MAX,
+					ImageFormat.SOURCE,
+					false
+				));
+			} catch (IOException e) {
+				LOGGER.error(
+					"An error occurred while generating thumbnail for RealAudio source: [\"{}\", \"{}\"]",
+					tag.getFirstTitle(),
+					tag.getFirstArtist()
+				);
+			}
+		}
+		media.setThumbready(true);
+
+		return true;
+	}
+
+	private static void parseRealAudioMetaData(ByteBuffer buffer, DLNAMediaAudio audio, short version) {
+		buffer.position(buffer.position() + (version == 4 ? 3 : 4)); // skip unknown
+		byte b = buffer.get();
+		if (b != 0) {
+			byte[] title = new byte[Math.min(b & 0xFF, buffer.remaining())];
+			buffer.get(title);
+			String titleString = new String(title, StandardCharsets.US_ASCII);
+			audio.setSongname(titleString);
+			audio.setAudioTrackTitleFromMetadata(titleString);
+		}
+		if (buffer.hasRemaining()) {
+			b = buffer.get();
+			if (b != 0) {
+				byte[] artist = new byte[Math.min(b & 0xFF, buffer.remaining())];
+				buffer.get(artist);
+				audio.setArtist(new String(artist, StandardCharsets.US_ASCII));
+			}
+		}
 	}
 }


### PR DESCRIPTION
It turns out that neither MediaInfo nor JAudioTagger can parse the earliest RA formats. They have a very confusing versioning scheme where RealAudio 1.0 is RA version 3 and RealAudio 2.0 is RA version 4 and 5. Don't ask me how they managed to think that this was good versioning practice, but because we had trouble parsing these I figured I could quickly "throw together" a parser since the file formats seemed very simple to parse. It turns out it wasn't quite that simple because there's very little information available about these, and the little I found wasn't entirely accurate. 

In any case, I think this is working properly now so since I've already made it, we might as well use it..?
