### PR TITLE
Post #1061 fixes

### DIFF
--- a/src/main/java/net/pms/dlna/CodeEnter.java
+++ b/src/main/java/net/pms/dlna/CodeEnter.java
@@ -33,7 +33,7 @@ public class CodeEnter extends VirtualFolder {
 	}
 
 	public CodeEnter(DLNAResource r) {
-		super(r.getName(), r.getThumbnailURL(DLNAImageProfile.JPEG_TN.toString()));
+		super(r.getName(), r.getThumbnailURL(DLNAImageProfile.JPEG_TN));
 		resource = r;
 		code = "";
 		enteredCode = "";

--- a/src/main/java/net/pms/dlna/DLNAImageProfile.java
+++ b/src/main/java/net/pms/dlna/DLNAImageProfile.java
@@ -29,7 +29,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.drew.metadata.MetadataException;
 import net.pms.image.ColorSpaceType;
 import net.pms.image.GIFInfo;
 import net.pms.image.ImageFormat;
@@ -57,26 +56,58 @@ import net.pms.image.PNGInfo.InterlaceMethod;
  * <p>
  * is true even if {@code H} and {@code V} are different in the two profiles.
  */
+@SuppressWarnings({"checkstyle:MethodName", "checkstyle:ParameterName"})
 public class DLNAImageProfile implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 	private static final Logger LOGGER = LoggerFactory.getLogger(DLNAImageProfile.class);
+
+	/** Int representation of GIF_LRG. */
 	public static final int GIF_LRG_INT = 1;
+
+	/** Int representation of JPEG_LRG. */
 	public static final int JPEG_LRG_INT = 2;
+
+	/** Int representation of JPEG_MED. */
 	public static final int JPEG_MED_INT = 3;
+
+	/** Int representation of JPEG_RES_H_V. */
 	public static final int JPEG_RES_H_V_INT = 4;
+
+	/** Int representation of JPEG_SM. */
 	public static final int JPEG_SM_INT = 5;
+
+	/** Int representation of JPEG_TN. */
 	public static final int JPEG_TN_INT = 6;
+
+	/** Int representation of PNG_LRG. */
 	public static final int PNG_LRG_INT = 7;
+
+	/** Int representation of PNG_TN. */
 	public static final int PNG_TN_INT = 8;
 
+	/** Integer representation of GIF_LRG. */
 	public static final Integer GIF_LRG_INTEGER = GIF_LRG_INT;
+
+	/** Integer representation of JPEG_LRG. */
 	public static final Integer JPEG_LRG_INTEGER = JPEG_LRG_INT;
+
+	/** Integer representation of JPEG_MED. */
 	public static final Integer JPEG_MED_INTEGER = JPEG_MED_INT;
+
+	/** Integer representation of JPEG_RES_H_V. */
 	public static final Integer JPEG_RES_H_V_INTEGER = JPEG_RES_H_V_INT;
+
+	/** Integer representation of JPEG_SM. */
 	public static final Integer JPEG_SM_INTEGER = JPEG_SM_INT;
+
+	/** Integer representation of JPEG_TN. */
 	public static final Integer JPEG_TN_INTEGER = JPEG_TN_INT;
+
+	/** Integer representation of PNG_LRG. */
 	public static final Integer PNG_LRG_INTEGER = PNG_LRG_INT;
+
+	/** Integer representation of PNG_TN. */
 	public static final Integer PNG_TN_INTEGER = PNG_TN_INT;
 
 	/**
@@ -142,7 +173,10 @@ public class DLNAImageProfile implements Serializable {
 		);
 	}
 
+	/** This profile's int value */
 	public final int imageProfileInt;
+
+	/** This profile's Integer value */
 	public final String imageProfileStr;
 	private final int horizontal;
 	private final int vertical;
@@ -158,15 +192,7 @@ public class DLNAImageProfile implements Serializable {
 	}
 
 	/**
-	 * Returns the string representation of this {@link DLNAImageProfile}.
-	 */
-	@Override
-	public String toString() {
-		return imageProfileStr;
-	}
-
-	/**
-	 * Returns the integer representation of this {@link DLNAImageProfile}.
+	 * @return The integer representation of this {@link DLNAImageProfile}.
 	 */
 	public int toInt() {
 		return imageProfileInt;
@@ -201,25 +227,60 @@ public class DLNAImageProfile implements Serializable {
 	}
 
 	/**
-	 * Converts the {@link String} passed as argument to a
-	 * {@link DLNAImageProfile}. If the conversion fails, this method returns
-	 * {@code null}.
+	 * Returns the string representation of this {@link DLNAImageProfile}.
 	 */
-	public static DLNAImageProfile toDLNAImageProfile(String argument) {
-		return toDLNAImageProfile(argument, null);
+	@Override
+	public String toString() {
+		return imageProfileStr;
+	}
+
+	/**
+	 * Gets the "default" extension for files of this {@link DLNAImageProfile}
+	 * in lower case. This is used for appending the correct extension to a
+	 * generated image.
+	 *
+	 * @return The default file extension.
+	 */
+	public String getDefaultExtension() {
+		switch (imageProfileInt) {
+			case GIF_LRG_INT:
+				return "gif";
+			case JPEG_LRG_INT:
+			case JPEG_MED_INT:
+			case JPEG_RES_H_V_INT:
+			case JPEG_SM_INT:
+			case JPEG_TN_INT:
+				return "jpg";
+			case PNG_LRG_INT:
+			case PNG_TN_INT:
+				return "png";
+			default:
+				throw new IllegalStateException(
+					"Profile value " + imageProfileInt + "is not implemented in DLNAImageProfile.getDefaultExtension()");
+		}
 	}
 
 	/**
 	 * Converts the integer passed as argument to a {@link DLNAImageProfile}.
 	 * If the conversion fails, this method returns {@code null}.
+	 *
+	 * @param value the integer value to convert to a {@link DLNAImageProfile}.
+	 * @return The resulting {@link DLNAImageProfile} or {@code null} if the
+	 *         conversion failed.
 	 */
 	public static DLNAImageProfile toDLNAImageProfile(int value) {
 		return toDLNAImageProfile(value, null);
 	}
 
 	/**
-	 * Converts the integer passed as argument to a {@link DLNAImageProfile}. If the
-	 * conversion fails, this method returns the specified default.
+	 * Converts the integer passed as argument to a {@link DLNAImageProfile}. If
+	 * the conversion fails, this method returns the specified default.
+	 *
+	 * @param value the integer value to convert to a {@link DLNAImageProfile}.
+	 * @param defaultImageProfile the {@link DLNAImageProfile} to return if the
+	 *            conversion fails.
+	 * @return The resulting {@link DLNAImageProfile} or
+	 *         {@code defaultImageProfile} if the conversion failed.
 	 */
 	public static DLNAImageProfile toDLNAImageProfile(int value, DLNAImageProfile defaultImageProfile) {
 		switch (value) {
@@ -247,7 +308,28 @@ public class DLNAImageProfile implements Serializable {
 	/**
 	 * Converts the {@link String} passed as argument to a
 	 * {@link DLNAImageProfile}. If the conversion fails, this method returns
+	 * {@code null}.
+	 *
+	 * @param argument the {@link String} to convert to a
+	 *            {@link DLNAImageProfile}.
+	 * @return The resulting {@link DLNAImageProfile} or {@code null} if the
+	 *         conversion failed.
+	 */
+	public static DLNAImageProfile toDLNAImageProfile(String argument) {
+		return toDLNAImageProfile(argument, null);
+	}
+
+	/**
+	 * Converts the {@link String} passed as argument to a
+	 * {@link DLNAImageProfile}. If the conversion fails, this method returns
 	 * the specified default.
+	 *
+	 * @param argument the {@link String} to convert to a
+	 *            {@link DLNAImageProfile}.
+	 * @param defaultImageProfile the {@link DLNAImageProfile} to return if the
+	 *            conversion fails.
+	 * @return The resulting {@link DLNAImageProfile} or
+	 *         {@code defaultImageProfile} if the conversion failed.
 	 */
 	public static DLNAImageProfile toDLNAImageProfile(String argument, DLNAImageProfile defaultImageProfile) {
 		if (argument == null) {
@@ -416,11 +498,15 @@ public class DLNAImageProfile implements Serializable {
 	/**
 	 * Performs GIF compliance checks. The result is stored in
 	 * {@code complianceResult}.
+	 *
+	 * @param imageInfo the {@link ImageInfo} instance to check.
+	 * @param complianceResult the {@link InternalComplianceResult} where the
+	 *            results are added.
 	 */
 	protected static void checkGIF(
 		ImageInfo imageInfo,
 		InternalComplianceResult complianceResult
-	) throws MetadataException {
+	) {
 
 		if (imageInfo == null || imageInfo.getFormat() != ImageFormat.GIF || !(imageInfo instanceof GIFInfo)) {
 			return;
@@ -443,11 +529,15 @@ public class DLNAImageProfile implements Serializable {
 	/**
 	 * Performs JPEG compliance checks. The result is stored in
 	 * {@code complianceResult}.
+	 *
+	 * @param imageInfo the {@link ImageInfo} instance to check.
+	 * @param complianceResult the {@link InternalComplianceResult} where the
+	 *            results are added.
 	 */
 	protected static void checkJPEG(
 		ImageInfo imageInfo,
 		InternalComplianceResult complianceResult
-	) throws MetadataException {
+	) {
 
 		if (imageInfo == null || imageInfo.getFormat() != ImageFormat.JPEG || !(imageInfo instanceof JPEGInfo)) {
 			return;
@@ -487,8 +577,7 @@ public class DLNAImageProfile implements Serializable {
 		complianceResult.formatCorrect = jpegInfo.getJFIFVersion() >= 0x102 || jpegInfo.getExifVersion() >= 100;
 		if (!complianceResult.formatCorrect && LOGGER.isTraceEnabled()) {
 			String jfifVersion = jpegInfo.getJFIFVersion() == ImageInfo.UNKNOWN ? null :
-				Double.toHexString((double) jpegInfo.getJFIFVersion() / 0x100)
-			;
+				Double.toHexString((double) jpegInfo.getJFIFVersion() / 0x100);
 			if (jfifVersion != null) {
 				jfifVersion = jfifVersion.replaceFirst("0x", "").replaceFirst("p-?\\d*", "");
 			}
@@ -592,11 +681,15 @@ public class DLNAImageProfile implements Serializable {
 	/**
 	 * Performs PNG compliance checks. The result is stored in
 	 * {@code complianceResult}.
+	 *
+	 * @param imageInfo the {@link ImageInfo} instance to check.
+	 * @param complianceResult the {@link InternalComplianceResult} where the
+	 *            results are added.
 	 */
 	protected static void checkPNG(
 		ImageInfo imageInfo,
 		InternalComplianceResult complianceResult
-	) throws MetadataException {
+	) {
 
 		if (imageInfo == null || imageInfo.getFormat() != ImageFormat.PNG || !(imageInfo instanceof PNGInfo)) {
 			return;
@@ -774,71 +867,64 @@ public class DLNAImageProfile implements Serializable {
 		}
 
 		InternalComplianceResult complianceResult = new InternalComplianceResult();
-		try {
-			DLNAImageProfile largestProfile;
-			switch (format) {
-				case JPEG:
-					// Since JPEG_RES_H_V has no upper limit, any resolution is ok
-					complianceResult.maxWidth = Integer.MAX_VALUE;
-					complianceResult.maxHeight = Integer.MAX_VALUE;
-					complianceResult.resolutionCorrect = true;
-					checkJPEG(imageInfo, complianceResult);
-					break;
-				case GIF:
-					largestProfile = DLNAImageProfile.GIF_LRG;
-					complianceResult.maxWidth = largestProfile.getMaxWidth();
-					complianceResult.maxHeight = largestProfile.getMaxHeight();
-					complianceResult.resolutionCorrect = largestProfile.isResolutionCorrect(imageInfo);
-					if (!complianceResult.resolutionCorrect) {
-						if (LOGGER.isTraceEnabled()) {
-							complianceResult.failures.add(String.format(
-								"GIF DLNA compliance failed with wrong resolution %d x %d (limits are %d x %d)",
-								imageInfo.getWidth(),
-								imageInfo.getHeight(),
-								largestProfile.getMaxWidth(),
-								largestProfile.getMaxHeight()
-							));
-						} else {
-							complianceResult.failures.add("resolution");
-						}
-					}
-					checkGIF(imageInfo, complianceResult);
-					break;
-				case PNG:
-					largestProfile = DLNAImageProfile.PNG_LRG;
-					complianceResult.maxWidth = largestProfile.getMaxWidth();
-					complianceResult.maxHeight = largestProfile.getMaxHeight();
-					complianceResult.resolutionCorrect = largestProfile.isResolutionCorrect(imageInfo);
-					if (!complianceResult.resolutionCorrect) {
-						if (LOGGER.isTraceEnabled()) {
-							complianceResult.failures.add(String.format(
-								"PNG DLNA compliance failed with wrong resolution %d x %d (limits are %d x %d)",
-								imageInfo.getWidth(),
-								imageInfo.getHeight(),
-								largestProfile.getMaxWidth(),
-								largestProfile.getMaxHeight()
-							));
-						} else {
-							complianceResult.failures.add("resolution");
-						}
-					}
-					checkPNG(imageInfo, complianceResult);
-					break;
-				default:
+		DLNAImageProfile largestProfile;
+		switch (format) {
+			case JPEG:
+				// Since JPEG_RES_H_V has no upper limit, any resolution is ok
+				complianceResult.maxWidth = Integer.MAX_VALUE;
+				complianceResult.maxHeight = Integer.MAX_VALUE;
+				complianceResult.resolutionCorrect = true;
+				checkJPEG(imageInfo, complianceResult);
+				break;
+			case GIF:
+				largestProfile = DLNAImageProfile.GIF_LRG;
+				complianceResult.maxWidth = largestProfile.getMaxWidth();
+				complianceResult.maxHeight = largestProfile.getMaxHeight();
+				complianceResult.resolutionCorrect = largestProfile.isResolutionCorrect(imageInfo);
+				if (!complianceResult.resolutionCorrect) {
 					if (LOGGER.isTraceEnabled()) {
 						complianceResult.failures.add(String.format(
-							"DLNA compliance failed with illegal image format \"%s\"",
-							format
+							"GIF DLNA compliance failed with wrong resolution %d x %d (limits are %d x %d)",
+							imageInfo.getWidth(),
+							imageInfo.getHeight(),
+							largestProfile.getMaxWidth(),
+							largestProfile.getMaxHeight()
 						));
 					} else {
-						complianceResult.failures.add("illegal format");
+						complianceResult.failures.add("resolution");
 					}
-			}
-		} catch (MetadataException e) {
-			complianceResult.formatCorrect = false;
-			complianceResult.colorsCorrect = false;
-			LOGGER.debug("MetadataException in checkCompliance: {}", e.getMessage());
-			LOGGER.trace("", e);
+				}
+				checkGIF(imageInfo, complianceResult);
+				break;
+			case PNG:
+				largestProfile = DLNAImageProfile.PNG_LRG;
+				complianceResult.maxWidth = largestProfile.getMaxWidth();
+				complianceResult.maxHeight = largestProfile.getMaxHeight();
+				complianceResult.resolutionCorrect = largestProfile.isResolutionCorrect(imageInfo);
+				if (!complianceResult.resolutionCorrect) {
+					if (LOGGER.isTraceEnabled()) {
+						complianceResult.failures.add(String.format(
+							"PNG DLNA compliance failed with wrong resolution %d x %d (limits are %d x %d)",
+							imageInfo.getWidth(),
+							imageInfo.getHeight(),
+							largestProfile.getMaxWidth(),
+							largestProfile.getMaxHeight()
+						));
+					} else {
+						complianceResult.failures.add("resolution");
+					}
+				}
+				checkPNG(imageInfo, complianceResult);
+				break;
+			default:
+				if (LOGGER.isTraceEnabled()) {
+					complianceResult.failures.add(String.format(
+						"DLNA compliance failed with illegal image format \"%s\"",
+						format
+					));
+				} else {
+					complianceResult.failures.add("illegal format");
+				}
 		}
 
 		return DLNAComplianceResult.toDLNAComplianceResult(complianceResult);
@@ -893,11 +979,10 @@ public class DLNAImageProfile implements Serializable {
 			return
 				width == horizontal &&
 				height == vertical;
-		} else {
-			return
-				width <= horizontal &&
-				height <= vertical;
 		}
+		return
+			width <= horizontal &&
+			height <= vertical;
 	}
 
 	/**
@@ -933,30 +1018,23 @@ public class DLNAImageProfile implements Serializable {
 			}
 		}
 
-		try {
-			switch (this.toInt()) {
-				case DLNAImageProfile.GIF_LRG_INT:
-					checkGIF(imageInfo, complianceResult);
-					break;
-				case DLNAImageProfile.JPEG_LRG_INT:
-				case DLNAImageProfile.JPEG_MED_INT:
-				case DLNAImageProfile.JPEG_RES_H_V_INT:
-				case DLNAImageProfile.JPEG_SM_INT:
-				case DLNAImageProfile.JPEG_TN_INT:
-					checkJPEG(imageInfo, complianceResult);
-					break;
-				case DLNAImageProfile.PNG_LRG_INT:
-				case DLNAImageProfile.PNG_TN_INT:
-					checkPNG(imageInfo, complianceResult);
-					break;
-				default:
-					throw new IllegalStateException("Illegal DLNA media profile");
-			}
-		} catch (MetadataException e) {
-			complianceResult.formatCorrect = false;
-			complianceResult.colorsCorrect = false;
-			LOGGER.debug("MetadataException in checkCompliance: {}", e.getMessage());
-			LOGGER.trace("", e);
+		switch (this.toInt()) {
+			case DLNAImageProfile.GIF_LRG_INT:
+				checkGIF(imageInfo, complianceResult);
+				break;
+			case DLNAImageProfile.JPEG_LRG_INT:
+			case DLNAImageProfile.JPEG_MED_INT:
+			case DLNAImageProfile.JPEG_RES_H_V_INT:
+			case DLNAImageProfile.JPEG_SM_INT:
+			case DLNAImageProfile.JPEG_TN_INT:
+				checkJPEG(imageInfo, complianceResult);
+				break;
+			case DLNAImageProfile.PNG_LRG_INT:
+			case DLNAImageProfile.PNG_TN_INT:
+				checkPNG(imageInfo, complianceResult);
+				break;
+			default:
+				throw new IllegalStateException("Illegal DLNA media profile");
 		}
 
 		return DLNAComplianceResult.toDLNAComplianceResult(complianceResult);
@@ -1059,6 +1137,14 @@ public class DLNAImageProfile implements Serializable {
 		 */
 		public final boolean conversionNeeded;
 
+		/**
+		 * Instantiates a new hypothetical result.
+		 *
+		 * @param width the estimated image width.
+		 * @param height the estimated image height.
+		 * @param size the estimated image size.
+		 * @param conversionNeeded the "conversion needed" evaluation result.
+		 */
 		public HypotheticalResult(int width, int height, Long size, boolean conversionNeeded) {
 			if (width < 1 || height < 1) {
 				// Use ImageInfo.UNKNOWN for unknown
@@ -1126,6 +1212,7 @@ public class DLNAImageProfile implements Serializable {
 	/**
 	 * Internal mutable compliance result data structure.
 	 */
+	@SuppressWarnings({"checkstyle:VisibilityModifier", "JavadocVariable"})
 	protected static class InternalComplianceResult {
 		public boolean resolutionCorrect = false;
 		public boolean formatCorrect = false;
@@ -1147,6 +1234,16 @@ public class DLNAImageProfile implements Serializable {
 		private final int maxHeight;
 		private final List<String> failures;
 
+		/**
+		 * Instantiates a new DLNA compliance result.
+		 *
+		 * @param resolutionCorrect the is resolution correct flag.
+		 * @param formatCorrect the is format correct flag.
+		 * @param colorsCorrect the are colors correct flag.
+		 * @param maxWidth the maximum image width.
+		 * @param maxHeight the maximum image height.
+		 * @param failures the {@link List} of failures.
+		 */
 		public DLNAComplianceResult(
 			boolean resolutionCorrect,
 			boolean formatCorrect,
@@ -1164,6 +1261,13 @@ public class DLNAImageProfile implements Serializable {
 			this.failures = failures;
 		}
 
+		/**
+		 * Instantiates a new {@link DLNAComplianceResult} from an
+		 * {@link InternalComplianceResult}.
+		 *
+		 * @param result the source {@link InternalComplianceResult}.
+		 * @return The resulting {@link DLNAComplianceResult}.
+		 */
 		protected static DLNAComplianceResult toDLNAComplianceResult(InternalComplianceResult result) {
 			return new DLNAComplianceResult(
 				result.resolutionCorrect,

--- a/src/main/java/net/pms/dlna/DLNAImageResElement.java
+++ b/src/main/java/net/pms/dlna/DLNAImageResElement.java
@@ -25,8 +25,8 @@ import net.pms.image.ImageFormat;
 import net.pms.image.ImageInfo;
 
 /**
- * This class is used to represent a {@code <res>} element representing an
- * image (including thumbnail) in a {@code DIDL-Lite} document.
+ * This class is used to represent a {@code <res>} element representing an image
+ * (including thumbnail) in a {@code DIDL-Lite} document.
  *
  * @author Nadahar
  */
@@ -36,18 +36,47 @@ public class DLNAImageResElement {
 	private final boolean thumbnail;
 	private final HypotheticalResult hypotheticalResult;
 
+	/**
+	 * Instantiates a new DLNA image {@code <res>} element.
+	 *
+	 * @param profile the {@link DLNAImageProfile} for this {@code <res>}
+	 *            element.
+	 * @param imageInfo the {@link ImageInfo} for the image represented by this
+	 *            {@code <res>} element.
+	 * @param thumbnail whether the source for this {@code <res>} element is a
+	 *            thumbnail.
+	 *
+	 * @see #isThumbnail()
+	 */
 	public DLNAImageResElement(DLNAImageProfile profile, ImageInfo imageInfo, boolean thumbnail) {
 		this(profile, imageInfo, thumbnail, null);
 	}
 
+	/**
+	 * Instantiates a new DLNA image {@code <res>} element.
+	 *
+	 * @param profile the {@link DLNAImageProfile} for this {@code <res>}
+	 *            element.
+	 * @param imageInfo the {@link ImageInfo} for the image represented by this
+	 *            {@code <res>} element.
+	 * @param thumbnail whether the source for this {@code <res>} element is a
+	 *            thumbnail.
+	 * @param overrideCIFlag The overridden CI flag for this {@code <res>}
+	 *            element. Pass {@code null} for automatic setting of the CI
+	 *            flag.
+	 *
+	 * @see #isThumbnail()
+	 */
 	public DLNAImageResElement(DLNAImageProfile profile, ImageInfo imageInfo, boolean thumbnail, Integer overrideCIFlag) {
 		this.profile = profile;
 		if (profile != null && imageInfo != null) {
 			hypotheticalResult = profile.calculateHypotheticalProperties(imageInfo);
-			ciFlag = overrideCIFlag == null
-				? hypotheticalResult.conversionNeeded
-					? Integer.valueOf(1) : Integer.valueOf(0)
-				: overrideCIFlag;
+			ciFlag = overrideCIFlag == null ?
+				(hypotheticalResult.conversionNeeded ?
+					Integer.valueOf(1) :
+					Integer.valueOf(0)
+				) :
+				overrideCIFlag;
 		} else {
 			hypotheticalResult = null;
 			ciFlag = overrideCIFlag;
@@ -70,7 +99,13 @@ public class DLNAImageResElement {
 	}
 
 	/**
-	 * @return Whether this element is a thumbnail.
+	 * Note: This can be confusing. This doesn't indicate whether the res
+	 * element is <b>used</b> as a thumbnail, but if the res element's source is
+	 * a thumbnail from UMS' point of view. For low resolution images (where the
+	 * resolution is equal or smaller than the cached thumbnail), the thumbnail
+	 * source can be used also for the image itself for increased performance.
+	 *
+	 * @return Whether this element has a thumbnail source.
 	 */
 	public boolean isThumbnail() {
 		return thumbnail;
@@ -84,21 +119,23 @@ public class DLNAImageResElement {
 	}
 
 	/**
-	 * The calculated image width or {@link ImageInfo#UNKNOWN} if unknown.
+	 * @return The calculated image width or {@link ImageInfo#UNKNOWN} if
+	 *         unknown.
 	 */
 	public int getWidth() {
 		return hypotheticalResult != null ? hypotheticalResult.width : ImageInfo.UNKNOWN;
 	}
 
 	/**
-	 * The calculated image height or {@link ImageInfo#UNKNOWN} if unknown.
+	 * @return The calculated image height or {@link ImageInfo#UNKNOWN} if
+	 *         unknown.
 	 */
 	public int getHeight() {
 		return hypotheticalResult != null ? hypotheticalResult.height : ImageInfo.UNKNOWN;
 	}
 
 	/**
-	 * The image size or {@code null} if unknown.
+	 * @return The image size or {@code null} if unknown.
 	 */
 	public Long getSize() {
 		return hypotheticalResult != null ? hypotheticalResult.size : null;
@@ -267,9 +304,8 @@ public class DLNAImageResElement {
 				) {
 					if (DLNAImageProfile.JPEG_RES_H_V.equals(o1.getProfile())) {
 						return -1;
-					} else {
-						return 1;
 					}
+					return 1;
 				}
 
 				if (o1.getWidth() != o2.getWidth()) {

--- a/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
@@ -583,15 +583,15 @@ public class DLNAMediaDatabase implements Runnable {
 					"TITLEVIDEOTRACK, VIDEOTRACKCOUNT, IMAGECOUNT, BITDEPTH " +
 				"FROM FILES " +
 				"WHERE " +
-					"FILENAME = ? AND MODIFIED = ?",
+					"FILENAME = ?",
 				ResultSet.TYPE_FORWARD_ONLY,
 				ResultSet.CONCUR_UPDATABLE
 			)) {
 				ps.setString(1, name);
-				ps.setTimestamp(2, new Timestamp(modified));
 				try (ResultSet rs = ps.executeQuery()) {
 					if (rs.next()) {
 						fileId = rs.getInt("ID");
+						rs.updateTimestamp("MODIFIED", new Timestamp(modified));
 						rs.updateInt("TYPE", type);
 						if (media != null) {
 							if (media.getDuration() != null) {

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -327,17 +327,16 @@ public class DLNAMediaInfo implements Cloneable {
 	public MediaType getMediaType() {
 		if (videoTrackCount > 0) {
 			return MediaType.VIDEO;
-		} else {
-			switch (audioTracks.size()) {
-				case 1 :
-					return MediaType.AUDIO;
-				case 0 :
-					if (imageCount > 0) {
-						return MediaType.IMAGE;
-					}
-				default :
-					return MediaType.UNKNOWN;
-			}
+		}
+		switch (audioTracks.size()) {
+			case 1 :
+				return MediaType.AUDIO;
+			case 0 :
+				if (imageCount > 0) {
+					return MediaType.IMAGE;
+				}
+			default :
+				return MediaType.UNKNOWN;
 		}
 	}
 
@@ -579,7 +578,11 @@ public class DLNAMediaInfo implements Cloneable {
 		args[13] = "pipe:";
 
 		// FIXME MPlayer should not be used if thumbnail generation is disabled
-		if (!configuration.isThumbnailGenerationEnabled() || !renderer.isThumbnails() || (configuration.isUseMplayerForVideoThumbs() && !dvrms)) {
+		if (
+			!configuration.isThumbnailGenerationEnabled() ||
+			renderer != null && !renderer.isThumbnails() ||
+			configuration.isUseMplayerForVideoThumbs() && !dvrms
+		) {
 			args[2] = "0";
 			for (int i = 5; i <= 13; i++) {
 				args[i] = "-an";
@@ -907,7 +910,6 @@ public class DLNAMediaInfo implements Cloneable {
 				if (thumbOnly && configuration.isThumbnailGenerationEnabled() && configuration.getImageThumbnailsEnabled()) {
 					LOGGER.trace("Creating thumbnail for \"{}\"", file.getName());
 
-					// XXX (Nadahar) - the below code needs update, as it will break with the next version of Metadata-extractor
 					// Create the thumbnail image
 					try {
 						if (imageInfo instanceof ExifInfo && ((ExifInfo) imageInfo).hasExifThumbnail() && !imageInfo.isImageIOSupported()) {
@@ -1405,6 +1407,7 @@ public class DLNAMediaInfo implements Cloneable {
 	/**
 	 * @deprecated Use {@link #StringUtil.convertTimeToString(durationSec, StringUtil.DURATION_TIME_FORMAT)} instead.
 	 */
+	@Deprecated
 	public static String getDurationString(double d) {
 		return convertTimeToString(d, DURATION_TIME_FORMAT);
 	}
@@ -2313,6 +2316,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * @since 1.50.0
 	 * @deprecated Use {@link #setThumb(DLNAThumbnail)} instead.
 	 */
+	@Deprecated
 	public void setThumb(byte[] thumb) {
 		try {
 			this.thumb = DLNAThumbnail.toThumbnail(

--- a/src/main/java/net/pms/dlna/FeedItem.java
+++ b/src/main/java/net/pms/dlna/FeedItem.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 
 public class FeedItem extends DLNAResource {
 	@Override
-	protected String getThumbnailURL(String profile) {
+	protected String getThumbnailURL(DLNAImageProfile profile) {
 		if (thumbURL == null) {
 			return null;
 		}

--- a/src/main/java/net/pms/dlna/RarredEntry.java
+++ b/src/main/java/net/pms/dlna/RarredEntry.java
@@ -38,7 +38,7 @@ public class RarredEntry extends DLNAResource implements IPushOutput {
 	private long length;
 
 	@Override
-	protected String getThumbnailURL(String profile) {
+	protected String getThumbnailURL(DLNAImageProfile profile) {
 		if (getType() == Format.IMAGE || getType() == Format.AUDIO) { // no thumbnail support for now for rarred videos
 			return null;
 		}

--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -329,7 +329,7 @@ public class RealFile extends MapFile {
 	}
 
 	@Override
-	protected String getThumbnailURL(String profile) {
+	protected String getThumbnailURL(DLNAImageProfile profile) {
 		if (getType() == Format.IMAGE && !configuration.getImageThumbnailsEnabled()) {
 			return null;
 		}

--- a/src/main/java/net/pms/dlna/SevenZipEntry.java
+++ b/src/main/java/net/pms/dlna/SevenZipEntry.java
@@ -44,7 +44,7 @@ public class SevenZipEntry extends DLNAResource implements IPushOutput {
 	private ISevenZipInArchive arc;
 
 	@Override
-	protected String getThumbnailURL(String profile) {
+	protected String getThumbnailURL(DLNAImageProfile profile) {
 		if (getType() == Format.IMAGE || getType() == Format.AUDIO) {
 			// no thumbnail support for now for zipped videos
 			return null;

--- a/src/main/java/net/pms/dlna/SubSelFile.java
+++ b/src/main/java/net/pms/dlna/SubSelFile.java
@@ -15,7 +15,7 @@ public class SubSelFile extends VirtualFolder {
 	private DLNAResource orig;
 
 	public SubSelFile(DLNAResource r) {
-		super(r.getDisplayName(), r.getThumbnailURL(DLNAImageProfile.JPEG_TN.toString()));
+		super(r.getDisplayName(), r.getThumbnailURL(DLNAImageProfile.JPEG_TN));
 		orig = r;
 	}
 

--- a/src/main/java/net/pms/dlna/ZippedEntry.java
+++ b/src/main/java/net/pms/dlna/ZippedEntry.java
@@ -37,7 +37,7 @@ public class ZippedEntry extends DLNAResource implements IPushOutput {
 	private ZipFile zipFile;
 
 	@Override
-	protected String getThumbnailURL(String profile) {
+	protected String getThumbnailURL(DLNAImageProfile profile) {
 		if (getType() == Format.IMAGE || getType() == Format.AUDIO) {
 			// no thumbnail support for now for zipped videos
 			return null;

--- a/src/main/java/net/pms/dlna/ZippedFile.java
+++ b/src/main/java/net/pms/dlna/ZippedFile.java
@@ -55,7 +55,7 @@ public class ZippedFile extends DLNAResource {
 	}
 
 	@Override
-	protected String getThumbnailURL(String profile) {
+	protected String getThumbnailURL(DLNAImageProfile profile) {
 		if (getType() == Format.IMAGE) {
 			// no thumbnail support for now for zip files
 			return null;

--- a/src/main/java/net/pms/image/ImageIOTools.java
+++ b/src/main/java/net/pms/image/ImageIOTools.java
@@ -47,7 +47,7 @@ import com.drew.metadata.Metadata;
  */
 public class ImageIOTools {
 
-    protected static final IIORegistry theRegistry = IIORegistry.getDefaultInstance();
+	protected static final IIORegistry theRegistry = IIORegistry.getDefaultInstance();
 
 	// Not to be instantiated
 	private ImageIOTools() {
@@ -57,8 +57,8 @@ public class ImageIOTools {
 	 * A copy of {@link ImageIO#read(InputStream)} that calls
 	 * {{@link #read(ImageInputStream)} instead of
 	 * {@link ImageIO#read(ImageInputStream)} and that returns
-     * {@link ImageReaderResult} instead of {@link BufferedImage}. This lets
-     * information about the detected format be retained.
+	 * {@link ImageReaderResult} instead of {@link BufferedImage}. This lets
+	 * information about the detected format be retained.
 	 *
 	 * <p><b>
 	 * This method consumes and closes {@code inputStream}.
@@ -68,39 +68,39 @@ public class ImageIOTools {
 	 *
 	 * @see ImageIO#read(InputStream)
 	 */
-    public static ImageReaderResult read(InputStream inputStream) throws IOException {
-        if (inputStream == null) {
-            throw new IllegalArgumentException("input == null!");
-        }
+	public static ImageReaderResult read(InputStream inputStream) throws IOException {
+		if (inputStream == null) {
+			throw new IllegalArgumentException("input == null!");
+		}
 
-        ImageInputStream stream = createImageInputStream(inputStream);
-        try {
-	        ImageReaderResult result = read(stream);
-	        if (result == null) {
-	        	inputStream.close();
-	        }
-	        return result;
-        } catch (RuntimeException | IOException e) {
-        	try {
-        		inputStream.close();
-        	} catch (Exception e2) {
-        		//Do nothing
-        	}
-        	if (e instanceof RuntimeException) {
-        		throw new ImageIORuntimeException(
-        			"An error occurred while trying to read image: " + e.getMessage(),
-        			(RuntimeException) e
-        		);
-        	}
-        	throw e;
-        }
-    }
+		ImageInputStream stream = createImageInputStream(inputStream);
+		try {
+			ImageReaderResult result = read(stream);
+			if (result == null) {
+				inputStream.close();
+			}
+			return result;
+		} catch (RuntimeException | IOException e) {
+			try {
+				inputStream.close();
+			} catch (Exception e2) {
+				//Do nothing
+			}
+			if (e instanceof RuntimeException) {
+				throw new ImageIORuntimeException(
+					"An error occurred while trying to read image: " + e.getMessage(),
+					(RuntimeException) e
+				);
+			}
+			throw e;
+		}
+	}
 
-    /**
-     * A copy of {@link ImageIO#read(ImageInputStream)} that returns
-     * {@link ImageReaderResult} instead of {@link BufferedImage}. This lets
-     * information about the detected format be retained.
-     *
+	/**
+	 * A copy of {@link ImageIO#read(ImageInputStream)} that returns
+	 * {@link ImageReaderResult} instead of {@link BufferedImage}. This lets
+	 * information about the detected format be retained.
+	 *
 	 * <b>
 	 * This method consumes and closes {@code stream}.
 	 * </b>
@@ -108,41 +108,41 @@ public class ImageIOTools {
 	 * @param stream an {@link ImageInputStream} to read from.
 	 *
 	 * @see ImageIO#read(ImageInputStream)
-     */
-    public static ImageReaderResult read(ImageInputStream stream) throws IOException {
-        if (stream == null) {
-            throw new IllegalArgumentException("stream == null!");
-        }
+	 */
+	public static ImageReaderResult read(ImageInputStream stream) throws IOException {
+		if (stream == null) {
+			throw new IllegalArgumentException("stream == null!");
+		}
 
-        try {
-	        Iterator<?> iter = ImageIO.getImageReaders(stream);
-	        if (!iter.hasNext()) {
-	        	throw new UnknownFormatException("Unable to find a suitable image reader");
-	        }
+		try {
+			Iterator<?> iter = ImageIO.getImageReaders(stream);
+			if (!iter.hasNext()) {
+				throw new UnknownFormatException("Unable to find a suitable image reader");
+			}
 
-	        ImageFormat inputFormat = null;
-	        BufferedImage bufferedImage = null;
-	        ImageReader reader = (ImageReader) iter.next();
-	        try {
-		        // Store the parsing result
-		        inputFormat = ImageFormat.toImageFormat(reader.getFormatName());
+			ImageFormat inputFormat = null;
+			BufferedImage bufferedImage = null;
+			ImageReader reader = (ImageReader) iter.next();
+			try {
+				// Store the parsing result
+				inputFormat = ImageFormat.toImageFormat(reader.getFormatName());
 
-		        reader.setInput(stream, true, true);
-	            bufferedImage = reader.read(0, reader.getDefaultReadParam());
-	        } finally {
-	            reader.dispose();
-	        }
-	        return bufferedImage != null ? new ImageReaderResult(bufferedImage, inputFormat) : null;
-        } catch (RuntimeException e) {
-        	throw new ImageIORuntimeException("An error occurred while trying to read image: " + e.getMessage(), e);
-        } finally {
-        	stream.close();
-        }
-    }
+				reader.setInput(stream, true, true);
+				bufferedImage = reader.read(0, reader.getDefaultReadParam());
+			} finally {
+				reader.dispose();
+			}
+			return bufferedImage != null ? new ImageReaderResult(bufferedImage, inputFormat) : null;
+		} catch (RuntimeException e) {
+			throw new ImageIORuntimeException("An error occurred while trying to read image: " + e.getMessage(), e);
+		} finally {
+			stream.close();
+		}
+	}
 
-    /**
-     * Tries to detect the input image file format using {@link ImageIO} and
-     * returns the result.
+	/**
+	 * Tries to detect the input image file format using {@link ImageIO} and
+	 * returns the result.
 	 * <p>
 	 * This method does not close {@code inputStream}.
 	 *
@@ -150,115 +150,115 @@ public class ImageIOTools {
 	 * @return The {@link ImageFormat} for the input.
 	 * @throws UnknownFormatException if the format could not be determined.
 	 * @throws IOException if an IO error occurred.
-     */
-    public static ImageFormat detectFileFormat(InputStream inputStream) throws IOException {
-        if (inputStream == null) {
-            throw new IllegalArgumentException("input == null!");
-        }
+	 */
+	public static ImageFormat detectFileFormat(InputStream inputStream) throws IOException {
+		if (inputStream == null) {
+			throw new IllegalArgumentException("input == null!");
+		}
 
-        try (ImageInputStream stream = createImageInputStream(inputStream)) {
-	        Iterator<?> iter = ImageIO.getImageReaders(stream);
-	        if (!iter.hasNext()) {
-	        	throw new UnknownFormatException("Unable to find a suitable image reader");
-	        }
+		try (ImageInputStream stream = createImageInputStream(inputStream)) {
+			Iterator<?> iter = ImageIO.getImageReaders(stream);
+			if (!iter.hasNext()) {
+				throw new UnknownFormatException("Unable to find a suitable image reader");
+			}
 
-	        ImageReader reader = (ImageReader) iter.next();
-	        ImageFormat format = ImageFormat.toImageFormat(reader.getFormatName());
-	        if (format == null) {
-	        	throw new UnknownFormatException("Unable to determine image format");
-	        }
-	        return format;
-        } catch (RuntimeException e) {
-        	throw new ImageIORuntimeException("An error occurred while trying to detect image format: " + e.getMessage(), e);
-        }
-    }
+			ImageReader reader = (ImageReader) iter.next();
+			ImageFormat format = ImageFormat.toImageFormat(reader.getFormatName());
+			if (format == null) {
+				throw new UnknownFormatException("Unable to determine image format");
+			}
+			return format;
+		} catch (RuntimeException e) {
+			throw new ImageIORuntimeException("An error occurred while trying to detect image format: " + e.getMessage(), e);
+		}
+	}
 
-    /**
-     * Tries to gather the data needed to populate a {@link ImageInfo} instance
-     * describing the input image.
-     *
+	/**
+	 * Tries to gather the data needed to populate a {@link ImageInfo} instance
+	 * describing the input image.
+	 *
 	 * <p>
 	 * This method does not close {@code inputStream}.
-     *
-     * @param inputStream the image whose information to gather.
-     * @param size the size of the image in bytes or
-     *             {@link ImageInfo#SIZE_UNKNOWN} if it can't be determined.
-     * @param metadata the {@link Metadata} instance to embed in the resulting
-     *                 {@link ImageInfo} instance.
+	 *
+	 * @param inputStream the image whose information to gather.
+	 * @param size the size of the image in bytes or
+	 *             {@link ImageInfo#SIZE_UNKNOWN} if it can't be determined.
+	 * @param metadata the {@link Metadata} instance to embed in the resulting
+	 *                 {@link ImageInfo} instance.
 	 * @param applyExifOrientation whether or not Exif orientation should be
 	 *            compensated for when setting width and height. This will also
 	 *            reset the Exif orientation information. <b>Changes will be
 	 *            applied to the {@code metadata} argument instance</b>.
-     * @return An {@link ImageInfo} instance describing the input image.
+	 * @return An {@link ImageInfo} instance describing the input image.
 	 * @throws UnknownFormatException if the format could not be determined.
-     * @throws IOException if an IO error occurred.
-     */
-    public static ImageInfo readImageInfo(InputStream inputStream, long size, Metadata metadata, boolean applyExifOrientation) throws IOException {
-        if (inputStream == null) {
-            throw new IllegalArgumentException("input == null!");
-        }
+	 * @throws IOException if an IO error occurred.
+	 */
+	public static ImageInfo readImageInfo(InputStream inputStream, long size, Metadata metadata, boolean applyExifOrientation) throws IOException {
+		if (inputStream == null) {
+			throw new IllegalArgumentException("input == null!");
+		}
 
-        try (ImageInputStream stream = createImageInputStream(inputStream)) {
-	        Iterator<?> iter = ImageIO.getImageReaders(stream);
-	        if (!iter.hasNext()) {
-	        	throw new UnknownFormatException("Unable to find a suitable image reader");
-	        }
+		try (ImageInputStream stream = createImageInputStream(inputStream)) {
+			Iterator<?> iter = ImageIO.getImageReaders(stream);
+			if (!iter.hasNext()) {
+				throw new UnknownFormatException("Unable to find a suitable image reader");
+			}
 
-	        ImageReader reader = (ImageReader) iter.next();
-	        try {
-	        	int width = -1;
-	        	int height = -1;
-		        ImageFormat format = ImageFormat.toImageFormat(reader.getFormatName());
-		        if (format == null) {
-		        	throw new UnknownFormatException("Unable to determine image format");
-		        }
+			ImageReader reader = (ImageReader) iter.next();
+			try {
+				int width = -1;
+				int height = -1;
+				ImageFormat format = ImageFormat.toImageFormat(reader.getFormatName());
+				if (format == null) {
+					throw new UnknownFormatException("Unable to determine image format");
+				}
 
-		        ColorModel colorModel = null;
-		        try {
-			        reader.setInput(stream, true, true);
-			        Iterator<ImageTypeSpecifier> iterator = reader.getImageTypes(0);
-			        if (iterator.hasNext()) {
-			        	colorModel = iterator.next().getColorModel();
-			        }
-			        width = reader.getWidth(0);
-			        height = reader.getHeight(0);
-		        } catch (RuntimeException e) {
-		        	throw new ImageIORuntimeException("Error reading image information: " + e.getMessage(), e);
-		        }
+				ColorModel colorModel = null;
+				try {
+					reader.setInput(stream, true, true);
+					Iterator<ImageTypeSpecifier> iterator = reader.getImageTypes(0);
+					if (iterator.hasNext()) {
+						colorModel = iterator.next().getColorModel();
+					}
+					width = reader.getWidth(0);
+					height = reader.getHeight(0);
+				} catch (RuntimeException e) {
+					throw new ImageIORuntimeException("Error reading image information: " + e.getMessage(), e);
+				}
 
-		        boolean imageIOSupport;
-		        if (format == ImageFormat.TIFF) {
-		        	// ImageIO thinks that it can read some "TIFF like" RAW formats,
-		        	// but fails when it actually tries, so we have to test it.
-			        try {
-			        	ImageReadParam param = reader.getDefaultReadParam();
-			        	param.setSourceRegion(new Rectangle(1, 1));
-			        	reader.read(0, param);
-			        	imageIOSupport = true;
-			        } catch (Exception e) {
-			        	// Catch anything here, we simply want to test if it fails.
-			        	imageIOSupport = false;
-			        }
-		        } else {
-		        	imageIOSupport = true;
-		        }
+				boolean imageIOSupport;
+				if (format == ImageFormat.TIFF) {
+					// ImageIO thinks that it can read some "TIFF like" RAW formats,
+					// but fails when it actually tries, so we have to test it.
+					try {
+						ImageReadParam param = reader.getDefaultReadParam();
+						param.setSourceRegion(new Rectangle(1, 1));
+						reader.read(0, param);
+						imageIOSupport = true;
+					} catch (Exception e) {
+						// Catch anything here, we simply want to test if it fails.
+						imageIOSupport = false;
+					}
+				} else {
+					imageIOSupport = true;
+				}
 
-		        ImageInfo imageInfo = ImageInfo.create(
-		        	width,
-		        	height,
-		        	format,
-		        	size,
-		        	colorModel,
-		        	metadata,
-		        	applyExifOrientation,
-		        	imageIOSupport
-		        );
-		        return imageInfo;
-	        } finally {
-	        	reader.dispose();
-	        }
-        }
-    }
+				ImageInfo imageInfo = ImageInfo.create(
+					width,
+					height,
+					format,
+					size,
+					colorModel,
+					metadata,
+					applyExifOrientation,
+					imageIOSupport
+				);
+				return imageInfo;
+			} finally {
+				reader.dispose();
+			}
+		}
+	}
 
 	/**
 	 * A copy of {@link ImageIO#createImageInputStream(Object)} that ignores
@@ -268,33 +268,33 @@ public class ImageIOTools {
 	 *
 	 * @see ImageIO#createImageInputStream(Object)
 	 */
-    public static ImageInputStream createImageInputStream(Object input)
-        throws IOException {
-        if (input == null) {
-            throw new IllegalArgumentException("input == null!");
-        }
+	public static ImageInputStream createImageInputStream(Object input)
+		throws IOException {
+		if (input == null) {
+			throw new IllegalArgumentException("input == null!");
+		}
 
-        Iterator<ImageInputStreamSpi> iter;
-        // Ensure category is present
-        try {
-            iter = theRegistry.getServiceProviders(ImageInputStreamSpi.class, true);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+		Iterator<ImageInputStreamSpi> iter;
+		// Ensure category is present
+		try {
+			iter = theRegistry.getServiceProviders(ImageInputStreamSpi.class, true);
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
 
-        while (iter.hasNext()) {
-            ImageInputStreamSpi spi = (ImageInputStreamSpi)iter.next();
-            if (spi.getInputClass().isInstance(input)) {
-                try {
-                    return spi.createInputStreamInstance(input, false, null);
-                } catch (IOException e) {
-                    throw new IIOException("Can't create cache file!", e);
-                }
-            }
-        }
+		while (iter.hasNext()) {
+			ImageInputStreamSpi spi = (ImageInputStreamSpi)iter.next();
+			if (spi.getInputClass().isInstance(input)) {
+				try {
+					return spi.createInputStreamInstance(input, false, null);
+				} catch (IOException e) {
+					throw new IIOException("Can't create cache file!", e);
+				}
+			}
+		}
 
-        return null;
-    }
+		return null;
+	}
 
 	/**
 	 * This is a wrapper around
@@ -313,16 +313,20 @@ public class ImageIOTools {
 		}
 	}
 
-    /**
-     * A simple container for more than one return value.
-     */
-    public static class ImageReaderResult {
-    	public final BufferedImage bufferedImage;
-    	public final ImageFormat imageFormat;
+	/**
+	 * A simple container for more than one return value.
+	 */
+	public static class ImageReaderResult {
+		public final BufferedImage bufferedImage;
+		public final ImageFormat imageFormat;
+		public final int width;
+		public final int height;
 
-    	public ImageReaderResult(BufferedImage bufferedImage, ImageFormat imageFormat) {
-    		this.bufferedImage = bufferedImage;
-    		this.imageFormat = imageFormat;
-    	}
-    }
+		public ImageReaderResult(BufferedImage bufferedImage, ImageFormat imageFormat) {
+			this.bufferedImage = bufferedImage;
+			this.imageFormat = imageFormat;
+			this.width = bufferedImage == null ? -1 : bufferedImage.getWidth();
+			this.height = bufferedImage == null ? -1 : bufferedImage.getHeight();
+		}
+	}
 }

--- a/src/main/java/net/pms/image/ImagesUtil.java
+++ b/src/main/java/net/pms/image/ImagesUtil.java
@@ -1172,7 +1172,7 @@ public class ImagesUtil {
 			}
 			sb.append("PadToSize = ").append(padToSize ? "True" : "False");
 			LOGGER.trace(
-				"Converting image with {} source to {} ({}) using the following parameters: {}",
+				"Converting {} image source to {} format and type {} using the following parameters: {}",
 				inputByteArray != null ? "byte array" : inputImage != null ? "Image" : "input stream",
 				outputProfile != null ? outputProfile : outputFormat,
 				dlnaThumbnail ? "DLNAThumbnail" : dlnaCompliant ? "DLNAImage" : "Image",
@@ -1496,12 +1496,12 @@ public class ImagesUtil {
 			.append(", Re-encode = ").append(reencode ? "True" : "False");
 
 			LOGGER.trace(
-				"Finished converting image from format {}{}. " +
-				"Output image width = {}, height = {} and output {}. Flags: {}",
+				"Finished converting {} {} image{}. " +
+				"Output image resolution: {}, {}. Flags: {}",
+				inputResult.width + "×" + inputResult.height,
 				inputResult.imageFormat,
 				orientation != ExifOrientation.TOP_LEFT ? " with orientation " + orientation : "",
-				bufferedImage.getWidth(),
-				bufferedImage.getHeight(),
+				bufferedImage.getWidth() + "×" + bufferedImage.getHeight(),
 				dlnaCompliant && outputProfile != null ? "profile: " + outputProfile : "format: " + outputFormat,
 				sb
 			);

--- a/src/main/java/net/pms/util/FullyPlayed.java
+++ b/src/main/java/net/pms/util/FullyPlayed.java
@@ -36,7 +36,6 @@ import net.pms.dlna.DLNAThumbnailInputStream;
 import net.pms.dlna.MediaMonitor;
 import net.pms.dlna.RealFile;
 import net.pms.image.ImageIOTools;
-import net.pms.image.ImagesUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
This is a small PR to rectify some small issues not detected in time for the merge of #1061:
* Made ```DLNAMediaDatabase.insertOrUpdateData()``` disregard file timestamp when looking for a file to update to avoid duplicates of the same file with different modified dates (if the file is edited or replaced). ```DLNAMediaDatabase.getData()``` still requires that the file timestamp matches, so it won't find it in the cache and will reparse the file. When parsing is complete, ```DLNAMediaDatabase.insertOrUpdateData()``` is called which should now update the existing entry instead of creating a new one for the same media file.
* Removed obsolete comment in DLNAMediaInfo
* Removed CI flag from DIDL-Lite string if the value is 0. This is an attempt at fixing @valib's issue with thumbnails being selected as the primary resource for video media.

@valib Please test and report back if this fixes it.
