### PR TITLE
Vulnerability check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,12 @@ GitHub only allows image attachments. Other attachments, for example zipped logs
 Remember to include a link to the attachment in your post here.
 
 If you prefer to upload your attachment elsewhere, please avoid sites with restricted access or captcha if possible.
+
+# Checking for known vulnerabilities in dependencies
+
+Run `mvn test net.ossindex:ossindex-maven-plugin:audit`
+
+# Checking for updated dependencies
+
+Run `mvn versions:display-plugin-updates`
+

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
 	<!-- this is not required, but is recommended for plugin version checks -->
 	<prerequisites>
-		<maven>2.2.1</maven>
+		<maven>3.0.0</maven>
 	</prerequisites>
 
 	<organization>
@@ -90,7 +90,7 @@
 		<binary-revision>62</binary-revision>
 
 		<maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
-		<git-commit-id-plugin-version>2.2.1</git-commit-id-plugin-version>
+		<git-commit-id-plugin-version>2.2.2</git-commit-id-plugin-version>
 		<maven-assembly-plugin-version>3.0.0</maven-assembly-plugin-version>
 		<logback-version>1.1.8</logback-version>
 
@@ -526,7 +526,7 @@
 						-->
 						<argLine>-Duser.language=en -Djna.nosys=true -XX:-UseSplitVerifier</argLine> <!-- only one argLine element is processed -->
 					</configuration>
-					<version>2.19.1</version>
+					<version>2.20</version>
 				</plugin>
 
 				<!-- 
@@ -675,7 +675,7 @@
 
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.6.1</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>
@@ -791,7 +791,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-surefire-report-plugin</artifactId>
-							<version>2.19.1</version>
+							<version>2.20</version>
 							<configuration>
 								<showSuccess>false</showSuccess>
 							</configuration>
@@ -1674,7 +1674,7 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
-						<version>1.5.0</version>
+						<version>1.6.0</version>
 						<executions>
 							<execution>
 								<phase>test</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
 		<dependency>
 			<groupId>net.coobird</groupId>
 			<artifactId>thumbnailator</artifactId>
-			<version>[0.4, 0.5)</version>
+			<version>0.4.8</version>
 		</dependency>
 		
 		<!-- 
@@ -421,6 +421,11 @@
 			<groupId>fm.last</groupId>
 			<artifactId>coverartarchive-api</artifactId>
 			<version>2.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>net.ossindex</groupId>
+			<artifactId>ossindex-maven-plugin</artifactId>
+			<version>2.1.1</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
 		<dependency>
 			<groupId>net.ossindex</groupId>
 			<artifactId>ossindex-maven-plugin</artifactId>
-			<version>2.1.1</version>
+			<version>2.1.2</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
Added the ability to run a Maven command to check dependencies for known vulnerabilities.

Can be run like `call mvn test net.ossindex:ossindex-maven-plugin:audit`