### PR TITLE
Implement GetProtocolInfo support

### DIFF
--- a/src/main/java/net/pms/configuration/IpFilter.java
+++ b/src/main/java/net/pms/configuration/IpFilter.java
@@ -31,9 +31,9 @@ import org.slf4j.LoggerFactory;
 /**
  * IP Filter class, which supports multiple wildcards, ranges. For example :
  * 127.0.0.1,192.168.0-1.*
- * 
+ *
  * @author zsombor
- * 
+ *
  */
 public class IpFilter {
 
@@ -92,7 +92,7 @@ public class IpFilter {
 
 			/*
 			 * (non-Javadoc)
-			 * 
+			 *
 			 * @see java.lang.Object#toString()
 			 */
 			@Override
@@ -250,20 +250,20 @@ public class IpFilter {
 		boolean log = isFirstDecision(addr);
 		if (matchers.isEmpty()) {
 			if (log) {
-				LOGGER.debug("No IP filter specified, access granted to " + addr);
+				LOGGER.trace("IP Filter: No IP filter specified, access granted to {}", addr.getHostAddress());
 			}
 			return true;
 		}
 		for (Predicate p : matchers) {
 			if (p.match(addr)) {
 				if (log) {
-					LOGGER.trace("Access granted to " + addr + " by rule: " + p);
+					LOGGER.trace("IP Filter: Access granted to {} with rule: {}", addr.getHostAddress(), p);
 				}
 				return true;
 			}
 		}
 		if (log) {
-			LOGGER.info("Access denied to " + addr);
+			LOGGER.info("IP Filter: Access denied to {}", addr.getHostName());
 		}
 		return false;
 	}

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -584,7 +584,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	public static RendererConfiguration getRendererConfigurationBySocketAddress(InetAddress sa) {
 		RendererConfiguration r = addressAssociation.get(sa);
 		if (r != null) {
-			LOGGER.debug("Matched media renderer \"" + r.getRendererName() + "\" based on address " + sa);
+			LOGGER.trace("Matched media renderer \"{}\" based on address {}", r.getRendererName(), sa.getHostAddress());
 		}
 		return r;
 	}
@@ -608,7 +608,12 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 			boolean isNew = !addressAssociation.containsKey(ia);
 			r = resolve(ia, ref);
 			if (r != null) {
-				LOGGER.debug("Matched " + (isNew ? "new " : "") + "media renderer \"" + r.getRendererName() + "\" based on headers " + sortedHeaders);
+				LOGGER.trace(
+					"Matched {}media renderer \"{}\" based on headers {}",
+					isNew ? "new " : "",
+					r.getRendererName(),
+					sortedHeaders
+				);
 			}
 		}
 		return r;
@@ -680,7 +685,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 			if (addressAssociation.containsKey(ia)) {
 				// Already seen, finish configuration if required
 				r = (DeviceConfiguration) addressAssociation.get(ia);
-				boolean higher = ref.getLoadingPriority() > r.getLoadingPriority() && recognized;
+				boolean higher = ref != null && ref.getLoadingPriority() > r.getLoadingPriority() && recognized;
 				if (!r.loaded || higher) {
 					LOGGER.debug("Finishing configuration for {}", r);
 					if (higher) {
@@ -701,12 +706,16 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 					r.setUpnpMode(ALLOW);
 				}
 			}
-		} catch (Exception e) {
+		} catch (ConfigurationException e) {
+			LOGGER.error("Configuration error while resolving renderer: {}", e.getMessage());
+			LOGGER.trace("", e);
 		}
 		if (!recognized) {
 			// Mark it as unloaded so actual recognition can happen later if UPnP sees it.
-			LOGGER.debug("Marking renderer \"{}\" at {} as unrecognized", r, ia);
-			r.loaded = false;
+			LOGGER.trace("Marking renderer \"{}\" at {} as unrecognized", r, ia.getHostAddress());
+			if (r != null) {
+				r.loaded = false;
+			}
 		}
 		return r;
 	}

--- a/src/main/java/net/pms/dlna/DLNAImageProfile.java
+++ b/src/main/java/net/pms/dlna/DLNAImageProfile.java
@@ -23,12 +23,19 @@ import java.awt.Dimension;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.fourthline.cling.support.model.Protocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import net.pms.dlna.protocolinfo.DLNAOrgProfileName;
+import net.pms.dlna.protocolinfo.KnownDLNAOrgProfileName;
+import net.pms.dlna.protocolinfo.MimeType;
+import net.pms.dlna.protocolinfo.ProtocolInfo;
 import net.pms.image.ColorSpaceType;
 import net.pms.image.GIFInfo;
 import net.pms.image.ImageFormat;
@@ -41,7 +48,6 @@ import net.pms.image.JPEGSubsamplingNotation;
 import net.pms.image.PNGInfo;
 import net.pms.image.ExifInfo.ExifColorSpace;
 import net.pms.image.PNGInfo.InterlaceMethod;
-
 
 /**
  * Definition and validation of the different DLNA media profiles for images.
@@ -57,73 +63,82 @@ import net.pms.image.PNGInfo.InterlaceMethod;
  * is true even if {@code H} and {@code V} are different in the two profiles.
  */
 @SuppressWarnings({"checkstyle:MethodName", "checkstyle:ParameterName"})
-public class DLNAImageProfile implements Serializable {
+public class DLNAImageProfile implements Comparable<DLNAImageProfile>, Serializable {
 
 	private static final long serialVersionUID = 1L;
 	private static final Logger LOGGER = LoggerFactory.getLogger(DLNAImageProfile.class);
 
-	/** Int representation of GIF_LRG. */
-	public static final int GIF_LRG_INT = 1;
+	/** Standard GIF mime-type */
+	public static final MimeType MIMETYPE_GIF = new MimeType("image", "gif");
 
-	/** Int representation of JPEG_LRG. */
-	public static final int JPEG_LRG_INT = 2;
+	/** Standard JPEG mime-type */
+	public static final MimeType MIMETYPE_JPEG = new MimeType("image", "jpeg");
 
-	/** Int representation of JPEG_MED. */
-	public static final int JPEG_MED_INT = 3;
-
-	/** Int representation of JPEG_RES_H_V. */
-	public static final int JPEG_RES_H_V_INT = 4;
-
-	/** Int representation of JPEG_SM. */
-	public static final int JPEG_SM_INT = 5;
-
-	/** Int representation of JPEG_TN. */
-	public static final int JPEG_TN_INT = 6;
-
-	/** Int representation of PNG_LRG. */
-	public static final int PNG_LRG_INT = 7;
-
-	/** Int representation of PNG_TN. */
-	public static final int PNG_TN_INT = 8;
+	/** Standard PNG mime-type */
+	public static final MimeType MIMETYPE_PNG = new MimeType("image", "png");
 
 	/** Integer representation of GIF_LRG. */
-	public static final Integer GIF_LRG_INTEGER = GIF_LRG_INT;
+	public static final int GIF_LRG_INT = 1;
 
 	/** Integer representation of JPEG_LRG. */
-	public static final Integer JPEG_LRG_INTEGER = JPEG_LRG_INT;
+	public static final int JPEG_LRG_INT = 2;
 
 	/** Integer representation of JPEG_MED. */
-	public static final Integer JPEG_MED_INTEGER = JPEG_MED_INT;
+	public static final int JPEG_MED_INT = 3;
 
 	/** Integer representation of JPEG_RES_H_V. */
-	public static final Integer JPEG_RES_H_V_INTEGER = JPEG_RES_H_V_INT;
+	public static final int JPEG_RES_H_V_INT = 4;
 
 	/** Integer representation of JPEG_SM. */
-	public static final Integer JPEG_SM_INTEGER = JPEG_SM_INT;
+	public static final int JPEG_SM_INT = 5;
 
 	/** Integer representation of JPEG_TN. */
-	public static final Integer JPEG_TN_INTEGER = JPEG_TN_INT;
+	public static final int JPEG_TN_INT = 6;
 
 	/** Integer representation of PNG_LRG. */
-	public static final Integer PNG_LRG_INTEGER = PNG_LRG_INT;
+	public static final int PNG_LRG_INT = 7;
 
 	/** Integer representation of PNG_TN. */
-	public static final Integer PNG_TN_INTEGER = PNG_TN_INT;
+	public static final int PNG_TN_INT = 8;
+
+	/** String representation of GIF_LRG. */
+	public static final String GIF_LRG_STRING = "GIF_LRG";
+
+	/** String representation of JPEG_LRG. */
+	public static final String JPEG_LRG_STRING = "JPEG_LRG";
+
+	/** String representation of JPEG_MED. */
+	public static final String JPEG_MED_STRING = "JPEG_MED";
+
+	/** String representation of JPEG_RES_H_V. */
+	public static final String JPEG_RES_H_V_STRING = "JPEG_RES_H_V";
+
+	/** String representation of JPEG_SM. */
+	public static final String JPEG_SM_STRING = "JPEG_SM";
+
+	/** String representation of JPEG_TN. */
+	public static final String JPEG_TN_STRING = "JPEG_TN";
+
+	/** String representation of PNG_LRG. */
+	public static final String PNG_LRG_STRING = "PNG_LRG";
+
+	/** String representation of PNG_TN. */
+	public static final String PNG_TN_STRING = "PNG_TN";
 
 	/**
 	 * {@code GIF_LRG} maximum resolution 1600 x 1200.
 	 */
-	public static final DLNAImageProfile GIF_LRG = new DLNAImageProfile(GIF_LRG_INT, "GIF_LRG", 1600, 1200);
+	public static final DLNAImageProfile GIF_LRG = new DLNAImageProfile(GIF_LRG_INT, GIF_LRG_STRING, 1600, 1200, null);
 
 	/**
 	 * {@code JPEG_LRG} maximum resolution 4096 x 4096.
 	 */
-	public static final DLNAImageProfile JPEG_LRG = new DLNAImageProfile(JPEG_LRG_INT, "JPEG_LRG", 4096, 4096);
+	public static final DLNAImageProfile JPEG_LRG = new DLNAImageProfile(JPEG_LRG_INT, JPEG_LRG_STRING, 4096, 4096, null);
 
 	/**
 	 * {@code JPEG_MED} maximum resolution 1024 x 768.
 	 */
-	public static final DLNAImageProfile JPEG_MED = new DLNAImageProfile(JPEG_MED_INT, "JPEG_MED", 1024, 768);
+	public static final DLNAImageProfile JPEG_MED = new DLNAImageProfile(JPEG_MED_INT, JPEG_MED_STRING, 1024, 768, null);
 
 	/**
 	 * {@code JPEG_RES_H_V} exact resolution H x V.<br>
@@ -133,32 +148,33 @@ public class DLNAImageProfile implements Serializable {
 	 * <br>
 	 * To create a valid profile, use {@link #createJPEG_RES_H_V(int, int)} instead.
 	 */
-	public static final DLNAImageProfile JPEG_RES_H_V = new DLNAImageProfile(JPEG_RES_H_V_INT, "JPEG_RES_H_V", -1, -1);
+	public static final DLNAImageProfile JPEG_RES_H_V = new DLNAImageProfile(JPEG_RES_H_V_INT, JPEG_RES_H_V_STRING, -1, -1, null);
 
 	/**
 	 * {@code JPEG_SM} maximum resolution 640 x 480.
 	 */
-	public static final DLNAImageProfile JPEG_SM = new DLNAImageProfile(JPEG_SM_INT, "JPEG_SM", 640, 480);
+	public static final DLNAImageProfile JPEG_SM = new DLNAImageProfile(JPEG_SM_INT, JPEG_SM_STRING, 640, 480, null);
 
 	/**
 	 * {@code JPEG_TN} maximum resolution 160 x 160.
 	 */
-	public static final DLNAImageProfile JPEG_TN = new DLNAImageProfile(JPEG_TN_INT, "JPEG_TN", 160, 160);
+	public static final DLNAImageProfile JPEG_TN = new DLNAImageProfile(JPEG_TN_INT, JPEG_TN_STRING, 160, 160, null);
 
 	/**
 	 * {@code PNG_LRG} maximum resolution 4096 x 4096.
 	 */
-	public static final DLNAImageProfile PNG_LRG = new DLNAImageProfile(PNG_LRG_INT, "PNG_LRG", 4096, 4096);
+	public static final DLNAImageProfile PNG_LRG = new DLNAImageProfile(PNG_LRG_INT, PNG_LRG_STRING, 4096, 4096, null);
 
 	/**
 	 * {@code PNG_TN} maximum resolution 160 x 160.
 	 */
-	public static final DLNAImageProfile PNG_TN = new DLNAImageProfile(PNG_TN_INT, "PNG_TN", 160, 160);
+	public static final DLNAImageProfile PNG_TN = new DLNAImageProfile(PNG_TN_INT, PNG_TN_STRING, 160, 160, null);
 
 	/**
 	 * Creates a new {@link #JPEG_RES_H_V} profile instance with the exact
-	 * resolution H x V. Set {@code H} and {@code V} for this instance. Not
-	 * applicable for other profiles.
+	 * resolution H x V. Set {@code H} and {@code V} for this instance. The
+	 * default mime-type {@code image/jpeg} is used. Not applicable for other
+	 * profiles.
 	 *
 	 * @param horizontal the {@code H} value.
 	 * @param vertical the {@code V} value.
@@ -169,26 +185,56 @@ public class DLNAImageProfile implements Serializable {
 			JPEG_RES_H_V_INT,
 			"JPEG_RES_" + Integer.toString(horizontal) + "_" + Integer.toString(vertical),
 			horizontal,
-			vertical
+			vertical,
+			null
 		);
 	}
 
-	/** This profile's int value */
-	public final int imageProfileInt;
+	/**
+	 * Creates a new {@link #JPEG_RES_H_V} profile instance with the exact
+	 * resolution H x V. Set {@code H} and {@code V} for this instance. Not
+	 * applicable for other profiles.
+	 *
+	 * @param horizontal the {@code H} value.
+	 * @param vertical the {@code V} value.
+	 * @param mimeType the {@link MimeType} for this profile.
+	 * @return The new {@link #JPEG_RES_H_V} instance.
+	 */
+	public static DLNAImageProfile createJPEG_RES_H_V(int horizontal, int vertical, MimeType mimeType) {
+		return new DLNAImageProfile(
+			JPEG_RES_H_V_INT,
+			"JPEG_RES_" + Integer.toString(horizontal) + "_" + Integer.toString(vertical),
+			horizontal,
+			vertical,
+			mimeType
+		);
+	}
 
-	/** This profile's Integer value */
-	public final String imageProfileStr;
+	/** This profile's integer value */
+	protected final int imageProfileInt;
+
+	/** This profile's string value */
+	protected final String imageProfileStr;
+	/** This profile's mime type value */
+	protected final MimeType mimeType;
 	private final int horizontal;
 	private final int vertical;
 
 	/**
 	 * Instantiate a {@link DLNAImageProfile} object.
 	 */
-	private DLNAImageProfile(int imageProfileInt, String imageProfileStr, int horizontal, int vertical) {
+	private DLNAImageProfile(
+		int imageProfileInt,
+		String imageProfileStr,
+		int horizontal,
+		int vertical,
+		MimeType mimeType
+	) {
 		this.imageProfileInt = imageProfileInt;
 		this.imageProfileStr = imageProfileStr;
 		this.horizontal = horizontal;
 		this.vertical = vertical;
+		this.mimeType = mimeType;
 	}
 
 	/**
@@ -196,34 +242,6 @@ public class DLNAImageProfile implements Serializable {
 	 */
 	public int toInt() {
 		return imageProfileInt;
-	}
-
-	/**
-	 * Converts a {@link DLNAImageProfile} to an {@link Integer} object.
-	 *
-	 * @return This {@link DLNAImageProfile}'s {@link Integer} mapping.
-	 */
-	public Integer toInteger() {
-		switch (imageProfileInt) {
-			case GIF_LRG_INT:
-				return GIF_LRG_INTEGER;
-			case JPEG_LRG_INT:
-				return JPEG_LRG_INTEGER;
-			case JPEG_MED_INT:
-				return JPEG_MED_INTEGER;
-			case JPEG_RES_H_V_INT:
-				return JPEG_RES_H_V_INTEGER;
-			case JPEG_SM_INT:
-				return JPEG_SM_INTEGER;
-			case JPEG_TN_INT:
-				return JPEG_TN_INTEGER;
-			case PNG_LRG_INT:
-				return PNG_LRG_INTEGER;
-			case PNG_TN_INT:
-				return PNG_TN_INTEGER;
-			default:
-				throw new IllegalStateException("DLNAImageProfile " + imageProfileStr + ", " + imageProfileInt + " is unknown.");
-		}
 	}
 
 	/**
@@ -261,15 +279,45 @@ public class DLNAImageProfile implements Serializable {
 	}
 
 	/**
-	 * Converts the integer passed as argument to a {@link DLNAImageProfile}.
-	 * If the conversion fails, this method returns {@code null}.
+	 * Converts the integer passed as argument to a {@link DLNAImageProfile}
+	 * using the default mime-type for the profile. If the conversion fails,
+	 * this method returns {@code null}.
 	 *
 	 * @param value the integer value to convert to a {@link DLNAImageProfile}.
 	 * @return The resulting {@link DLNAImageProfile} or {@code null} if the
 	 *         conversion failed.
 	 */
 	public static DLNAImageProfile toDLNAImageProfile(int value) {
-		return toDLNAImageProfile(value, null);
+		return toDLNAImageProfile(value, null, null);
+	}
+
+	/**
+	 * Converts the integer passed as argument to a {@link DLNAImageProfile}. If
+	 * the conversion fails, this method returns {@code null}.
+	 *
+	 * @param value the integer value to convert to a {@link DLNAImageProfile}.
+	 * @param mimeType the {@link MimeType} to use for the resulting
+	 *            {@link DLNAImageProfile}.
+	 * @return The resulting {@link DLNAImageProfile} or {@code null} if the
+	 *         conversion failed.
+	 */
+	public static DLNAImageProfile toDLNAImageProfile(int value, MimeType mimeType) {
+		return toDLNAImageProfile(value, null, mimeType);
+	}
+
+	/**
+	 * Converts the integer passed as argument to a {@link DLNAImageProfile}
+	 * using the default mime-type for the profile. If the conversion fails,
+	 * this method returns the specified default.
+	 *
+	 * @param value the integer value to convert to a {@link DLNAImageProfile}.
+	 * @param defaultImageProfile the {@link DLNAImageProfile} to return if the
+	 *            conversion fails.
+	 * @return The resulting {@link DLNAImageProfile} or
+	 *         {@code defaultImageProfile} if the conversion failed.
+	 */
+	public static DLNAImageProfile toDLNAImageProfile(int value, DLNAImageProfile defaultImageProfile) {
+		return toDLNAImageProfile(value, defaultImageProfile, null);
 	}
 
 	/**
@@ -279,30 +327,72 @@ public class DLNAImageProfile implements Serializable {
 	 * @param value the integer value to convert to a {@link DLNAImageProfile}.
 	 * @param defaultImageProfile the {@link DLNAImageProfile} to return if the
 	 *            conversion fails.
+	 * @param mimeType the {@link MimeType} to use for the resulting
+	 *            {@link DLNAImageProfile}.
 	 * @return The resulting {@link DLNAImageProfile} or
 	 *         {@code defaultImageProfile} if the conversion failed.
 	 */
-	public static DLNAImageProfile toDLNAImageProfile(int value, DLNAImageProfile defaultImageProfile) {
+	public static DLNAImageProfile toDLNAImageProfile(
+		int value, DLNAImageProfile
+		defaultImageProfile,
+		MimeType mimeType
+	) {
+		/*
+		 * Note: Even though this will work without checking if the mimeType is
+		 * blank and just sending it as a parameter, doing it this way allows
+		 * reuse of the default instances.
+		 */
 		switch (value) {
 			case GIF_LRG_INT:
-				return GIF_LRG;
+				return mimeType == null ?
+					DLNAImageProfile.GIF_LRG :
+					new DLNAImageProfile(GIF_LRG_INT, GIF_LRG_STRING, 1600, 1200, mimeType);
 			case JPEG_LRG_INT:
-				return JPEG_LRG;
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_LRG :
+					new DLNAImageProfile(JPEG_LRG_INT, JPEG_LRG_STRING, 4096, 4096, mimeType);
 			case JPEG_MED_INT:
-				return JPEG_MED;
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_MED :
+					new DLNAImageProfile(JPEG_MED_INT, JPEG_MED_STRING, 1024, 768, mimeType);
 			case JPEG_RES_H_V_INT:
-				return JPEG_RES_H_V;
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_RES_H_V :
+					new DLNAImageProfile(JPEG_RES_H_V_INT, JPEG_RES_H_V_STRING, -1, -1, mimeType);
 			case JPEG_SM_INT:
-				return JPEG_SM;
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_SM :
+					new DLNAImageProfile(JPEG_SM_INT, JPEG_SM_STRING, 640, 480, mimeType);
 			case JPEG_TN_INT:
-				return JPEG_TN;
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_TN :
+					new DLNAImageProfile(JPEG_TN_INT, JPEG_TN_STRING, 160, 160, mimeType);
 			case PNG_LRG_INT:
-				return PNG_LRG;
+				return mimeType == null ?
+					DLNAImageProfile.PNG_LRG :
+					new DLNAImageProfile(PNG_LRG_INT, PNG_LRG_STRING, 4096, 4096, mimeType);
 			case PNG_TN_INT:
-				return PNG_TN;
+				return mimeType == null ?
+					DLNAImageProfile.PNG_TN :
+					new DLNAImageProfile(PNG_TN_INT, PNG_TN_STRING, 160, 160, mimeType);
 			default:
 				return defaultImageProfile;
+
 		}
+	}
+
+	/**
+	 * Converts the {@link String} passed as argument to a
+	 * {@link DLNAImageProfile} using the default mime-type for the profile. If
+	 * the conversion fails, this method returns {@code null}.
+	 *
+	 * @param argument the {@link String} to convert to a
+	 *            {@link DLNAImageProfile}.
+	 * @return The resulting {@link DLNAImageProfile} or {@code null} if the
+	 *         conversion failed.
+	 */
+	public static DLNAImageProfile toDLNAImageProfile(String argument) {
+		return toDLNAImageProfile(argument, null, null);
 	}
 
 	/**
@@ -312,17 +402,19 @@ public class DLNAImageProfile implements Serializable {
 	 *
 	 * @param argument the {@link String} to convert to a
 	 *            {@link DLNAImageProfile}.
+	 * @param mimeType the {@link MimeType} to use for the resulting
+	 *            {@link DLNAImageProfile}.
 	 * @return The resulting {@link DLNAImageProfile} or {@code null} if the
 	 *         conversion failed.
 	 */
-	public static DLNAImageProfile toDLNAImageProfile(String argument) {
-		return toDLNAImageProfile(argument, null);
+	public static DLNAImageProfile toDLNAImageProfile(String argument, MimeType mimeType) {
+		return toDLNAImageProfile(argument, null, mimeType);
 	}
 
 	/**
 	 * Converts the {@link String} passed as argument to a
-	 * {@link DLNAImageProfile}. If the conversion fails, this method returns
-	 * the specified default.
+	 * {@link DLNAImageProfile} using the default mime-type for the profile. If
+	 * the conversion fails, this method returns the specified default.
 	 *
 	 * @param argument the {@link String} to convert to a
 	 *            {@link DLNAImageProfile}.
@@ -335,25 +427,67 @@ public class DLNAImageProfile implements Serializable {
 		if (argument == null) {
 			return defaultImageProfile;
 		}
+		return toDLNAImageProfile(argument, defaultImageProfile, null);
+	}
+
+	/**
+	 * Converts the {@link String} passed as argument to a
+	 * {@link DLNAImageProfile}. If the conversion fails, this method returns
+	 * the specified default.
+	 *
+	 * @param argument the {@link String} to convert to a
+	 *            {@link DLNAImageProfile}.
+	 * @param defaultImageProfile the {@link DLNAImageProfile} to return if the
+	 *            conversion fails.
+	 * @param mimeType the {@link MimeType} to use for the resulting
+	 *            {@link DLNAImageProfile}.
+	 * @return The resulting {@link DLNAImageProfile} or
+	 *         {@code defaultImageProfile} if the conversion failed.
+	 */
+	public static DLNAImageProfile toDLNAImageProfile(String argument, DLNAImageProfile defaultImageProfile, MimeType mimeType) {
+		if (argument == null) {
+			return defaultImageProfile;
+		}
 
 		argument = argument.toUpperCase(Locale.ROOT);
+		/*
+		 * Note: Even though this will work without checking if the mimeType is
+		 * blank and just sending it as a parameter, doing it this way allows
+		 * reuse of the default instances.
+		 */
 		switch (argument) {
-			case "GIF_LRG":
-				return DLNAImageProfile.GIF_LRG;
-			case "JPEG_LRG":
-				return DLNAImageProfile.JPEG_LRG;
-			case "JPEG_MED":
-				return DLNAImageProfile.JPEG_MED;
-			case "JPEG_RES_H_V":
-				return DLNAImageProfile.JPEG_RES_H_V;
-			case "JPEG_SM":
-				return DLNAImageProfile.JPEG_SM;
-			case "JPEG_TN":
-				return DLNAImageProfile.JPEG_TN;
-			case "PNG_LRG":
-				return DLNAImageProfile.PNG_LRG;
-			case "PNG_TN":
-				return DLNAImageProfile.PNG_TN;
+			case GIF_LRG_STRING:
+				return mimeType == null ?
+					DLNAImageProfile.GIF_LRG :
+					new DLNAImageProfile(GIF_LRG_INT, GIF_LRG_STRING, 1600, 1200, mimeType);
+			case JPEG_LRG_STRING:
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_LRG :
+					new DLNAImageProfile(JPEG_LRG_INT, JPEG_LRG_STRING, 4096, 4096, mimeType);
+			case JPEG_MED_STRING:
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_MED :
+					new DLNAImageProfile(JPEG_MED_INT, JPEG_MED_STRING, 1024, 768, mimeType);
+			case JPEG_RES_H_V_STRING:
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_RES_H_V :
+					new DLNAImageProfile(JPEG_RES_H_V_INT, JPEG_RES_H_V_STRING, -1, -1, mimeType);
+			case JPEG_SM_STRING:
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_SM :
+					new DLNAImageProfile(JPEG_SM_INT, JPEG_SM_STRING, 640, 480, mimeType);
+			case JPEG_TN_STRING:
+				return mimeType == null ?
+					DLNAImageProfile.JPEG_TN :
+					new DLNAImageProfile(JPEG_TN_INT, JPEG_TN_STRING, 160, 160, mimeType);
+			case PNG_LRG_STRING:
+				return mimeType == null ?
+					DLNAImageProfile.PNG_LRG :
+					new DLNAImageProfile(PNG_LRG_INT, PNG_LRG_STRING, 4096, 4096, mimeType);
+			case PNG_TN_STRING:
+				return mimeType == null ?
+					DLNAImageProfile.PNG_TN :
+					new DLNAImageProfile(PNG_TN_INT, PNG_TN_STRING, 160, 160, mimeType);
 			default:
 				if (argument.startsWith("JPEG_RES")) {
 					Matcher matcher = Pattern.compile("^JPEG_RES_?(\\d+)[X_](\\d+)").matcher(argument);
@@ -362,12 +496,129 @@ public class DLNAImageProfile implements Serializable {
 							JPEG_RES_H_V_INT,
 							"JPEG_RES_" + matcher.group(1) + "_" + matcher.group(2),
 							Integer.parseInt(matcher.group(1)),
-							Integer.parseInt(matcher.group(2))
+							Integer.parseInt(matcher.group(2)),
+							mimeType
 						);
 					}
 				}
 				return defaultImageProfile;
 		}
+	}
+
+	/**
+	 * Parses and converts a {@link ProtocolInfo} to a one or more
+	 * {@link DLNAImageProfile}(s). If the conversion fails, this method returns
+	 * {@code null}.
+	 *
+	 * @param protocolInfo the {@link ProtocolInfo} instance to parse.
+	 * @return The resulting {@link DLNAImageProfile}(s) or {@code null} if the
+	 *         conversion failed.
+	 */
+	public static Set<DLNAImageProfile> toDLNAImageProfiles(ProtocolInfo protocolInfo) {
+		Set<DLNAImageProfile> result = new HashSet<>();
+		if (
+			protocolInfo != null && (
+				protocolInfo.getProtocol() == Protocol.HTTP_GET ||
+				protocolInfo.getProtocol() == Protocol.ALL
+			) &&
+			protocolInfo.getMimeType() != null && (
+				protocolInfo.getMimeType().isAnyType() ||
+				"image".equals(protocolInfo.getMimeType().getType().trim().toLowerCase(Locale.ROOT))
+			)
+		) {
+			DLNAOrgProfileName dlnaProfileName = protocolInfo.getDLNAProfileName();
+			if (dlnaProfileName != null) {
+				if (dlnaProfileName instanceof KnownDLNAOrgProfileName) {
+					switch ((KnownDLNAOrgProfileName) dlnaProfileName) {
+						case GIF_LRG:
+							result.add(GIF_LRG);
+							break;
+						case JPEG_LRG:
+							result.add(JPEG_LRG);
+							break;
+						case JPEG_MED:
+							result.add(JPEG_MED);
+							break;
+						case JPEG_RES_H_V:
+							result.add(JPEG_RES_H_V);
+							break;
+						case JPEG_SM:
+							result.add(JPEG_SM);
+							break;
+						case JPEG_TN:
+							result.add(JPEG_TN);
+							break;
+						case PNG_LRG:
+							result.add(PNG_LRG);
+							break;
+						case PNG_TN:
+							result.add(PNG_TN);
+							break;
+						case JPEG_SM_ICO:
+						case JPEG_LRG_ICO:
+						case PNG_SM_ICO:
+						case PNG_LRG_ICO:
+						default:
+							break;
+					}
+				} else {
+					// Handles specified JPEG_RES_H_V profiles and any other "unknowns"
+					DLNAImageProfile profile = toDLNAImageProfile(dlnaProfileName.getValue(), null, protocolInfo.getMimeType());
+					if (profile != null) {
+						result.add(profile);
+						LOGGER.trace(
+							"DLNAImageProfile parsed \"{}\" as {}",
+							protocolInfo,
+							profile
+						);
+					} else if (LOGGER.isDebugEnabled()) {
+						LOGGER.debug(
+							"DLNAImageProfile was unable to parse DLNA profile from \"{}\"",
+							protocolInfo
+						);
+					}
+				}
+				return result;
+			}
+			if (protocolInfo.getProfileName() != null) {
+				// If we find a profile name that isn't a DLNA profile name, we're not interested
+				return result;
+			}
+			MimeType mimeType = protocolInfo.getMimeType();
+			if (
+				mimeType == null ||
+				mimeType.isAnyType() ||
+				mimeType.isAnySubtype()
+			) {
+				result.add(JPEG_TN);
+				result.add(JPEG_SM);
+				result.add(JPEG_MED);
+				result.add(JPEG_LRG);
+				result.add(JPEG_RES_H_V);
+				result.add(PNG_TN);
+				result.add(PNG_LRG);
+				result.add(GIF_LRG);
+				LOGGER.trace(
+					"DLNAImageProfile parsed \"{}\" as all image profiles",
+					protocolInfo
+				);
+			} else if (MIMETYPE_GIF.equals(mimeType)) {
+				result.add(new DLNAImageProfile(GIF_LRG_INT, GIF_LRG_STRING, 1600, 1200, mimeType));
+				LOGGER.trace("DLNAImageProfile parsed \"{}\" as all GIF profiles", protocolInfo);
+			} else if (MIMETYPE_JPEG.equals(mimeType)) {
+				result.add(new DLNAImageProfile(JPEG_LRG_INT, JPEG_LRG_STRING, 4096, 4096, mimeType));
+				result.add(new DLNAImageProfile(JPEG_MED_INT, JPEG_MED_STRING, 1024, 768, mimeType));
+				result.add(new DLNAImageProfile(JPEG_RES_H_V_INT, JPEG_RES_H_V_STRING, -1, -1, mimeType));
+				result.add(new DLNAImageProfile(JPEG_SM_INT, JPEG_SM_STRING, 640, 480, mimeType));
+				result.add(new DLNAImageProfile(JPEG_TN_INT, JPEG_TN_STRING, 160, 160, mimeType));
+				LOGGER.trace("DLNAImageProfile parsed \"{}\" as all JPEG profiles", protocolInfo);
+			} else if (MIMETYPE_PNG.equals(mimeType)) {
+				result.add(new DLNAImageProfile(PNG_LRG_INT, PNG_LRG_STRING, 4096, 4096, mimeType));
+				result.add(new DLNAImageProfile(PNG_TN_INT, PNG_TN_STRING, 160, 160, mimeType));
+				LOGGER.trace("DLNAImageProfile parsed \"{}\" as all PNG profiles", protocolInfo);
+			}
+		}
+		return result;
 	}
 
 	/**
@@ -392,19 +643,38 @@ public class DLNAImageProfile implements Serializable {
 	}
 
 	/**
-	 * @return The mime type for this {@link DLNAImageProfile}.
+	 * @return The {@link MimeType} for this {@link DLNAImageProfile}.
 	 */
-	public String getMimeType() {
+	public MimeType getMimeType() {
+		if (mimeType != null) {
+			return mimeType;
+		}
+		return getDefaultMimeType();
+	}
+
+	/**
+	 * @return The default {@link MimeType} for this
+	 *         {@link DLNAImageProfile}.
+	 */
+	public MimeType getDefaultMimeType() {
 		switch (getFormat()) {
 			case GIF:
-				return "image/gif";
+				return MIMETYPE_GIF;
 			case JPEG:
-				return "image/jpeg";
+				return MIMETYPE_JPEG;
 			case PNG:
-				return "image/png";
+				return MIMETYPE_PNG;
 			default:
 				throw new IllegalStateException("Format is missing from switch statement");
 		}
+	}
+
+	/**
+	 * @return The formatted mime-type {@link String} for this
+	 *         {@link DLNAImageProfile}.
+	 */
+	public String getMimeTypeString() {
+		return getMimeType().toStringWithoutParameters();
 	}
 
 	/**
@@ -1113,6 +1383,28 @@ public class DLNAImageProfile implements Serializable {
 			return false;
 		}
 		return true;
+	}
+
+	@Override
+	public int compareTo(DLNAImageProfile o) {
+		if (o == null) {
+			return -1;
+		}
+		int result = Integer.compare(imageProfileInt, o.imageProfileInt);
+		if (result != 0) {
+			return result;
+		}
+
+		if (imageProfileStr == null && o.imageProfileStr == null) {
+			return 0;
+		}
+		if (imageProfileStr == null) {
+			return 1;
+		}
+		if (o.imageProfileStr == null) {
+			return -1;
+		}
+		return imageProfileStr.compareTo(o.imageProfileStr);
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAImageResElement.java
+++ b/src/main/java/net/pms/dlna/DLNAImageResElement.java
@@ -20,9 +20,13 @@
 package net.pms.dlna;
 
 import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
 import net.pms.dlna.DLNAImageProfile.HypotheticalResult;
+import net.pms.dlna.protocolinfo.ProtocolInfo;
 import net.pms.image.ImageFormat;
 import net.pms.image.ImageInfo;
+import net.pms.network.UPNPControl.Renderer;
 
 /**
  * This class is used to represent a {@code <res>} element representing an image
@@ -353,5 +357,50 @@ public class DLNAImageResElement {
 				return 0;
 			}
 		};
+	}
+
+	/**
+	 * Filter out {@link DLNAImageResElement}s not supported by {@code renderer}.
+	 *
+	 * @param resElements the {@link List} of {@link DLNAImageResElement}s to filter.
+	 * @param renderer the {@link Renderer} to use for filtering.
+	 */
+	public static void filterResElements(List<DLNAImageResElement> resElements, Renderer renderer) {
+		if (
+			renderer == null ||
+			renderer.deviceProtocolInfo == null ||
+			renderer.deviceProtocolInfo.isImageProfilesEmpty()
+		) {
+			return;
+		}
+		Iterator<DLNAImageResElement> iterator = resElements.iterator();
+		while (iterator.hasNext()) {
+			DLNAImageResElement resElement = iterator.next();
+			if (!renderer.deviceProtocolInfo.imageProfilesContains(resElement.getProfile())) {
+				iterator.remove();
+			}
+		}
+	}
+
+	/**
+	 * Checks whether a given {@link DLNAImageProfile} is supported by
+	 * {@code renderer} according to acquired {@link ProtocolInfo} information.
+	 * If no information or no supported image profiles are available, it's
+	 * considered supported. The reason is that not all renderers provide this
+	 * information, which means that all must be assumed supported as opposed to
+	 * none.
+	 *
+	 * @param profile the {@link DLNAImageProfile} whose support to examine.
+	 * @param renderer the {@link Renderer} for which to check supported
+	 *            {@link DLNAImageProfile}s.
+	 * @return {@code true} if {@code profile} is supported or no image profile
+	 *         information is available, {@code false} otherwise.
+	 */
+	public static boolean isImageProfileSupported(DLNAImageProfile profile, Renderer renderer) {
+		return
+			renderer == null ||
+			renderer.deviceProtocolInfo == null ||
+			renderer.deviceProtocolInfo.isImageProfilesEmpty() ||
+			renderer.deviceProtocolInfo.imageProfilesContains(profile);
 	}
 }

--- a/src/main/java/net/pms/dlna/protocolinfo/AribOrJpProfileName.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/AribOrJpProfileName.java
@@ -1,0 +1,147 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA compatible renderers
+ * based on the http://www.ps3mediaserver.org. Copyright (C) 2012 UMS
+ * developers.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import net.pms.dlna.protocolinfo.ProtocolInfoAttributeName.KnownProtocolInfoAttributeName;
+
+/**
+ * This interface represents {@code ARIB.OR.JP_PN} attributes.
+ *
+ * @author Nadahar
+ */
+@SuppressWarnings("checkstyle:InterfaceIsType")
+public interface AribOrJpProfileName extends ProfileName {
+
+	/** The static {@code NONE} instance representing a blank/empty value */
+	AribOrJpProfileName NONE = new DefaultAribOrJpProfileName("");
+
+	/**
+	 * The static factory singleton instance used to create and retrieve
+	 * {@link AribOrJpProfileName} instances.
+	 */
+	AribOrJpProfileNameFactory FACTORY = new AribOrJpProfileNameFactory();
+
+	/** The static attribute name always used for this class */
+	ProtocolInfoAttributeName NAME = KnownProtocolInfoAttributeName.ARIB_OR_JP_PN;
+
+	/**
+	 * A factory for creating, caching and retrieving
+	 * {@link AribOrJpProfileName} instances.
+	 */
+	public static class AribOrJpProfileNameFactory extends AbstractProfileNameFactory<AribOrJpProfileName> {
+
+		/**
+		 * For internal use only, use {@link AribOrJpProfileName#FACTORY} to get
+		 * the singleton instance.
+		 */
+		protected AribOrJpProfileNameFactory() {
+		}
+
+		@Override
+		protected AribOrJpProfileName getNoneInstance() {
+			return NONE;
+		}
+
+		@Override
+		protected AribOrJpProfileName searchKnownInstances(String value) {
+			// Check for known instances
+			for (KnownAribOrJpProfileName knownAttribute : KnownAribOrJpProfileName.values()) {
+				if (value.equals(knownAttribute.getValue())) {
+					return knownAttribute;
+				}
+			}
+			return null;
+		}
+
+		@Override
+		protected AribOrJpProfileName getNewInstance(String value) {
+			return new DefaultAribOrJpProfileName(value);
+		}
+	}
+
+	/**
+	 * This contains predefined {@code ARIB.OR.JP_PN} values.
+	 */
+	public enum KnownAribOrJpProfileName implements AribOrJpProfileName {
+
+		/**
+		 * MPEG2-Video ({@code ISO/IEC 13818-2}) and MPEG2-AAC (
+		 * {@code ISO/IEC 13818-7}) partial transport stream format with time
+		 * stamp with mime-type
+		 * {@code application/X-arib-cp;CONTENTFORMAT=<content-mimetype>}.
+		 * <p>
+		 * For full specification, see <a href=
+		 * "http://www.arib.or.jp/english/html/overview/doc/6-STD-B21v4_6-E1.pdf"
+		 * >ARIB STD – B21</a> chapter <b>9.2.4</b>.
+		 */
+		MPEG_TTS_CP;
+
+		@Override
+		public String getValue() {
+			return super.toString();
+		}
+
+		@Override
+		public String toString() {
+			return NAME + " = " + super.toString();
+		}
+
+		@Override
+		public ProtocolInfoAttributeName getName() {
+			return NAME;
+		}
+
+		@Override
+		public String getNameString() {
+			return NAME.getName();
+		}
+
+		@Override
+		public String getAttributeString() {
+			return NAME + "=" + super.toString();
+		}
+
+	}
+
+	/**
+	 * This is the default, immutable class implementing
+	 * {@link AribOrJpProfileName}. {@link AribOrJpProfileNameFactory} creates
+	 * and caches instances of this class.
+	 */
+	public static class DefaultAribOrJpProfileName extends AbstractDefaultProfileName implements AribOrJpProfileName {
+
+		private static final long serialVersionUID = 1L;
+
+		/**
+		 * For internal use only, use
+		 * {@link AribOrJpProfileNameFactory#createProfileName} to create new
+		 * instances.
+		 *
+		 * @param value the profile name.
+		 */
+		protected DefaultAribOrJpProfileName(String value) {
+			super(value);
+		}
+
+		@Override
+		public ProtocolInfoAttributeName getName() {
+			return NAME;
+		}
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgConversionIndicator.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgConversionIndicator.java
@@ -1,0 +1,166 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import net.pms.dlna.protocolinfo.ProtocolInfoAttributeName.KnownProtocolInfoAttributeName;
+import net.pms.util.ParseException;
+
+/**
+ * This class is immutable and represents the {@code DLNA.ORG_FLAGS} parameter.
+ * This can be used for both DLNA and non-DLNA content.
+ *
+ * @author Nadahar
+ */
+public final class DLNAOrgConversionIndicator implements ProtocolInfoAttribute {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The static attribute name always used for this class */
+	public static final ProtocolInfoAttributeName NAME = KnownProtocolInfoAttributeName.DLNA_ORG_CI;
+
+	/**
+	 * The static factory singleton instance used to retrieve static
+	 * {@link DLNAOrgConversionIndicator} instances.
+	 */
+	public static final DLNAOrgConversionIndicatorFactory FACTORY = new DLNAOrgConversionIndicatorFactory();
+
+	/**
+	 * The static {@code TRUE} instance representing converted/transcoded
+	 * content with the value 1.
+	 */
+	public static final DLNAOrgConversionIndicator TRUE = new DLNAOrgConversionIndicator(true);
+
+	/**
+	 * The static {@code YES} instance representing converted/transcoded content
+	 * with the value 1.
+	 */
+	public static final DLNAOrgConversionIndicator YES = TRUE;
+
+	/**
+	 * The static {@code FALSE} instance representing original/non-transcoded
+	 * content with the value 0.
+	 */
+	public static final DLNAOrgConversionIndicator FALSE = new DLNAOrgConversionIndicator(false);
+
+	/**
+	 * The static {@code NO} instance representing original/non-transcoded
+	 * content with the value 0.
+	 */
+	public static final DLNAOrgConversionIndicator NO = FALSE;
+
+	/** The state */
+	protected final boolean state;
+
+	/**
+	 * For internal use only, use one of the static instances instead.
+	 *
+	 * @see #TRUE
+	 * @see #FALSE
+	 * @see #YES
+	 * @see #NO
+	 *
+	 * @param state the state.
+	 */
+	protected DLNAOrgConversionIndicator(boolean state) {
+		this.state = state;
+	}
+
+	@Override
+	public ProtocolInfoAttributeName getName() {
+		return NAME;
+	}
+
+	@Override
+	public String getNameString() {
+		return NAME.getName();
+	}
+
+	@Override
+	public String getValue() {
+		return state ? "1" : "0";
+	}
+
+	/*
+	 * XXX This currently returns blank for 0/false. While this isn't
+	 * technically correct, it avoids a confusion with some old Panasonic Viera
+	 * renderers which will pick any resource with CI=0 without considering the
+	 * media type. Since the implied value also is CI=0, this shouldn't pose a
+	 * problem.
+	 */
+	@Override
+	public String getAttributeString() {
+		return state ? NAME + "=1" : "";
+	}
+
+	/**
+	 * A factory used to retrieve static {@link DLNAOrgConversionIndicator}
+	 * instances.
+	 */
+	public static class DLNAOrgConversionIndicatorFactory {
+
+		/**
+		 * For internal use only, use {@link DLNAOrgConversionIndicator#FACTORY}
+		 * instead.
+		 */
+		protected DLNAOrgConversionIndicatorFactory() {
+		}
+
+		/**
+		 * Retrieves a static {@link DLNAOrgConversionIndicator} instance by
+		 * parsing {@code value}. Valid values are {@code "0"} or {@code "1"}
+		 * only. If {@code value} is {@code null} or blank,
+		 * {@link DLNAOrgConversionIndicator#FALSE} is returned.
+		 *
+		 * @param value the {@code DLNA.ORG_CI} attribute value to parse.
+		 * @return The corresponding {@link DLNAOrgConversionIndicator}
+		 *         instance.
+		 * @throws ParseException if {@code value} can't be parsed.
+		 */
+		public DLNAOrgConversionIndicator getConversionIndicator(String value) throws ParseException {
+			if (isBlank(value)) {
+				return FALSE;
+			}
+
+			value = value.trim();
+			switch (value) {
+				case "0":
+					return FALSE;
+				case "1":
+					return TRUE;
+				default:
+					throw new ParseException("Cannot parse DLNA conversion indicator value \"" + value + "\"");
+			}
+		}
+
+		/**
+		 * Retrieves a static {@link DLNAOrgConversionIndicator} instance
+		 * corresponding to the given argument.
+		 *
+		 * @param ci the {@code DLNA.ORG_CI} flag value.
+		 * @return The corresponding {@link DLNAOrgConversionIndicator}
+		 *         instance.
+		 */
+		public DLNAOrgConversionIndicator getConversionIndicator(boolean ci) {
+			return ci ? TRUE : FALSE;
+		}
+	}
+
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgFlags.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgFlags.java
@@ -1,0 +1,642 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import net.pms.dlna.MediaType;
+import net.pms.dlna.protocolinfo.ProtocolInfoAttributeName.KnownProtocolInfoAttributeName;
+
+/**
+ * This class is immutable and represents the {@code DLNA.ORG_FLAGS} parameter.
+ * This can only be used for DLNA content.
+ *
+ * @author Nadahar
+ */
+public class DLNAOrgFlags implements ProtocolInfoAttribute {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The first/most significant bits/flags. */
+	protected final long high;
+
+	/** The last/least significant bits/flags. */
+	protected final long low;
+
+	/** The static name of this attribute. */
+	public static final ProtocolInfoAttributeName NAME = KnownProtocolInfoAttributeName.DLNA_ORG_FLAGS;
+
+	/**
+	 * A {@link DLNAOrgFlags} instance that represents the implied flags where
+	 * all flags are 0 and results in an empty parameter string.
+	 */
+	public static final DLNAOrgFlags IMPLIED = new DLNAOrgFlags(0, 0);
+
+	/**
+	 * Calculates the "effective" flags for a {@link DLNAOrgFlags} instance by
+	 * applying DLNA conditional rules for some flags. {@code null} can be
+	 * passed to get the flags that represent an omitted {@code DLNA.ORG_FLAGS}
+	 * parameter.
+	 *
+	 * @param flags the {@link DLNAOrgFlags} instance to process.
+	 * @param mediaType the {@link MediaType} of the media for which this flag
+	 *            applies.
+	 * @return A new {@link DLNAOrgFlags} instance where illegal combinations
+	 *         have been corrected.
+	 */
+	public static DLNAOrgFlags getEffectiveFlags(DLNAOrgFlags flags, MediaType mediaType) {
+		long high = flags == null ? 0 : flags.high;
+
+		if (flags == null || !flags.isDLNA15()) {
+			high &= ~(1L << 63);
+			high &= ~(1L << 62);
+			high &= ~(1L << 61);
+			high &= ~(1L << 60);
+			high &= ~(1L << 59);
+			high &= ~(1L << 58);
+			high &= ~(1L << 57);
+			if (mediaType == MediaType.AUDIO || mediaType == MediaType.VIDEO) {
+				high |= 1L << 56;
+			} else {
+				high &= ~(1L << 56);
+			}
+			// XHTML Print documents and media collection files too, when/if there is a MediaType for those
+			if (mediaType == MediaType.IMAGE) {
+				high |= 1L << 55;
+			} else {
+				high &= ~(1L << 55);
+			}
+			high &= ~(1L << 54);
+			if (flags != null) {
+				if (flags.isCleartextByteFullDataSeek()) {
+					high |= 1L << 48;
+				}
+			}
+			high &= ~(1L << 46);
+		} else {
+			if (flags.isCleartextByteFullDataSeek() || flags.isCleartextLimitedDataSeek()) {
+				high |= 1L << 48;
+			}
+		}
+		if (high == 0 && (flags == null || flags.low == 0)) {
+			return IMPLIED;
+		}
+		return new DLNAOrgFlags(high, flags == null ? 0 : flags.low);
+	}
+
+	/**
+	 * Creates a new {@link DLNAOrgFlagsBuilder} instance which can be used
+	 * to {@link #build} an {@link DLNAOrgFlags} instance.
+	 *
+	 * @param isDLNA15 Sets bit 20: dlna-v1.5-flag (DLNA v1.5 versioning
+	 *            flag).
+	 * @return The {@link DLNAOrgFlagsBuilder} instance.
+	 */
+	public static DLNAOrgFlagsBuilder builder(boolean isDLNA15) {
+		return new DLNAOrgFlagsBuilder(isDLNA15);
+	}
+
+	/**
+	 * Creates a new {@link DLNAOrgFlags} instance based on a string of
+	 * hexadecimal digits. The argument can be either only the "primary-flags"
+	 * (the first 8 digits) or the full flag (all 32 digits). values.
+	 *
+	 * @param hexValue the {@link String} containing only characters
+	 *            representing hexadecimal values ({@code 0-9, a-f, A-F}).
+	 */
+	public DLNAOrgFlags(String hexValue) {
+		if (StringUtils.isBlank(hexValue)) {
+			throw new IllegalArgumentException("hexValue cannot be empty");
+		}
+		try {
+			if (hexValue.length() == 8) {
+				high = Long.parseLong(hexValue, 16) << 32;
+				low = 0;
+			} else if (hexValue.length() == 32) {
+				high = Long.parseLong(hexValue.substring(0, 8), 16) << 32 + Long.parseLong(hexValue.substring(8, 16), 16); //Unsigned
+				low  = Long.parseLong(hexValue.substring(16, 24), 16) << 32 + Long.parseLong(hexValue.substring(24), 16); //Unsigned
+			} else {
+				throw new IllegalArgumentException("hexValue must be 8 or 32 digits long");
+			}
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException("hexValue must be a valid hexadecimal number with 8 or 32 digits", e);
+		}
+	}
+
+	/**
+	 * Creates a new {@link DLNAOrgFlags} instance based on the given bit
+	 * values.
+	 *
+	 * @param highValue the first 64 bits/flags.
+	 * @param lowValue the last 64 bits/flags.
+	 */
+	public DLNAOrgFlags(long highValue, long lowValue) {
+		this.high = highValue;
+		this.low = lowValue;
+	}
+
+	/**
+	 * Bit-31: sp-flag (Sender Paced flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isSenderPaced() {
+		return ((high >> 63) & 1) == 1;
+	}
+
+	/**
+	 * Bit-30: lop-npt (Limited Operations flag: Time-Based Seek).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isLimitedOperationsTimeBasedSeek() {
+		return ((high >> 62) & 1) == 1;
+	}
+
+	/**
+	 * Bit-29: lop-bytes (Limited Operations flag: Byte-Based Seek).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isLimitedOperationsByteBasedSeek() {
+		return ((high >> 61) & 1) == 1;
+	}
+
+	/**
+	 * Bit-28: playcontainer-param (DLNA PlayContainer flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isPlayContainer() {
+		return ((high >> 60) & 1) == 1;
+	}
+
+	/**
+	 * Bit 27: s0-increasing (UCDAM s0 Increasing flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isS0Increasing() {
+		return ((high >> 59) & 1) == 1;
+	}
+
+	/**
+	 * Bit 26: sN-increasing (UCDAM sN Increasing flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isSNIncreasing() {
+		return ((high >> 58) & 1) == 1;
+	}
+
+	/**
+	 * Bit-25: rtsp-pause (Pause media operation support for RTP Serving
+	 * Endpoints).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isRtspPause() {
+		return ((high >> 57) & 1) == 1;
+	}
+
+	/**
+	 * Bit 24: tm-s (Streaming mode flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isStreamingMode() {
+		return ((high >> 56) & 1) == 1;
+	}
+
+	/**
+	 * Bit 23: tm-i (Interactive mode flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isInteractive() {
+		return ((high >> 55) & 1) == 1;
+	}
+
+	/**
+	 * Bit 22: tm-b (Background mode flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isBackgroundMode() {
+		return ((high >> 54) & 1) == 1;
+	}
+
+	/**
+	 * Bit 21: http-stalling (HTTP Connection Stalling flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isHttpConnectionStalling() {
+		return ((high >> 53) & 1) == 1;
+	}
+
+	/**
+	 * Bit 20: dlna-v1.5-flag (DLNA v1.5 versioning flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isDLNA15() {
+		return ((high >> 52) & 1) == 1;
+	}
+
+	/**
+	 * Bit 16: LP-flag (Link Protected content flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isLinkProtectedContent() {
+		return ((high >> 48) & 1) == 1;
+	}
+
+	/**
+	 * Bit 15: cleartextbyteseek-full flag (Cleartext Byte Full Data Seek flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isCleartextByteFullDataSeek() {
+		return ((high >> 47) & 1) == 1;
+	}
+
+	/**
+	 * Bit 14: lop-cleartextbytes flag (Cleartext Limited Data Seek flag).
+	 *
+	 * @return {@code true} if the flag is {@code 1}, {@code false} if the flag
+	 *         is {@code 0}.
+	 */
+	public boolean isCleartextLimitedDataSeek() {
+		return ((high >> 46) & 1) == 1;
+	}
+
+	/**
+	 * Calculates the "effective" flags for this {@link DLNAOrgFlags} instance
+	 * by applying DLNA conditional rules for some flags.
+	 *
+	 * @param mediaType the {@link MediaType} of the media for which this
+	 *            instance applies.
+	 * @return The new {@link DLNAOrgFlags} instance where illegal combinations
+	 *         have been corrected.
+	 */
+	public DLNAOrgFlags getEffectiveFlags(MediaType mediaType) {
+		return DLNAOrgFlags.getEffectiveFlags(this, mediaType);
+	}
+
+	@Override
+	public ProtocolInfoAttributeName getName() {
+		return NAME;
+	}
+
+	@Override
+	public String getNameString() {
+		return NAME.getName();
+	}
+
+	@Override
+	public String getValue() {
+		DLNAOrgFlags flags = DLNAOrgFlags.getEffectiveFlags(this, MediaType.UNKNOWN);
+		return String.format("%016x", flags.high) + String.format("%016x", flags.low);
+	}
+
+	/**
+	 * Returns a formatted {@code DLNA.ORG_FLAGS} attribute string for use in
+	 * {@code protocolInfo}. If this {@link DLNAOrgFlags} instance has an empty
+	 * value, or represents the implied default
+	 * {@code DLNA.ORG_FLAGS=00000000000000000000000000000000}, an empty string
+	 * is returned.
+	 *
+	 * @return The formatted {@code DLNA.ORG_FLAGS} attribute or an empty
+	 *         {@link String}.
+	 */
+	@Override
+	public String getAttributeString() {
+		DLNAOrgFlags flags = DLNAOrgFlags.getEffectiveFlags(this, MediaType.UNKNOWN);
+		if (flags.high == 0 || (flags.high & ~(3L << 55)) == 0) {
+			return "";
+		}
+		return
+			NAME + "=" +
+			String.format("%016x", flags.high) + String.format("%016x", flags.low);
+	}
+
+	/**
+	 * Gets the first 32 bits representing the {@code primary-flags}.
+	 *
+	 * @return The most significant {@link Integer}.
+	 */
+	public int getPrimaryValue() {
+		return (int) (high >> 32);
+	}
+
+	/**
+	 * Gets the first 64 bits of the 128 bits in {@code DLNA.ORG_FLAGS}.
+	 *
+	 * @return The most significant {@link Long}.
+	 */
+	public long getHighValue() {
+		return high;
+	}
+
+	/**
+	 * Gets the last 64 bits of the 128 bits in {@code DLNA.ORG_FLAGS}.
+	 *
+	 * @return The least significant {@link Long}.
+	 */
+	public long getLowValue() {
+		return low;
+	}
+
+	@Override
+	public String toString() {
+		List<String> enabledFlags = new ArrayList<>();
+		if (isSenderPaced()) {
+			enabledFlags.add("Sender Paced");
+		}
+		if (isLimitedOperationsTimeBasedSeek()) {
+			enabledFlags.add("Limited Operations: Time Based Seek");
+		}
+		if (isLimitedOperationsByteBasedSeek()) {
+			enabledFlags.add("Limited Operations: Byte Based Seek");
+		}
+		if (isS0Increasing()) {
+			enabledFlags.add("UCDAM s0 Increasing");
+		}
+		if (isSNIncreasing()) {
+			enabledFlags.add("UCDAM sN Increasing");
+		}
+		if (isRtspPause()) {
+			enabledFlags.add("RTSP Pause");
+		}
+		if (isStreamingMode()) {
+			enabledFlags.add("Streaming Mode");
+		}
+		if (isInteractive()) {
+			enabledFlags.add("Interactive");
+		}
+		if (isBackgroundMode()) {
+			enabledFlags.add("Background Mode");
+		}
+		if (isHttpConnectionStalling()) {
+			enabledFlags.add("HTTP Connection Stalling");
+		}
+		if (isDLNA15()) {
+			enabledFlags.add("DLNA 1.5");
+		}
+		if (isLinkProtectedContent()) {
+			enabledFlags.add("Link Protected Content");
+		}
+		if (isCleartextByteFullDataSeek()) {
+			enabledFlags.add("Cleartext Byte Full Data Seek");
+		}
+		if (isCleartextLimitedDataSeek()) {
+			enabledFlags.add("Cleartext Limited Data Seek");
+		}
+		return NAME + " = " + enabledFlags.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (int) (high ^ (high >>> 32));
+		result = prime * result + (int) (low ^ (low >>> 32));
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof DLNAOrgFlags)) {
+			return false;
+		}
+		DLNAOrgFlags other = (DLNAOrgFlags) obj;
+		if (high != other.high) {
+			return false;
+		}
+		if (low != other.low) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * A builder class to build {@link DLNAOrgFlags} instances by setting
+	 * individual flags.
+	 */
+	public static class DLNAOrgFlagsBuilder {
+
+		/** The first/most significant bits/flags. */
+		protected long high;
+
+		/** The last/least significant bits/flags. */
+		protected long low;
+
+		/**
+		 * Creates a new {@link DLNAOrgFlagsBuilder} instance which can be used
+		 * to {@link #build} an {@link DLNAOrgFlags} instance.
+		 *
+		 * @param isDLNA15 Sets bit 20: dlna-v1.5-flag (DLNA v1.5 versioning
+		 *            flag).
+		 */
+		public DLNAOrgFlagsBuilder(boolean isDLNA15) {
+			high = (isDLNA15 ? 1L : 0L) << 52;
+			low = 0;
+		}
+
+		/**
+		 * Creates a {@link DLNAOrgFlags} instance from this {@link DLNAOrgFlagsBuilder}.
+		 *
+		 * @return The new {@link DLNAOrgFlags} instance.
+		 */
+		public DLNAOrgFlags build() {
+			return high == 0 && low == 0 ? IMPLIED : new DLNAOrgFlags(high, low);
+		}
+
+		/**
+		 * Sets bit-31: sp-flag (Sender Paced flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder senderPaced() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 63 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit-30: lop-npt (Limited Operations flag: Time-Based Seek).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder limitedOperationsTimeBasedSeek() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 62 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit-29: lop-bytes (Limited Operations flag: Byte-Based Seek).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder limitedOperationsByteBasedSeek() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 61 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit-28: playcontainer-param (DLNA PlayContainer flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder playContainer() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 60 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit 27: s0-increasing (UCDAM s0 Increasing flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder s0Increasing() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 59 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit 26: sN-increasing (UCDAM sN Increasing flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder sNIncreasing() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 58 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit-25: rtsp-pause (Pause media operation support for RTP
+		 * Serving Endpoints).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder rtspPause() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 57 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit 24: tm-s (Streaming mode flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder streamingMode() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 56 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit 23: tm-i (Interactive mode flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder interactive() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 55 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit 22: tm-b (Background mode flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder backgroundMode() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 54 : 0;
+			return this;
+		}
+
+		/**
+		 * Sets bit 21: http-stalling (HTTP Connection Stalling flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder httpConnectionStalling() {
+			high |= 1L << 53;
+			return this;
+		}
+
+		/**
+		 * Sets bit 16: LP-flag (Link Protected content flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder linkProtectedContent() {
+			high |= 1L << 48;
+			return this;
+		}
+
+		/**
+		 * Sets bit 15: cleartextbyteseek-full flag (Cleartext Byte Full Data
+		 * Seek flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder cleartextByteFullDataSeek() {
+			high |= 1L << 47;
+			high |= 1L << 48;
+			return this;
+		}
+
+		/**
+		 * Sets bit 14: lop-cleartextbytes flag (Cleartext Limited Data Seek
+		 * flag).
+		 *
+		 * @return The {@link DLNAOrgFlagsBuilder} instance.
+		 */
+		public DLNAOrgFlagsBuilder cleartextLimitedDataSeek() {
+			high |= ((high >> 52) & 1) == 1 ? 1L << 46 : 0;
+			if (((high >> 46) & 1) == 1) {
+				high |= 1L << 48;
+			}
+			return this;
+		}
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgOperations.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgOperations.java
@@ -1,0 +1,342 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA compatible renderers
+ * based on the http://www.ps3mediaserver.org. Copyright (C) 2012 UMS
+ * developers.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.fourthline.cling.support.model.Protocol;
+import net.pms.dlna.protocolinfo.ProtocolInfoAttributeName.KnownProtocolInfoAttributeName;
+import net.pms.util.ParseException;
+
+/**
+ * This class represents {@code DLNA.ORG_OP} attributes. This can be used for
+ * both DLNA and non-DLNA content.
+ *
+ * @author Nadahar
+ */
+public abstract class DLNAOrgOperations implements ProtocolInfoAttribute {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The static attribute name always used for this class */
+	public static final ProtocolInfoAttributeName NAME = KnownProtocolInfoAttributeName.DLNA_ORG_OP;
+
+	/**
+	 * The static factory singleton instance used to retrieve
+	 * {@link DLNAOrgOperations} instances.
+	 */
+	public static final DLNAOrgOperationsFactory FACTORY = new DLNAOrgOperationsFactory();
+
+	/** The state */
+	protected final byte state;
+
+	/**
+	 * For internal use only, use {@link #FACTORY} to get instances.
+	 *
+	 * @param flagA flag A.
+	 * @param flagB flag B.
+	 */
+	protected DLNAOrgOperations(boolean flagA, boolean flagB) {
+		state = packFlags(flagA, flagB);
+	}
+
+	@Override
+	public ProtocolInfoAttributeName getName() {
+		return NAME;
+	}
+
+	@Override
+	public String getNameString() {
+		return NAME.getName();
+	}
+
+	@Override
+	public String getValue() {
+		return state > 0 ? ((state & 2) > 0 ? "1" : "0") + ((state & 1) > 0 ? "1" : "0") : "";
+	}
+
+	@Override
+	public String getAttributeString() {
+		String result = getValue();
+		return isBlank(result) ? "" : NAME + "=" + result;
+	}
+
+	/**
+	 * Validates if this {@link DLNAOrgOperations} instance can be used together
+	 * with a given {@link DLNAOrgFlags} instance without breaking DLNA rules.
+	 *
+	 * @param flags the {@link DLNAOrgFlags} instance to validate against.
+	 * @return {@code true} if validation succeeded or {@code flags} was
+	 *         {@code null}, {@code false} otherwise.
+	 */
+	public boolean validate(DLNAOrgFlags flags) {
+		// Assuming that "null" means no FLAGS parameter
+		if (flags != null && state > 0) {
+			if (flags.isS0Increasing() || flags.isLimitedOperationsTimeBasedSeek() || flags.isLimitedOperationsByteBasedSeek()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Validates if this {@link DLNAOrgOperations} instance can be used in a
+	 * given {@link ProtocolInfo} instance without breaking DLNA rules.
+	 * <p>
+	 * <b>Note:</b> Currently {@code res@size} and {@code res@duration} isn't
+	 * implemented in {@link ProtocolInfo}, which means that the related
+	 * requirements can't be verified.
+	 *
+	 * @param protocolInfo the {@link ProtocolInfo} instance to verify for.
+	 * @return {@code true} if the validation succeeded, false otherwise.
+	 */
+	public boolean validate(ProtocolInfo protocolInfo) {
+		return validate(protocolInfo.getFlags());
+		// XXX When implemented in ProtocolInfo, verify that Size is given if B
+		// flag is true
+		// XXX When implemented in ProtocolInfo, verify that Duration is given
+		// if A flag is true
+	}
+
+	/**
+	 * For internal use only, packs the flags into bits in a {@code byte}.
+	 *
+	 * @param flagA flag A.
+	 * @param flagB flag B.
+	 * @return A byte with the corresponding bits set.
+	 */
+	protected static byte packFlags(boolean flagA, boolean flagB) {
+		return (byte) ((flagA ? 2 : 0) | (flagB ? 1 : 0));
+	}
+
+	/**
+	 * A factory for retrieving static {@link DLNAOrgOperations} instances.
+	 */
+	public static class DLNAOrgOperationsFactory {
+
+		/** Internal regex pattern for validation of strings for parsing */
+		protected static final Pattern STRING_PATTERN = Pattern.compile("^\\s*([01])([01])\\s*$");
+
+		/**
+		 * For internal use only, use {@link DLNAOrgOperations#FACTORY} to get
+		 * the singleton instance.
+		 */
+		protected DLNAOrgOperationsFactory() {
+		}
+
+		/**
+		 * Retrieves the correct static {@link DLNAOrgOperationsHTTP} or
+		 * {@link DLNAOrgOperationsRTP} instance by parsing a
+		 * {@code DLNA.ORG_OP} string value. Only the form {@code "nn"} where
+		 * {@code n} is either {@code 0} or {@code 1} is valid.
+		 * <p>
+		 * If {@code protocol} is anything but {@link Protocol#HTTP_GET} or
+		 * {@link Protocol#RTSP_RTP_UDP}, {@code null} is returned. If
+		 * {@code value} is {@code null} or blank, it is parsed as if it were
+		 * {@code "00"}.
+		 *
+		 * @param protocol the {@link Protocol} for which this
+		 *            {@link DLNAOrgOperations} instance applies.
+		 * @param value the {@code DLNA.ORG_OP} string value.
+		 * @return The corresponding static {@link DLNAOrgOperationsHTTP} or
+		 *         {@link DLNAOrgOperationsRTP} instance, or {@code null} if
+		 *         none could be found.
+		 * @throws ParseException if {@code value} can't be parsed.
+		 */
+		public DLNAOrgOperations getOperations(Protocol protocol, String value) throws ParseException {
+			if (protocol == null) {
+				return null;
+			}
+			if (isBlank(value)) {
+				return getOperations(protocol, false, false);
+			}
+			Matcher matcher = STRING_PATTERN.matcher(value);
+			if (!matcher.find()) {
+				throw new ParseException("Unable to parse \"" + value + "\" as a DLNA operations value");
+			}
+
+			return getOperations(protocol, "1".equals(matcher.group(1)), "1".equals(matcher.group(2)));
+		}
+
+		/**
+		 * Retrieves the correct static {@link DLNAOrgOperationsHTTP} or
+		 * {@link DLNAOrgOperationsRTP} instance based on {@code flags}.
+		 * {@link DLNAOrgOperationsFlags#TIME_SEEK} is ignored for
+		 * {@link Protocol#RTSP_RTP_UDP}.
+		 * <p>
+		 * If {@code protocol} is anything but {@link Protocol#HTTP_GET} or
+		 * {@link Protocol#RTSP_RTP_UDP}, {@code null} is returned. If
+		 * {@code flags} is {@code null}, it is parsed as if it were empty.
+		 *
+		 * @param protocol the {@link Protocol} for which this
+		 *            {@link DLNAOrgOperations} instance applies.
+		 * @param flags the {@link DLNAOrgOperationsFlags} to set.
+		 * @return The corresponding static {@link DLNAOrgOperationsHTTP} or
+		 *         {@link DLNAOrgOperationsRTP} instance, or {@code null} if
+		 *         none could be found.
+		 */
+		public DLNAOrgOperations getOperations(Protocol protocol, DLNAOrgOperationsFlags... flags) {
+			boolean flagA = false;
+			boolean flagB = false;
+			if (flags != null && protocol == Protocol.HTTP_GET) {
+				for (DLNAOrgOperationsFlags flag : flags) {
+					flagA = flag == DLNAOrgOperationsFlags.TIME_SEEK;
+					flagB = flag == DLNAOrgOperationsFlags.HEADER;
+				}
+			} else if (flags != null && protocol == Protocol.RTSP_RTP_UDP) {
+				for (DLNAOrgOperationsFlags flag : flags) {
+					flagA = flag == DLNAOrgOperationsFlags.HEADER;
+				}
+			} else {
+				return null;
+			}
+			return getOperations(protocol, flagA, flagB);
+		}
+
+		/**
+		 * Retrieves the correct static {@link DLNAOrgOperationsHTTP} or
+		 * {@link DLNAOrgOperationsRTP} instance based on {@code flagA} and
+		 * {@code flagB}. {@code flagB} is ignored for
+		 * {@link Protocol#RTSP_RTP_UDP}.
+		 * <p>
+		 * If {@code protocol} is anything but {@link Protocol#HTTP_GET} or
+		 * {@link Protocol#RTSP_RTP_UDP}, {@code null} is returned.
+		 *
+		 * @param protocol the {@link Protocol} for which this
+		 *            {@link DLNAOrgOperations} instance applies.
+		 * @param flagA the first flag.
+		 * @param flagB the second flag.
+		 * @return The corresponding static {@link DLNAOrgOperationsHTTP} or
+		 *         {@link DLNAOrgOperationsRTP} instance, or {@code null} if
+		 *         none could be found.
+		 */
+		public DLNAOrgOperations getOperations(Protocol protocol, boolean flagA, boolean flagB) {
+			if (protocol == Protocol.HTTP_GET) {
+				switch (packFlags(flagA, flagB)) {
+					case 1:
+						return DLNAOrgOperationsHTTP.HTTP_HEADER;
+					case 2:
+						return DLNAOrgOperationsHTTP.HTTP_TIME_SEEK;
+					case 3:
+						return DLNAOrgOperationsHTTP.HTTP_BOTH;
+					default:
+						return DLNAOrgOperationsHTTP.NONE;
+				}
+			} else if (protocol == Protocol.RTSP_RTP_UDP) {
+				switch (packFlags(flagA, flagB)) {
+					case 2:
+						return DLNAOrgOperationsRTP.RTP_HEADER;
+					default:
+						return DLNAOrgOperationsRTP.NONE;
+				}
+			}
+			return null;
+		}
+
+	}
+
+	/**
+	 * This class represents {@code DLNA.ORG_OP} attributes for HTTP transports.
+	 * This can be used for both DLNA and non-DLNA content.
+	 *
+	 * @author Nadahar
+	 */
+	public static class DLNAOrgOperationsHTTP extends DLNAOrgOperations {
+
+		private static final long serialVersionUID = 1L;
+
+		/** Neither flag is set, corresponds to {@code "00"} */
+		public static final DLNAOrgOperations NONE = new DLNAOrgOperationsHTTP(false, false);
+
+		/**
+		 * {@code TimeSeekRange.dlna.org} HTTP header support is set, corresponds
+		 * to {@code "10"}
+		 */
+		public static final DLNAOrgOperations HTTP_TIME_SEEK = new DLNAOrgOperationsHTTP(true, false);
+
+
+		/** Range HTTP header support is set, corresponds to {@code "01"} */
+		public static final DLNAOrgOperations HTTP_HEADER = new DLNAOrgOperationsHTTP(false, true);
+
+		/**
+		 * Both {@code TimeSeekRange.dlna.org} HTTP header and Range HTTP header
+		 * support is set, corresponds to {@code "11"}
+		 */
+		public static final DLNAOrgOperations HTTP_BOTH = new DLNAOrgOperationsHTTP(true, true);
+
+		/**
+		 * For internal use only, use that static instances or
+		 * {@link DLNAOrgOperations#FACTORY} to retrieve instances.
+		 *
+		 * @see #NONE
+		 * @see #HTTP_TIME_SEEK
+		 * @see #HTTP_HEADER
+		 * @see #HTTP_BOTH
+		 *
+		 * @param timeSeekRange the {@code TimeSeekRange.dlna.org} HTTP header
+		 *            flag.
+		 * @param rangeHttpHeader the Range HTTP header flag.
+		 */
+		protected DLNAOrgOperationsHTTP(boolean timeSeekRange, boolean rangeHttpHeader) {
+			super(timeSeekRange, rangeHttpHeader);
+		}
+	}
+
+	/**
+	 * This class represents {@code DLNA.ORG_OP} attributes for RTP transports.
+	 * This can be used for both DLNA and non-DLNA content.
+	 *
+	 * @author Nadahar
+	 */
+	public static class DLNAOrgOperationsRTP extends DLNAOrgOperations {
+
+		private static final long serialVersionUID = 1L;
+
+		/** Neither flag is set, corresponds to {@code "00"} */
+		public static final DLNAOrgOperations NONE = new DLNAOrgOperationsRTP(false);
+
+		/** Range header support is set, corresponds to {@code "10"} */
+		public static final DLNAOrgOperations RTP_HEADER = new DLNAOrgOperationsRTP(true);
+
+		/**
+		 * For internal use only, use that static instances or
+		 * {@link DLNAOrgOperations#FACTORY} to retrieve instances.
+		 *
+		 * @see #NONE
+		 * @see #RTP_HEADER
+		 *
+		 * @param rangeHeader the Range header flag.
+		 */
+		protected DLNAOrgOperationsRTP(boolean rangeHeader) {
+			super(rangeHeader, false);
+		}
+	}
+
+	/**
+	 * This {@code enum} represents the individual {@code DLNA.ORG_OP} flags.
+	 */
+	public enum DLNAOrgOperationsFlags {
+		/** {@code TimeSeekRange.dlna.org} HTTP header */
+		TIME_SEEK,
+
+		/** Range HTTP header or Range header depending on the {@link Protocol} */
+		HEADER;
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgPlaySpeeds.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgPlaySpeeds.java
@@ -1,0 +1,405 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import net.pms.dlna.protocolinfo.ProtocolInfoAttributeName.KnownProtocolInfoAttributeName;
+import net.pms.util.Rational;
+
+/**
+ * This class is immutable and represents {@code DLNA.ORG_PS} attributes. This
+ * can be used for both DLNA and non-DLNA content.
+ *
+ * @author Nadahar
+ */
+public class DLNAOrgPlaySpeeds implements ProtocolInfoAttribute {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The static {@code NONE} instance representing a blank/empty value */
+	public static final DLNAOrgPlaySpeeds NONE = new DLNAOrgPlaySpeeds(new Rational[0]);
+
+	/**
+	 * The static factory used to create and retrieve {@link DLNAOrgPlaySpeeds}
+	 * instances.
+	 */
+	public static final DLNAOrgPlaySpeedsFactory FACTORY = new DLNAOrgPlaySpeedsFactory();
+
+	/** The static attribute name always used for this class */
+	public static final ProtocolInfoAttributeName NAME = KnownProtocolInfoAttributeName.DLNA_ORG_PS;
+
+	/** The {@link Set} of {@link Rational} play speeds */
+	protected final SortedSet<Rational> speeds;
+
+	/** The cached {@link String} representation. */
+	protected final String stringValue;
+
+	/** The cached {@code hashCode} */
+	protected final int hashCode;
+
+	/**
+	 * For internal use only, use {@link #FACTORY} to create new instances.
+	 *
+	 * @param speeds the play-speed values.
+	 */
+	private DLNAOrgPlaySpeeds(Rational... speeds) {
+		TreeSet<Rational> speedSet = new TreeSet<>();
+		for (Rational speed : speeds) {
+			if (speed != null && !Rational.ONE.equals(speed)) {
+				speedSet.add(speed);
+			}
+		}
+		this.speeds = Collections.unmodifiableSortedSet(speedSet);
+		this.stringValue = generateStringValue(this.speeds);
+		this.hashCode = calculateHashCode();
+	}
+
+	/**
+	 * For internal use only, use {@link #FACTORY} to create new instances.
+	 *
+	 * @param speeds the play-speed values.
+	 */
+	private DLNAOrgPlaySpeeds(SortedSet<Rational> speedSet) {
+		TreeSet<Rational> newSpeedsSet = new TreeSet<>();
+		for (Rational speed : speedSet) {
+			if (speed != null && !Rational.ONE.equals(speed)) {
+				newSpeedsSet.add(speed);
+			}
+		}
+		speeds = Collections.unmodifiableSortedSet(newSpeedsSet);
+		stringValue = generateStringValue(speeds);
+		hashCode = calculateHashCode();
+	}
+
+
+	/**
+	 * @return The unmodifiable {@link Set} or {@link Rational} play speeds for
+	 *         this {@link DLNAOrgPlaySpeeds} instance.
+	 */
+	public SortedSet<Rational> getSpeeds() {
+		return speeds;
+	}
+
+	@Override
+	public ProtocolInfoAttributeName getName() {
+		return NAME;
+	}
+
+	@Override
+	public String getNameString() {
+		return NAME.getName();
+	}
+
+	@Override
+	public String getValue() {
+		return stringValue;
+	}
+
+	@Override
+	public String getAttributeString() {
+		return isBlank(stringValue) ? "" : NAME + "=" + stringValue;
+	}
+
+	@Override
+	public String toString() {
+		return stringValue;
+	}
+
+	@Override
+	public int hashCode() {
+		return hashCode;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (object == null) {
+			return false;
+		}
+		if (!(object instanceof DLNAOrgPlaySpeeds)) {
+			return false;
+		}
+		DLNAOrgPlaySpeeds other = (DLNAOrgPlaySpeeds) object;
+		if (speeds == null) {
+			return other.speeds == null;
+		} else if (speeds.size() != other.speeds.size()) {
+			return false;
+		}
+		// Using the cached hashCode for performance
+		return hashCode == other.hashCode;
+	}
+
+	/**
+	 * Generates a string representation of a {@link Set} of {@link Rational}
+	 * play speeds. Used for generating the cached string representation.
+	 *
+	 * @param speeds the {@link Set} of {@link Rational} play speeds.
+	 * @return The {@link String} representation.
+	 */
+	protected static String generateStringValue(SortedSet<Rational> speeds) {
+		StringBuilder sb = new StringBuilder();
+		for (Rational speed : speeds) {
+			if (speed != null && !Rational.ONE.equals(speed)) {
+				if (sb.length() > 0) {
+					sb.append(",");
+				}
+				sb.append(speed);
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Calculates the cached {@code hashCode}.
+	 *
+	 * @return the calculated {@code hashCode}.
+	 */
+	protected int calculateHashCode() {
+		final int prime = 31;
+		int result = 1;
+		if (speeds == null) {
+			result = prime * result;
+		} else {
+			for (Rational speed : speeds) {
+				if (speed != null) {
+					result = prime * result + speed.hashCode();
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * A factory for creating, caching and retrieving {@link DLNAOrgPlaySpeeds}
+	 * instances.
+	 */
+	public static class DLNAOrgPlaySpeedsFactory {
+
+		/** The instance cache lock. */
+		protected final ReentrantReadWriteLock instanceCacheLock = new ReentrantReadWriteLock();
+
+		/** The instance cache. */
+		protected final HashSet<DLNAOrgPlaySpeeds> instanceCache = new HashSet<>();
+
+		/**
+		 * For internal use only, use {@link DLNAOrgPlaySpeeds#FACTORY} to get
+		 * the singleton instance.
+		 */
+		private DLNAOrgPlaySpeedsFactory() {
+		}
+
+		/**
+		 * Retrieves an instance of {@link DLNAOrgPlaySpeeds} representing the
+		 * comma separated list of play speeds in {@code values} from the
+		 * predefined instances or the cache. If no such
+		 * {@link DLNAOrgPlaySpeeds} instance exists, {@code null} is returned.
+		 *
+		 * @param values a comma separated list of play speeds in rational form.
+		 * @return The {@link DLNAOrgPlaySpeeds} instance or {@code null}.
+		 * @throws NumberFormatException If {@code values} cannot be parsed.
+		 */
+		public DLNAOrgPlaySpeeds getPlaySpeeds(String values) {
+
+			// Check for static instances
+			if (isBlank(values)) {
+				return NONE;
+			}
+
+			// Parse the values
+			values = values.trim();
+			String[] valueArray = values.split("\\s*,\\s*");
+			TreeSet<Rational> valueSet = new TreeSet<>();
+			for (String value : valueArray) {
+				if (isNotBlank(value)) {
+					valueSet.add(new Rational(value));
+				}
+			}
+			return getPlaySpeeds(valueSet);
+		}
+
+		/**
+		 * Retrieves an instance of {@link DLNAOrgPlaySpeeds} representing the
+		 * given {@link Rational} play speed values from the predefined
+		 * instances or the cache. If no such {@link DLNAOrgPlaySpeeds} instance
+		 * exists, {@code null} is returned.
+		 *
+		 * @param values the {@link Rational} play speed values.
+		 * @return The {@link DLNAOrgPlaySpeeds} instance or {@code null}.
+		 */
+		public DLNAOrgPlaySpeeds getPlaySpeeds(Rational... values) {
+
+			// Check for static instances
+			if (values == null || values.length == 0) {
+				return NONE;
+			}
+
+			// Check for cached instances
+			return getPlaySpeeds(new TreeSet<Rational>(Arrays.asList(values)));
+		}
+
+		/**
+		 * Retrieves an instance of {@link DLNAOrgPlaySpeeds} representing the
+		 * {@link SortedSet} of {@link Rational} play speeds in {@code speedSet}
+		 * from the predefined instances or the cache. If no such
+		 * {@link DLNAOrgPlaySpeeds} instance exists, {@code null} is returned.
+		 *
+		 * @param speedSet a {@link SortedSet} of {@link Rational} play speeds.
+		 * @return The {@link DLNAOrgPlaySpeeds} instance or {@code null}.
+		 */
+		public DLNAOrgPlaySpeeds getPlaySpeeds(SortedSet<Rational> speedSet) {
+
+			// Check for static instances
+			if (speedSet == null || speedSet.isEmpty()) {
+				return NONE;
+			}
+
+			// Check for cached instances
+			String stringValue = generateStringValue(speedSet);
+			instanceCacheLock.readLock().lock();
+			try {
+				for (DLNAOrgPlaySpeeds cachedAttribute : instanceCache) {
+					if (stringValue.equals(cachedAttribute.getValue())) {
+						return cachedAttribute;
+					}
+				}
+			} finally {
+				instanceCacheLock.readLock().unlock();
+			}
+			return null;
+		}
+
+		/**
+		 * Creates or retrieves an instance of {@link DLNAOrgPlaySpeeds}
+		 * representing the comma separated list of play speeds in
+		 * {@code values}. Any existing predefined or cached instances are first
+		 * checked, and if none are found for {@code values} a new instance is
+		 * created.
+		 *
+		 * @param values a comma separated list of play speeds in rational form.
+		 * @return The {@link DLNAOrgPlaySpeeds} instance.
+		 * @throws NumberFormatException If {@code values} cannot be parsed.
+		 */
+		public DLNAOrgPlaySpeeds createPlaySpeeds(String values) {
+
+			// Check for static instances
+			if (isBlank(values)) {
+				return NONE;
+			}
+
+			// Parse the values
+			values = values.trim();
+			String[] valueArray = values.split("\\s*,\\s*");
+			TreeSet<Rational> valueSet = new TreeSet<>();
+			for (String value : valueArray) {
+				if (isNotBlank(value)) {
+					valueSet.add(new Rational(value));
+				}
+			}
+
+			return createPlaySpeeds(valueSet);
+		}
+
+		/**
+		 * Creates or retrieves an instance of {@link DLNAOrgPlaySpeeds}
+		 * representing the given {@link Rational} play speed values. Any
+		 * existing predefined or cached instances are first checked, and if
+		 * none are found for {@code values} a new instance is created.
+		 *
+		 * @param values the {@link Rational} play speed values.
+		 * @return The {@link DLNAOrgPlaySpeeds} instance.
+		 */
+		public DLNAOrgPlaySpeeds createPlaySpeeds(Rational... values) {
+			// Check for static instances
+			if (values == null || values.length == 0) {
+				return NONE;
+			}
+
+			// Remove any "1" values from the set, they are prohibited by DLNA
+			SortedSet<Rational> cleanedSpeedSet = new TreeSet<>(Arrays.asList(values));
+			if (cleanedSpeedSet.contains(Rational.ONE)) {
+				cleanedSpeedSet.remove(Rational.ONE);
+			}
+
+			return createPlaySpeeds(cleanedSpeedSet);
+		}
+
+		/**
+		 * Creates or retrieves an instance of {@link DLNAOrgPlaySpeeds}
+		 * representing {@link SortedSet} of {@link Rational} play speeds in
+		 * {@code speedSet}. Any existing predefined or cached instances are
+		 * first checked, and if none are found for {@code speedSet} a new
+		 * instance is created.
+		 *
+		 * @param speedSet a {@link SortedSet} of {@link Rational} play speeds.
+		 * @return The {@link DLNAOrgPlaySpeeds} instance.
+		 */
+		public DLNAOrgPlaySpeeds createPlaySpeeds(SortedSet<Rational> speedSet) {
+
+			// Check for static instances
+			if (speedSet == null || speedSet.isEmpty()) {
+				return NONE;
+			}
+
+			// Remove any "1" values from the set, they are prohibited by DLNA
+			SortedSet<Rational> cleanedSpeedSet;
+			if (speedSet.contains(Rational.ONE)) {
+				// Don't modify the argument (we don't even know if it's mutable)
+				cleanedSpeedSet = new TreeSet<>(speedSet);
+				cleanedSpeedSet.remove(Rational.ONE);
+			} else {
+				cleanedSpeedSet = speedSet;
+			}
+
+			// Check if an instance for this value already exists
+			DLNAOrgPlaySpeeds instance = getPlaySpeeds(cleanedSpeedSet);
+			if (instance != null) {
+				return instance;
+			}
+
+			// Prepare to create a new instance
+			instanceCacheLock.writeLock().lock();
+			try {
+				// Check cache again as it could have been added while the
+				// lock was released
+				instance = getPlaySpeeds(cleanedSpeedSet);
+				if (instance != null) {
+					return instance;
+				}
+
+				// None was found, create the instance
+				instance = new DLNAOrgPlaySpeeds(cleanedSpeedSet);
+				instanceCache.add(instance);
+				return instance;
+			} finally {
+				instanceCacheLock.writeLock().unlock();
+			}
+		}
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgProfileName.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/DLNAOrgProfileName.java
@@ -1,0 +1,112 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import org.fourthline.cling.support.model.dlna.DLNAProfiles;
+import net.pms.dlna.protocolinfo.ProtocolInfoAttributeName.KnownProtocolInfoAttributeName;
+
+/**
+ * This interface represents {@code DLNA.ORG_PN} attributes. This can only be
+ * used for DLNA content.
+ *
+ * @author Nadahar
+ */
+@SuppressWarnings("checkstyle:InterfaceIsType")
+public interface DLNAOrgProfileName extends ProfileName {
+
+	/** The static {@code NONE} instance representing a blank/empty value */
+	DLNAOrgProfileName NONE = new DefaultDLNAOrgProfileName("");
+
+	/**
+	 * The static factory singleton instance used to create and retrieve
+	 * {@link DLNAOrgProfileName} instances.
+	 */
+	DLNAOrgProfileNameFactory FACTORY = new DLNAOrgProfileNameFactory();
+
+	/** The static attribute name always used for this class */
+	ProtocolInfoAttributeName NAME = KnownProtocolInfoAttributeName.DLNA_ORG_PN;
+
+	/**
+	 * A factory for creating, caching and retrieving {@link DLNAOrgProfileName}
+	 * instances.
+	 */
+	public static class DLNAOrgProfileNameFactory extends AbstractProfileNameFactory<DLNAOrgProfileName> {
+
+		/**
+		 * For internal use only, use {@link DLNAOrgProfileName#FACTORY} to get
+		 * the singleton instance.
+		 */
+		protected DLNAOrgProfileNameFactory() {
+			// Add the profiles already defined by Cling
+			for (DLNAProfiles profile : DLNAProfiles.values()) {
+				if (profile != DLNAProfiles.NONE) {
+					instanceCache.add(new DefaultDLNAOrgProfileName(profile.getCode()));
+				}
+			}
+		}
+
+		@Override
+		protected DLNAOrgProfileName getNoneInstance() {
+			return NONE;
+		}
+
+		@Override
+		protected DLNAOrgProfileName searchKnownInstances(String value) {
+			// Check for known instances
+			for (KnownDLNAOrgProfileName knownAttribute : KnownDLNAOrgProfileName.values()) {
+				if (value.equals(knownAttribute.getValue())) {
+					return knownAttribute;
+				}
+			}
+			return null;
+		}
+
+		@Override
+		protected DLNAOrgProfileName getNewInstance(String value) {
+			return new DefaultDLNAOrgProfileName(value);
+		}
+	}
+
+	/**
+	 * This is the default, immutable class implementing
+	 * {@link DLNAOrgProfileName}. {@link DLNAOrgProfileNameFactory} creates and
+	 * caches instances of this class.
+	 */
+	public static class DefaultDLNAOrgProfileName extends AbstractDefaultProfileName implements DLNAOrgProfileName {
+
+		private static final long serialVersionUID = 1L;
+
+		/**
+		 * For internal use only, use
+		 * {@link DLNAOrgProfileNameFactory#createProfileName} to create new
+		 * instances.
+		 *
+		 * @param value the profile name.
+		 */
+		protected DefaultDLNAOrgProfileName(String value) {
+			super(value);
+		}
+
+		@Override
+		public ProtocolInfoAttributeName getName() {
+			return NAME;
+		}
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/DeviceProtocolInfo.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/DeviceProtocolInfo.java
@@ -1,0 +1,779 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.translate.CharSequenceTranslator;
+import org.apache.commons.lang3.text.translate.LookupTranslator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.pms.util.ParseException;
+
+/**
+ * This class represents a device's {@code ProtocolInfo} elements, typically
+ * {@code Source} or {@code Sink} from {@code GetProtocolInfo}.
+ * <p>
+ * This class is thread-safe.
+ *
+ * @author Nadahar
+ */
+public class DeviceProtocolInfo implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The logger. */
+	private static final Logger LOGGER = LoggerFactory.getLogger(DeviceProtocolInfo.class);
+
+	/** The static singleton {@code GetProtocolInfo} {@code Source} identifier */
+	public static final DeviceProtocolInfoSource<DeviceProtocolInfo> GET_PROTOCOLINFO_SOURCE = new GetProtocolInfoType() {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public String getType() {
+			return "GetProtocolInfo Source";
+		}
+	};
+
+	/** The static singleton {@code GetProtocolInfo} {@code Sink} identifier */
+	public static final DeviceProtocolInfoSource<DeviceProtocolInfo> GET_PROTOCOLINFO_SINK = new GetProtocolInfoType() {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public String getType() {
+			return "GetProtocolInfo Sink";
+		}
+	};
+
+	/**
+	 * A regex for splitting a comma separated list of {@code protocolInfo}
+	 * entries returned from {@code GetProtocolInfo} while taking DLNA comma
+	 * escaping rules into account.
+	 */
+	public static final String COMMA_SPLIT_REGEX = "\\s*(?:(?<!\\\\),|(?<!\\\\)\\\\\\\\,)\\s*";
+
+	/**
+	 * A {@link CharSequenceTranslator} for unescaping individual
+	 * {@code GetProtocolInfo} elements.
+	 */
+	public static final CharSequenceTranslator PROTOCOLINFO_UNESCAPE =
+		new LookupTranslator(
+			new String[][] {
+				{"\\\\", "\\"},
+				{"\\,", ","}
+			}
+		);
+
+	/**
+	 * A {@link CharSequenceTranslator} for escaping individual
+	 * {@code GetProtocolInfo} elements.
+	 */
+	public static final CharSequenceTranslator PROTOCOLINFO_ESCAPE =
+		new LookupTranslator(
+			new String[][] {
+				{",", "\\,"},
+				{"\\", "\\\\"},
+			}
+		);
+
+	/** The sets lock. */
+	protected final ReentrantReadWriteLock setsLock = new ReentrantReadWriteLock();
+
+	/** The {@link Map} of {@link ProtocolInfo} {@link Set}s. */
+	protected final HashMap<DeviceProtocolInfoSource<?>, SortedSet<ProtocolInfo>> protocolInfoSets = new HashMap<>();
+
+	/**
+	 * Creates a new empty instance.
+	 */
+	public DeviceProtocolInfo() {
+	}
+
+	/**
+	 * Creates a new instance with containing the content from the parsing of
+	 * {@code protocolInfoString}.
+	 *
+	 * @param type The {@link DeviceProtocolInfoSource} of
+	 *            {@code protocolInfoString}, must be either
+	 *            {@link #GET_PROTOCOLINFO_SINK} or
+	 *            {@link #GET_PROTOCOLINFO_SOURCE}.
+	 * @param protocolInfoString a comma separated string of
+	 *            {@code protocolInfo} representations.
+	 */
+	public DeviceProtocolInfo(GetProtocolInfoType type, String protocolInfoString) {
+		add(type, protocolInfoString);
+	}
+
+	/**
+	 * Tries to parse {@code protocolInfoString} and add the resulting
+	 * {@link ProtocolInfo} instances.
+	 *
+	 * @param type The {@link DeviceProtocolInfoSource} that identifies the
+	 *            source of these {@code protocolInfo}s.
+	 * @param protocolInfoString a comma separated string of
+	 *            {@code protocolInfo} representations whose presence is to be
+	 *            ensured.
+	 * @return {@code true} if this changed as a result of the call. Returns
+	 *         {@code false} this already contains the specified element(s).
+	 */
+	public boolean add(DeviceProtocolInfoSource<?> type, String protocolInfoString) {
+		if (StringUtils.isBlank(protocolInfoString)) {
+			return false;
+		}
+
+		String[] elements = protocolInfoString.trim().split(COMMA_SPLIT_REGEX);
+		boolean result = false;
+		setsLock.writeLock().lock();
+		try {
+			SortedSet<ProtocolInfo> currentSet;
+			if (protocolInfoSets.containsKey(type)) {
+				currentSet = protocolInfoSets.get(type);
+			} else {
+				currentSet = new TreeSet<ProtocolInfo>();
+				protocolInfoSets.put(type, currentSet);
+			}
+
+			for (String element : elements) {
+				try {
+					result |= currentSet.add(new ProtocolInfo(unescapeString(element)));
+				} catch (ParseException e) {
+					LOGGER.warn(
+						"Unable to parse protocolInfo from \"{}\", this profile will not be registered: {}",
+						element,
+						e.getMessage()
+					);
+					LOGGER.trace("", e);
+				}
+			}
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+		return result;
+	}
+
+
+	// Standard java.util.Collection methods.
+
+
+	/**
+	 * Returns the number of elements of the given
+	 * {@link DeviceProtocolInfoSource} type. If this contains more than
+	 * {@link Integer#MAX_VALUE} elements, returns {@link Integer#MAX_VALUE}.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type to get the number
+	 *            of elements for.
+	 * @return The number of elements in the {@link Set} for {@code type}.
+	 */
+	public int size(DeviceProtocolInfoSource<?> type) {
+		setsLock.readLock().lock();
+		try {
+			SortedSet<ProtocolInfo> set = protocolInfoSets.get(type);
+			return set == null ? 0 : set.size();
+		} finally {
+			setsLock.readLock().unlock();
+		}
+	}
+
+	/**
+	 * Returns the total number of elements of all
+	 * {@link DeviceProtocolInfoSource} types. If the result is greater than
+	 * {@link Integer#MAX_VALUE} elements, returns {@link Integer#MAX_VALUE}.
+	 *
+	 * @return The number of elements.
+	 */
+	public int size() {
+		long result = 0;
+		setsLock.readLock().lock();
+		try {
+			for (SortedSet<ProtocolInfo> set : protocolInfoSets.values()) {
+				if (set != null) {
+					result += set.size();
+				}
+			}
+		} finally {
+			setsLock.readLock().unlock();
+		}
+		return result > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) result;
+	}
+
+	/**
+	 * Checks if the {@link Set} for the given {@link DeviceProtocolInfoSource}
+	 * type is empty.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type to check.
+	 * @return {@code true} if {@code protocolInfoSets} contains no elements of
+	 *         {@code type}.
+	 */
+	public boolean isEmpty(DeviceProtocolInfoSource<?> type) {
+		setsLock.readLock().lock();
+		try {
+			SortedSet<ProtocolInfo> set = protocolInfoSets.get(type);
+			return set == null ? true : set.isEmpty();
+		} finally {
+			setsLock.readLock().unlock();
+		}
+	}
+
+	/**
+	 * Checks if all the {@link DeviceProtocolInfoSource} {@link Set}s are
+	 * empty.
+	 *
+	 * @return {@code true} if neither of the {@link DeviceProtocolInfoSource}
+	 *         {@link Set}s contain any elements, {@code false} otherwise.
+	 */
+	public boolean isEmpty() {
+		setsLock.readLock().lock();
+		try {
+			for (SortedSet<ProtocolInfo> set : protocolInfoSets.values()) {
+				if (set != null && !set.isEmpty()) {
+					return false;
+				}
+			}
+		} finally {
+			setsLock.readLock().unlock();
+		}
+		return true;
+	}
+
+	/**
+	 * Returns {@code true} if the {@link Set} for the given
+	 * {@link DeviceProtocolInfoSource} contains the specified element.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type to check.
+	 * @param protocolInfo the element whose presence is to be tested.
+	 * @return {@code true} if the {@link Set} for the given
+	 *         {@link DeviceProtocolInfoSource} contains the specified element,
+	 *         {@code false} otherwise.
+	 */
+	public boolean contains(DeviceProtocolInfoSource<?> type, ProtocolInfo protocolInfo) {
+		setsLock.readLock().lock();
+		try {
+			SortedSet<ProtocolInfo> set = protocolInfoSets.get(type);
+			return set == null ? false : set.contains(protocolInfo);
+		} finally {
+			setsLock.readLock().unlock();
+		}
+	}
+
+	/**
+	 * Returns {@code true} if any of the {@link DeviceProtocolInfoSource}
+	 * {@link Set}s contains the specified element.
+	 *
+	 * @param protocolInfo the element whose presence is to be tested.
+	 * @return {@code true} if any of the {@link DeviceProtocolInfoSource}
+	 *         {@link Set}s contains the specified element {@code false}
+	 *         otherwise.
+	 */
+	public boolean contains(ProtocolInfo protocolInfo) {
+		setsLock.readLock().lock();
+		try {
+			for (SortedSet<ProtocolInfo> set : protocolInfoSets.values()) {
+				if (set != null && set.contains(protocolInfo)) {
+					return true;
+				}
+			}
+		} finally {
+			setsLock.readLock().unlock();
+		}
+		return false;
+	}
+
+	/**
+	 * Returns a sorted array containing all of the elements in the {@link Set}
+	 * for the given {@link DeviceProtocolInfoSource}.
+	 * <p>
+	 * The returned array will be "safe" in that no reference to it is
+	 * maintained. (In other words, this method must allocate a new array). The
+	 * caller is thus free to modify the returned array.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type whose elements to
+	 *            convert to an {@code array}.
+	 * @return An array containing all the {@link ProtocolInfo} instances in the
+	 *         {@link Set} for {@code type}.
+	 */
+	public ProtocolInfo[] toArray(DeviceProtocolInfoSource<?> type) {
+		setsLock.readLock().lock();
+		try {
+			SortedSet<ProtocolInfo> set = protocolInfoSets.get(type);
+			return set == null ? null : set.toArray(new ProtocolInfo[protocolInfoSets.size()]);
+		} finally {
+			setsLock.readLock().unlock();
+		}
+	}
+
+	/**
+	 * Returns a sorted array containing all of the elements for all of the
+	 * {@link DeviceProtocolInfoSource} {@link Set}s.
+	 * <p>
+	 * The returned array will be "safe" in that no reference to it is
+	 * maintained. (In other words, this method must allocate a new array). The
+	 * caller is thus free to modify the returned array.
+	 *
+	 * @return An array containing all the {@link ProtocolInfo} instances.
+	 */
+	public ProtocolInfo[] toArray() {
+		SortedSet<ProtocolInfo> result = new TreeSet<>();
+		setsLock.readLock().lock();
+		try {
+			for (SortedSet<ProtocolInfo> set : protocolInfoSets.values()) {
+				if (set != null) {
+					result.addAll(set);
+				}
+			}
+		} finally {
+			setsLock.readLock().unlock();
+		}
+		return result.toArray(new ProtocolInfo[result.size()]);
+	}
+
+	/**
+	 * Returns {@code true} if the {@link Set} for the given
+	 * {@link DeviceProtocolInfoSource} contains all of the elements in the
+	 * specified collection.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type to check.
+	 * @param collection a {@link Collection} to be checked for containment.
+	 * @return {@code true} if {@link Set} for {@code type} contains all of the
+	 *         elements in {@code collection}.
+	 *
+	 * @see #contains(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #contains(ProtocolInfo)
+	 * @see #containsAll(Collection)
+	 */
+
+	public boolean containsAll(DeviceProtocolInfoSource<?> type, Collection<ProtocolInfo> collection) {
+		setsLock.readLock().lock();
+		try {
+			SortedSet<ProtocolInfo> set = protocolInfoSets.get(type);
+			return set == null ? false : set.containsAll(collection);
+		} finally {
+			setsLock.readLock().unlock();
+		}
+	}
+
+	/**
+	 * Returns {@code true} if any of the {@link DeviceProtocolInfoSource}
+	 * {@link Set}s contains the elements in the specified collection.
+	 *
+	 * @param collection a {@link Collection} to be checked for containment.
+	 * @return {@code true} if any of the {@link DeviceProtocolInfoSource}
+	 *         {@link Set}s contains the elements in {@code collection}.
+	 *
+	 * @see #contains(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #contains(ProtocolInfo)
+	 * @see #containsAll(DeviceProtocolInfoSource, Collection)
+	 */
+	public boolean containsAll(Collection<ProtocolInfo> collection) {
+		setsLock.readLock().lock();
+		try {
+			for (ProtocolInfo protocolInfo : collection) {
+				if (!contains(protocolInfo)) {
+					return false;
+				}
+			}
+		} finally {
+			setsLock.readLock().unlock();
+		}
+		return true;
+	}
+
+	/**
+	 * Removes all elements in the {@link Set} for the given
+	 * {@link DeviceProtocolInfoSource}.
+	 *
+	 * @param type The {@link DeviceProtocolInfoSource} type to clear.
+	 */
+	public void clear(DeviceProtocolInfoSource<?> type) {
+		setsLock.writeLock().lock();
+		try {
+			SortedSet<ProtocolInfo> set = protocolInfoSets.get(type);
+			if (set != null) {
+				set.clear();
+			}
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Removes all elements in all of the {@link DeviceProtocolInfoSource}
+	 * {@link Set}s.
+	 */
+	public void clear() {
+		setsLock.writeLock().lock();
+		try {
+			protocolInfoSets.clear();
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Ensures that the {@link Set} for the given
+	 * {@link DeviceProtocolInfoSource} contains the specified element. Returns
+	 * {@code true} if {@code protocolInfo} was added a result of the call, or
+	 * {@code false} the {@link Set} for the given
+	 * {@link DeviceProtocolInfoSource} already contains the specified element.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type.
+	 * @param protocolInfo element whose presence is to be ensured.
+	 * @return {@code true} if the {@link Set} for {@code type} changed as a
+	 *         result of the call, {@code false} otherwise.
+	 */
+	public boolean add(DeviceProtocolInfoSource<?> type, ProtocolInfo protocolInfo) {
+		setsLock.writeLock().lock();
+		try {
+			SortedSet<ProtocolInfo> currentSet;
+			if (protocolInfoSets.containsKey(type)) {
+				currentSet = protocolInfoSets.get(type);
+			} else {
+				currentSet = new TreeSet<ProtocolInfo>();
+				protocolInfoSets.put(type, currentSet);
+			}
+
+			if (currentSet.add(protocolInfo)) {
+				return true;
+			}
+			return false;
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Ensures that the {@link Set} for the given
+	 * {@link DeviceProtocolInfoSource} contains all of the elements in the
+	 * specified collection.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type.
+	 * @param collection a {@link Collection} containing elements to be added.
+	 * @return {@code true} if the {@link Set} for {@code type} changed as a
+	 *         result of the call, {@code false} otherwise.
+	 *
+	 * @see #add(DeviceProtocolInfoSource, ProtocolInfo)
+	 */
+	public boolean addAll(DeviceProtocolInfoSource<?> type, Collection<? extends ProtocolInfo> collection) {
+		setsLock.writeLock().lock();
+		try {
+			SortedSet<ProtocolInfo> currentSet;
+			if (protocolInfoSets.containsKey(type)) {
+				currentSet = protocolInfoSets.get(type);
+			} else {
+				currentSet = new TreeSet<ProtocolInfo>();
+				protocolInfoSets.put(type, currentSet);
+			}
+
+			if (currentSet.addAll(collection)) {
+				return true;
+			}
+			return false;
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Removes a given instance of {@link ProtocolInfo}, if it is present in the
+	 * {@link Set} for the given {@link DeviceProtocolInfoSource}. Returns
+	 * {@code true} if the {@link Set} for the given
+	 * {@link DeviceProtocolInfoSource} contained the specified element (or
+	 * equivalently, if the {@link Set} for the given
+	 * {@link DeviceProtocolInfoSource} changed as a result of the call).
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type.
+	 * @param protocolInfo element to be removed, if present.
+	 * @return {@code true} if an element was removed from the {@link Set} for
+	 *         {@code type} as a result of this call, {@code false} otherwise.
+	 */
+	public boolean remove(DeviceProtocolInfoSource<?> type, ProtocolInfo protocolInfo) {
+		setsLock.writeLock().lock();
+		try {
+			SortedSet<ProtocolInfo> set = protocolInfoSets.get(type);
+			if (set != null) {
+				if (set.remove(protocolInfo)) {
+					return true;
+				}
+			}
+			return false;
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Removes all instances of {@code protocolInfo} from all the
+	 * {@link DeviceProtocolInfoSource} {@link Set}s, if it is present. Returns
+	 * {@code true} if any of the {@link DeviceProtocolInfoSource} {@link Set}s
+	 * contained the specified element (or equivalently, if any of the
+	 * {@link DeviceProtocolInfoSource} {@link Set}s changed as a result of the
+	 * call).
+	 *
+	 * @param protocolInfo element to be removed, if present.
+	 * @return {@code true} if an element was removed as a result of this call,
+	 *         {@code false} otherwise.
+	 */
+	public boolean remove(ProtocolInfo protocolInfo) {
+		boolean result = false;
+		setsLock.writeLock().lock();
+		try {
+			for (SortedSet<ProtocolInfo> set : protocolInfoSets.values()) {
+				result |= set != null && set.remove(protocolInfo);
+			}
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+		return result;
+	}
+
+	/**
+	 * Removes all elements from the {@link Set} for the given
+	 * {@link DeviceProtocolInfoSource} that are also contained in
+	 * {@code collection}.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type.
+	 * @param collection a {@link Collection} containing the elements to be
+	 *            removed.
+	 * @return {@code true} if this call resulted in a change.
+	 *
+	 * @see #remove(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #remove(ProtocolInfo)
+	 * @see #contains(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #contains(ProtocolInfo)
+	 * @see #removeAll(Collection)
+	 */
+	public boolean removeAll(DeviceProtocolInfoSource<?> type, Collection<ProtocolInfo> collection) {
+		setsLock.writeLock().lock();
+		try {
+			SortedSet<ProtocolInfo> set = protocolInfoSets.get(type);
+			if (set != null && set.removeAll(collection)) {
+				return true;
+			}
+			return false;
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Removes all elements from all the {@link DeviceProtocolInfoSource}
+	 * {@link Set}s that are also contained in {@code collection}.
+	 *
+	 * @param collection a {@link Collection} containing the elements to be
+	 *            removed.
+	 * @return {@code true} if this call resulted in a change.
+	 *
+	 * @see #remove(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #remove(ProtocolInfo)
+	 * @see #contains(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #contains(ProtocolInfo)
+	 * @see #removeAll(DeviceProtocolInfoSource, Collection)
+	 */
+	public boolean removeAll(Collection<ProtocolInfo> collection) {
+		boolean result = false;
+		setsLock.writeLock().lock();
+		try {
+			for (SortedSet<ProtocolInfo> set : protocolInfoSets.values()) {
+				result |= set != null && set.removeAll(collection);
+			}
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+		return result;
+	}
+
+	/**
+	 * Retains only the elements that are contained in {@code collection} from
+	 * the {@link Set} for the given {@link DeviceProtocolInfoSource}. In other
+	 * words, removes all elements that are not contained in {@code collection}
+	 * from the {@link Set} for the given {@link DeviceProtocolInfoSource}.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type.
+	 * @param collection a {@link Collection} containing elements to be
+	 *            retained.
+	 * @return {@code true} if this call resulted in a change.
+	 *
+	 * @see #remove(ProtocolInfo)
+	 * @see #remove(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #contains(ProtocolInfo)
+	 * @see #contains(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #retainAll(Collection)
+	 */
+	public boolean retainAll(DeviceProtocolInfoSource<?> type, Collection<ProtocolInfo> collection) {
+		setsLock.writeLock().lock();
+		try {
+			SortedSet<ProtocolInfo> set = protocolInfoSets.get(type);
+			if (set != null && set.retainAll(collection)) {
+				return true;
+			}
+			return false;
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Retains only the elements that are contained in {@code collection} in all
+	 * the {@link DeviceProtocolInfoSource} {@link Set}s. In other words,
+	 * removes all elements from all the {@link DeviceProtocolInfoSource}
+	 * {@link Set}s that are not contained in {@code collection}.
+	 *
+	 * @param collection a {@link Collection} containing elements to be
+	 *            retained.
+	 * @return {@code true} if this call resulted in a change.
+	 *
+	 * @see #remove(ProtocolInfo)
+	 * @see #remove(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #contains(ProtocolInfo)
+	 * @see #contains(DeviceProtocolInfoSource, ProtocolInfo)
+	 * @see #retainAll(DeviceProtocolInfoSource, Collection)
+	 */
+	public boolean retainAll(Collection<ProtocolInfo> collection) {
+		boolean result = false;
+		setsLock.writeLock().lock();
+		try {
+			for (SortedSet<ProtocolInfo> set : protocolInfoSets.values()) {
+				result |= set != null && set.retainAll(collection);
+			}
+		} finally {
+			setsLock.writeLock().unlock();
+		}
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return toString(null, false);
+	}
+
+	/**
+	 * Returns a string representation of this {@link DeviceProtocolInfo}
+	 * instance showing only the {@link ProtocolInfo} instances of the given
+	 * {@link DeviceProtocolInfoSource} type. If {@code debug} is {@code true},
+	 * verbose output is returned.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type to include.
+	 * @return A string representation of this {@link DeviceProtocolInfo}.
+	 */
+	public String toString(DeviceProtocolInfoSource<?> type) {
+		return toString(type, false);
+	}
+
+	/**
+	 * Returns a string representation of this {@link DeviceProtocolInfo}
+	 * instance. If {@code debug} is {@code true}, verbose output is returned.
+	 *
+	 * @param debug whether or not verbose output should be generated.
+	 * @return A string representation of this {@link DeviceProtocolInfo}.
+	 */
+	public String toString(boolean debug) {
+		return toString(null, debug);
+	}
+
+	/**
+	 * Returns a string representation of this {@link DeviceProtocolInfo}
+	 * instance showing only the {@link ProtocolInfo} instances of the given
+	 * {@link DeviceProtocolInfoSource} type. If {@code debug} is {@code true},
+	 * verbose output is returned.
+	 *
+	 * @param type the {@link DeviceProtocolInfoSource} type to include. Use
+	 *            {@code null} for all types.
+	 * @param debug whether or not verbose output should be generated.
+	 * @return A string representation of this {@link DeviceProtocolInfo}.
+	 */
+	public String toString(DeviceProtocolInfoSource<?> type, boolean debug) {
+		StringBuilder sb = new StringBuilder();
+		setsLock.readLock().lock();
+		try {
+			if (protocolInfoSets != null && !protocolInfoSets.isEmpty()) {
+				for (Entry<DeviceProtocolInfoSource<?>, SortedSet<ProtocolInfo>>  entry : protocolInfoSets.entrySet()) {
+					if (type == null || type.equals(entry.getKey())) {
+						if (!entry.getValue().isEmpty()) {
+							sb.append(entry.getKey().getType()).append(" entries:\n");
+							for (ProtocolInfo protocolInfo : entry.getValue()) {
+								if (protocolInfo != null) {
+									sb.append("  ").append(debug ?
+										protocolInfo.toDebugString() :
+										protocolInfo.toString()
+									).append("\n");
+								}
+							}
+							sb.append("\n");
+						}
+					}
+				}
+			}
+		} finally {
+			setsLock.readLock().unlock();
+		}
+		return sb.toString();
+	}
+
+
+	// Static methods
+
+
+	/**
+	 * Escapes {@code protocolInfo} strings for use in {@code GetProtocolInfo}
+	 * in accordance with DLNA comma escaping rules.
+	 *
+	 * @param unescapedString the {@code protocolInfo} string to escape.
+	 * @return The escaped {@link String};
+	 */
+	public static String escapeString(String unescapedString) {
+		return PROTOCOLINFO_ESCAPE.translate(unescapedString);
+	}
+
+	/**
+	 * Unescapes {@code protocolInfo} strings after splitting a string from
+	 * {@code GetProtocolInfo} into individual elements in accordance with DLNA
+	 * comma escaping rules.
+	 *
+	 * @param escapedString the {@code protocolInfo} string to unescape.
+	 * @return The unescaped {@link String};
+	 */
+	public static String unescapeString(String escapedString) {
+		return PROTOCOLINFO_UNESCAPE.translate(escapedString);
+	}
+
+	/**
+	 * This is an abstract implementation of {@link DeviceProtocolInfoSource}
+	 * where {@link DeviceProtocolInfo} is the parsing class.
+	 *
+	 * @author Nadahar
+	 */
+	public abstract static class GetProtocolInfoType extends DeviceProtocolInfoSource<DeviceProtocolInfo> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Class<DeviceProtocolInfo> getClazz() {
+			return DeviceProtocolInfo.class;
+		}
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/DeviceProtocolInfoSource.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/DeviceProtocolInfoSource.java
@@ -1,0 +1,62 @@
+package net.pms.dlna.protocolinfo;
+
+import java.io.Serializable;
+
+/**
+ * This abstract class is used to identify the source of a given {@link ProtocolInfo}
+ * instance stored in {@link DeviceProtocolInfo}.
+ *
+ * @param <T> The class responsible for parsing the given source.
+ *
+ * @author Nadahar
+ */
+public abstract class DeviceProtocolInfoSource<T> implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * @return The {@link Class} responsible for parsing this
+	 *         {@link DeviceProtocolInfoSource}.
+	 */
+	public abstract Class<T> getClazz();
+
+	/**
+	 * @return The {@link String} representation of the source.
+	 */
+	public abstract String getType();
+
+	@Override
+	public String toString() {
+		return getType();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((getType() == null) ? 0 : getType().hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (object == null) {
+			return false;
+		}
+		if (!(object instanceof DeviceProtocolInfoSource)) {
+			return false;
+		}
+		DeviceProtocolInfoSource<?> other = (DeviceProtocolInfoSource<?>) object;
+		if (getType() == null) {
+			if (other.getType() != null) {
+				return false;
+			}
+		} else if (!getType().equals(other.getType())) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/KnownDLNAOrgProfileName.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/KnownDLNAOrgProfileName.java
@@ -1,0 +1,530 @@
+package net.pms.dlna.protocolinfo;
+
+
+/**
+ * This {@code enum} contains predefined {@code DLNA.ORG_PN} values that
+ * isn't already defined in {@link DLNAProfiles}.
+ *
+ * @author Nadahar
+ */
+public enum KnownDLNAOrgProfileName implements DLNAOrgProfileName {
+	// XXX Add profiles, there are lots missing
+
+	/**
+	 * AVC HD/SD video with AC-3 audio including dual-mono channel mode,
+	 * wrapped in MPEG-2 TS with valid timestamp for 60 Hz system.
+	 */
+	AVC_TS_HD_60_AC3_X_T,
+
+	/**
+	 * AVC wrapped in MPEG-2 transport stream, Main/High profile, with
+	 * MPEG-2 AAC audio, with a valid non-zero timestamp field.
+	 */
+	AVC_TS_JP_AAC_T,
+
+	/**
+	 * AVC video wrapped in MPEG-2 transport stream, as constrained by SCTE
+	 * standards, with AC-3, Enhanced AC-3, MPEG-4 HE-AAC v2 or MPEG-1 Layer II
+	 * audio, without a timestamp field.
+	 */
+	AVC_TS_NA_ISO,
+
+	/**
+	 * AVC video wrapped in MPEG-2 transport stream, as constrained by SCTE
+	 * standards, with AC-3, Enhanced AC-3, MPEG-4 HE-AAC v2 or MPEG-1 Layer II
+	 * audio, with a valid non-zero timestamp field.
+	 */
+	AVC_TS_NA_T,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video for a 24 Hz system, wrapped
+	 * in MPEG-2 transport stream, with AC-3 audio, with a zero value
+	 * timestamp field.
+	 */
+	DTCP_AVC_TS_HD_24_AC3,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video for a 24 Hz system, wrapped
+	 * in MPEG-2 transport stream, with AC-3 audio, without a timestamp
+	 * field.
+	 */
+	DTCP_AVC_TS_HD_24_AC3_ISO,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video for a 24 Hz system, wrapped
+	 * in MPEG-2 transport stream, with AC-3 audio, with a valid non-zero
+	 * timestamp field.
+	 */
+	DTCP_AVC_TS_HD_24_AC3_T,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video for a 50 Hz system, wrapped
+	 * in MPEG-2 transport stream, with AC-3 audio, with a zero value
+	 * timestamp field.
+	 */
+	DTCP_AVC_TS_HD_50_AC3,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video for a 50 Hz system, wrapped
+	 * in MPEG-2 transport stream, with AC-3 audio, without a timestamp
+	 * field.
+	 */
+	DTCP_AVC_TS_HD_50_AC3_ISO,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video for a 50 Hz system, wrapped
+	 * in MPEG-2 transport stream, with AC-3 audio, with a valid non-zero
+	 * timestamp field.
+	 */
+	DTCP_AVC_TS_HD_50_AC3_T,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video for a 60 Hz system, wrapped
+	 * in MPEG-2 transport stream, with AC-3 audio, with a zero value
+	 * timestamp field.
+	 */
+	DTCP_AVC_TS_HD_60_AC3,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video for a 60 Hz system, wrapped
+	 * in MPEG-2 transport stream, with AC-3 audio, without a timestamp
+	 * field.
+	 */
+	DTCP_AVC_TS_HD_60_AC3_ISO,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video for a 60 Hz system, wrapped
+	 * in MPEG-2 transport stream, with AC-3 audio, with a valid non-zero
+	 * timestamp field.
+	 */
+	DTCP_AVC_TS_HD_60_AC3_T,
+
+	/**
+	 * DTCP-IP Link Protection, AVC HD/SD video with AC-3 audio including
+	 * dual-mono channel mode, wrapped in MPEG-2 TS with valid timestamp for
+	 * 60 Hz system.
+	 */
+	DTCP_AVC_TS_HD_60_AC3_X_T,
+
+	/**
+	 * DTCP-IP Link Protection, AVC wrapped in MPEG-2 transport stream,
+	 * Main/High profile, with MPEG-2 AAC audio, with a valid non-zero
+	 * timestamp field.
+	 */
+	DTCP_AVC_TS_JP_AAC_T,
+
+	/**
+	 * DTCP-IP Link Protection, AVC wrapped in MPEG-2 transport stream main
+	 * profile HD with AAC LTP audio with valid timestamp field.
+	 */
+	DTCP_AVC_TS_MP_HD_AAC_LTP_T,
+
+	/** DTCP-IP Link Protection, Profile for NTSC-formatted AV class media. */
+	DTCP_MPEG_PS_NTSC,
+
+	/** DTCP-IP Link Protection, Profile for NTSC-formatted AV class media. */
+	DTCP_MPEG_PS_NTSC_XAC3,
+
+	/** DTCP-IP Link Protection, Profile for PAL-formatted AV class media. */
+	DTCP_MPEG_PS_PAL,
+
+	/** DTCP-IP Link Protection, Profile for PAL-formatted AV class media. */
+	DTCP_MPEG_PS_PAL_XAC3,
+
+	/**
+	 * DTCP-IP Link Protection, Korea region profile for High Definition AV
+	 * class utilizing a DLNA Transport Packet without a Timestamp field.
+	 */
+	DTCP_MPEG_TS_HD_KO,
+
+	/**
+	 * DTCP-IP Link Protection, Korea region profile for High Definition AV
+	 * class utilizing a DLNA Transport Packet without a Timestamp field.
+	 */
+	DTCP_MPEG_TS_HD_KO_ISO,
+
+	/**
+	 * DTCP-IP Link Protection, Korea region profile for High Definition AV
+	 * class utilizing a DLNA Transport Packet with a valid non-zero timestamp.
+	 */
+	DTCP_MPEG_TS_HD_KO_T,
+
+	/**
+	 * DTCP-IP Link Protection, North America region profile for High
+	 * Definition AV class utilizing a DLNA Transport Packet with zero value
+	 * timestamp.
+	 */
+	DTCP_MPEG_TS_HD_NA,
+
+	/**
+	 * DTCP-IP Link Protection, North America region profile for High
+	 * Definition AV class utilizing a DLNA Transport Packet without a
+	 * Timestamp field.
+	 */
+	DTCP_MPEG_TS_HD_NA_ISO,
+
+	/**
+	 * DTCP-IP Link Protection, North America region profile for High
+	 * Definition AV class utilizing a DLNA Transport Packet with a valid
+	 * non-zero timestamp.
+	 */
+	DTCP_MPEG_TS_HD_NA_T,
+
+	/**
+	 * DTCP-IP Link Protection, MPEG-2 Main Profile at Main, High-1 440 and
+	 * High Level with MPEG-2 AAC encapsulated in MPEG-2 TS with valid
+	 * timestamp.
+	 */
+	DTCP_MPEG_TS_JP_T,
+
+	/**
+	 * DTCP-IP Link Protection, MPEG-2 Main Profile at Main Level with AC-3
+	 * encapsulated in MPEG-2 TS with valid timestamp for 525/60 system.
+	 */
+	DTCP_MPEG_TS_SD_60_AC3_T,
+
+	/**
+	 * DTCP-IP Link Protection, European region profile for Standard
+	 * Definition AV class utilizing a DLNA Transport Packet with zero value
+	 * timestamp.
+	 */
+	DTCP_MPEG_TS_SD_EU,
+
+	/**
+	 * DTCP-IP Link Protection, MPEG-2 Video, wrapped in MPEG-2 transport
+	 * stream, Main Profile, Standard Definition, with AC-3 audio, without a
+	 * timestamp field.
+	 */
+	DTCP_MPEG_TS_SD_EU_AC3_ISO,
+
+	/**
+	 * DTCP-IP Link Protection, MPEG-2 Video, wrapped in MPEG-2 transport
+	 * stream, Main Profile Standard Definition, with AC-3 audio, with a
+	 * valid non-zero timestamp field.
+	 */
+	DTCP_MPEG_TS_SD_EU_AC3_T,
+
+	/**
+	 * DTCP-IP Link Protection, European region profile for Standard
+	 * Definition AV class utilizing a DLNA Transport Packet without a
+	 * Timestamp field.
+	 */
+	DTCP_MPEG_TS_SD_EU_ISO,
+
+	/**
+	 * DTCP-IP Link Protection, European region profile for Standard
+	 * Definition AV class utilizing a DLNA Transport Packet with a valid
+	 * non-zero timestamp.
+	 */
+	DTCP_MPEG_TS_SD_EU_T,
+
+	/**
+	 * DTCP-IP Link Protection, MPEG-2 Video, encapsulated in MPEG-2
+	 * transport stream, Main Profile at Main Level, with MPEG-1 L2 audio,
+	 * with a valid non-zero timestamp field.
+	 */
+	DTCP_MPEG_TS_SD_JP_MPEG1_L2_T,
+
+	/**
+	 * DTCP-IP Link Protection, Korea region profile for Standard Definition AV
+	 * utilizing a DLNA Transport Packet with zero value timestamp.
+	 */
+	DTCP_MPEG_TS_SD_KO,
+
+	/**
+	 * DTCP-IP Link Protection, Korea region profile for Standard Definition AV
+	 * class utilizing a DLNA Transport Packet without a Timestamp field.
+	 */
+	DTCP_MPEG_TS_SD_KO_ISO,
+
+	/**
+	 * DTCP-IP Link Protection, Korea region profile for Standard Definition AV
+	 * class utilizing a DLNA Transport Packet with a valid non-zero timestamp.
+	 */
+	DTCP_MPEG_TS_SD_KO_T,
+
+	/**
+	 * DTCP-IP Link Protection, North America region profile for Standard
+	 * Definition AV class utilizing a DLNA Transport Packet with zero value
+	 * timestamp.
+	 */
+	DTCP_MPEG_TS_SD_NA,
+
+	/**
+	 * DTCP-IP Link Protection, North America region profile for Standard
+	 * Definition AV class utilizing a DLNA Transport Packet without a
+	 * Timestamp field.
+	 */
+	DTCP_MPEG_TS_SD_NA_ISO,
+
+	/**
+	 * DTCP-IP Link Protection, North America region profile for Standard
+	 * Definition AV class utilizing a DLNA Transport Packet with a valid
+	 * non-zero timestamp.
+	 */
+	DTCP_MPEG_TS_SD_NA_T,
+
+	/**
+	 * DTCP-IP Link Protection, High resolution video (Main Profile at High
+	 * Level) with full WMA audio.
+	 */
+	DTCP_WMVHIGH_FULL,
+
+	/**
+	 * DTCP-IP Link Protection, High resolution video (Main Profile at High
+	 * Level) with WMA professional audio.
+	 */
+	DTCP_WMVHIGH_PRO,
+
+	/**
+	 * DTCP-IP Link Protection, Medium resolution video (Main Profile at Medium
+	 * Level) with baseline WMA audio.
+	 */
+	DTCP_WMVMED_BASE,
+
+	/**
+	 * DTCP-IP Link Protection, Medium resolution video (Main Profile at Medium
+	 * Level) with full WMA audio.
+	 */
+	DTCP_WMVMED_FULL,
+
+	/**
+	 * DTCP-IP Link Protection, Medium resolution video (Main Profile at Medium
+	 * Level) with WMA professional audio.
+	 */
+	DTCP_WMVMED_PRO,
+
+	/** Profile for image media class content of high resolution. */
+	GIF_LRG,
+
+	/** Profile for image media class content of high resolution. */
+	JPEG_LRG,
+
+	/** Profile for large icons */
+	JPEG_LRG_ICO,
+
+	/** Profile for image media class content of medium resolution. */
+	JPEG_MED,
+
+	/**
+	 * Profile for image media class content. Values &lt;H&gt; and &lt;V&gt;
+	 * indicate the horizontal and vertical resolutions in pixel numbers.
+	 */
+	JPEG_RES_H_V,
+
+	/** Profile for image media class content of small resolution. */
+	JPEG_SM,
+
+	/** Profile for small icons */
+	JPEG_SM_ICO,
+
+	/** Profile for image thumbnails. */
+	JPEG_TN,
+
+	/**
+	 * Korea region profile for High Definition AV class utilizing a DLNA
+	 * Transport Packet with zero value timestamp.
+	 */
+	MPEG_TS_HD_KO,
+
+	/**
+	 * Korea region profile for High Definition AV class utilizing a DLNA
+	 * Transport Packet without a Timestamp field.
+	 */
+	MPEG_TS_HD_KO_ISO,
+
+	/**
+	 * Korea region profile for High Definition AV class utilizing a DLNA
+	 * Transport Packet with a valid non-zero timestamp.
+	 */
+	MPEG_TS_HD_KO_T,
+
+	/**
+	 * MPEG-2 Main Profile at Main, High-1 440 and High Level with MPEG-2
+	 * AAC encapsulated in MPEG-2 TS with valid timestamp.
+	 */
+	MPEG_TS_JP_T,
+
+	/**
+	 * MPEG-2 HD/SD video wrapped in MPEG-2 transport stream as constrained by
+	 * SCTE-43 standards, with AC-3 audio, without a timestamp field.
+	 */
+	MPEG_TS_NA_ISO,
+
+	/**
+	 * MPEG-2 Video, wrapped in MPEG-2 transport stream, Main Profile,
+	 * Standard Definition, with AC-3 audio, without a timestamp field.
+	 */
+	MPEG_TS_SD_EU_AC3_ISO,
+
+	/**
+	 * MPEG-2 Video, wrapped in MPEG-2 transport stream, Main Profile
+	 * Standard Definition, with AC-3 audio, with a valid non-zero timestamp
+	 * field.
+	 */
+	MPEG_TS_SD_EU_AC3_T,
+
+	/**
+	 * MPEG-2 Video, encapsulated in MPEG-2 transport stream, Main Profile
+	 * at Main Level, with MPEG-1 L2 audio, with a valid non-zero timestamp
+	 * field.
+	 */
+	MPEG_TS_SD_JP_MPEG1_L2_T,
+
+	/**
+	 * Korea region profile for Standard Definition AV utilizing a DLNA
+	 * Transport Packet with zero value timestamp.
+	 */
+	MPEG_TS_SD_KO,
+
+	/**
+	 * Korea region profile for Standard Definition AV class utilizing a DLNA
+	 * Transport Packet without a Timestamp field.
+	 */
+	MPEG_TS_SD_KO_ISO,
+
+	/**
+	 * Korea region profile for Standard Definition AV class utilizing a DLNA
+	 * Transport Packet with a valid non-zero timestamp.
+	 */
+	MPEG_TS_SD_KO_T,
+
+	/** Profile for image class content of high resolution. */
+	PNG_LRG,
+
+	/** Profile for large icons */
+	PNG_LRG_ICO,
+
+	/** Profile for small icons */
+	PNG_SM_ICO,
+
+	/** Profile for image thumbnails */
+	PNG_TN,
+
+	/** Unofficial, unspecified WAV */
+	WAV,
+
+	/** WMA content (bit rates less than 193 kbit/s). */
+	WMABASE,
+
+	/** WMA content. */
+	WMAFULL,
+
+	/** WMA Lossless – stereo 16 bit, 2 channel. */
+	WMALSL,
+
+	/** WMA Lossless – Surround 24 bit, 5.1 channel. */
+	WMALSL_MULT5,
+
+	/** WMA professional version. */
+	WMAPRO,
+
+	/**
+	 * WMDRM-ND Link Protection System, WMA content (bit rates less than 193
+	 * kbit/s).
+	 */
+	WMDRM_WMABASE,
+
+	/** WMDRM-ND Link Protection System, WMA content. */
+	WMDRM_WMAFULL,
+
+	/**
+	 * WMDRM-ND Link Protection System, WMA Lossless – stereo 16 bit, 2
+	 * channel.
+	 */
+	WMDRM_WMALSL,
+
+	/**
+	 * WMDRM-ND Link Protection System, High resolution video (Main Profile
+	 * at High Level) with full WMA audio.
+	 */
+	WMDRM_WMVHIGH_FULL,
+
+	/**
+	 * WMDRM-ND Link Protection System, Medium resolution video (Main
+	 * Profile at Medium Level) with baseline WMA audio.
+	 */
+	WMDRM_WMVMED_BASE,
+
+	/**
+	 * WMDRM-ND Link Protection System, Medium resolution video (Main
+	 * Profile at Medium Level) with full WMA audio.
+	 */
+	WMDRM_WMVMED_FULL,
+
+	/**
+	 * High resolution video (Main Profile at High Level) with full WMA
+	 * audio.
+	 */
+	WMVHIGH_FULL,
+
+	/**
+	 * High resolution video (Main Profile at High Level) with WMA
+	 * professional audio.
+	 */
+	WMVHIGH_PRO,
+
+	/** HighMAT profile. */
+	WMVHM_BASE,
+
+	/**
+	 * Medium resolution video (Main Profile at Medium Level) with baseline
+	 * WMA audio.
+	 */
+	WMVMED_BASE,
+
+	/**
+	 * Medium resolution video (Main Profile at Medium Level) with full WMA
+	 * audio.
+	 */
+	WMVMED_FULL,
+
+	/**
+	 * Medium resolution video (Main Profile at Medium Level) with WMA
+	 * professional audio.
+	 */
+	WMVMED_PRO,
+
+	/**
+	 * Low resolution video (Simple Profile at Low Level) with baseline WMA
+	 * audio.
+	 */
+	WMVSPLL_BASE,
+
+	/**
+	 * Low resolution video (Simple profile at Medium Level) with baseline
+	 * WMA audio.
+	 */
+	WMVSPML_BASE,
+
+	/**
+	 * Low resolution video (Simple Profile at Medium Level) with MP3 audio.
+	 */
+	WMVSPML_MP3;
+
+	@Override
+	public String getAttributeString() {
+		return NAME + "=" + super.toString();
+	}
+
+	@Override
+	public ProtocolInfoAttributeName getName() {
+		return NAME;
+	}
+
+	@Override
+	public String getNameString() {
+		return NAME.getName();
+	}
+
+	@Override
+	public String getValue() {
+		return super.toString();
+	}
+
+	@Override
+	public String toString() {
+		return NAME + " = " + super.toString();
+	}
+
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/MimeType.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/MimeType.java
@@ -1,0 +1,379 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.pms.util.ParseException;
+
+/**
+ * This immutable class represents a mime-type.
+ *
+ * @author Nadahar
+ */
+public class MimeType implements Comparable<MimeType>, Serializable {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MimeType.class);
+	private static final long serialVersionUID = 1L;
+
+	/** The wildcard character */
+	public static final String ANY = "*";
+
+	/** A mime-type that represent any type and any subtype */
+	public static final MimeType ANYANY = new MimeType();
+
+	/** The type. */
+	protected final String type;
+
+	/** The subtype. */
+	protected final String subtype;
+
+	/** The {@link Map} of parameters. */
+	protected final Map<String, String> parameters;
+
+	/** The cached {@link #toString()} value */
+	protected final String stringValue;
+
+	/**
+	 * Creates a new {@link MimeType} instance with both {@code type} and
+	 * {@code subtype} set to {@link MimeType#ANY}.
+	 */
+	protected MimeType() {
+		this(ANY, ANY);
+	}
+
+	/**
+	 * Creates a new {@link MimeType} instance using the given values.
+	 *
+	 * @param type the first part of the mime-type.
+	 * @param subtype the second part of the mime-type.
+	 */
+	public MimeType(String type, String subtype) {
+		this(type, subtype, null);
+	}
+
+	/**
+	 * Creates a new {@link MimeType} instance using the given values.
+	 *
+	 * @param type the first part of the mime-type.
+	 * @param subtype the second part of the mime-type.
+	 * @param parameters a {@link Map} of additional parameters for this
+	 *            mime-type.
+	 */
+	public MimeType(String type, String subtype, Map<String, String> parameters) {
+		this.type = type == null ? ANY : type;
+		this.subtype = subtype == null ? ANY : subtype;
+		if (parameters == null) {
+			this.parameters = Collections.EMPTY_MAP;
+		} else {
+			TreeMap<String, String> map = new TreeMap<String, String>(new Comparator<String>() {
+
+				@Override
+				public int compare(String o1, String o2) {
+					return o1.compareToIgnoreCase(o2);
+				}
+
+			});
+			for (Entry<String, String> entry : parameters.entrySet()) {
+				map.put(entry.getKey(), entry.getValue());
+			}
+			this.parameters = Collections.unmodifiableSortedMap(map);
+		}
+		this.stringValue = generateStringValue();
+	}
+
+	/**
+	 * @return The {@code type} (first) part of this {@link MimeType}.
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @return Whether the {@code type} (first) part of this
+	 *         {@link MimeType} matches anything.
+	 */
+	public boolean isAnyType() {
+		return isBlank(type) || ANY.equals(type);
+	}
+
+	/**
+	 * @return The {@code subtype} (second) part of this {@link MimeType}.
+	 */
+	public String getSubtype() {
+		return subtype;
+	}
+
+	/**
+	 * @return Whether the {@code subtype} (second) part of this
+	 *         {@link MimeType} matches anything.
+	 */
+	public boolean isAnySubtype() {
+		return ANY.equals(subtype);
+	}
+
+	/**
+	 *
+	 * @return A {@link Map} containing the {@code parameters} of this
+	 *         {@link MimeType}. If no parameters exist, an empty
+	 *         {@link Map} is returned, not {@code null}.
+	 */
+	public Map<String, String> getParameters() {
+		return parameters;
+	}
+
+	/**
+	 * Determines whether this and {@code other} is compatible. That means being
+	 * either equal or having {@link #ANY} in {@code type} or {@code subtype} is
+	 * such a way that they can describe the same content without taking
+	 * parameters into account.
+	 *
+	 * @param other the {@link MimeType} to check compatibility against.
+	 * @return {@code true} of this and {@code other} is compatible,
+	 *         {@code false} otherwise.
+	 */
+	public boolean isCompatible(MimeType other) {
+		if (other == null) {
+			return false;
+		}
+		if (
+			(isBlank(type) || ANY.equals(type)) &&
+			isBlank(subtype) ||
+			(isBlank(other.type) || ANY.equals(other.type)) &&
+			isBlank(other.subtype)
+		) {
+			return true;
+		} else if (isBlank(type) || (isBlank(other.type))) {
+			return
+				isBlank(subtype) ||
+				isBlank(other.subtype) ||
+				ANY.equals(subtype) ||
+				ANY.equals(other.subtype) ||
+				subtype.toLowerCase(Locale.ROOT).equals(other.subtype.toLowerCase(Locale.ROOT));
+		} else if (
+			type.toLowerCase(Locale.ROOT).equals(other.type.toLowerCase(Locale.ROOT)) &&
+			(
+				isBlank(subtype) ||
+				ANY.equals(subtype) ||
+				isBlank(other.subtype) ||
+				ANY.equals(other.subtype)
+			)
+		) {
+			return true;
+		} else if (isBlank(subtype) || isBlank(other.subtype)) {
+			return false;
+		} else {
+			return
+				type.toLowerCase(Locale.ROOT).equals(other.type.toLowerCase(Locale.ROOT)) &&
+				subtype.toLowerCase(Locale.ROOT).equals(other.subtype.toLowerCase(Locale.ROOT));
+		}
+	}
+
+	/**
+	 * Creates a new {@link MimeType} by attempting to parse
+	 * {@code stringValue}.
+	 *
+	 * @param stringValue the {@link String} to parse.
+	 * @return The new {@link MimeType}.
+	 * @throws ParseException If {@code stringValue} isn't a valid mime-type.
+	 */
+	public static MimeType valueOf(String stringValue) throws ParseException {
+		if (isBlank(stringValue)) {
+			return ANYANY;
+		}
+
+		String[] parts = stringValue.trim().split("\\s*;\\s*");
+		String[] elements = parts[0].split("\\s*/\\s*");
+
+		String type = null;
+		String subtype = null;
+
+		if (elements.length < 2) {
+			if (parts[0].equals(ANY) || isBlank(parts[0])) {
+				type = ANY;
+				subtype = ANY;
+			} else {
+				type = elements[0];
+				subtype = ANY;
+			}
+		} else if (elements.length == 2) {
+			type = elements[0];
+			subtype = elements[1];
+		} else if (elements.length > 2) {
+			throw new ParseException("Error parsing mimetype \"" + parts[0] + "\" from \"" + stringValue + "\"");
+		}
+
+		if (parts.length > 1) {
+			HashMap<String, String> parameterMap = new HashMap<>();
+			for (int i = 1; i < parts.length; i++) {
+				if (isBlank(parts[i])) {
+					continue;
+				}
+				String[] parameter = parts[i].trim().split("\\s*=\\s*");
+				if (parameter.length == 2 && isNotBlank(parameter[0])) {
+					parameterMap.put(parameter[0], parameter[1]);
+				} else if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("MimeType: Unable to parse parameter \"{}\" - it will be ignored", parts[i]);
+				}
+			}
+			return new MimeType(type, subtype, parameterMap);
+		}
+		return new MimeType(type, subtype);
+	}
+
+	/**
+	 * Determines if this {@link MimeType} is a Digital Rights Management
+	 * mime-type.
+	 *
+	 * @return {@code true} if this {@link MimeType} represents DRM
+	 *         mime-type, {@code false} otherwise.
+	 */
+	public boolean isDRM() {
+		return isDTCP();
+	}
+
+	/**
+	 * Determines if this {@link MimeType} is in the special DLNA-DRM format
+	 * defined in the Digital Transmission Content Protection IP specification
+	 * {@code DTCP-IP}.
+	 *
+	 * @return {@code true} if this {@link MimeType} represents a DTCP
+	 *         mime-type, {@code false} otherwise.
+	 */
+	public boolean isDTCP() {
+		return "application".equalsIgnoreCase(type) && "x-dtcp1".equalsIgnoreCase(subtype);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof MimeType)) {
+			return false;
+		}
+		MimeType other = (MimeType) obj;
+		if (parameters == null) {
+			if (other.parameters != null) {
+				return false;
+			}
+		} else if (!parameters.equals(other.parameters)) {
+			return false;
+		}
+		if (subtype == null) {
+			if (other.subtype != null) {
+				return false;
+			}
+		} else if (other.subtype == null) {
+			return false;
+		} else if (!subtype.toLowerCase(Locale.ROOT).equals(other.subtype.toLowerCase(Locale.ROOT))) {
+			return false;
+		}
+		if (type == null) {
+			if (other.type != null) {
+				return false;
+			}
+		} else if (other.type == null) {
+			return false;
+		} else if (!type.toLowerCase(Locale.ROOT).equals(other.type.toLowerCase(Locale.ROOT))) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((parameters == null) ? 0 : parameters.hashCode());
+		result = prime * result + ((subtype == null) ? 0 : subtype.toLowerCase(Locale.ROOT).hashCode());
+		result = prime * result + ((type == null) ? 0 : type.toLowerCase(Locale.ROOT).hashCode());
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return stringValue;
+	}
+
+	/**
+	 * Generates the {@link String} value for caching of the {@link #toString()}
+	 * value.
+	 *
+	 * @return The generated {@link String} value.
+	 */
+	protected String generateStringValue() {
+		StringBuilder sb = new StringBuilder(toStringWithoutParameters());
+		if (parameters != null && parameters.size() > 0) {
+			for (Entry<String, String> parameter : parameters.entrySet()) {
+				sb.append(";").append(parameter.getKey()).append("=").append(parameter.getValue());
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Creates a {@link org.seamless.util.MimeType} from this instance.
+	 *
+	 * @return The new {@link org.seamless.util.MimeType} instance.
+	 */
+	public org.seamless.util.MimeType toSeamlessMimeType() {
+		return new org.seamless.util.MimeType(type, subtype, parameters);
+	}
+
+	/**
+	 * The same as {@link #toString()} but without any trailing parameters.
+	 *
+	 * @return The "basic mime-type" formatted {@link String}.
+	 */
+	public String toStringWithoutParameters() {
+		return type + "/" + subtype;
+	}
+
+	@Override
+	public int compareTo(MimeType other) {
+		if (other == null) {
+			return -1;
+		}
+		if (stringValue == null && other.stringValue != null) {
+			return 1;
+		}
+		if (stringValue != null && other.stringValue == null) {
+			return -1;
+		}
+		if (stringValue != null && other.stringValue != null) {
+			return stringValue.compareTo(other.stringValue);
+		}
+		return 0;
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/PanasonicComProfileName.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/PanasonicComProfileName.java
@@ -1,0 +1,164 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import net.pms.dlna.protocolinfo.ProtocolInfoAttributeName.KnownProtocolInfoAttributeName;
+
+/**
+ * This interface represents {@code PANASONIC.COM_PN} attributes.
+ *
+ * @author Nadahar
+ */
+@SuppressWarnings("checkstyle:InterfaceIsType")
+public interface PanasonicComProfileName extends ProfileName {
+
+	/** The static {@code NONE} instance representing a blank/empty value */
+	PanasonicComProfileName NONE = new DefaultPanasonicComProfileName("");
+
+	/**
+	 * The static factory singleton instance used to create and retrieve
+	 * {@link PanasonicComProfileName} instances.
+	 */
+	PanasonicComProfileNameFactory FACTORY = new PanasonicComProfileNameFactory();
+
+	/** The static attribute name always used for this class */
+	ProtocolInfoAttributeName NAME = KnownProtocolInfoAttributeName.PANASONIC_COM_PN;
+
+	/**
+	 * A factory for creating, caching and retrieving {@link PanasonicComProfileName}
+	 * instances.
+	 */
+	public static class PanasonicComProfileNameFactory extends AbstractProfileNameFactory<PanasonicComProfileName> {
+
+		/**
+		 * For internal use only, use {@link PanasonicComProfileName#FACTORY} to
+		 * get the singleton instance.
+		 */
+		protected PanasonicComProfileNameFactory() {
+		}
+
+		@Override
+		protected PanasonicComProfileName getNoneInstance() {
+			return NONE;
+		}
+
+		@Override
+		protected PanasonicComProfileName searchKnownInstances(String value) {
+			// Check for known instances
+			for (KnownPanasonicComProfileName knownAttribute : KnownPanasonicComProfileName.values()) {
+				if (value.equals(knownAttribute.getValue())) {
+					return knownAttribute;
+				}
+			}
+			return null;
+		}
+
+		@Override
+		protected PanasonicComProfileName getNewInstance(String value) {
+			return new DefaultPanasonicComProfileName(value);
+		}
+	}
+
+	/**
+	 * This contains predefined {@code PANASONIC.COM_PN} values.
+	 */
+	public enum KnownPanasonicComProfileName implements PanasonicComProfileName {
+		//XXX Add profiles
+
+		/** Undefined image profile. */
+		MPO_3D,
+
+		/** Undefined video profile. */
+		PV_DIVX_DIV3,
+
+		/** Undefined video profile. */
+		PV_DIVX_DIV4,
+
+		/** Undefined video profile. */
+		PV_DIVX_DIVX,
+
+		/** Undefined video profile. */
+		PV_DIVX_DX50,
+
+		/** Undefined DRM video profile. */
+		PV_DRM_DIVX_DIV3,
+
+		/** Undefined DRM video profile. */
+		PV_DRM_DIVX_DIV4,
+
+		/** Undefined DRM video profile. */
+		PV_DRM_DIVX_DIVX,
+
+		/** Undefined DRM video profile. */
+		PV_DRM_DIVX_DX50;
+
+		@Override
+		public String getValue() {
+			return super.toString();
+		}
+
+		@Override
+		public String toString() {
+			return NAME + " = " + super.toString();
+		}
+
+		@Override
+		public ProtocolInfoAttributeName getName() {
+			return NAME;
+		}
+
+		@Override
+		public String getNameString() {
+			return NAME.getName();
+		}
+
+		@Override
+		public String getAttributeString() {
+			return NAME + "=" + super.toString();
+		}
+
+	}
+
+	/**
+	 * This is the default, immutable class implementing
+	 * {@link PanasonicComProfileName}. {@link PanasonicComProfileNameFactory}
+	 * creates and caches instances of this class.
+	 */
+	public static class DefaultPanasonicComProfileName extends AbstractDefaultProfileName implements PanasonicComProfileName {
+
+		private static final long serialVersionUID = 1L;
+
+		/**
+		 * For internal use only, use
+		 * {@link PanasonicComProfileNameFactory#createProfileName} to create
+		 * new instances.
+		 *
+		 * @param value the profile name.
+		 */
+		protected DefaultPanasonicComProfileName(String value) {
+			super(value);
+		}
+
+		@Override
+		public ProtocolInfoAttributeName getName() {
+			return NAME;
+		}
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/PanasonicDmpProfiles.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/PanasonicDmpProfiles.java
@@ -1,0 +1,526 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.commons.lang3.StringUtils;
+import org.fourthline.cling.support.model.Protocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.pms.configuration.RendererConfiguration;
+import net.pms.dlna.protocolinfo.PanasonicComProfileName.KnownPanasonicComProfileName;
+import net.pms.util.ParseException;
+
+/**
+ * This class handles a Panasonic DMP's {@link ProfileName}s from the custom
+ * {@code X-PANASONIC-DMP-Profile} HTTP header field.
+ * <p>
+ * The {@code X-PANASONIC-DMP-Profile} doesn't provide {@code protocolInfo}
+ * information, it simply lists a set of supported DLNA and non-DLNA format
+ * profiles. This class still makes {@link ProtocolInfo} instances that
+ * "represent" the listed profiles when this can be "reasonably deducted". This
+ * allows the information given in {@code X-PANASONIC-DMP-Profile} to be
+ * accessed as a "drop in replacement" for the information gotten from renderers
+ * with {@code GetProtocolInfo}.
+ * <p>
+ * Any instance of {@link PanasonicDmpProfiles} must be "linked" with a
+ * {@link DeviceProtocolInfo} instance that represents the same device. The
+ * {@link ProtocolInfo} instances parsed or added is stored in this "linked"
+ * instance.
+ * <p>
+ * This class is thread-safe.
+ *
+ * @author Nadahar
+ */
+public class PanasonicDmpProfiles implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The logger. */
+	private static final Logger LOGGER = LoggerFactory.getLogger(PanasonicDmpProfiles.class);
+
+	/** The static singleton {@code X-PANASONIC-DMP-Profile} identifier */
+	public static final DeviceProtocolInfoSource<PanasonicDmpProfiles> PANASONIC_DMP = new PanasonicDmpProfileType();
+
+	/** The populated status */
+	protected volatile boolean populated;
+
+	/** The linked {@link DeviceProtocolInfo} */
+	protected final DeviceProtocolInfo deviceProtocolInfo;
+
+	/**
+	 * Creates a new empty instance.
+	 *
+	 * @param deviceProtocolInfo the {@link DeviceProtocolInfo} instance to link
+	 *            with the new instance.
+	 */
+	public PanasonicDmpProfiles(DeviceProtocolInfo deviceProtocolInfo) {
+		if (deviceProtocolInfo == null) {
+			throw new IllegalArgumentException("deviceProtocolInfo cannot be null");
+		}
+		this.deviceProtocolInfo = deviceProtocolInfo;
+	}
+
+	/**
+	 * Creates a new instance, tries to parse {@code dmpProfileString} and adds
+	 * the resulting {@link ProtocolInfo} instances to the {@link Set} of
+	 * {@link ProtocolInfo} in {@code deviceProtocolInfo}.
+	 *
+	 * @param deviceProtocolInfo the {@link DeviceProtocolInfo} instance to link
+	 *            with the new instance.
+	 * @param dmpProfilesString a comma separated string of {@code protocolInfo}
+	 *            representations.
+	 */
+	public PanasonicDmpProfiles(DeviceProtocolInfo deviceProtocolInfo, String dmpProfilesString) {
+		if (deviceProtocolInfo == null) {
+			throw new IllegalArgumentException("deviceProtocolInfo cannot be null");
+		}
+		this.deviceProtocolInfo = deviceProtocolInfo;
+		add(dmpProfilesString);
+	}
+
+	/**
+	 * @return {@code true} if the {@link Set} of {@link ProtocolInfo} in
+	 *         {@code deviceProtocolInfo} has already been populated with
+	 *         information from a {@code X-PANASONIC-DMP-Profile} field,
+	 *         {@code false} otherwise.
+	 */
+	public boolean isPopulated() {
+		return populated;
+	}
+
+	/**
+	 * Tries to parse {@code dmpProfilesString} and adds the resulting
+	 * {@link ProtocolInfo} instances to the {@link Set} of type
+	 * {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo}.
+	 *
+	 * @param dmpProfilesString a space separated string of format profile
+	 *            representations whose presence is to be ensured.
+	 * @return {@code true} if the {@link Set} of {@link ProtocolInfo} in
+	 *         {@code deviceProtocolInfo} changed as a result of the call.
+	 *         Returns {@code false} this already contains the specified
+	 *         elements.
+	 */
+	public boolean add(String dmpProfilesString) {
+		if (StringUtils.isBlank(dmpProfilesString)) {
+			return false;
+		}
+
+		dmpProfilesString = dmpProfilesString.replaceFirst("\\s*X-PANASONIC-DMP-Profile:\\s*", "").trim();
+		String[] elements = dmpProfilesString.trim().split("\\s+");
+
+		SortedSet<ProtocolInfo> protocolInfoSet = new TreeSet<>();
+		for (String element : elements) {
+			try {
+				ProtocolInfo protocolInfo = dmpProfileToProtocolInfo(element);
+				if (protocolInfo != null) {
+					protocolInfoSet.add(protocolInfo);
+				}
+			} catch (ParseException e) {
+				LOGGER.warn(
+					"Unable to parse protocolInfo from \"{}\", this profile will not be registered: {}",
+					element,
+					e.getMessage());
+				LOGGER.trace("", e);
+			}
+		}
+		boolean result = false;
+		if (!protocolInfoSet.isEmpty()) {
+			result = deviceProtocolInfo.addAll(PANASONIC_DMP, protocolInfoSet);
+		}
+
+		populated |= result;
+		return result;
+	}
+
+	// Standard java.util.Collection methods
+
+
+	/**
+	 * Returns the number of elements of type {@link PanasonicDmpProfileType} in
+	 * {@code deviceProtocolInfo}. If this contains more than
+	 * {@link Integer#MAX_VALUE} elements, returns {@link Integer#MAX_VALUE}.
+	 *
+	 * @return The number of elements in the {@link Set} for
+	 *         {@link PanasonicDmpProfiles}.
+	 */
+	public int size() {
+		return deviceProtocolInfo.size(PANASONIC_DMP);
+	}
+
+	/**
+	 * Checks if the {@link Set} of type {@link PanasonicDmpProfileType} in
+	 * {@code deviceProtocolInfo} is empty.
+	 *
+	 * @return {@code true} if {@code deviceProtocolInfo} contains no elements
+	 *         of type {@link PanasonicDmpProfileType}, {@code false} otherwise.
+	 */
+	public boolean isEmpty() {
+		return deviceProtocolInfo.isEmpty(PANASONIC_DMP);
+	}
+
+	/**
+	 * Returns {@code true} if the {@link Set} of type
+	 * {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo} contains
+	 * the specified element.
+	 *
+	 * @param protocolInfo the element whose presence is to be tested.
+	 * @return {@code true} if the {@link Set} of type
+	 *         {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo}
+	 *         contains the specified element, {@code false} otherwise.
+	 */
+	public boolean contains(ProtocolInfo protocolInfo) {
+		return deviceProtocolInfo.contains(PANASONIC_DMP, protocolInfo);
+	}
+
+	/**
+	 * Returns a sorted array containing all of the elements of the {@link Set}
+	 * of type {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo}.
+	 * <p>
+	 * The returned array will be "safe" in that no reference to it is
+	 * maintained. (In other words, this method must allocate a new array). The
+	 * caller is thus free to modify the returned array.
+	 *
+	 * @return An array containing the {@link ProtocolInfo} instances.
+	 */
+	public ProtocolInfo[] toArray() {
+		return deviceProtocolInfo.toArray(PANASONIC_DMP);
+	}
+
+
+	/**
+	 * Returns {@code true} if the {@link Set} of type
+	 * {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo} contains
+	 * all of the elements in the specified collection.
+	 *
+	 * @param collection a {@link Collection} to be checked for containment.
+	 * @return {@code true} if the {@link Set} of type
+	 *         {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo}
+	 *         collection contains all of the elements in {@code collection}.
+	 *
+	 * @see #contains(ProtocolInfo))
+	 */
+	public boolean containsAll(Collection<ProtocolInfo> collection) {
+		return deviceProtocolInfo.containsAll(PANASONIC_DMP, collection);
+	}
+
+
+	/**
+	 * Removes all elements from the {@link Set} of type
+	 * {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo}.
+	 */
+	public void clear() {
+		deviceProtocolInfo.clear(PANASONIC_DMP);
+		populated = false;
+	}
+
+	/**
+	 * Ensures that the the {@link Set} of type {@link PanasonicDmpProfileType}
+	 * in {@code deviceProtocolInfo} contains the specified element. Returns
+	 * {@code true} if the {@link Set} changed as a result of the call. Returns
+	 * {@code false} the {@link Set} already contains the specified element.
+	 *
+	 * @param protocolInfo element whose presence is to be ensured.
+	 * @return {@code true} if the the {@link Set} of type
+	 *         {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo}
+	 *         changed as a result of the call, {@code false} otherwise.
+	 */
+	public boolean add(ProtocolInfo protocolInfo) {
+		if (deviceProtocolInfo.add(PANASONIC_DMP, protocolInfo)) {
+			populated = true;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Adds all of the elements in the specified collection to the {@link Set}
+	 * of type {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo}.
+	 *
+	 * @param collection a {@link Collection} containing the elements to be
+	 *            added.
+	 * @return {@code true} if the {@link Set} of type
+	 *         {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo}
+	 *         changed as a result of the call, {@code false} otherwise.
+	 *
+	 * @see #add(ProtocolInfo)
+	 */
+	public boolean addAll(Collection<? extends ProtocolInfo> collection) {
+		if (deviceProtocolInfo.addAll(PANASONIC_DMP, collection)) {
+			populated = true;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Removes a single instance of {@link ProtocolInfo} from the {@link Set} of
+	 * type {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo}, if it
+	 * is present. Returns {@code true} if the {@link Set} contained the
+	 * specified element (or equivalently, if the {@link Set} of type
+	 * {@link PanasonicDmpProfileType} in {@code deviceProtocolInfo} changed as
+	 * a result of the call).
+	 *
+	 * @param protocolInfo element to be removed, if present.
+	 * @return {@code true} if an element was removed as a result of this call,
+	 *         {@code false} otherwise.
+	 */
+	public boolean remove(ProtocolInfo protocolInfo) {
+		return deviceProtocolInfo.remove(PANASONIC_DMP, protocolInfo);
+	}
+
+	/**
+	 * Removes all elements that are also contained in {@code collection} from
+	 * the {@link Set} of type {@link PanasonicDmpProfileType} in
+	 * {@code deviceProtocolInfo}.
+	 *
+	 * @param collection a {@link Collection} containing the elements to be
+	 *            removed.
+	 * @return {@code true} if this call resulted in a change.
+	 *
+	 * @see #remove(ProtocolInfo)
+	 * @see #contains(ProtocolInfo)
+	 */
+	public boolean removeAll(Collection<ProtocolInfo> collection) {
+		if (deviceProtocolInfo.removeAll(PANASONIC_DMP, collection)) {
+			if (deviceProtocolInfo.isEmpty(PANASONIC_DMP)) {
+				populated = false;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Retains only the elements that are contained in {@code collection} in the
+	 * {@link Set} of type {@link PanasonicDmpProfileType} in
+	 * {@code deviceProtocolInfo}. In other words, removes all elements that are
+	 * not contained in {@code collection}.
+	 *
+	 * @param collection a {@link Collection} containing the elements to be
+	 *            retained.
+	 * @return {@code true} if this call resulted in a change.
+	 *
+	 * @see #remove(ProtocolInfo)
+	 * @see #contains(ProtocolInfo)
+	 */
+	public boolean retainAll(Collection<ProtocolInfo> collection) {
+		if (deviceProtocolInfo.removeAll(collection)) {
+			if (deviceProtocolInfo.isEmpty()) {
+				populated = false;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return deviceProtocolInfo.toString(PANASONIC_DMP, false);
+	}
+
+	/**
+	 * Returns a string representation of the {@link Set} of type
+	 * {@link PanasonicDmpProfileType} in the linked {@link DeviceProtocolInfo}
+	 * instance. If {@code debug} is {@code true}, verbose output is returned.
+	 *
+	 * @param debug whether or not verbose output should be generated.
+	 * @return The string representation.
+	 */
+	public String toString(boolean debug) {
+		return deviceProtocolInfo.toString(PANASONIC_DMP, debug);
+	}
+
+
+	// Static methods
+
+
+	/**
+	 * Creates a {@link DeviPanasonicDmpProfiles} instance for {@code renderer}
+	 * as needed. Parses {@code dmpProfilesString} and store the results in the
+	 * linked {@link DeviceProtocolInfo} instance. This method assumes that the
+	 * renderer sends the same string every time.
+	 *
+	 * @param dmpProfilesString the {@code X-PANASONIC-DMP-Profile} string to
+	 *            parse.
+	 * @param renderer the {@link RendererConfiguration} for which to apply the
+	 *            parsing results.
+	 * @throws IllegalStateException If {@code renderer}'s
+	 *             {@code deviceProtocolInfo} is {@code null}.
+	 */
+	public static void parsePanasonicDmpProfiles(String dmpProfilesString, RendererConfiguration renderer) {
+		if (renderer == null) {
+			return;
+		}
+		if (renderer.deviceProtocolInfo == null) {
+			throw new IllegalStateException(
+				"Panasonic DMP profiles cannot be parsed before the renderer's deviceProtocolInfo is instantiated"
+			);
+		}
+		boolean added = false;
+		if (renderer.panasonicDmpProfiles == null) {
+			renderer.panasonicDmpProfiles = new PanasonicDmpProfiles(renderer.deviceProtocolInfo, dmpProfilesString);
+			added = true;
+		} else if (!renderer.panasonicDmpProfiles.isPopulated()) {
+			added = renderer.panasonicDmpProfiles.add(dmpProfilesString);
+		}
+		if (added && LOGGER.isTraceEnabled() && !renderer.panasonicDmpProfiles.isEmpty()) {
+			LOGGER.trace(
+				"Received X-PANASONIC-DMP-Profiles from \"{}\":\n\n{}",
+				renderer.getConfName(),
+				renderer.panasonicDmpProfiles
+			);
+		}
+	}
+
+	/**
+	 * Tries to convert an element from a {@code X-PANASONIC-DMP-Profile} string
+	 * to a {@link ProtocolInfo} instance. This is a manual mapping which must
+	 * be extended when new profiles are discovered.
+	 *
+	 * @param dmpProfile the {@code X-PANASONIC-DMP-Profile} string element.
+	 * @return A new {@link ProtocolInfo} instance if one could be created, or
+	 *         {@code null}.
+	 * @throws ParseException If there is a problem while parsing
+	 *             {@code dmpProfile}.
+	 */
+	public static ProtocolInfo dmpProfileToProtocolInfo(String dmpProfile) throws ParseException {
+		if (isBlank(dmpProfile)) {
+			return null;
+		}
+		dmpProfile = dmpProfile.trim();
+		ProtocolInfoAttribute attribute = DLNAOrgProfileName.FACTORY.getProfileName(dmpProfile);
+		if (attribute != null) {
+			// Mime-types must be mapped manually, as this information is missing from X-PANASONIC-DMP-Profile
+			MimeType mimeType;
+			if (attribute.getValue().startsWith("JPEG")) {
+				mimeType = new MimeType("image", "jpeg");
+			} else if (attribute.getValue().startsWith("PNG")) {
+				mimeType = new MimeType("image", "png");
+			} else if (attribute.getValue().startsWith("GIF")) {
+				mimeType = new MimeType("image", "gif");
+			} else if (attribute.getValue().startsWith("MPEG")) {
+				mimeType = new MimeType("video", "mpeg");
+			} else if (attribute.getValue().startsWith("AC3")) {
+				mimeType = new MimeType("audio", "vnd.dolby.dd-raw");
+			} else if (attribute.getValue().startsWith("AMR")) {
+				mimeType = new MimeType("audio", "3gpp");
+			} else if (attribute.getValue().startsWith("LPCM")) {
+				mimeType = new MimeType("audio", "L16");
+			} else if (attribute.getValue().startsWith("MP2")) {
+				mimeType = new MimeType("audio", "mpeg");
+			} else if (attribute.getValue().startsWith("MP3")) {
+				mimeType = new MimeType("audio", "mpeg");
+			} else if (attribute.getValue().startsWith("AAC")) {
+				mimeType = new MimeType("audio", "mp4");
+			} else if (attribute.getValue().startsWith("WMA")) {
+				mimeType = new MimeType("audio", "x-ms-wma");
+			} else if (attribute.getValue().startsWith("MPEG4")) {
+				mimeType = new MimeType("video", "mp4");
+			} else if (attribute.getValue().startsWith("MPEG")) {
+				mimeType = new MimeType("video", "mpeg");
+			} else if (attribute.getValue().startsWith("WMV")) {
+				mimeType = new MimeType("video", "x-ms-wmv");
+			} else if (attribute.getValue().startsWith("VC1")) {
+				mimeType = new MimeType("video", "mpeg");
+			} else {
+				throw new ParseException("Can't infer mime-type for \"" + attribute + "\"");
+			}
+			return new ProtocolInfo(
+				Protocol.HTTP_GET,
+				ProtocolInfo.WILDCARD,
+				mimeType,
+				Collections.singletonMap(attribute.getName(), attribute)
+			);
+		}
+		attribute = PanasonicComProfileName.FACTORY.getProfileName(dmpProfile);
+		if (attribute != null) {
+			// Mime-types must be mapped manually, as this information is missing from X-PANASONIC-DMP-Profile
+			if (attribute instanceof KnownPanasonicComProfileName) {
+				MimeType mimeType;
+				switch ((KnownPanasonicComProfileName) attribute) {
+					case MPO_3D:
+						mimeType = new MimeType("image", "mpo");
+						break;
+					case PV_DIVX_DIV3:
+					case PV_DIVX_DIV4:
+					case PV_DIVX_DIVX:
+					case PV_DIVX_DX50:
+						mimeType = new MimeType("video", "divx");
+						break;
+					case PV_DRM_DIVX_DIV3:
+					case PV_DRM_DIVX_DIV4:
+					case PV_DRM_DIVX_DIVX:
+					case PV_DRM_DIVX_DX50:
+						// No idea what mime-type they use for DRM, or how to handle them
+						return null;
+					default:
+						throw new ParseException("Unimplemented PANASONIC.COM_PN profile \"" + attribute + "\"");
+				}
+				return new ProtocolInfo(
+					Protocol.HTTP_GET,
+					ProtocolInfo.WILDCARD,
+					mimeType,
+					Collections.singletonMap(attribute.getName(), attribute)
+				);
+			}
+			throw new ParseException("Can't infer mime-type for \"" + attribute + "\"");
+		}
+
+		// No match found for known DLNA.ORG_PN or PANASONIC.COM_PN profiles
+		LOGGER.debug("Warning: Unable to parse X-PANASONIC-DMP-Profile \"{}\"", dmpProfile);
+		return null;
+	}
+
+	/**
+	 * This is an implementation of {@link DeviceProtocolInfoSource} where
+	 * {@link PanasonicDmpProfiles} is the parsing class.
+	 *
+	 * @author Nadahar
+	 */
+	public static class PanasonicDmpProfileType extends DeviceProtocolInfoSource<PanasonicDmpProfiles> {
+
+		private static final long serialVersionUID = 1L;
+
+		/**
+		 * Not to be instantiated, use
+		 * {@link PanasonicDmpProfiles#PANASONIC_DMP} instead.
+		 */
+		protected PanasonicDmpProfileType() {
+		}
+
+		@Override
+		public Class<PanasonicDmpProfiles> getClazz() {
+			return PanasonicDmpProfiles.class;
+		}
+
+		@Override
+		public String getType() {
+			return "X-PANASONIC-DMP-Profile";
+		}
+	}
+
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/ProfileName.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/ProfileName.java
@@ -1,0 +1,391 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This interface represents {@code protocolInfo} profile name attributes like
+ * {@code DLNA.ORG_PN} or {@code SONY.COM_PN}.
+ *
+ * @author Nadahar
+ */
+public interface ProfileName extends ProtocolInfoAttribute {
+
+	/**
+	 * An abstract factory for creating, caching and retrieving
+	 * {@link ProfileName} instances.
+	 *
+	 * @param <E> the instance type
+	 */
+	public abstract static class AbstractProfileNameFactory<E extends ProfileName> {
+
+		/** The logger. */
+		private static final Logger LOGGER = LoggerFactory.getLogger(AbstractProfileNameFactory.class);
+
+		/** The instance cache lock. */
+		protected final ReentrantReadWriteLock instanceCacheLock = new ReentrantReadWriteLock();
+
+		/** The instance cache. */
+		protected final HashSet<E> instanceCache = new HashSet<>();
+
+		/**
+		 * Gets the static {@code NONE} instance used for representing
+		 * blank/empty values.
+		 *
+		 * @return the {@code NONE} instance.
+		 */
+		protected abstract E getNoneInstance();
+
+		/**
+		 * Searches through the predefined "known" instances, if any. Returns
+		 * the instance if a match is found, otherwise {@code null}.
+		 *
+		 * @param value the value to search for.
+		 * @return The found {@link ProfileName} or {@code null}.
+		 */
+		protected abstract E searchKnownInstances(String value);
+
+		/**
+		 * Creates a new instance of the concrete type {@link E}.
+		 *
+		 * @param value the value to use for the new instance.
+		 * @return The new instance of {@link E}.
+		 */
+		protected abstract E getNewInstance(String value);
+
+		/**
+		 * Retrieves an instance of {@link E} representing the profile name
+		 * {@code value} from the predefined instances or the cache. If no such
+		 * {@link E} instance exists, {@code null} is returned.
+		 *
+		 * @param value the profile name value.
+		 * @return The profile name instance of {@link E} or {@code null}.
+		 */
+		public E getProfileName(String value) {
+
+			// Check for static instances
+			if (isBlank(value)) {
+				return getNoneInstance();
+			}
+			value = value.trim().toUpperCase(Locale.ROOT);
+
+			// Check for known instances
+			E instance = searchKnownInstances(value);
+			if (instance != null) {
+				return instance;
+			}
+
+			// Check for cached instances
+			instanceCacheLock.readLock().lock();
+			try {
+				for (E cachedAttribute : instanceCache) {
+					if (value.equals(cachedAttribute.getValue())) {
+						return cachedAttribute;
+					}
+				}
+			} finally {
+				instanceCacheLock.readLock().unlock();
+			}
+			return null;
+		}
+
+		/**
+		 * Creates or retrieves an instance of {@link E} representing the
+		 * profile name {@code value}. Any existing predefined or cached
+		 * instances are first checked, and if none are found for {@code value}
+		 * a new instance is created.
+		 *
+		 * @param value the profile name value.
+		 * @return The profile name instance of {@link E}.
+		 */
+		public E createProfileName(String value) {
+
+			// Check if an instance for this value already exists
+			E instance = getProfileName(value);
+			if (instance != null) {
+				return instance;
+			}
+
+			// Null values will already have been handled above
+			value = value.trim().toUpperCase(Locale.ROOT);
+
+			// Prepare to create a new instance
+			instanceCacheLock.writeLock().lock();
+			try {
+				// Check cache again as it could have been added while the
+				// lock was released
+				for (E cachedAttribute : instanceCache) {
+					if (value.equals(cachedAttribute.getValue())) {
+						return cachedAttribute;
+					}
+				}
+
+				// None was found, create the instance
+				instance = getNewInstance(value);
+				instanceCache.add(instance);
+				LOGGER.trace("{} added unknown profile \"{}\"", getClass().getSimpleName(), value);
+				return instance;
+			} finally {
+				instanceCacheLock.writeLock().unlock();
+			}
+		}
+	}
+
+	/**
+	 * An abstract, immutable class of a default profile name implementation.
+	 * Default profile name classes are used by the {@code ProfileNameFactories}
+	 * when creating new instances not handled by any other class implementing
+	 * that interface.
+	 */
+	public abstract static class AbstractDefaultProfileName implements ProfileName {
+
+		private static final long serialVersionUID = 1L;
+
+		/** The profile name value. */
+		protected final String value;
+
+		/**
+		 * Instantiates a new {@link AbstractDefaultProfileName}. For use by
+		 * subclasses only.
+		 *
+		 * @param value the profile name value.
+		 */
+		protected AbstractDefaultProfileName(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String getValue() {
+			return value;
+		}
+
+		@Override
+		public String toString() {
+			return getName() + " = " + value;
+		}
+
+		@Override
+		public abstract ProtocolInfoAttributeName getName();
+
+		@Override
+		public String getNameString() {
+			return getName() == null ? "" : getName().getName();
+		}
+
+		@Override
+		public String getAttributeString() {
+			return
+				isBlank(getNameString()) || isBlank(value) ?
+					"" :
+					getNameString() + "=" + value;
+		}
+	}
+
+	/**
+	 * A factory for creating, caching and retrieving
+	 * {@link DefaultGenericProfileName} instances.
+	 */
+	public static class DefaultGenericProfileNameFactory {
+
+		/** The logger. */
+		private static final Logger LOGGER = LoggerFactory.getLogger(AbstractProfileNameFactory.class);
+
+		/** The instance cache lock. */
+		protected final ReentrantReadWriteLock instanceCacheLock = new ReentrantReadWriteLock();
+
+		/** The instance cache. */
+		protected final HashMap<ProtocolInfoAttributeName, HashSet<DefaultGenericProfileName>> instanceCache = new HashMap<>();
+
+		/**
+		 * For internal use only, use {@link DefaultGenericProfileName#FACTORY}
+		 * instead.
+		 */
+		protected DefaultGenericProfileNameFactory() {
+		}
+
+		/**
+		 * Retrieves an instance of {@link DefaultGenericProfileName}
+		 * representing attribute name {@code name} and profile name
+		 * {@code value} from the cache. If no such
+		 * {@link DefaultGenericProfileName} instance exists, {@code null} is
+		 * returned.
+		 *
+		 * @param name the attribute name.
+		 * @param value the profile name value.
+		 * @return The {@link DefaultGenericProfileName} instance or
+		 *         {@code null}.
+		 */
+		public DefaultGenericProfileName getProfileName(String name, String value) {
+			return getProfileName(ProtocolInfoAttributeName.FACTORY.createAttributeName(name), value);
+		}
+
+		/**
+		 * Retrieves an instance of {@link DefaultGenericProfileName}
+		 * representing attribute name {@code name} and profile name
+		 * {@code value} from the cache. If no such
+		 * {@link DefaultGenericProfileName} instance exists, {@code null} is
+		 * returned.
+		 *
+		 * @param name the {@link ProtocolInfoAttributeName}.
+		 * @param value the profile name value.
+		 * @return The {@link DefaultGenericProfileName} instance or
+		 *         {@code null}.
+		 */
+		public DefaultGenericProfileName getProfileName(ProtocolInfoAttributeName name, String value) {
+
+			// Make all blank values the same
+			if (isBlank(value)) {
+				value = "";
+			} else {
+				value = value.trim().toUpperCase(Locale.ROOT);
+			}
+
+			// Check for cached instances
+			instanceCacheLock.readLock().lock();
+			try {
+				HashSet<DefaultGenericProfileName> set = instanceCache.get(name);
+				if (set != null) {
+					for (DefaultGenericProfileName cachedProfileName : set) {
+						if (value.equals(cachedProfileName.getValue())) {
+							return cachedProfileName;
+						}
+					}
+				}
+			} finally {
+				instanceCacheLock.readLock().unlock();
+			}
+			return null;
+		}
+
+		/**
+		 * Creates or retrieves an instance of {@link DefaultGenericProfileName}
+		 * representing the profile name {@code value}. All cached instances are
+		 * checked first, and if none are found for {@code name} and
+		 * {@code value} a new instance is created and cached.
+		 *
+		 * @param name the attribute name.
+		 * @param value the profile name value.
+		 * @return The {@link DefaultGenericProfileName} instance.
+		 */
+		public DefaultGenericProfileName createProfileName(String name, String value) {
+			return createProfileName(ProtocolInfoAttributeName.FACTORY.createAttributeName(name), value);
+		}
+
+		/**
+		 * Creates or retrieves an instance of {@link DefaultGenericProfileName}
+		 * representing the profile name {@code value}. All cached instances are
+		 * checked first, and if none are found for {@code name} and
+		 * {@code value} a new instance is created and cached.
+		 *
+		 * @param name the {@link ProtocolInfoAttributeName}.
+		 * @param value the profile name value.
+		 * @return The {@link DefaultGenericProfileName} instance.
+		 */
+		public DefaultGenericProfileName createProfileName(ProtocolInfoAttributeName name, String value) {
+
+			// Check if an instance for this value already exists
+			DefaultGenericProfileName instance = getProfileName(name, value);
+			if (instance != null) {
+				return instance;
+			}
+
+			// Make all blank values the same
+			if (isBlank(value)) {
+				value = "";
+			} else {
+				value = value.trim().toUpperCase(Locale.ROOT);
+			}
+
+			// Prepare to create a new instance
+			instanceCacheLock.writeLock().lock();
+			try {
+				// Check cache again as it could have been added while the
+				// lock was released
+				HashSet<DefaultGenericProfileName> set = instanceCache.get(name);
+				if (set != null) {
+					for (DefaultGenericProfileName cachedProfileName : set) {
+						if (value.equals(cachedProfileName.getValue())) {
+							return cachedProfileName;
+						}
+					}
+				} else {
+					// Store this set
+					set = new HashSet<>();
+					instanceCache.put(name, set);
+				}
+
+				// None was found, create the instance
+				instance = new DefaultGenericProfileName(name, value);
+				set.add(instance);
+				LOGGER.trace("Adding unknown generic \"{}\" profile name \"{}\"", name, value);
+				return instance;
+			} finally {
+				instanceCacheLock.writeLock().unlock();
+			}
+		}
+	}
+
+	/**
+	 * This is the default, immutable class implementing generic
+	 * {@link ProfileName}, that is {@link ProfileName} types that doesn't have
+	 * a specific implementation. At this time, that is any {@code _PN}
+	 * attributes except {@code DLNA.ORG_PN}.
+	 * <p>
+	 * {@link DefaultGenericProfileNameFactory} creates and caches instances of
+	 * this class.
+	 */
+	public static class DefaultGenericProfileName extends AbstractDefaultProfileName {
+
+		private static final long serialVersionUID = 1L;
+
+		/**
+		 * The static factory singleton instance used to create and retrieve
+		 * {@link DefaultGenericProfileName} instances.
+		 */
+		public static final DefaultGenericProfileNameFactory FACTORY = new DefaultGenericProfileNameFactory();
+
+		/** The attribute name */
+		protected final ProtocolInfoAttributeName name;
+
+		/**
+		 * For internal use only, use {@link #FACTORY} to create new instances.
+		 *
+		 * @param name the {@link ProtocolInfoAttributeName}.
+		 * @param value the profile name.
+		 */
+		protected DefaultGenericProfileName(ProtocolInfoAttributeName name, String value) {
+			super(value);
+			this.name = name;
+		}
+
+		@Override
+		public ProtocolInfoAttributeName getName() {
+			return name;
+		}
+
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfo.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfo.java
@@ -1,0 +1,883 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.fourthline.cling.support.model.Protocol;
+import org.fourthline.cling.support.model.dlna.DLNAAttribute;
+import org.fourthline.cling.support.model.dlna.DLNAProfiles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.pms.dlna.protocolinfo.ProtocolInfoAttributeName.KnownProtocolInfoAttributeName;
+import net.pms.util.ParseException;
+
+
+/**
+ * This immutable class represents a {@code protocolInfo} element.
+ *
+ * @author Nadahar
+ */
+public class ProtocolInfo implements Comparable<ProtocolInfo>, Serializable {
+
+	private static final long serialVersionUID = 1L;
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProtocolInfo.class);
+
+	/** The wildcard character {@code "*"} */
+	public static final String WILDCARD = "*";
+
+	/** A static instance of an empty attribute map */
+	public static final SortedMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> EMPTYMAP =
+		Collections.unmodifiableSortedMap(createEmptyAttributesMap());
+
+	/** The protocol (first field) of {@code protocolInfo} */
+	protected final Protocol protocol;
+
+	/** The network (second field) of {@code protocolInfo} */
+	protected final String network;
+
+	/** The contentType (third field) of {@code protocolInfo} */
+	protected final MimeType mimeType;
+
+	/** The {@code additionalInfo} (fourth field) of {@code protocolInfo} */
+	protected final String additionalInfo;
+
+	/** The attributes parsed from {@code additionalInfo}. */
+	protected final SortedMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> attributes;
+
+	/** The cached string representation of {@link #attributes}. */
+	protected final String attributesString;
+
+	/** The cached string representation. */
+	protected final String stringValue;
+
+	/**
+	 * Creates a new instance by parsing a {@code ProtocolInfo} string.
+	 *
+	 * @param protocolInfoString the {@link String} to parse.
+	 * @throws ParseException If {@code protocolInfoString} can't be parsed.
+	 */
+	public ProtocolInfo(String protocolInfoString) throws ParseException {
+		String tmpNetwork = WILDCARD;
+		MimeType tmpMimeType = MimeType.ANYANY;
+		String tmpAdditionalInfo = WILDCARD;
+
+		if (isBlank(protocolInfoString)) {
+			protocol = Protocol.ALL;
+		} else {
+			protocolInfoString = protocolInfoString.trim();
+			String[] elements = protocolInfoString.split("\\s*:\\s*");
+			protocol = Protocol.value(elements[0]);
+			if (elements.length > 1) {
+				tmpNetwork = elements[1];
+			}
+			if (elements.length > 2) {
+				tmpMimeType = createMimeType(elements[2]);
+			}
+			if (elements.length > 3) {
+				tmpAdditionalInfo = elements[3];
+			}
+			if (elements.length > 4) {
+				throw new ParseException("Invalid protocolInfo string \"" + protocolInfoString + "\"");
+			}
+		}
+
+		network = tmpNetwork;
+		mimeType = tmpMimeType;
+		additionalInfo = tmpAdditionalInfo;
+		attributes = Collections.unmodifiableSortedMap(parseAdditionalInfo());
+		attributesString = generateAttributesString();
+		stringValue = generateStringValue();
+	}
+
+	/**
+	 * Creates a new instance using the provided information.
+	 *
+	 * @param protocol the {@link Protocol} for the new instance. Use
+	 *            {@code null} for "any".
+	 * @param network the network for the new instance. Use {@code null} or
+	 *            blank for "any".
+	 * @param contentFormat the content format for the new instance. Use
+	 *            {@code null} or blank for "any".
+	 * @param additionalInfo the additional information for the new instance.
+	 */
+	public ProtocolInfo(Protocol protocol, String network, String contentFormat, String additionalInfo) {
+		this.protocol = protocol == null ? Protocol.ALL : protocol;
+		this.network = isBlank(network) ? WILDCARD : network;
+		this.mimeType = createMimeType(contentFormat);
+		this.additionalInfo = isBlank(additionalInfo) ? WILDCARD : additionalInfo;
+		this.attributes = Collections.unmodifiableSortedMap(parseAdditionalInfo());
+		this.attributesString = generateAttributesString();
+		this.stringValue = generateStringValue();
+	}
+
+	/**
+	 * Creates a new instance using the provided information.
+	 *
+	 * @param protocol the {@link Protocol} for the new instance. Use
+	 *            {@code null} for "any".
+	 * @param network the network for the new instance. Use {@code null} or
+	 *            blank for "any".
+	 * @param mimeType the mime-type for the new instance. Use {@code null} or
+	 *            {@link MimeType#ANYANY} for "any".
+	 * @param additionalInfo the additional information for the new instance.
+	 */
+	public ProtocolInfo(Protocol protocol, String network, MimeType mimeType, String additionalInfo) {
+		this.protocol = protocol == null ? Protocol.ALL : protocol;
+		this.network = isBlank(network) ? WILDCARD : network;
+		this.mimeType = mimeType == null ? MimeType.ANYANY : mimeType;
+		this.additionalInfo = isBlank(additionalInfo) ? WILDCARD : additionalInfo;
+		this.attributes = Collections.unmodifiableSortedMap(parseAdditionalInfo());
+		this.attributesString = generateAttributesString();
+		this.stringValue = generateStringValue();
+	}
+
+	/**
+	 * Creates a new instance using the provided information.
+	 *
+	 * @param protocol the {@link Protocol} for the new instance. Use
+	 *            {@code null} for "any".
+	 * @param network the network for the new instance. Use {@code null} or
+	 *            blank for "any".
+	 * @param contentFormat the content format for the new instance. Use
+	 *            {@code null} or blank for "any".
+	 * @param attributes a {@link Map} of {@link ProtocolInfoAttributeName} and
+	 *            {@link ProtocolInfoAttribute} pairs for the new instance.
+	 */
+	public ProtocolInfo(
+		Protocol protocol,
+		String network,
+		String contentFormat,
+		Map<ProtocolInfoAttributeName, ProtocolInfoAttribute> attributes
+	) {
+		this.protocol = protocol == null ? Protocol.ALL : protocol;
+		this.network = isBlank(network) ? WILDCARD : network;
+		this.mimeType = createMimeType(contentFormat);
+		TreeMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> tmpAttributes = createEmptyAttributesMap();
+		tmpAttributes.putAll(attributes);
+		this.attributes = Collections.unmodifiableSortedMap(tmpAttributes);
+		this.attributesString = generateAttributesString();
+		this.additionalInfo = this.attributesString;
+		this.stringValue = generateStringValue();
+	}
+
+	/**
+	 * Creates a new instance using the provided information.
+	 *
+	 * @param protocol the {@link Protocol} for the new instance. Use
+	 *            {@code null} for "any".
+	 * @param network the network for the new instance. Use {@code null} or
+	 *            blank for "any".
+	 * @param mimeType the mime-type for the new instance. Use {@code null} or
+	 *            {@link MimeType#ANYANY} for "any".
+	 * @param attributes a {@link Map} of {@link ProtocolInfoAttributeName} and
+	 *            {@link ProtocolInfoAttribute} pairs for the new instance.
+	 */
+	public ProtocolInfo(
+		Protocol protocol,
+		String network,
+		MimeType mimeType,
+		Map<ProtocolInfoAttributeName, ProtocolInfoAttribute> attributes
+	) {
+		this.protocol = protocol == null ? Protocol.ALL : protocol;
+		this.network = isBlank(network) ? WILDCARD : network;
+		this.mimeType = mimeType == null ? MimeType.ANYANY : mimeType;
+		TreeMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> tmpAttributes = createEmptyAttributesMap();
+		tmpAttributes.putAll(attributes);
+		this.attributes = Collections.unmodifiableSortedMap(tmpAttributes);
+		this.attributesString = generateAttributesString();
+		this.additionalInfo = this.attributesString;
+		this.stringValue = generateStringValue();
+	}
+
+	/**
+	 * Creates a new instance using the provided information.
+	 *
+	 * @param protocol the {@link Protocol} for the new instance. Use
+	 *            {@code null} for "any".
+	 * @param network the network for the new instance. Use {@code null} or
+	 *            blank for "any".
+	 * @param contentFormat the content format for the new instance. Use
+	 *            {@code null} or blank for "any".
+	 * @param attributes an {@link EnumMap} with {@link DLNAAttribute}s the new
+	 *            instance.
+	 */
+	public ProtocolInfo(
+		Protocol protocol,
+		String network,
+		String contentFormat,
+		EnumMap<DLNAAttribute.Type, DLNAAttribute<?>> attributes
+	) {
+		this.protocol = protocol == null ? Protocol.ALL : protocol;
+		this.network = isBlank(network) ? WILDCARD : network;
+		this.mimeType = createMimeType(contentFormat);
+		this.attributes = Collections.unmodifiableSortedMap(dlnaAttributesToAttributes(attributes));
+		this.attributesString = generateAttributesString();
+		this.additionalInfo = this.attributesString;
+		this.stringValue = generateStringValue();
+	}
+
+	/**
+	 * Creates a new instance using the provided information.
+	 *
+	 * @param protocol the {@link Protocol} for the new instance. Use
+	 *            {@code null} for "any".
+	 * @param network the network for the new instance. Use {@code null} or
+	 *            blank for "any".
+	 * @param mimeType the mime-type for the new instance. Use {@code null} or
+	 *            {@link MimeType#ANYANY} for "any".
+	 * @param attributes an {@link EnumMap} with {@link DLNAAttribute}s for the
+	 *            new instance.
+	 */
+	public ProtocolInfo(
+		Protocol protocol,
+		String network,
+		MimeType mimeType,
+		EnumMap<DLNAAttribute.Type, DLNAAttribute<?>> attributes
+	) {
+		this.protocol = protocol == null ? Protocol.ALL : protocol;
+		this.network = isBlank(network) ? WILDCARD : network;
+		this.mimeType = mimeType == null ? MimeType.ANYANY : mimeType;
+		this.attributes = Collections.unmodifiableSortedMap(dlnaAttributesToAttributes(attributes));
+		this.attributesString = generateAttributesString();
+		this.additionalInfo = this.attributesString;
+		this.stringValue = generateStringValue();
+	}
+
+	/**
+	 * Creates a new instance based on a {@link DLNAProfiles} profile.
+	 *
+	 * @param protocol the {@link Protocol} for the new instance.
+	 * @param profile the {@link DLNAProfiles} profile for the new instance.
+	 */
+	public ProtocolInfo(Protocol protocol, DLNAProfiles profile) {
+		this.protocol = protocol == null ? Protocol.ALL : protocol;
+		this.network = WILDCARD;
+		this.mimeType = createMimeType(profile.getContentFormat());
+		SortedMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> tmpAttributes = createEmptyAttributesMap();
+		DLNAOrgProfileName profileName = DLNAOrgProfileName.FACTORY.createProfileName(profile.getCode());
+		tmpAttributes.put(profileName.getName(), profileName);
+		this.attributes = Collections.unmodifiableSortedMap(tmpAttributes);
+		this.attributesString = generateAttributesString();
+		this.additionalInfo = this.attributesString;
+		this.stringValue = generateStringValue();
+	}
+
+	/**
+	 * Creates a new instance based on a {@link DLNAProfiles} profile and
+	 * additional {@link DLNAAttribute}s.
+	 *
+	 * @param protocol the {@link Protocol} for the new instance.
+	 * @param profile the {@link DLNAProfiles} profile for the new instance.
+	 * @param dlnaAttributes an {@link EnumMap} with {@link DLNAAttribute}s for
+	 *            the new instance.
+	 */
+	public ProtocolInfo(
+		Protocol protocol,
+		DLNAProfiles profile,
+		EnumMap<DLNAAttribute.Type, DLNAAttribute<?>> dlnaAttributes
+	) {
+		this.protocol = protocol == null ? Protocol.ALL : protocol;
+		this.network = WILDCARD;
+		this.mimeType = createMimeType(profile.getContentFormat());
+		TreeMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> tmpAttributes =
+			dlnaAttributesToAttributes(dlnaAttributes);
+		DLNAOrgProfileName profileName = DLNAOrgProfileName.FACTORY.createProfileName(profile.getCode());
+		tmpAttributes.put(profileName.getName(), profileName);
+		this.attributes = Collections.unmodifiableSortedMap(tmpAttributes);
+		this.attributesString = generateAttributesString();
+		this.additionalInfo = this.attributesString;
+		this.stringValue = generateStringValue();
+	}
+
+	/**
+	 * Creates a new instance from a {@link org.fourthline.cling.support.model.ProtocolInfo} instance.
+	 *
+	 * @param template the {@link org.fourthline.cling.support.model.ProtocolInfo} instance.
+	 */
+	public ProtocolInfo(org.fourthline.cling.support.model.ProtocolInfo template) {
+		this(template.getProtocol(),
+			template.getNetwork(),
+			template.getContentFormat(),
+			template.getAdditionalInfo()
+		);
+	}
+
+	/**
+	 * @return The {@code DLNA.ORG_PN} (DLNA media format profile) for this
+	 *         {@link ProtocolInfo} or {@code null} if it isn't defined.
+	 */
+	public DLNAOrgProfileName getDLNAProfileName() {
+		ProtocolInfoAttribute pnAttribute =
+			attributes.get(KnownProtocolInfoAttributeName.DLNA_ORG_PN);
+		return pnAttribute instanceof DLNAOrgProfileName ?
+			(DLNAOrgProfileName) pnAttribute :
+			null;
+	}
+
+	/**
+	 * @return The {@code DLNA.ORG_OP} of this {@link ProtocolInfo} or
+	 *         {@code null} if it isn't defined.
+	 */
+	public DLNAOrgOperations getDLNAOperations() {
+		ProtocolInfoAttribute operationsAttribute =
+			attributes.get(KnownProtocolInfoAttributeName.DLNA_ORG_OP);
+		return operationsAttribute instanceof DLNAOrgOperations ?
+			(DLNAOrgOperations) operationsAttribute :
+			null;
+	}
+
+	/**
+	 * @return The {@code DLNA.ORG_PS} of this {@link ProtocolInfo} or
+	 *         {@code null} if it isn't defined.
+	 */
+	public DLNAOrgPlaySpeeds getDLNAPlaySpeeds() {
+		ProtocolInfoAttribute playSpeedsAttribute =
+			attributes.get(KnownProtocolInfoAttributeName.DLNA_ORG_PS);
+		return playSpeedsAttribute instanceof DLNAOrgPlaySpeeds ?
+			(DLNAOrgPlaySpeeds) playSpeedsAttribute :
+			null;
+	}
+
+	/**
+	 * @return The {@code DLNA.ORG_CI} of this {@link ProtocolInfo} or
+	 *         {@code null} if it isn't defined.
+	 */
+	public DLNAOrgConversionIndicator getDLNAConversionIndicator() {
+		ProtocolInfoAttribute conversionIndicatorAttribute =
+			attributes.get(KnownProtocolInfoAttributeName.DLNA_ORG_CI);
+		return conversionIndicatorAttribute instanceof DLNAOrgConversionIndicator ?
+			(DLNAOrgConversionIndicator) conversionIndicatorAttribute :
+			null;
+	}
+
+	/**
+	 * @return The {@code DLNA.ORG_FLAGS} of this {@link ProtocolInfo} or
+	 *         {@code null} if it isn't defined.
+	 */
+	public DLNAOrgFlags getFlags() {
+		ProtocolInfoAttribute flagsAttribute =
+			attributes.get(KnownProtocolInfoAttributeName.DLNA_ORG_FLAGS);
+		return flagsAttribute instanceof DLNAOrgFlags ?
+			(DLNAOrgFlags) flagsAttribute :
+			null;
+	}
+
+	/**
+	 * Searches for a {@link ProfileName} (any attribute name ending with
+	 * {@code "_PN"} among the attributes, and returns the first one found.
+	 * There is supposed to be zero or one {@link ProfileName} for any given
+	 * instance of {@link ProtocolInfo}. If none is found, {@code null} is
+	 * returned.
+	 * <p>
+	 * <b>Note: This will return any {@link ProfileName}, not just
+	 * {@link DLNAOrgProfileName}s</b>. If you're looking for a
+	 * {@code DLNA.ORG_PN}, use {@link #getDLNAProfileName} instead.
+	 *
+	 * @return The {@code DLNA.ORG_PN} (DLNA media format profile) for this
+	 *         {@link ProtocolInfo} or {@code null} if it isn't defined.
+	 */
+	public ProfileName getProfileName() {
+		for (ProtocolInfoAttribute attribute : attributes.values()) {
+			if (attribute instanceof ProfileName) {
+				return (ProfileName) attribute;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Gets the cached {@link String} generated from the attributes map. This
+	 * should be identical to {@link #getAdditionalInfo()}.
+	 *
+	 * @return The {@link String} representation of {@link #attributes}.
+	 */
+	public String getAttributesString() {
+		return attributesString;
+	}
+
+	/**
+	 * For internal use only. Generates a {@link String} representation of the
+	 * {@link ProtocolInfoAttribute}s in {@link #attributes}.
+	 *
+	 * @return The {@link String} representation.
+	 */
+	protected String generateAttributesString() {
+		if (attributes == null || attributes.isEmpty()) {
+			return "";
+		}
+
+		StringBuilder sb = new StringBuilder();
+		for (ProtocolInfoAttribute attribute : attributes.values()) {
+			String attributeString = attribute.getAttributeString();
+			if (isNotBlank(attributeString)) {
+				if (sb.length() > 0) {
+					sb.append(";");
+				}
+				sb.append(attributeString);
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Gets the {@link MimeType} created from the content format of this
+	 * {@link ProtocolInfo}.
+	 *
+	 * @return The {@link MimeType}.
+	 */
+	public MimeType getMimeType() {
+		return mimeType;
+	}
+
+	/**
+	 * For internal use only, creates the {@link MimeType} that is stored in
+	 * {@code this.mimeType}.
+	 *
+	 * @param contentFormat the {@code protocolInfo} {@code contentFormat} to
+	 *            parse.
+	 * @return A new {@link MimeType} instance.
+	 */
+	protected MimeType createMimeType(String contentFormat) {
+		try {
+			return MimeType.valueOf(contentFormat);
+		} catch (ParseException e) {
+			LOGGER.error("Error parsing MimeType from \"{}\": {}", contentFormat, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return MimeType.ANYANY;
+	}
+
+	/**
+	 * Creates a new {@link org.seamless.util.MimeType} from the
+	 * {@link MimeType} of this {@link ProtocolInfo}. To get the
+	 * {@link MimeType}, use {@link #getMimeType()} instead.
+	 *
+	 * @return The corresponding {@link org.seamless.util.MimeType}.
+	 * @throws IllegalArgumentException if
+	 *             {@link org.seamless.util.MimeType#valueOf()} can't parse this
+	 *             {@link MimeType}.
+	 * @see #getMimeType()
+	 */
+	public org.seamless.util.MimeType getSeamlessMimeType() throws IllegalArgumentException {
+		return org.seamless.util.MimeType.valueOf(mimeType.toString());
+	}
+
+	/**
+	 * Parses {@code additionalInfo}.
+	 *
+	 * @return The {@link SortedMap} of parsed {@link ProtocolInfoAttribute}s.
+	 */
+	protected SortedMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> parseAdditionalInfo() {
+		if (isBlank(additionalInfo) || WILDCARD.equals(additionalInfo.trim())) {
+			return EMPTYMAP;
+		}
+		TreeMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> result = createEmptyAttributesMap();
+		String[] attributeStrings = additionalInfo.trim().toUpperCase(Locale.ROOT).split("\\s*;\\s*");
+		for (String attributeString : attributeStrings) {
+			if (isBlank(attributeString)) {
+				continue;
+			}
+			String[] attributeEntry = attributeString.split("\\s*=\\s*");
+			if (attributeEntry.length == 2) {
+				try {
+					ProtocolInfoAttribute attribute = ProtocolInfoAttribute.FACTORY.createAttribute(
+						attributeEntry[0],
+						attributeEntry[1],
+						protocol
+					);
+
+					if (attribute != null) {
+						result.put(attribute.getName(), attribute);
+					} else {
+						LOGGER.debug("Failed to parse attribute \"{}\"", attributeString);
+					}
+				} catch (ParseException e) {
+					LOGGER.debug("Failed to parse attribute \"{}\": {}", attributeString, e.getMessage());
+					LOGGER.trace("", e);
+				}
+			} else {
+				LOGGER.debug("Invalid ProtocolInfo attribute \"{}\"", attributeString);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * @return the {@link Protocol} of this {@link ProtocolInfo}.
+	 */
+	public Protocol getProtocol() {
+		return protocol;
+	}
+
+	/**
+	 * @return the {@code network} of this {@link ProtocolInfo}.
+	 */
+	public String getNetwork() {
+		return network;
+	}
+
+	/**
+	 * @return the {@code contentFormat} of this {@link ProtocolInfo}.
+	 */
+	public String getContentFormat() {
+		return mimeType.toString();
+	}
+
+	/**
+	 * @return the {@code additionalInfo} of this {@link ProtocolInfo}.
+	 */
+	public String getAdditionalInfo() {
+		return additionalInfo;
+	}
+
+
+	/**
+	 * The attributes are the content of {@code additionalInfo} in parsed form.
+	 *
+	 * @return the attributes of this {@link ProtocolInfo}.
+	 */
+	public SortedMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> getAttributes() {
+		return attributes;
+	}
+
+	/**
+	 * Returns a debug string representation of this {@link ProtocolInfo}.
+	 *
+	 * @return The debug {@link String} representation.
+	 */
+	public String toDebugString() {
+		StringBuilder sb = new StringBuilder();
+
+		sb	.append("Protocol: ").append(protocol)
+			.append(", Network: ").append(network)
+			.append(", ContentFormat/MimeType: ").append(mimeType);
+
+		if (isNotBlank(additionalInfo)) {
+			sb.append(", AdditionalInfo: ").append(additionalInfo);
+		}
+
+		if (!mimeType.toString().equals(mimeType.toStringWithoutParameters())) {
+			sb.append(", Simple MimeType: ").append(mimeType.toStringWithoutParameters());
+		}
+		if (mimeType.isDRM()) {
+			sb.append(", DRM");
+		}
+		if (!mimeType.getParameters().isEmpty()) {
+			sb.append(", MimeType Parameters: ").append(mimeType.getParameters());
+		}
+
+		if (attributes != null && !attributes.isEmpty()) {
+			sb.append(", Attributes: ").append(attributes);
+		}
+
+		return sb.toString();
+	}
+
+	@Override
+	public String toString() {
+		return stringValue;
+	}
+
+	/**
+	 * For internal use only, generates the string representation of this
+	 * {@link ProtocolInfo} for use for the cached {@link #toString()} value.
+	 *
+	 * @return The string representation.
+	 */
+	protected String generateStringValue() {
+		StringBuilder sb = new StringBuilder();
+		sb	.append(protocol == null ? WILDCARD : protocol).append(":")
+			.append(isBlank(network) ? WILDCARD : network).append(":")
+			.append(mimeType == null ? MimeType.ANYANY : mimeType).append(":")
+			.append(isBlank(attributesString) ? WILDCARD : attributesString);
+		return sb.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((additionalInfo == null) ? 0 : additionalInfo.hashCode());
+		result = prime * result + ((attributesString == null) ? 0 : attributesString.hashCode());
+		result = prime * result + ((mimeType == null) ? 0 : mimeType.hashCode());
+		result = prime * result + ((network == null) ? 0 : network.hashCode());
+		result = prime * result + ((protocol == null) ? 0 : protocol.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof ProtocolInfo)) {
+			return false;
+		}
+		ProtocolInfo other = (ProtocolInfo) obj;
+		if (additionalInfo == null) {
+			if (other.additionalInfo != null) {
+				return false;
+			}
+		} else if (!additionalInfo.equals(other.additionalInfo)) {
+			return false;
+		}
+		if (attributesString == null) {
+			if (other.attributesString != null) {
+				return false;
+			}
+		} else if (!attributesString.equals(other.attributesString)) {
+			return false;
+		}
+		if (mimeType == null) {
+			if (other.mimeType != null) {
+				return false;
+			}
+		} else if (!mimeType.equals(other.mimeType)) {
+			return false;
+		}
+		if (network == null) {
+			if (other.network != null) {
+				return false;
+			}
+		} else if (!network.equals(other.network)) {
+			return false;
+		}
+		if (protocol != other.protocol) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Converts an {@link EnumMap} of
+	 * {@link org.fourthline.cling.support.model.dlna.DLNAAttribute}s to a
+	 * {@link TreeMap} of {@link ProtocolInfoAttribute}s.
+	 *
+	 * @param dlnaAttributes the {@link EnumMap} of
+	 *            {@link org.fourthline.cling.support.model.dlna.DLNAAttribute}s
+	 *            to convert.
+	 * @return A {@link TreeMap} containing the converted
+	 *         {@link ProtocolInfoAttribute}s.
+	 */
+	public static TreeMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> dlnaAttributesToAttributes(
+		EnumMap<DLNAAttribute.Type,
+		DLNAAttribute<?>> dlnaAttributes
+	) {
+		TreeMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> attributes = createEmptyAttributesMap();
+		for (Entry<DLNAAttribute.Type, DLNAAttribute<?>> entry: dlnaAttributes.entrySet()) {
+			try {
+				ProtocolInfoAttribute attribute = ProtocolInfoAttribute.FACTORY.createAttribute(
+					entry.getKey().getAttributeName(),
+					entry.getValue().getString(),
+					Protocol.HTTP_GET
+				);
+				if (attribute != null) {
+					attributes.put(attribute.getName(), attribute);
+				}
+			} catch (ParseException e) {
+				LOGGER.debug(
+					"Couldn't parse DLNAAttribute \"{}\" = \"{}\": {}",
+					entry.getKey().getAttributeName(),
+					entry.getValue().getString(), e.getMessage()
+				);
+				LOGGER.trace("", e);
+			}
+		}
+		return attributes;
+	}
+
+	/**
+	 * A convenience method to create an empty {@link TreeMap} of
+	 * {@link ProtocolInfoAttribute}s with the correct {@link Comparator}
+	 * {@link AttributeComparator}.
+	 *
+	 * @return The empty attributes map.
+	 */
+	public static TreeMap<ProtocolInfoAttributeName, ProtocolInfoAttribute> createEmptyAttributesMap() {
+		return new TreeMap<>(new AttributeComparator());
+	}
+
+	/**
+	 * DLNA requires {@code protocolInfo} attributes to appear in a certain
+	 * order. Any {@link SortedMap} that is initialized with this
+	 * {@link Comparator} will automatically sort its elements according to this
+	 * custom order.
+	 *
+	 * It is vital that any {@link Map} used to store
+	 * {@link ProtocolInfoAttribute}s in relation to {@link ProtocolInfo} use
+	 * this class as it's {@link Comparator}.
+	 *
+	 * @author Nadahar
+	 */
+	public static class AttributeComparator implements Comparator<ProtocolInfoAttributeName>, Serializable {
+
+		private static final long serialVersionUID = 1L;
+		/** Defines the sort order for known attributes */
+		public static final List<ProtocolInfoAttributeName> DEFINED_ORDER =
+			Collections.unmodifiableList(Arrays.asList(new ProtocolInfoAttributeName[] {
+			KnownProtocolInfoAttributeName.DLNA_ORG_PN,
+			KnownProtocolInfoAttributeName.DLNA_ORG_OP,
+			KnownProtocolInfoAttributeName.DLNA_ORG_PS,
+			KnownProtocolInfoAttributeName.DLNA_ORG_CI,
+			KnownProtocolInfoAttributeName.DLNA_ORG_FLAGS,
+			KnownProtocolInfoAttributeName.ARIB_OR_JP_PN,
+			KnownProtocolInfoAttributeName.DTV_MVP_PN,
+			KnownProtocolInfoAttributeName.PANASONIC_COM_PN,
+			KnownProtocolInfoAttributeName.MICROSOFT_COM_PN,
+			KnownProtocolInfoAttributeName.SHARP_COM_PN,
+			KnownProtocolInfoAttributeName.SONY_COM_PN
+		}));
+
+		@Override
+		public int compare(ProtocolInfoAttributeName o1, ProtocolInfoAttributeName o2) {
+			if (o1 == null && o2 == null) {
+				return 0;
+			}
+			if (o1 == null) {
+				return 1;
+			}
+			if (o2 == null) {
+				return -1;
+			}
+
+			int o1Index = DEFINED_ORDER.indexOf(o1);
+			int o2Index = DEFINED_ORDER.indexOf(o2);
+
+			// Sort by defined order if both arguments are defined
+			if (o1Index >= 0 && o2Index >= 0) {
+				return o1Index - o2Index;
+			}
+
+			// Sort by string value if none of the arguments are defined
+			if (o1Index < 0 && o2Index < 0) {
+				return o1.getName().compareTo(o2.getName());
+			}
+
+			// Sort defined arguments before undefined arguments
+			if (o1Index < 0) {
+				return 1;
+			}
+			if (o2Index < 0) {
+				return -1;
+			}
+
+			// Sort alphabetically by name
+			String o1Name = o1.getName();
+			String o2Name = o2.getName();
+
+			if (o1Name == null && o2Name == null) {
+				return 0;
+			}
+			if (o1Name == null) {
+				return 1;
+			}
+			if (o2Name == null) {
+				return -1;
+			}
+			return o1Name.compareTo(o2Name);
+		}
+	}
+
+	/**
+	 * Compares {@link ProtocolInfo} instances for sorting. Sorting is done in
+	 * this order: {@code protocol}, {@code network}, {@code contentFormat} and
+	 * {@code additionalInfo}.
+	 *
+	 * @param other the {@link ProtocolInfo} instance to compare to.
+	 */
+	@Override
+	public int compareTo(ProtocolInfo other) {
+
+		if (other == null) {
+			return -1;
+		}
+
+		// Protocol
+		if (protocol == null && other.protocol != null) {
+			return 1;
+		}
+		if (protocol != null && other.protocol == null) {
+			return -1;
+		}
+		int result;
+		if (protocol != null && other.protocol != null) {
+			result = protocol.compareTo(other.protocol);
+			if (result != 0) {
+				return result;
+			}
+		}
+
+		// Network
+		if (network == null && other.network != null) {
+			return 1;
+		}
+		if (network != null && other.network == null) {
+			return -1;
+		}
+		if (network != null && other.network != null) {
+			result = network.compareTo(other.network);
+			if (result != 0) {
+				return result;
+			}
+		}
+
+		// ContentFormat/MimeType
+		if (mimeType == null && other.mimeType != null) {
+			return 1;
+		}
+		if (mimeType != null && other.mimeType == null) {
+			return -1;
+		}
+		if (mimeType != null && other.mimeType != null) {
+			result = mimeType.compareTo(other.mimeType);
+			if (result != 0) {
+				return result;
+			}
+		}
+
+		// AdditionalInfo
+		if (additionalInfo == null && other.additionalInfo != null) {
+			return 1;
+		}
+		if (additionalInfo != null && other.additionalInfo == null) {
+			return -1;
+		}
+		if (additionalInfo != null && other.additionalInfo != null) {
+			return additionalInfo.compareTo(other.additionalInfo);
+		}
+
+		return 0;
+	}
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfoAttribute.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfoAttribute.java
@@ -1,0 +1,446 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA compatible renderers
+ * based on the http://www.ps3mediaserver.org. Copyright (C) 2012 UMS
+ * developers.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.io.Serializable;
+import org.fourthline.cling.support.model.Protocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.pms.dlna.protocolinfo.ProfileName.DefaultGenericProfileName;
+import net.pms.util.ParseException;
+
+/**
+ * This interface represents attributes found in the {@code additionalInfo} part
+ * of {@code protocolInfo}.
+ *
+ * @author Nadahar
+ */
+public interface ProtocolInfoAttribute extends Serializable {
+
+	/**
+	 * The static factory singleton instance for creating or retrieve
+	 * predefined and cached {@link ProtocolInfoAttribute} instances.
+	 */
+	ProtocolInfoAttributeFactory FACTORY = new ProtocolInfoAttributeFactory();
+
+	/**
+	 * @return The {@link ProtocolInfoAttributeName} instance for this
+	 *         {@link ProtocolInfoAttribute}.
+	 */
+	ProtocolInfoAttributeName getName();
+
+	/**
+	 * @return The {@link String} value of this {@link ProtocolInfoAttribute}'s
+	 *         {@link ProtocolInfoAttributeName} instance.
+	 */
+	String getNameString();
+
+	/**
+	 * @return The {@link String} value of this {@link ProtocolInfoAttribute}.
+	 */
+	String getValue();
+
+	/**
+	 * Returns a formatted attribute string for use in {@code protocolInfo}. If
+	 * this {@link ProtocolInfoAttribute} has an empty name or value, or
+	 * represents the implied default, an empty string is returned.
+	 *
+	 * @return The formatted attribute or an empty {@link String}.
+	 */
+	String getAttributeString();
+
+	/**
+	 * A factory for creating or retrieving cached
+	 * {@link ProtocolInfoAttribute} instances.
+	 */
+	public static class ProtocolInfoAttributeFactory {
+
+		/** The logger. */
+		private static final Logger LOGGER = LoggerFactory.getLogger(ProtocolInfoAttributeFactory.class);
+
+		/**
+		 * For internal use only, use {@link ProtocolInfoAttribute#FACTORY}
+		 * instead.
+		 */
+		protected ProtocolInfoAttributeFactory() {
+		}
+
+		/**
+		 * Retrieves a predefined or cached {@link ProtocolInfoAttribute}
+		 * instance if it exists. If no matching instance is found, {@code null}
+		 * is returned.
+		 * <p>
+		 * <b>{@link DLNAOrgOperations} can't be retrieved with this method and
+		 * will throw an {@link IllegalArgumentException}</b>, use
+		 * {@link #getAttribute(String, String, Protocol)} instead.
+		 * <p>
+		 * <b>Note:</b> {@link DLNAOrgFlags} isn't predefined or cached and
+		 * will always return {@code null}.
+		 * <p>
+		 * This method can only retrieve values in their {@link String} form.
+		 * Use the factory methods of the individual classes to retrieve
+		 * instances for values of other types.
+		 *
+		 * @param attributeName the attribute name {@link String} value.
+		 * @param attributeValue the attribute {@link String} value.
+		 * @return The existing instance or {@code null}.
+		 * @throws ParseException If {@code attributeValue} can't be parsed.
+		 * @throws IllegalArgumentException If {@code attributeName} is
+		 *             {@code "DLNA.ORG_OP"}.
+		 */
+		public ProtocolInfoAttribute getAttribute(
+			String attributeName,
+			String attributeValue
+		) throws ParseException {
+			return getAttribute(
+				ProtocolInfoAttributeName.FACTORY.createAttributeName(attributeName),
+				attributeValue
+			);
+		}
+
+		/**
+		 * Retrieves a predefined or cached {@link ProtocolInfoAttribute}
+		 * instance if it exists. If no matching instance is found, {@code null}
+		 * is returned.
+		 * <p>
+		 * <b>{@link DLNAOrgOperations} can't be retrieved with this method and
+		 * will throw an {@link IllegalArgumentException}</b>, use
+		 * {@link #getAttribute(ProtocolInfoAttributeName, String, Protocol)}
+		 * instead.
+		 * <p>
+		 * <b>Note:</b> {@link DLNAOrgFlags} isn't predefined or cached and
+		 * will always return {@code null}.
+		 * <p>
+		 * This method can only retrieve values in their {@link String} form.
+		 * Use the factory methods of the individual classes to retrieve
+		 * instances for values of other types.
+		 *
+		 * @param attributeName the {@link ProtocolInfoAttributeName}.
+		 * @param attributeValue the attribute {@link String} value.
+		 * @return The existing instance or {@code null}.
+		 * @throws ParseException If {@code attributeValue} can't be parsed.
+		 * @throws IllegalArgumentException If {@code attributeName} is
+		 *             {@link DLNAOrgOperations#NAME}.
+		 */
+		public ProtocolInfoAttribute getAttribute(
+			ProtocolInfoAttributeName attributeName,
+			String attributeValue
+		) throws ParseException {
+			if (DLNAOrgOperations.NAME.equals(attributeName)) {
+				throw new IllegalArgumentException(
+					"Cannot get DLNA.ORG_FLAGS instance because protocol information is needed " +
+					"- use an overloaded version of this method which takes a protocol argument");
+			}
+			return getAttribute(attributeName, attributeValue, null);
+		}
+
+		/**
+		 * Retrieves a predefined or cached {@link ProtocolInfoAttribute}
+		 * instance if it exists. If no matching instance is found, {@code null}
+		 * is returned.
+		 * <p>
+		 * <b>Note:</b> {@link DLNAOrgFlags} isn't predefined or cached and
+		 * will always return {@code null}.
+		 * <p>
+		 * This method can only retrieve values in their {@link String} form.
+		 * Use the factory methods of the individual classes to retrieve
+		 * instances for values of other types.
+		 *
+		 * @param attributeName the attribute name {@link String} value.
+		 * @param attributeValue the attribute {@link String} value.
+		 * @param protocol the {@link Protocol} of the {@code protocolInfo} this
+		 *            {@link ProtocolInfoAttribute} belongs to. This parameter
+		 *            is only used when retrieving {@link DLNAOrgOperations}
+		 *            instances and can be {@code null} for other attribute
+		 *            types.
+		 * @return The existing instance or {@code null}.
+		 * @throws ParseException If {@code attributeValue} can't be parsed.
+		 */
+		public ProtocolInfoAttribute getAttribute(
+			String attributeName,
+			String attributeValue,
+			Protocol protocol
+		) throws ParseException {
+			return getAttribute(
+				ProtocolInfoAttributeName.FACTORY.createAttributeName(attributeName),
+				attributeValue,
+				protocol
+			);
+		}
+
+		/**
+		 * Retrieves a predefined or cached {@link ProtocolInfoAttribute}
+		 * instance if it exists. If no matching instance is found, {@code null}
+		 * is returned.
+		 * <p>
+		 * <b>Note:</b> {@link DLNAOrgFlags} isn't predefined or cached and
+		 * will always return {@code null}.
+		 * <p>
+		 * This method can only retrieve values in their {@link String} form.
+		 * Use the factory methods of the individual classes to retrieve
+		 * instances for values of other types.
+		 *
+		 * @param attributeName the {@link ProtocolInfoAttributeName}.
+		 * @param attributeValue the attribute {@link String} value.
+		 * @param protocol the {@link Protocol} of the {@code protocolInfo} this
+		 *            {@link ProtocolInfoAttribute} belongs to. This parameter
+		 *            is only used when retrieving {@link DLNAOrgOperations}
+		 *            instances and can be {@code null} for other attribute
+		 *            types.
+		 * @return The existing instance or {@code null}.
+		 * @throws ParseException If {@code attributeValue} can't be parsed.
+		 */
+		public ProtocolInfoAttribute getAttribute(
+			ProtocolInfoAttributeName attributeName,
+			String attributeValue,
+			Protocol protocol
+		) throws ParseException {
+			if (attributeName == null) {
+				return null;
+			}
+
+			/* Check predefined and cached types, the following classes don't have
+			 * predefined or cached types and will always return null:
+			 *
+			 * - DLNAOrgFlags
+			 *
+			 */
+			if (DLNAOrgConversionIndicator.NAME.equals(attributeName)) {
+				return DLNAOrgConversionIndicator.FACTORY.getConversionIndicator(attributeValue);
+			} else if (DLNAOrgOperations.NAME.equals(attributeName)) {
+				return DLNAOrgOperations.FACTORY.getOperations(protocol, attributeValue);
+			} else if (DLNAOrgPlaySpeeds.NAME.equals(attributeName)) {
+				return DLNAOrgPlaySpeeds.FACTORY.getPlaySpeeds(attributeValue);
+			} else if (DLNAOrgProfileName.NAME.equals(attributeName)) {
+				return DLNAOrgProfileName.FACTORY.getProfileName(attributeValue);
+			} else if (attributeName.getName().contains("_PN")) {
+				return DefaultGenericProfileName.FACTORY.getProfileName(attributeName, attributeValue);
+			}
+			return null;
+		}
+
+		/**
+		 * Retrieves a predefined or cached {@link ProtocolInfoAttribute}
+		 * instance if it exists. If no matching instance is found, a new will
+		 * be created.
+		 * <p>
+		 * <b>{@link DLNAOrgOperations} can't be retrieved with this method and
+		 * will throw an {@link IllegalArgumentException}</b>, use
+		 * {@link #createAttribute(String, String, Protocol)} instead.
+		 * <p>
+		 * This method can only retrieve or create values in their
+		 * {@link String} form. Use the factory methods of the individual
+		 * classes to retrieve or create instances for values of other types.
+		 *
+		 * @param attributeName the attribute name {@link String} value.
+		 * @param attributeValue the attribute {@link String} value.
+		 * @return The existing or created instance.
+		 * @throws ParseException If {@code attributeValue} can't be parsed.
+		 * @throws IllegalArgumentException If {@code attributeName} is
+		 *             {@code "DLNA.ORG_OP"}.
+		 */
+		public ProtocolInfoAttribute createAttribute(
+			String attributeName,
+			String attributeValue
+		) throws ParseException {
+			return createAttribute(
+				ProtocolInfoAttributeName.FACTORY.createAttributeName(attributeName),
+				attributeValue
+			);
+		}
+
+		/**
+		 * Retrieves a predefined or cached {@link ProtocolInfoAttribute}
+		 * instance if it exists. If no matching instance is found, a new will
+		 * be created.
+		 * <p>
+		 * <b>{@link DLNAOrgOperations} can't be retrieved with this method and
+		 * will throw an {@link IllegalArgumentException}</b>, use
+		 * {@link #createAttribute(ProtocolInfoAttributeName, String, Protocol)}
+		 * instead.
+		 * <p>
+		 * This method can only retrieve or create values in their
+		 * {@link String} form. Use the factory methods of the individual
+		 * classes to retrieve or create instances for values of other types.
+		 *
+		 * @param attributeName the {@link ProtocolInfoAttributeName}.
+		 * @param attributeValue the attribute {@link String} value.
+		 * @return The existing or created instance.
+		 * @throws ParseException If {@code attributeValue} can't be parsed.
+		 * @throws IllegalArgumentException If {@code attributeName} is
+		 *             {@link DLNAOrgOperations#NAME}.
+		 */
+		public ProtocolInfoAttribute createAttribute(
+			ProtocolInfoAttributeName attributeName,
+			String attributeValue
+		) throws ParseException {
+			if (DLNAOrgOperations.NAME.equals(attributeName)) {
+				throw new IllegalArgumentException(
+					"Cannot create DLNA.ORG_FLAGS instance because protocol information is needed " +
+					"- use an overloaded version of this method which takes a protocol argument");
+			}
+			return createAttribute(attributeName, attributeValue, null);
+		}
+
+		/**
+		 * Retrieves a predefined or cached {@link ProtocolInfoAttribute}
+		 * instance if it exists. If no matching instance is found, a new will
+		 * be created.
+		 * <p>
+		 * This method can only retrieve or create values in their {@link String} form.
+		 * Use the factory methods of the individual classes to retrieve or create
+		 * instances for values of other types.
+		 *
+		 * @param attributeName the attribute name {@link String} value.
+		 * @param attributeValue the attribute {@link String} value.
+		 * @param protocol the {@link Protocol} of the {@code protocolInfo} this
+		 *            {@link ProtocolInfoAttribute} belongs to. This parameter
+		 *            is only used when retrieving {@link DLNAOrgOperations}
+		 *            instances and can be {@code null} for other attribute
+		 *            types.
+		 * @return The existing or created instance.
+		 * @throws ParseException If {@code attributeValue} can't be parsed.
+		 */
+		public ProtocolInfoAttribute createAttribute(
+			String attributeName,
+			String attributeValue,
+			Protocol protocol
+		) throws ParseException {
+			return createAttribute(
+				ProtocolInfoAttributeName.FACTORY.createAttributeName(attributeName),
+				attributeValue,
+				protocol
+			);
+		}
+
+		/**
+		 * Retrieves a predefined or cached {@link ProtocolInfoAttribute}
+		 * instance if it exists. If no matching instance is found, a new will
+		 * be created.
+		 * <p>
+		 * This method can only retrieve or create values in their {@link String} form.
+		 * Use the factory methods of the individual classes to retrieve or create
+		 * instances for values of other types.
+		 *
+		 * @param attributeName the {@link ProtocolInfoAttributeName}.
+		 * @param attributeValue the attribute {@link String} value.
+		 * @param protocol the {@link Protocol} of the {@code protocolInfo} this
+		 *            {@link ProtocolInfoAttribute} belongs to. This parameter
+		 *            is only used when retrieving {@link DLNAOrgOperations}
+		 *            instances and can be {@code null} for other attribute
+		 *            types.
+		 * @return The existing or created instance.
+		 * @throws ParseException If {@code attributeValue} can't be parsed.
+		 */
+		public ProtocolInfoAttribute createAttribute(
+			ProtocolInfoAttributeName attributeName,
+			String attributeValue,
+			Protocol protocol
+		) throws ParseException {
+			if (attributeName == null) {
+				return null;
+			}
+
+			/* Check predefined and cached types, the following classes only has predefined instances:
+			 *
+			 * - DLNAOrgConversionIndicator
+			 * - DLNAOrgOperations
+			 *
+			 */
+			ProtocolInfoAttribute instance = getAttribute(attributeName, attributeValue, protocol);
+			if (instance != null) {
+				return instance;
+			}
+
+			if (DLNAOrgPlaySpeeds.NAME.equals(attributeName)) {
+				return DLNAOrgPlaySpeeds.FACTORY.createPlaySpeeds(attributeValue);
+			} else if (DLNAOrgFlags.NAME.equals(attributeName)) {
+				DLNAOrgFlags flags = new DLNAOrgFlags(attributeValue);
+				if (DLNAOrgFlags.IMPLIED.equals(flags)) {
+					return DLNAOrgFlags.IMPLIED;
+				}
+				return flags;
+			} else if (attributeName == DLNAOrgProfileName.NAME) {
+				return DLNAOrgProfileName.FACTORY.createProfileName(attributeValue);
+			} else if (attributeName.getName().contains("_PN")) {
+				return DefaultGenericProfileName.FACTORY.createProfileName(attributeName, attributeValue);
+			}
+
+			// Create a new "generic" instance
+			LOGGER.trace("Creating unknown ProtocolInfoAttribute \"{}\" with value \"{}\"", attributeName, attributeValue);
+			return new StringAttribute(attributeName, attributeValue);
+		}
+	}
+
+	/**
+	 * The most basic {@link ProtocolInfoAttribute} implementation where the
+	 * value is simply a {@link String}. Immutable.
+	 */
+	public static class StringAttribute implements ProtocolInfoAttribute {
+
+		private static final long serialVersionUID = 1L;
+
+		/** The attribute name */
+		protected final ProtocolInfoAttributeName name;
+
+		/** The {@link String} value */
+		protected final String value;
+
+		/**
+		 * Creates a new instance with the given values.
+		 *
+		 * @param name the attribute name.
+		 * @param value the attribute value.
+		 */
+		public StringAttribute(ProtocolInfoAttributeName name, String value) {
+			this.name = name;
+			this.value = value;
+		}
+
+		@Override
+		public ProtocolInfoAttributeName getName() {
+			return name;
+		}
+
+		@Override
+		public String getNameString() {
+			return name == null ? null : name.getName();
+		}
+
+		@Override
+		public String getValue() {
+			return value;
+		}
+
+		@Override
+		public String toString() {
+			return name + " = " + value;
+		}
+
+		@Override
+		public String getAttributeString() {
+			return
+				name == null || isBlank(name.getName()) || isBlank(value) ?
+					"" :
+					name.getName() + "=" + value;
+		}
+	}
+
+}

--- a/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfoAttribute.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfoAttribute.java
@@ -232,6 +232,8 @@ public interface ProtocolInfoAttribute extends Serializable {
 				return DLNAOrgProfileName.FACTORY.getProfileName(attributeValue);
 			} else if (PanasonicComProfileName.NAME.equals(attributeName)) {
 				return PanasonicComProfileName.FACTORY.getProfileName(attributeValue);
+			} else if (AribOrJpProfileName.NAME.equals(attributeName)) {
+				return AribOrJpProfileName.FACTORY.getProfileName(attributeValue);
 			} else if (attributeName.getName().contains("_PN")) {
 				return DefaultGenericProfileName.FACTORY.getProfileName(attributeName, attributeValue);
 			}
@@ -383,6 +385,8 @@ public interface ProtocolInfoAttribute extends Serializable {
 				return DLNAOrgProfileName.FACTORY.createProfileName(attributeValue);
 			} else if (PanasonicComProfileName.NAME.equals(attributeName)) {
 				return PanasonicComProfileName.FACTORY.createProfileName(attributeValue);
+			} else if (AribOrJpProfileName.NAME.equals(attributeName)) {
+				return AribOrJpProfileName.FACTORY.createProfileName(attributeValue);
 			} else if (attributeName.getName().contains("_PN")) {
 				return DefaultGenericProfileName.FACTORY.createProfileName(attributeName, attributeValue);
 			}

--- a/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfoAttribute.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfoAttribute.java
@@ -230,6 +230,8 @@ public interface ProtocolInfoAttribute extends Serializable {
 				return DLNAOrgPlaySpeeds.FACTORY.getPlaySpeeds(attributeValue);
 			} else if (DLNAOrgProfileName.NAME.equals(attributeName)) {
 				return DLNAOrgProfileName.FACTORY.getProfileName(attributeValue);
+			} else if (PanasonicComProfileName.NAME.equals(attributeName)) {
+				return PanasonicComProfileName.FACTORY.getProfileName(attributeValue);
 			} else if (attributeName.getName().contains("_PN")) {
 				return DefaultGenericProfileName.FACTORY.getProfileName(attributeName, attributeValue);
 			}
@@ -379,6 +381,8 @@ public interface ProtocolInfoAttribute extends Serializable {
 				return flags;
 			} else if (attributeName == DLNAOrgProfileName.NAME) {
 				return DLNAOrgProfileName.FACTORY.createProfileName(attributeValue);
+			} else if (PanasonicComProfileName.NAME.equals(attributeName)) {
+				return PanasonicComProfileName.FACTORY.createProfileName(attributeValue);
 			} else if (attributeName.getName().contains("_PN")) {
 				return DefaultGenericProfileName.FACTORY.createProfileName(attributeName, attributeValue);
 			}

--- a/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfoAttributeName.java
+++ b/src/main/java/net/pms/dlna/protocolinfo/ProtocolInfoAttributeName.java
@@ -1,0 +1,259 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna.protocolinfo;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This interface represents {@code protocolInfo} attribute names like
+ * {@code DLNA.ORG_OP}, {@code DLNA.ORG_PS} and {@code DLNA.ORG_FLAGS}.
+ *
+ * @author Nadahar
+ */
+public interface ProtocolInfoAttributeName extends Serializable {
+
+	/** The static {@code NONE} instance representing a blank/empty name */
+	ProtocolInfoAttributeName NONE = new GenericProtocolInfoAttributeName("");
+
+	/**
+	 * The static {@code WILDCARD} instance representing an asterisk
+	 * ({@code *}).
+	 */
+	ProtocolInfoAttributeName WILDCARD = new GenericProtocolInfoAttributeName("*");
+
+	/**
+	 * The static factory used to create and retrieve
+	 * {@link ProtocolInfoAttributeName} instances.
+	 */
+	ProtocolInfoAttributeNameFactory FACTORY = new ProtocolInfoAttributeNameFactory();
+
+	/**
+	 * Get the attribute name as a {@link String} value.
+	 *
+	 * @return The attribute name {@link String}.
+	 */
+	String getName();
+
+	/**
+	 * A factory for creating, caching and retrieving
+	 * {@link ProtocolInfoAttributeName} instances.
+	 */
+	public static class ProtocolInfoAttributeNameFactory {
+
+		/** The logger. */
+		private static final Logger LOGGER = LoggerFactory.getLogger(ProtocolInfoAttributeNameFactory.class);
+
+		/** The instance cache lock. */
+		private final ReentrantReadWriteLock instanceCacheLock = new ReentrantReadWriteLock();
+
+		/** The instance cache. */
+		private final HashSet<ProtocolInfoAttributeName> instanceCache = new HashSet<>();
+
+		/**
+		 * For internal use only, use {@link ProtocolInfoAttributeName#FACTORY}
+		 * to get the singleton instance.
+		 */
+		protected ProtocolInfoAttributeNameFactory() {
+		}
+
+		/**
+		 * Retrieves a {@link ProtocolInfoAttributeName} instance representing
+		 * the attribute name {@code name} from the predefined instances or the
+		 * cache. If no such {@link ProtocolInfoAttributeName} instance exists,
+		 * {@code null} is returned.
+		 *
+		 * @param name the attribute name.
+		 * @return The {@link ProtocolInfoAttributeName} instance or
+		 *         {@code null}.
+		 */
+		public ProtocolInfoAttributeName getAttributeName(String name) {
+
+			// Check for static instances
+			if (isBlank(name)) {
+				return NONE;
+			}
+			name = name.trim().toUpperCase(Locale.ROOT);
+
+			if ("*".equals(name)) {
+				return WILDCARD;
+			}
+
+			// Check for known instances
+			for (KnownProtocolInfoAttributeName knownAttribute : KnownProtocolInfoAttributeName.values()) {
+				if (name.equals(knownAttribute.getName())) {
+					return knownAttribute;
+				}
+			}
+
+			// Check for cached instances
+			instanceCacheLock.readLock().lock();
+			try {
+				for (ProtocolInfoAttributeName cachedAttribute : instanceCache) {
+					if (name.equals(cachedAttribute.getName())) {
+						return cachedAttribute;
+					}
+				}
+			} finally {
+				instanceCacheLock.readLock().unlock();
+			}
+			return null;
+		}
+
+		/**
+		 * Creates or retrieves a {@link ProtocolInfoAttributeName} instance
+		 * representing the attribute name {@code name}. Any existing predefined
+		 * or cached instances are first checked, and if none are found for
+		 * {@code value} a new instance is created.
+		 *
+		 * @param name the profile name.
+		 * @return The {@link ProtocolInfoAttributeName} instance.
+		 */
+		public ProtocolInfoAttributeName createAttributeName(String name) {
+
+			ProtocolInfoAttributeName instance = getAttributeName(name);
+			if (instance != null) {
+				return instance;
+			}
+
+			// Null values will already have been handled above
+			name = name.trim().toUpperCase(Locale.ROOT);
+
+			// Prepare to create a new instance
+			instanceCacheLock.writeLock().lock();
+			try {
+				// Check cache again as it could have been added while the lock
+				// was released
+				for (ProtocolInfoAttributeName cachedAttribute : instanceCache) {
+					if (name.equals(cachedAttribute.getName())) {
+						return cachedAttribute;
+					}
+				}
+
+				// None was found, create the instance
+				instance = new GenericProtocolInfoAttributeName(name);
+				instanceCache.add(instance);
+				LOGGER.trace("ProtocolInfoAttributeNameFactory added unknown attribute name \"{}\"", name);
+				return instance;
+			} finally {
+				instanceCacheLock.writeLock().unlock();
+			}
+		}
+	}
+
+	/**
+	 * This contains predefined, known {@code protocolInfo} attribute names.
+	 */
+	public enum KnownProtocolInfoAttributeName implements ProtocolInfoAttributeName {
+		// The order is important for protocolInfo
+
+		/** DLNA.ORG_PN */
+		DLNA_ORG_PN("DLNA.ORG_PN"),
+
+		/** ARIB.OR.JP_PN */
+		ARIB_OR_JP_PN("ARIB.OR.JP_PN"),
+
+		/** DTV_MVP_PN */
+		DTV_MVP_PN("DTV_MVP_PN"),
+
+		/** PANASONIC.COM_PN */
+		PANASONIC_COM_PN("PANASONIC.COM_PN"),
+
+		/** MICROSOFT.COM_PN */
+		MICROSOFT_COM_PN("MICROSOFT.COM_PN"),
+
+		/** SHARP.COM_PN */
+		SHARP_COM_PN("SHARP.COM_PN"),
+
+		/** SONY.COM_PN */
+		SONY_COM_PN("SONY.COM_PN"),
+
+		/** DLNA.ORG_OP */
+		DLNA_ORG_OP("DLNA.ORG_OP"),
+
+		/** DLNA.ORG_PS */
+		DLNA_ORG_PS("DLNA.ORG_PS"),
+
+		/** DLNA.ORG_CI */
+		DLNA_ORG_CI("DLNA.ORG_CI"),
+
+		/** DLNA.ORG_FLAGS */
+		DLNA_ORG_FLAGS("DLNA.ORG_FLAGS"),
+
+		/** DLNA.ORG_MAXSP */
+		DLNA_ORG_MAXSP("DLNA.ORG_MAXSP");
+
+		private final String name;
+
+		private KnownProtocolInfoAttributeName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+	}
+
+	/**
+	 * This is the default/generic class implementing
+	 * {@link ProtocolInfoAttributeName}.
+	 * {@link ProtocolInfoAttributeNameFactory} creates and caches instances of
+	 * this class. Immutable.
+	 */
+	public static class GenericProtocolInfoAttributeName implements ProtocolInfoAttributeName {
+
+		private static final long serialVersionUID = 1L;
+
+		/** The attribute name value. */
+		protected final String name;
+
+		/**
+		 * For internal use only, use
+		 * {@link ProtocolInfoAttributeNameFactory#createAttributeName} to
+		 * create new instances.
+		 *
+		 * @param name the attribute name.
+		 */
+		protected GenericProtocolInfoAttributeName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+	}
+}

--- a/src/main/java/net/pms/network/HTTPServer.java
+++ b/src/main/java/net/pms/network/HTTPServer.java
@@ -23,6 +23,8 @@ import java.net.*;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ServerSocketChannel;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.pms.Messages;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
@@ -33,6 +35,8 @@ import org.jboss.netty.channel.ChannelFactory;
 import org.jboss.netty.channel.group.ChannelGroup;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
+import org.jboss.netty.util.ThreadNameDeterminer;
+import org.jboss.netty.util.ThreadRenamingRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,13 +108,14 @@ public class HTTPServer implements Runnable {
 			address = new InetSocketAddress(port);
 		}
 
-		LOGGER.info("Created socket: " + address);
+		LOGGER.info("Created socket: {}", address);
 
 		if (configuration.isHTTPEngineV2()) { // HTTP Engine V2
-			group = new DefaultChannelGroup("myServer");
+			ThreadRenamingRunnable.setThreadNameDeterminer(ThreadNameDeterminer.CURRENT);
+			group = new DefaultChannelGroup("HTTPServer");
 			factory = new NioServerSocketChannelFactory(
-				Executors.newCachedThreadPool(),
-				Executors.newCachedThreadPool()
+				Executors.newCachedThreadPool(new NettyBossThreadFactory()),
+				Executors.newCachedThreadPool(new NettyWorkerThreadFactory())
 			);
 
 			ServerBootstrap bootstrap = new ServerBootstrap(factory);
@@ -152,7 +157,7 @@ public class HTTPServer implements Runnable {
 				hostname = InetAddress.getLocalHost().getHostAddress();
 			}
 
-			runnable = new Thread(this, "HTTP Server");
+			runnable = new Thread(this, "HTTPv1 Request Handler");
 			runnable.setDaemon(false);
 			runnable.start();
 		}
@@ -229,12 +234,10 @@ public class HTTPServer implements Runnable {
 				// basic IP filter: solntcev at gmail dot com
 				boolean ignore = false;
 
-				if (configuration.getIpFiltering().allowed(inetAddress)) {
-					LOGGER.trace("Receiving a request from: " + ip);
-				} else {
+				if (!configuration.getIpFiltering().allowed(inetAddress)) {
 					ignore = true;
 					socket.close();
-					LOGGER.trace("Ignoring request from: " + ip);
+					LOGGER.trace("Ignoring request from {}:{}" + ip, socket.getPort());
 				}
 
 				if (!ignore) {
@@ -245,7 +248,7 @@ public class HTTPServer implements Runnable {
 						count++;
 					}
 					RequestHandler request = new RequestHandler(socket);
-					Thread thread = new Thread(request, "Request Handler " + count);
+					Thread thread = new Thread(request, "HTTPv1 Request Worker " + count);
 					thread.start();
 				}
 			} catch (ClosedByInterruptException e) {
@@ -265,6 +268,56 @@ public class HTTPServer implements Runnable {
 					LOGGER.debug("Caught exception", e);
 				}
 			}
+		}
+	}
+
+	/**
+	 * A {@link ThreadFactory} that creates Netty worker threads.
+	 */
+	static class NettyWorkerThreadFactory implements ThreadFactory {
+		private final ThreadGroup group;
+		private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+		NettyWorkerThreadFactory() {
+			group = new ThreadGroup("Netty worker group");
+			group.setDaemon(false);
+		}
+
+		@Override
+		public Thread newThread(Runnable runnable) {
+			Thread thread = new Thread(group, runnable, "HTTPv2 Request Worker " + threadNumber.getAndIncrement());
+			if (thread.isDaemon()) {
+				thread.setDaemon(false);
+			}
+			if (thread.getPriority() != Thread.NORM_PRIORITY) {
+				thread.setPriority(Thread.NORM_PRIORITY);
+			}
+			return thread;
+		}
+	}
+
+	/**
+	 * A {@link ThreadFactory} that creates Netty boss threads.
+	 */
+	static class NettyBossThreadFactory implements ThreadFactory {
+		private final ThreadGroup group;
+		private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+		NettyBossThreadFactory() {
+			group = new ThreadGroup("Netty boss group");
+			group.setDaemon(false);
+		}
+
+		@Override
+		public Thread newThread(Runnable runnable) {
+			Thread thread = new Thread(group, runnable, "HTTPv2 Request Handler " + threadNumber.getAndIncrement());
+			if (thread.isDaemon()) {
+				thread.setDaemon(false);
+			}
+			if (thread.getPriority() != Thread.NORM_PRIORITY) {
+				thread.setPriority(Thread.NORM_PRIORITY);
+			}
+			return thread;
 		}
 	}
 }

--- a/src/main/java/net/pms/network/HTTPXMLHelper.java
+++ b/src/main/java/net/pms/network/HTTPXMLHelper.java
@@ -31,7 +31,46 @@ class HTTPXMLHelper {
 	static final String SEARCHRESPONSE_FOOTER = "</u:SearchResponse>";
 	static final String SORTCAPS_RESPONSE = "<u:GetSortCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SortCaps></SortCaps></u:GetSortCapabilitiesResponse>";
 	static final String SEARCHCAPS_RESPONSE = "<u:GetSearchCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SearchCaps></SearchCaps></u:GetSearchCapabilitiesResponse>";
-	static final String PROTOCOLINFO_RESPONSE = "<u:GetProtocolInfoResponse xmlns:u=\"urn:schemas-upnp-org:service:ConnectionManager:1\"><Source>http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_SM,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_MED,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_LRG,http-get:*:audio/mpeg:DLNA.ORG_PN=MP3,http-get:*:audio/L16:DLNA.ORG_PN=LPCM,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_24_AC3_ISO;SONY.COM_PN=AVC_TS_HD_24_AC3_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_24_AC3;SONY.COM_PN=AVC_TS_HD_24_AC3,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_24_AC3_T;SONY.COM_PN=AVC_TS_HD_24_AC3_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_PS_PAL,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_PS_NTSC,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_50_L2_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_60_L2_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_EU_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_50_AC3_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_50_L2_ISO;SONY.COM_PN=HD2_50_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_60_AC3_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_60_L2_ISO;SONY.COM_PN=HD2_60_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_50_L2_T;SONY.COM_PN=HD2_50_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_60_L2_T;SONY.COM_PN=HD2_60_T,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_50_AC3_ISO;SONY.COM_PN=AVC_TS_HD_50_AC3_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_50_AC3;SONY.COM_PN=AVC_TS_HD_50_AC3,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_60_AC3_ISO;SONY.COM_PN=AVC_TS_HD_60_AC3_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_60_AC3;SONY.COM_PN=AVC_TS_HD_60_AC3,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_50_AC3_T;SONY.COM_PN=AVC_TS_HD_50_AC3_T,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_60_AC3_T;SONY.COM_PN=AVC_TS_HD_60_AC3_T,http-get:*:video/x-mp2t-mphl-188:*,http-get:*:*:*,http-get:*:video/*:*,http-get:*:audio/*:*,http-get:*:image/*:*</Source><Sink></Sink></u:GetProtocolInfoResponse>";
+	static final String PROTOCOLINFO_RESPONSE =
+		"<u:GetProtocolInfoResponse xmlns:u=\"urn:schemas-upnp-org:service:ConnectionManager:1\"><Source>" +
+		"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN," +
+		"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_SM," +
+		"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_MED," +
+		"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_LRG," +
+		"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_RES_H_V," +
+		"http-get:*:image/png:DLNA.ORG_PN=PNG_TN," +
+		"http-get:*:image/png:DLNA.ORG_PN=PNG_LRG," +
+		"http-get:*:image/gif:DLNA.ORG_PN=GIF_LRG," +
+		"http-get:*:audio/mpeg:DLNA.ORG_PN=MP3," +
+		"http-get:*:audio/L16:DLNA.ORG_PN=LPCM," +
+		"http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_24_AC3_ISO;SONY.COM_PN=AVC_TS_HD_24_AC3_ISO," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_24_AC3;SONY.COM_PN=AVC_TS_HD_24_AC3," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_24_AC3_T;SONY.COM_PN=AVC_TS_HD_24_AC3_T," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_PS_PAL," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_PS_NTSC," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_50_L2_T," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_60_L2_T," +
+		"http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_EU_ISO," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU_T," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_50_AC3_T," +
+		"http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_50_L2_ISO;SONY.COM_PN=HD2_50_ISO," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_60_AC3_T," +
+		"http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_60_L2_ISO;SONY.COM_PN=HD2_60_ISO," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_50_L2_T;SONY.COM_PN=HD2_50_T," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_60_L2_T;SONY.COM_PN=HD2_60_T," +
+		"http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_50_AC3_ISO;SONY.COM_PN=AVC_TS_HD_50_AC3_ISO," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_50_AC3;SONY.COM_PN=AVC_TS_HD_50_AC3," +
+		"http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_HD_60_AC3_ISO;SONY.COM_PN=AVC_TS_HD_60_AC3_ISO," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_60_AC3;SONY.COM_PN=AVC_TS_HD_60_AC3," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_50_AC3_T;SONY.COM_PN=AVC_TS_HD_50_AC3_T," +
+		"http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_HD_60_AC3_T;SONY.COM_PN=AVC_TS_HD_60_AC3_T," +
+		"http-get:*:video/x-mp2t-mphl-188:*," +
+		"http-get:*:*:*," +
+		"http-get:*:video/*:*," +
+		"http-get:*:audio/*:*," +
+		"http-get:*:image/*:*" +
+		"</Source><Sink></Sink></u:GetProtocolInfoResponse>";
 	static final String RESULT_HEADER = "<Result>";
 	static final String RESULT_FOOTER = "</Result>";
 	static final String DIDL_HEADER = "&lt;DIDL-Lite xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:sec=\"http://www.sec.co.kr/\" xmlns:pv=\"http://www.pv.com/pvns/\"&gt;";

--- a/src/main/java/net/pms/network/RequestHandler.java
+++ b/src/main/java/net/pms/network/RequestHandler.java
@@ -25,15 +25,26 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.StringTokenizer;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
 import net.pms.PMS;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.external.StartStopListenerDelegate;
+import net.pms.util.StringUtil;
 import static net.pms.util.StringUtil.convertStringToTime;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
 public class RequestHandler implements Runnable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RequestHandler.class);
@@ -62,7 +73,7 @@ public class RequestHandler implements Runnable {
 	public RequestHandler(Socket socket) throws IOException {
 		this.socket = socket;
 		this.output = socket.getOutputStream();
-		this.br = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+		this.br = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
 	}
 
 	@Override
@@ -86,7 +97,6 @@ public class RequestHandler implements Runnable {
 				throw new IOException("Access denied for address " + ia + " based on IP filter");
 			}
 
-			LOGGER.trace("Opened request handler on socket " + socket);
 			PMS.get().getRegistry().disableGoToSleep();
 
 			// The handler makes a couple of attempts to recognize a renderer from its requests.
@@ -107,7 +117,7 @@ public class RequestHandler implements Runnable {
 			String line = br.readLine();
 			while (line != null && line.length() > 0) {
 				headerLines.add(line);
-				if (unrecognized) {
+				if (sortedHeaders != null) {
 					sortedHeaders.put(line);
 				}
 				line = br.readLine();
@@ -119,7 +129,6 @@ public class RequestHandler implements Runnable {
 			}
 
 			for (String headerLine : headerLines) {
-				LOGGER.trace("Received on socket: " + headerLine);
 
 				// The request object is created inside the while loop.
 				if (request != null && request.getMediaRenderer() == null && renderer != null) {
@@ -128,7 +137,7 @@ public class RequestHandler implements Runnable {
 				if (headerLine.toUpperCase().startsWith("USER-AGENT")) {
 					// Is the request from our own Cling service, i.e. self-originating?
 					if (isSelf && headerLine.contains("UMS/")) {
-						LOGGER.trace("Ignoring self-originating request from " + ia + ":" + remoteAddress.getPort());
+						//LOGGER.trace("Ignoring self-originating request from {}:{}", ia, remoteAddress.getPort());
 						return;
 					}
 					userAgentString = headerLine.substring(headerLine.indexOf(':') + 1).trim();
@@ -210,7 +219,8 @@ public class RequestHandler implements Runnable {
 						}
 					}
 				} catch (IllegalArgumentException e) {
-					LOGGER.error("Error in parsing HTTP headers", e);
+					LOGGER.error("Error parsing HTTP headers: {}", e.getMessage());
+					LOGGER.trace("", e);
 				}
 			}
 
@@ -223,25 +233,24 @@ public class RequestHandler implements Runnable {
 					renderer = RendererConfiguration.resolve(ia, null);
 					request.setMediaRenderer(renderer);
 					if (renderer != null) {
-						LOGGER.trace("Using default media renderer: " + renderer.getConfName());
+						LOGGER.debug("Using default media renderer \"{}\"", renderer.getConfName());
 
 						if (userAgentString != null && !userAgentString.equals("FDSSDP")) {
 							// We have found an unknown renderer
 							identifiers.add(0, "User-Agent: " + userAgentString);
 							renderer.setIdentifiers(identifiers);
-							LOGGER.info("Media renderer was not recognized. Possible identifying HTTP headers:"
-								+ StringUtils.join(identifiers, ", "));
+							LOGGER.info(
+								"Media renderer was not recognized. Possible identifying HTTP headers:\n{}",
+								StringUtils.join(identifiers, "\n")
+							);
 						}
 					} else {
 						// If RendererConfiguration.resolve() didn't return the default renderer
 						// it means we know via upnp that it's not really a renderer.
 						return;
 					}
-				} else {
-					if (userAgentString != null) {
-						LOGGER.trace("HTTP User-Agent: " + userAgentString);
-					}
-					LOGGER.trace("Recognized media renderer: " + renderer.getRendererName());
+				} else if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("Recognized media renderer \"{}\"", renderer.getRendererName());
 				}
 			}
 
@@ -249,12 +258,14 @@ public class RequestHandler implements Runnable {
 				char buf[] = new char[receivedContentLength];
 				br.read(buf);
 				if (request != null) {
-					request.setTextContent(new String(buf));
+					String textContent = new String(buf);
+					request.setTextContent(textContent);
+					if (LOGGER.isTraceEnabled()) {
+						logMessageReceived(headerLines, textContent, socket.getRemoteSocketAddress(), renderer);
+					}
+				} else if (LOGGER.isTraceEnabled() ){
+					logMessageReceived(headerLines, null, socket.getRemoteSocketAddress(), renderer);
 				}
-			}
-
-			if (request != null) {
-				LOGGER.trace("HTTP: " + request.getArgument() + " / " + request.getLowRange() + "-" + request.getHighRange());
 			}
 
 			if (request != null) {
@@ -265,13 +276,18 @@ public class RequestHandler implements Runnable {
 				request.getInputStream().close();
 			}
 		} catch (IOException e) {
-			LOGGER.trace("Unexpected IO error: " + e.getClass().getName() + ": " + e.getMessage());
+			LOGGER.error("Unexpected IO error in {}: {}", getClass().getName(), e.getMessage());
+			// "An established connection was aborted by the software in your host machine"
+			// is localized on Windows so there's no way to differentiate it
+			// from other IOExceptions.
+			//LOGGER.trace("", e);
 			if (request != null && request.getInputStream() != null) {
 				try {
-					LOGGER.trace("Closing input stream: " + request.getInputStream());
+					LOGGER.trace("Closing input stream: {}", request.getInputStream());
 					request.getInputStream().close();
 				} catch (IOException e1) {
-					LOGGER.error("Error closing input stream", e1);
+					LOGGER.error("Error closing input stream: {}", e1);
+					LOGGER.trace("", e1);
 				}
 			}
 		} finally {
@@ -281,12 +297,85 @@ public class RequestHandler implements Runnable {
 				br.close();
 				socket.close();
 			} catch (IOException e) {
-				LOGGER.error("Error closing connection: ", e);
+				LOGGER.error("Error closing connection: {}", e.getMessage());
+				LOGGER.trace("", e);
 			}
 
 			startStopListenerDelegate.stop();
-			LOGGER.trace("Close connection");
 		}
+	}
+
+	private static void logMessageReceived(List<String> headerLines, String content, SocketAddress remote, RendererConfiguration renderer) {
+		StringBuilder header = new StringBuilder();
+		String soapAction = null;
+
+		if (headerLines != null) {
+			if (!headerLines.isEmpty()) {
+				header.append(headerLines.get(0)).append("\n\n");
+			}
+			if (headerLines.size() > 1) {
+				header.append("HEADER:\n");
+				for (int i = 1; i < headerLines.size(); i++) {
+					if (isNotBlank(headerLines.get(i))) {
+						header.append("  ").append(headerLines.get(i)).append("\n");
+						if (headerLines.get(i).toUpperCase(Locale.ROOT).contains("SOAPACTION")) {
+							soapAction = headerLines.get(i).toUpperCase(Locale.ROOT).replaceFirst("\\s*SOAPACTION:\\s*", "");
+						}
+					}
+				}
+			}
+		} else {
+			header.append("No header information available\n");
+		}
+
+		String formattedContent = null;
+		if (StringUtils.isNotBlank(content)) {
+			try {
+				formattedContent = StringUtil.prettifyXML(content, 4);
+			} catch (XPathExpressionException | SAXException | ParserConfigurationException | TransformerException e) {
+				LOGGER.trace("XML parsing failed with:\n{}", e);
+				formattedContent = "  Content isn't valid XML, using text formatting: " + e.getMessage()  + "\n";
+				formattedContent += "    " + content.replaceAll("\n", "\n    ") + "\n";
+			}
+		}
+		String requestType = "";
+		// Map known requests to request type
+		if (soapAction != null) {
+			if (soapAction.contains("CONTENTDIRECTORY:1#BROWSE")) {
+				requestType = "browse ";
+			} else if (soapAction.contains("CONTENTDIRECTORY:1#SEARCH")) {
+				requestType = "search ";
+			}
+		}
+		String rendererName;
+		if (renderer != null) {
+			if (isNotBlank(renderer.getRendererName())) {
+				if (isBlank(renderer.getConfName()) || renderer.getRendererName().equals(renderer.getConfName())) {
+					rendererName = renderer.getRendererName();
+				} else {
+					rendererName = renderer.getRendererName() + " [" + renderer.getConfName() + "]";
+				}
+			} else if (isNotBlank(renderer.getConfName())) {
+				rendererName = renderer.getConfName();
+			} else {
+				rendererName = "Unnamed";
+			}
+		} else {
+			rendererName = "Unknown";
+		}
+		if (remote instanceof InetSocketAddress) {
+			rendererName +=
+				" (" + ((InetSocketAddress) remote).getAddress().getHostAddress() +
+				":" + ((InetSocketAddress) remote).getPort() + ")";
+		}
+
+		LOGGER.trace(
+			"Received a {}request from {}:\n\n{}{}",
+			requestType,
+			rendererName,
+			header,
+			StringUtils.isNotBlank(formattedContent) ? "\nCONTENT:\n" + formattedContent : ""
+		);
 	}
 
 	/**
@@ -297,7 +386,7 @@ public class RequestHandler implements Runnable {
 	 * @param inetAddress The internet address to verify.
 	 * @return True when not allowed, false otherwise.
 	 */
-	private boolean filterIp(InetAddress inetAddress) {
+	private static boolean filterIp(InetAddress inetAddress) {
 		return !PMS.getConfiguration().getIpFiltering().allowed(inetAddress);
 	}
 }

--- a/src/main/java/net/pms/network/RequestHandler.java
+++ b/src/main/java/net/pms/network/RequestHandler.java
@@ -36,6 +36,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 import net.pms.PMS;
 import net.pms.configuration.RendererConfiguration;
+import net.pms.dlna.protocolinfo.PanasonicDmpProfiles;
 import net.pms.external.StartStopListenerDelegate;
 import net.pms.util.StringUtil;
 import static net.pms.util.StringUtil.convertStringToTime;
@@ -141,6 +142,8 @@ public class RequestHandler implements Runnable {
 						return;
 					}
 					userAgentString = headerLine.substring(headerLine.indexOf(':') + 1).trim();
+				} else if (renderer != null && headerLine.startsWith("X-PANASONIC-DMP-Profile:")) {
+					PanasonicDmpProfiles.parsePanasonicDmpProfiles(headerLine, renderer);
 				}
 
 				try {

--- a/src/main/java/net/pms/network/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/RequestHandlerV2.java
@@ -38,6 +38,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 import net.pms.PMS;
 import net.pms.configuration.RendererConfiguration;
+import net.pms.dlna.protocolinfo.PanasonicDmpProfiles;
 import net.pms.external.StartStopListenerDelegate;
 import net.pms.util.StringUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -145,6 +146,8 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 
 			if (headerLine.toUpperCase().startsWith("USER-AGENT")) {
 				userAgentString = headerLine.substring(headerLine.indexOf(':') + 1).trim();
+			} else if (renderer != null && name.equals("X-PANASONIC-DMP-Profile")) {
+				PanasonicDmpProfiles.parsePanasonicDmpProfiles(headers.get(name), renderer);
 			}
 
 			try {

--- a/src/main/java/net/pms/network/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/RequestHandlerV2.java
@@ -18,6 +18,8 @@
  */
 package net.pms.network;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -25,13 +27,19 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
 import net.pms.PMS;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.external.StartStopListenerDelegate;
+import net.pms.util.StringUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -41,6 +49,7 @@ import org.jboss.netty.handler.codec.frame.TooLongFrameException;
 import org.jboss.netty.handler.codec.http.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
 public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RequestHandlerV2.class);
@@ -75,16 +84,15 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 	};
 
 	@Override
-	public void messageReceived(ChannelHandlerContext ctx, MessageEvent e)
-		throws Exception {
+	public void messageReceived(ChannelHandlerContext ctx, MessageEvent event) throws Exception {
 		RequestV2 request = null;
 		RendererConfiguration renderer = null;
 		String userAgentString = null;
 		ArrayList<String> identifiers = new ArrayList<>();
 
-		HttpRequest nettyRequest = this.nettyRequest = (HttpRequest) e.getMessage();
+		HttpRequest nettyRequest = this.nettyRequest = (HttpRequest) event.getMessage();
 
-		InetSocketAddress remoteAddress = (InetSocketAddress) e.getChannel().getRemoteAddress();
+		InetSocketAddress remoteAddress = (InetSocketAddress) event.getChannel().getRemoteAddress();
 		InetAddress ia = remoteAddress.getAddress();
 
 		// Is the request from our own Cling service, i.e. self-originating?
@@ -94,17 +102,15 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 
 		// Filter if required
 		if (isSelf || filterIp(ia)) {
-			e.getChannel().close();
-			LOGGER.trace(isSelf ?
-				("Ignoring self-originating request from " + ia + ":" + remoteAddress.getPort()) :
-				("Access denied for address " + ia + " based on IP filter"));
+			event.getChannel().close();
+			/*if (isSelf && LOGGER.isTraceEnabled()) {
+				LOGGER.trace("Ignoring self-originating request from {}:{}", ia, remoteAddress.getPort());
+			}*/
 			return;
 		}
 
-		LOGGER.trace("Opened request handler on socket " + remoteAddress);
 		PMS.get().getRegistry().disableGoToSleep();
 		request = new RequestV2(nettyRequest.getMethod().getName(), nettyRequest.getUri().substring(1));
-		LOGGER.trace("Request: " + nettyRequest.getProtocolVersion().getText() + " : " + request.getMethod() + " : " + request.getArgument());
 
 		if (nettyRequest.getProtocolVersion().getMinorVersion() == 0) {
 			request.setHttp10(true);
@@ -136,7 +142,6 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 		while (iterator.hasNext()) {
 			String name = iterator.next();
 			String headerLine = name + ": " + headers.get(name);
-			LOGGER.trace("Received on socket: " + headerLine);
 
 			if (headerLine.toUpperCase().startsWith("USER-AGENT")) {
 				userAgentString = headerLine.substring(headerLine.indexOf(':') + 1).trim();
@@ -208,7 +213,8 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 					}
 				}
 			} catch (Exception ee) {
-				LOGGER.error("Error parsing HTTP headers", ee);
+				LOGGER.error("Error parsing HTTP headers: {}", ee.getMessage());
+				LOGGER.trace("", ee);
 			}
 		}
 
@@ -221,14 +227,16 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 			renderer = RendererConfiguration.resolve(ia, null);
 			request.setMediaRenderer(renderer);
 			if (renderer != null) {
-				LOGGER.trace("Using default media renderer: " + renderer.getConfName());
+				LOGGER.debug("Using default media renderer \"{}\"", renderer.getConfName());
 
 				if (userAgentString != null && !userAgentString.equals("FDSSDP")) {
 					// We have found an unknown renderer
 					identifiers.add(0, "User-Agent: " + userAgentString);
 					renderer.setIdentifiers(identifiers);
-					LOGGER.info("Media renderer was not recognized. Possible identifying HTTP headers:"
-						+ StringUtils.join(identifiers, ", "));
+					LOGGER.info(
+						"Media renderer was not recognized. Possible identifying HTTP headers:\n{}",
+						StringUtils.join(identifiers, "\n")
+					);
 					PMS.get().setRendererFound(renderer);
 				}
 			} else {
@@ -236,24 +244,100 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 				// it means we know via upnp that it's not really a renderer.
 				return;
 			}
-		} else {
-			if (userAgentString != null) {
-				LOGGER.trace("HTTP User-Agent: " + userAgentString);
-			}
-
-			LOGGER.trace("Recognized media renderer: " + renderer.getRendererName());
+		} else if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("Recognized media renderer \"{}\"", renderer.getRendererName());
 		}
 
 		if (nettyRequest.headers().contains(HttpHeaders.Names.CONTENT_LENGTH)) {
 			byte data[] = new byte[(int) HttpHeaders.getContentLength(nettyRequest)];
 			ChannelBuffer content = nettyRequest.getContent();
 			content.readBytes(data);
-			request.setTextContent(new String(data, "UTF-8"));
+			String textContent = new String(data, "UTF-8");
+			request.setTextContent(textContent);
+			if (LOGGER.isTraceEnabled()) {
+				logMessageReceived(event, textContent, renderer);
+			}
+		} else if (LOGGER.isTraceEnabled() ){
+			logMessageReceived(event, null, renderer);
 		}
 
-		LOGGER.trace("HTTP: " + request.getArgument() + " / " + request.getLowRange() + "-" + request.getHighRange());
+		writeResponse(ctx, event, request, ia);
+	}
 
-		writeResponse(ctx, e, request, ia);
+	private static void logMessageReceived(MessageEvent event, String content, RendererConfiguration renderer) {
+		StringBuilder header = new StringBuilder();
+		String soapAction = null;
+		if (event.getMessage() instanceof HttpRequest) {
+			header.append(((HttpRequest) event.getMessage()).getMethod());
+			header.append(" ").append(((HttpRequest) event.getMessage()).getUri());
+		}
+		if (event.getMessage() instanceof HttpMessage) {
+			if (header.length() > 0) {
+				header.append(" ");
+			}
+			header.append(((HttpMessage) event.getMessage()).getProtocolVersion().getText());
+			header.append("\n\n");
+			header.append("HEADER:\n");
+			for (Entry<String, String> entry : ((HttpMessage) event.getMessage()).headers().entries()) {
+				if (StringUtils.isNotBlank(entry.getKey())) {
+					header.append("  ").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+					if ("SOAPACTION".equalsIgnoreCase(entry.getKey())) {
+						soapAction = entry.getValue().toUpperCase(Locale.ROOT);
+					}
+				}
+			}
+		} else {
+			header.append("Unknown class: ").append(event.getClass().getSimpleName()).append("\n");
+			header.append(event).append("\n");
+		}
+		String formattedContent = null;
+		if (StringUtils.isNotBlank(content)) {
+			try {
+				formattedContent = StringUtil.prettifyXML(content, 4);
+			} catch (XPathExpressionException | SAXException | ParserConfigurationException | TransformerException e) {
+				LOGGER.trace("XML parsing failed with:\n{}", e);
+				formattedContent = "  Content isn't valid XML, using text formatting: " + e.getMessage()  + "\n";
+				formattedContent += "    " + content.replaceAll("\n", "\n    ") + "\n";
+			}
+		}
+		String requestType = "";
+		// Map known requests to request type
+		if (soapAction != null) {
+			if (soapAction.contains("CONTENTDIRECTORY:1#BROWSE")) {
+				requestType = "browse ";
+			} else if (soapAction.contains("CONTENTDIRECTORY:1#SEARCH")) {
+				requestType = "search ";
+			}
+		}
+		String rendererName;
+		if (renderer != null) {
+			if (isNotBlank(renderer.getRendererName())) {
+				if (isBlank(renderer.getConfName()) || renderer.getRendererName().equals(renderer.getConfName())) {
+					rendererName = renderer.getRendererName();
+				} else {
+					rendererName = renderer.getRendererName() + " [" + renderer.getConfName() + "]";
+				}
+			} else if (isNotBlank(renderer.getConfName())) {
+				rendererName = renderer.getConfName();
+			} else {
+				rendererName = "Unnamed";
+			}
+		} else {
+			rendererName = "Unknown";
+		}
+		if (event.getChannel().getRemoteAddress() instanceof InetSocketAddress) {
+			rendererName +=
+				" (" + ((InetSocketAddress) event.getChannel().getRemoteAddress()).getAddress().getHostAddress() +
+				":" + ((InetSocketAddress) event.getChannel().getRemoteAddress()).getPort() + ")";
+		}
+
+		LOGGER.trace(
+			"Received a {}request from {}:\n\n{}{}",
+			requestType,
+			rendererName,
+			header,
+			StringUtils.isNotBlank(formattedContent) ? "\nCONTENT:\n" + formattedContent : ""
+		);
 	}
 
 	/**
@@ -264,7 +348,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 	 * @param inetAddress The internet address to verify.
 	 * @return True when not allowed, false otherwise.
 	 */
-	private boolean filterIp(InetAddress inetAddress) {
+	private static boolean filterIp(InetAddress inetAddress) {
 		return !PMS.getConfiguration().getIpFiltering().allowed(inetAddress);
 	}
 
@@ -343,7 +427,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 		ch.close();
 	}
 
-	private void sendError(ChannelHandlerContext ctx, HttpResponseStatus status) {
+	private static void sendError(ChannelHandlerContext ctx, HttpResponseStatus status) {
 		HttpResponse response = new DefaultHttpResponse(
 			HttpVersion.HTTP_1_1, status);
 		response.headers().set(

--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -13,6 +13,7 @@ import net.pms.PMS;
 import static net.pms.network.UPNPHelper.sleep;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import net.pms.dlna.protocolinfo.DeviceProtocolInfo;
+import net.pms.dlna.protocolinfo.PanasonicDmpProfiles;
 import net.pms.util.BasicPlayer;
 import net.pms.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
@@ -156,6 +157,7 @@ public class UPNPControl {
 		private Thread monitor;
 		public volatile boolean active, renew;
 		public final DeviceProtocolInfo deviceProtocolInfo = new DeviceProtocolInfo();
+		public volatile PanasonicDmpProfiles panasonicDmpProfiles;
 
 		public Renderer(String uuid) {
 			this();

--- a/src/main/java/net/pms/util/FullyPlayed.java
+++ b/src/main/java/net/pms/util/FullyPlayed.java
@@ -93,10 +93,12 @@ public class FullyPlayed {
 
 	/**
 	 * Adds a text overlay to the given thumbnail and returns it.
+	 * <p>
+	 * <b>This method either consumes and closes {@code thumb} or it returns it
+	 * in a reset state ({@code position = 0}).</b>
 	 *
-	 * @param thumb the source thumb to add the overlay to
-	 * @param mediaType the type of media the thumbnail is for
-	 * @return The modified thumbnail
+	 * @param thumb the source thumbnail to add the overlay to.
+	 * @return The processed thumbnail.
 	 */
 	public static DLNAThumbnailInputStream addFullyPlayedOverlay(DLNAThumbnailInputStream thumb) {
 		if (thumbnailOverlayImage == null) {
@@ -132,13 +134,18 @@ public class FullyPlayed {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		try {
 			ImageIOTools.imageIOWrite(image, thumb != null ? thumb.getFormat().toString() : "jpg", out);
+			if (thumb != null) {
+				thumb.close();
+			}
 			return DLNAThumbnailInputStream.toThumbnailInputStream(out.toByteArray());
 		} catch (IOException e) {
 			LOGGER.error("Could not write thumbnail byte array: {}", e.getMessage());
 			LOGGER.trace("", e);
 		}
 
-		thumb.fullReset();
+		if (thumb != null) {
+			thumb.fullReset();
+		}
 		return thumb;
 	}
 

--- a/src/main/java/net/pms/util/Rational.java
+++ b/src/main/java/net/pms/util/Rational.java
@@ -1,0 +1,1492 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.util;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This is an immutable class for holding a rational without loss of precision.
+ * As a consequence, a new instance is generated for every mathematical
+ * operation. The reduced rationale and most string values are generated during
+ * construction and cached for later retrieval.
+ * <p>
+ * This class has methods for doing basic operations mathematical operations,
+ * and constructors for various number formats. This class implements
+ * {@link Number} for easy conversion to other number formats, and
+ * {@link Comparable} so two values can be compared and the values can be
+ * sorted. In addition to {@link Comparable#compareTo}, there are
+ * {@link #compareTo} methods that accepts most primitive number types and any
+ * class implementing {@link Number}.
+ * <p>
+ * All the {@link #compareTo} can be used as a "replacement" for the six boolean comparison operators ({@literal <}, ==, {@literal >},
+ * {@literal >=}, !=, {@literal <=}) since these are not supported for "custom" number types.
+ * The suggested idiom for performing
+ * these comparisons is: {@code (x.compareTo(y)} &lt;<i>op</i>&gt;
+ * {@code 0)}, where &lt;<i>op</i>&gt; is one of the six comparison
+ * operators.
+ * <p>
+ * Static methods for finding the greatest common divisor and the least common
+ * multiple for two integers are also provided with
+ * {@link #getGreatestCommonDivisor} and {@link #getLeastCommonMultiple}.
+ *
+ * This class is "inspired" by the following:
+ * <ul>
+ * <li>http://introcs.cs.princeton.edu/java/32class/Rational.java.html</li>
+ * <li>com.drew.lang.Rational</li>
+ * <li>org.apache.commons.lang.math.Fraction</li>
+ * <li>com.twelvemonkeys.imageio.metadata.exif.Rational</li>
+ * <li>java.math.BigInteger</li>
+ * <li>java.math.BigDecimal</li>
+ * <li>java.math.MutableBigInteger</li>
+ * </ul>
+ *
+ * @author Nadahar
+ */
+public class Rational extends Number implements Comparable<Rational> {
+
+	/** The static instance representing the value 0 */
+	public static final Rational ZERO = new Rational();
+
+	/** The static instance representing the value 1 */
+	public static final Rational ONE = new Rational(1L);
+
+	/** Internal static string for 0 */
+	protected static final String STRING_ZERO = "0";
+
+	/** Internal static string for 1 */
+	protected static final String STRING_ONE = "1";
+
+	/** Internal regex pattern for validation of strings for parsing */
+	protected static final Pattern STRING_PATTERN = Pattern.compile("^\\s*(-?\\d+)\\s*(?:/\\s*(-?\\d+))?\\s*$");
+
+	/**
+	 * The locale-insensitive {@link DecimalFormat} used for
+	 * {@link #toDecimalString} and {@link #toDebugString}.
+	 */
+	protected static final DecimalFormat DECIMALFORMAT = new DecimalFormat(
+		"#0.####################",
+		DecimalFormatSymbols.getInstance(Locale.ROOT)
+	);
+
+	private static final long serialVersionUID = 1L;
+
+	/** The numerator, which also holds the sign of this {@link Rational}. */
+	protected final BigInteger numerator;
+
+	/** The denominator, which is positive by definition. */
+	protected final BigInteger denominator;
+
+	/**
+	 * The numerator of the reduced {@link Rational}, which also holds the sign.
+	 */
+	protected final BigInteger reducedNumerator;
+
+	/** The denominator of the reduced {@link Rational}, always positive. */
+	protected final BigInteger reducedDenominator;
+
+	/**
+	 * The greatest common divisor of {@code numerator} and {@code denominator}.
+	 * This is the number by which {@code numerator} and {@code denominator} are
+	 * divided to produce {@code reducedNumerator} and {@code reducedDenominator}
+	 */
+	protected final BigInteger greatestCommonDivisor;
+
+	/** The cached string value */
+	protected final String stringValue;
+
+	/** The cached reduced string value */
+	protected final String reducedStringValue;
+
+	/** The cached decimal string value */
+	protected final String decimalStringValue;
+
+	/** The cached hashCode */
+	protected final int hashCode;
+
+	/**
+	 * Creates a new instance that represents the value zero. Use {@link #ZERO}
+	 * instead.
+	 */
+	protected Rational() {
+		numerator = BigInteger.ZERO;
+		denominator = BigInteger.ONE;
+		greatestCommonDivisor = BigInteger.ONE;
+		reducedNumerator = numerator;
+		reducedDenominator = denominator;
+		stringValue = STRING_ZERO;
+		reducedStringValue = STRING_ZERO;
+		decimalStringValue = STRING_ZERO;
+		hashCode = calculateHashCode();
+	}
+
+	/**
+	 * Creates a new instance that represents the value of {@code value}.
+	 *
+	 * @param value the value.
+	 */
+	public Rational(double value) {
+		this(BigDecimal.valueOf(value));
+	}
+
+	/**
+	 * Creates a new instance that represents the value of {@code value}.
+	 *
+	 * @param value the value.
+	 */
+	public Rational(BigDecimal value) {
+		if (value.signum() == 0) {
+			this.numerator = BigInteger.ZERO;
+			denominator = BigInteger.ONE;
+		} else {
+			if (value.scale() > 0) {
+				BigInteger unscaled = value.unscaledValue();
+				BigInteger tmpDenominator = BigInteger.TEN.pow(value.scale());
+				BigInteger tmpGreatestCommonDivisor = unscaled.gcd(tmpDenominator);
+				numerator = unscaled.divide(tmpGreatestCommonDivisor);
+				denominator = tmpDenominator.divide(tmpGreatestCommonDivisor);
+			} else {
+				numerator = value.toBigIntegerExact();
+				denominator = BigInteger.ONE;
+			}
+		}
+		greatestCommonDivisor = BigInteger.ONE;
+		reducedNumerator = numerator;
+		reducedDenominator = denominator;
+		stringValue = generateRationalString(numerator, denominator);
+		reducedStringValue = stringValue;
+		decimalStringValue = generateDecimalString(numerator, denominator);
+		hashCode = calculateHashCode();
+	}
+
+	/**
+	 * Creates a new instance by parsing {@code value}. The format must be
+	 * either {@code integer numerator/integer denominator} or
+	 * {@code integer numerator} for the parsing to succeed. Signs are
+	 * understood for both numerator and denominator. If {@code value} is blank
+	 * or {@code null}, a {@link Rational} instance representing zero is
+	 * created. If {@code value} can't be parsed, a
+	 * {@link NumberFormatException} is thrown.
+	 *
+	 * @param value the {@link String} value to parse.
+	 * @throws NumberFormatException If {@code value} cannot be parsed.
+	 */
+	public Rational(String value) {
+		if (isBlank(value)) {
+			numerator = BigInteger.ZERO;
+			denominator = BigInteger.ONE;
+			greatestCommonDivisor = BigInteger.ONE;
+			reducedNumerator = numerator;
+			reducedDenominator = denominator;
+			stringValue = STRING_ZERO;
+			reducedStringValue = STRING_ZERO;
+			decimalStringValue = STRING_ZERO;
+		} else {
+			Matcher matcher = STRING_PATTERN.matcher(value);
+			if (!matcher.find()) {
+				throw new NumberFormatException(
+					"Invalid value \"" + value +
+					"\". The value must be either \"integer/integer\" or \"integer\""
+				);
+			}
+			if (value.indexOf("/") > 0) {
+				if (matcher.group(2).startsWith("-")) {
+					// Keep the signum in the numerator
+					numerator = new BigInteger(matcher.group(1)).negate();
+					denominator = new BigInteger(matcher.group(2)).negate();
+				} else {
+					numerator = new BigInteger(matcher.group(1));
+					denominator = new BigInteger(matcher.group(2));
+				}
+				greatestCommonDivisor = calculateGreatestCommonDivisor(numerator, denominator);
+				reducedNumerator = numerator.divide(greatestCommonDivisor);
+				reducedDenominator = denominator.divide(greatestCommonDivisor);
+				stringValue = generateRationalString(numerator, denominator);
+				reducedStringValue = generateRationalString(reducedNumerator, reducedDenominator);
+			} else {
+				numerator = new BigInteger(matcher.group(1));
+				denominator = BigInteger.ONE;
+				greatestCommonDivisor = BigInteger.ONE;
+				reducedNumerator = numerator;
+				reducedDenominator = denominator;
+				stringValue = generateRationalString(numerator, denominator);
+				reducedStringValue = stringValue;
+			}
+			decimalStringValue = generateDecimalString(reducedNumerator, reducedDenominator);
+		}
+		hashCode = calculateHashCode();
+	}
+
+	/**
+	 * Creates a new instance that represents the value of {@code value}.
+	 *
+	 * @param value the value.
+	 */
+	public Rational(int value) {
+		this((long) value);
+	}
+
+	/**
+	 * Creates a new instance that represents the value of {@code value}.
+	 *
+	 * @param value the value.
+	 */
+	public Rational(long value) {
+		numerator = BigInteger.valueOf(value);
+		denominator = BigInteger.ONE;
+		greatestCommonDivisor = BigInteger.ONE;
+		reducedNumerator = numerator;
+		reducedDenominator = denominator;
+		stringValue = Long.toString(value);
+		reducedStringValue = stringValue;
+		decimalStringValue = stringValue;
+		hashCode = calculateHashCode();
+	}
+
+	/**
+	 * Creates a new instance that represents the value of {@code value}.
+	 *
+	 * @param value the value.
+	 */
+	public Rational(BigInteger value) {
+		numerator = value;
+		denominator = BigInteger.ONE;
+		greatestCommonDivisor = BigInteger.ONE;
+		reducedNumerator = numerator;
+		reducedDenominator = denominator;
+		stringValue = generateRationalString(numerator, denominator);
+		reducedStringValue = stringValue;
+		decimalStringValue = stringValue;
+		hashCode = calculateHashCode();
+	}
+
+	/**
+	 * Creates a new instance with the given {@code numerator} and
+	 * {@code denominator}.
+	 *
+	 * @param numerator the numerator.
+	 * @param denominator the denominator.
+	 */
+	public Rational(int numerator, int denominator) {
+		this((long) numerator, (long) denominator);
+	}
+
+	/**
+	 * Creates a new instance with the given {@code numerator} and
+	 * {@code denominator}.
+	 *
+	 * @param numerator the numerator.
+	 * @param denominator the denominator.
+	 */
+	public Rational(long numerator, long denominator) {
+		if (denominator == 0) {
+			throw new IllegalArgumentException("denominator can't be zero");
+		}
+		if (numerator == 0) {
+			this.numerator = BigInteger.ZERO;
+			this.denominator = BigInteger.ONE;
+		} else if (denominator < 0) {
+			this.numerator = BigInteger.valueOf(-numerator);
+			this.denominator = BigInteger.valueOf(-denominator);
+		} else {
+			this.numerator = BigInteger.valueOf(numerator);
+			this.denominator = BigInteger.valueOf(denominator);
+		}
+		stringValue = generateRationalString(this.numerator, this.denominator);
+		long gcd = calculateGreatestCommonDivisor(numerator, denominator);
+		this.greatestCommonDivisor = BigInteger.valueOf(gcd);
+		if (gcd == 1) {
+			this.reducedNumerator = this.numerator;
+			this.reducedDenominator = this.denominator;
+			reducedStringValue = stringValue;
+		} else {
+			this.reducedNumerator = this.numerator.divide(this.greatestCommonDivisor);
+			this.reducedDenominator = this.denominator.divide(this.greatestCommonDivisor);
+			reducedStringValue = generateRationalString(this.reducedNumerator, this.reducedDenominator);
+		}
+		decimalStringValue = generateDecimalString(this.reducedNumerator, this.reducedDenominator);
+		hashCode = calculateHashCode();
+	}
+
+	/**
+	 * Creates a new instance with the given {@code numerator} and
+	 * {@code denominator}.
+	 *
+	 * @param numerator the numerator.
+	 * @param denominator the denominator.
+	 */
+	public Rational(BigInteger numerator, BigInteger denominator) {
+		if (denominator == null || denominator.signum() == 0) {
+			throw new IllegalArgumentException("denominator can't be zero");
+		}
+		if (numerator == null || numerator.signum() == 0) {
+			this.numerator = BigInteger.ZERO;
+			this.denominator = BigInteger.ONE;
+		} else if (denominator.signum() < 0) {
+			this.numerator = numerator.negate();
+			this.denominator = denominator.negate();
+		} else {
+			this.numerator = numerator;
+			this.denominator = denominator;
+		}
+		stringValue = generateRationalString(this.numerator, this.denominator);
+
+		this.greatestCommonDivisor = calculateGreatestCommonDivisor(this.numerator, this.denominator);
+		if (BigInteger.ONE.equals(this.greatestCommonDivisor)) {
+			this.reducedNumerator = this.numerator;
+			this.reducedDenominator = this.denominator;
+			reducedStringValue = stringValue;
+		} else {
+			this.reducedNumerator = this.numerator.divide(this.greatestCommonDivisor);
+			this.reducedDenominator = this.denominator.divide(this.greatestCommonDivisor);
+			reducedStringValue = generateRationalString(this.reducedNumerator, this.reducedDenominator);
+		}
+		decimalStringValue = generateDecimalString(this.reducedNumerator, this.reducedDenominator);
+		hashCode = calculateHashCode();
+	}
+
+
+	// Operations
+
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this * value)}.
+	 *
+	 * @param value the value to be multiplied by this {@link Rational}.
+	 * @return The multiplication result.
+	 */
+	public Rational multiply(int value) {
+		return multiply(BigInteger.valueOf(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this * value)}.
+	 *
+	 * @param value the value to be multiplied by this {@link Rational}.
+	 * @return The multiplication result.
+	 */
+	public Rational multiply(long value) {
+		return multiply(BigInteger.valueOf(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this * value)}.
+	 *
+	 * @param value the value to be multiplied by this {@link Rational}.
+	 * @return The multiplication result.
+	 */
+	public Rational multiply(BigInteger value) {
+		if (value == null || value.signum() == 0) {
+			return ZERO;
+		}
+		if (BigInteger.ONE.equals(value.abs())) {
+			return value.signum() < 0 ? negate() : this;
+		}
+
+		return new Rational(reducedNumerator.multiply(value), reducedDenominator);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this * value)}.
+	 *
+	 * @param value the value to be multiplied by this {@link Rational}.
+	 * @return The multiplication result.
+	 */
+	public Rational multiply(double value) {
+		return multiply(new Rational(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this * value)}.
+	 *
+	 * @param value the value to be multiplied by this {@link Rational}.
+	 * @return The multiplication result.
+	 */
+	public Rational multiply(BigDecimal value) {
+		return multiply(new Rational(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this * value)}.
+	 *
+	 * @param value the value to be multiplied by this {@link Rational}.
+	 * @return The multiplication result.
+	 */
+	public Rational multiply(Rational value) {
+		if (value == null || value.numerator.signum() == 0) {
+			return ZERO;
+		}
+		if (value.numerator.equals(value.denominator)) {
+			return value.numerator.signum() < 0 ? this.negate() : this;
+		}
+
+		BigInteger newNumerator = reducedNumerator.multiply(value.reducedNumerator);
+		BigInteger newDenominator = reducedDenominator.multiply(value.reducedDenominator);
+		BigInteger gcd = newNumerator.gcd(newDenominator);
+		return new Rational(newNumerator.divide(gcd), newDenominator.divide(gcd));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this - value)}.
+	 *
+	 * @param value the value to be subtracted from this {@link Rational}.
+	 * @return The subtraction result.
+	 */
+	public Rational subtract(int value) {
+		return add(-value);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this - value)}.
+	 *
+	 * @param value the value to be subtracted from this {@link Rational}.
+	 * @return The subtraction result.
+	 */
+	public Rational subtract(long value) {
+		return add(-value);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this - value)}.
+	 *
+	 * @param value the value to be subtracted from this {@link Rational}.
+	 * @return The subtraction result.
+	 */
+	public Rational subtract(BigInteger value) {
+		return add(value.negate());
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this - value)}.
+	 *
+	 * @param value the value to be subtracted from this {@link Rational}.
+	 * @return The subtraction result.
+	 */
+	public Rational subtract(double value) {
+		return add(-value);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this - value)}.
+	 *
+	 * @param value the value to be subtracted from this {@link Rational}.
+	 * @return The subtraction result.
+	 */
+	public Rational subtract(BigDecimal value) {
+		return add(value.negate());
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this - value)}.
+	 *
+	 * @param value the value to be subtracted from this {@link Rational}.
+	 * @return The subtraction result.
+	 */
+	public Rational subtract(Rational value) {
+		if (value == null || value.numerator.signum() == 0) {
+			return this;
+		}
+		return add(value.negate());
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this + value)}.
+	 *
+	 * @param value the value to be added to this {@link Rational}.
+	 * @return The addition result.
+	 */
+	public Rational add(int value) {
+		return add((long) value);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this + value)}.
+	 *
+	 * @param value the value to be added to this {@link Rational}.
+	 * @return The addition result.
+	 */
+	public Rational add(long value) {
+		return add(BigInteger.valueOf(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this + value)}.
+	 *
+	 * @param value the value to be added to this {@link Rational}.
+	 * @return The addition result.
+	 */
+	public Rational add(BigInteger value) {
+		if (value == null || value.signum() == 0) {
+			return this;
+		}
+		if (BigInteger.ONE.equals(denominator)) {
+			return new Rational(numerator.add(value), denominator);
+		}
+		return new Rational(numerator.add(value.multiply(denominator)), denominator);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this + value)}.
+	 *
+	 * @param value the value to be added to this {@link Rational}.
+	 * @return The addition result.
+	 */
+	public Rational add(double value) {
+		return add(new Rational(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this + value)}.
+	 *
+	 * @param value the value to be added to this {@link Rational}.
+	 * @return The addition result.
+	 */
+	public Rational add(BigDecimal value) {
+		return add(new Rational(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this + value)}.
+	 *
+	 * @param value the value to be added to this {@link Rational}.
+	 * @return The addition result.
+	 */
+	public Rational add(Rational value) {
+		if (value == null || value.numerator.signum() == 0) {
+			return this;
+		}
+		if (this.numerator.signum() == 0) {
+			return value;
+		}
+		BigInteger lcm = calculateLeastCommonMultiple(denominator, value.denominator);
+		return new Rational(numerator.multiply(lcm.divide(denominator)).add(
+			value.numerator.multiply(lcm.divide(value.denominator))), lcm);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is the reciprocal of this
+	 * {@code (1 / this)}.
+	 *
+	 * @return The reciprocal result.
+	 */
+	public Rational reciprocal() {
+		return numerator.signum() == 0 ? this : new Rational(denominator, numerator);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this / value)}.
+	 *
+	 * @param value the value by which this {@link Rational} is to be divided.
+	 * @return The division result.
+	 * @throws IllegalArgumentException if {@code value} is zero.
+	 */
+	public Rational divide(int value) {
+		return divide((long) value);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this / value)}.
+	 *
+	 * @param value the value by which this {@link Rational} is to be divided.
+	 * @return The division result.
+	 * @throws IllegalArgumentException if {@code value} is zero.
+	 */
+	public Rational divide(long value) {
+		if (value == 0) {
+			throw new IllegalArgumentException("value cannot be zero/divison by zero");
+		}
+		if (numerator.signum() == 0 || value == 1) {
+			return this;
+		}
+		if (value == -1) {
+			return negate();
+		}
+
+		// Keep the sign in the numerator and the denominator positive
+		if (value < 0) {
+			return new Rational(reducedNumerator.negate(), reducedDenominator.multiply(BigInteger.valueOf(-value)));
+		}
+		return new Rational(reducedNumerator, reducedDenominator.multiply(BigInteger.valueOf(value)));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this / value)}.
+	 *
+	 * @param value the value by which this {@link Rational} is to be divided.
+	 * @return The division result.
+	 * @throws IllegalArgumentException if {@code value} is zero.
+	 */
+	public Rational divide(BigInteger value) {
+		if (value == null || value.signum() == 0) {
+			throw new IllegalArgumentException("value cannot be zero/divison by zero");
+		}
+		if (numerator.signum() == 0) {
+			return this;
+		}
+		if (BigInteger.ONE.equals(value.abs())) {
+			return value.signum() < 0 ? negate() : this;
+		}
+
+		// Keep the sign in the numerator and the denominator positive
+		if (value.signum() < 0) {
+			return new Rational(reducedNumerator.negate(), reducedDenominator.multiply(value.negate()));
+		}
+		return new Rational(reducedNumerator, reducedDenominator.multiply(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this / value)}.
+	 *
+	 * @param value the value by which this {@link Rational} is to be divided.
+	 * @return The division result.
+	 * @throws IllegalArgumentException if {@code value} is zero.
+	 */
+	public Rational divide(double value) {
+		if (value == 0) {
+			throw new IllegalArgumentException("value cannot be zero/divison by zero");
+		}
+		if (numerator.signum() == 0 || value == 1) {
+			return this;
+		}
+		if (value == -1) {
+			return negate();
+		}
+		return divide(new Rational(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this / value)}.
+	 *
+	 * @param value the value by which this {@link Rational} is to be divided.
+	 * @return The division result.
+	 * @throws IllegalArgumentException if {@code value} is zero.
+	 */
+	public Rational divide(BigDecimal value) {
+		if (value == null || value.signum() == 0) {
+			throw new IllegalArgumentException("value cannot be zero/divison by zero");
+		}
+		if (numerator.signum() == 0 ||  BigDecimal.ONE.equals(value.abs())) {
+			return value.signum() < 0 ? negate() : this;
+		}
+		return divide(new Rational(value));
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (this / value)}.
+	 *
+	 * @param value the value by which this {@link Rational} is to be divided.
+	 * @return The division result.
+	 * @throws IllegalArgumentException if {@code value} is zero.
+	 */
+	public Rational divide(Rational value) {
+		if (value == null || value.numerator.signum() == 0) {
+			throw new IllegalArgumentException("value cannot be zero/divison by zero");
+		}
+		return numerator.signum() == 0 ? this : multiply(value.reciprocal());
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is {@code (-this)}.
+	 *
+	 * @return The negated result.
+	 */
+	public Rational negate() {
+		if (numerator.signum() == 0) {
+			return this;
+		}
+		return new Rational(numerator.negate(), denominator);
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is the absolute value of this
+	 * {@code (abs(this))}.
+	 *
+	 * @return The absolute result.
+	 */
+	public Rational abs() {
+		return numerator.signum() < 0 ? new Rational(numerator.negate(), denominator) : this;
+	}
+
+	/**
+	 * Returns a {@link Rational} whose value is
+	 * <tt>(this<sup>exponent</sup>)</tt>.
+	 *
+	 * @param exponent exponent to which this {@link Rational} is to be raised.
+	 * @return <tt>this<sup>exponent</sup></tt>
+	 */
+	public Rational pow(int exponent) {
+		if (exponent == 0) {
+			return ONE;
+		}
+		if (exponent == 1) {
+			return this;
+		}
+		if (exponent < 0) {
+			if (exponent == Integer.MIN_VALUE) {
+				return this.reciprocal().pow(2).pow(-(exponent / 2));
+			}
+			return this.reciprocal().pow(-exponent);
+		}
+		Rational result = multiply(this);
+		if ((exponent % 2) == 0) {
+			return result.pow(exponent / 2);
+		}
+		return result.pow(exponent / 2).multiply(this);
+	}
+
+	/**
+	 * Returns the signum function of this {@link Rational}.
+	 *
+	 * @return -1, 0 or 1 as the value of this {@link Rational} is negative,
+	 *         zero or positive.
+	 */
+	public int signum() {
+		return numerator.signum();
+	}
+
+	/**
+	 * @return Whether the value of this {@link Rational} can be expressed as an
+	 *         integer value.
+	 */
+	public boolean isInteger() {
+		return BigInteger.ONE.equals(reducedDenominator);
+	}
+
+
+	// Getters
+
+
+	/**
+	 * @return The numerator.
+	 */
+	public BigInteger getNumerator() {
+		return numerator;
+	}
+
+	/**
+	 * @return The denominator.
+	 */
+	public BigInteger getDenominator() {
+		return denominator;
+	}
+
+	/**
+	 * The reduced numerator is the numerator divided by
+	 * {@link #getGreatestCommonDivisor}.
+	 *
+	 * @return The reduced numerator.
+	 */
+	public BigInteger getReducedNumerator() {
+		return reducedNumerator;
+	}
+
+	/**
+	 * The reduced denominator is the denominator divided by
+	 * {@link #getGreatestCommonDivisor}.
+	 *
+	 * @return The reduced denominator.
+	 */
+	public BigInteger getReducedDenominator() {
+		return reducedDenominator;
+	}
+
+	/**
+	 * @return the greatest common divisor of the numerator and the denominator.
+	 */
+	public BigInteger getGreatestCommonDivisor() {
+		return greatestCommonDivisor;
+	}
+
+
+	// String methods
+
+
+	/**
+	 * Returns a string representation of this {@link Rational} in it's rational
+	 * form {@code (1/2, 4 or 16/9)}.
+	 *
+	 * @return The {@link String} representation.
+	 */
+	@Override
+	public String toString() {
+		return stringValue;
+	}
+
+
+	/**
+	 * Returns a string representation of this {@link Rational} in it's reduced
+	 * rational form {@code (1/2, 4 or 16/9)}. The reduced form is when both
+	 * numerator and denominator have been divided by the greatest common
+	 * divisor.
+	 *
+	 * @return The reduced {@link String} representation.
+	 */
+	public String toReducedString() {
+		return reducedStringValue;
+	}
+
+	/**
+	 * Returns a decimal representation of this {@link Rational}. The decimal
+	 * representation is limited to 20 decimals using
+	 * {@link RoundingMode#HALF_EVEN} and is formatted with {@link Locale#ROOT}
+	 * without grouping.
+	 *
+	 * @return The decimal {@link String} representation.
+	 */
+	public String toDecimalString() {
+		return decimalStringValue;
+	}
+
+	/**
+	 * Returns a debug string representation of this {@link Rational}. The debug
+	 * representation is a combination of {@link #toString},
+	 * {@link #toReducedString} and {@link #toDecimalString}.
+	 *
+	 * @return The debug {@link String} representation.
+	 */
+	public String toDebugString() {
+		StringBuilder sb = new StringBuilder("Value: ");
+		sb.append(stringValue).append(", Reduced: ").append(reducedStringValue).append(", Decimal: ").append(decimalStringValue);
+		return sb.toString();
+	}
+
+	/**
+	 * Returns a hexadecimal string representation of this {@link Rational} in
+	 * it's rational form {@code (a/2, ff or 16/c)}.
+	 *
+	 * @return The hexadecimal {@link String} representation.
+	 */
+	public String toHexString() {
+		return generateRationalHexString(numerator, denominator);
+	}
+
+	/**
+	 * Returns a hexadecimal string representation of this {@link Rational} in it's reduced
+	 * rational form {@code (5, ff or 16/c)}. The reduced form is when both
+	 * numerator and denominator have been divided by the greatest common
+	 * divisor.
+	 *
+	 * @return The reduced hexadecimal {@link String} representation.
+	 */
+	public String toReducedHexString() {
+		return generateRationalHexString(reducedNumerator, reducedDenominator);
+	}
+
+
+	// Conversion to other Number formats
+
+
+	/**
+	 * Converts this {@link Rational} to an {@code int}. This conversion is
+	 * analogous to the <i>narrowing primitive conversion</i> from
+	 * {@code double} to {@code int} as defined in section 5.1.3 of <cite>The
+	 * Java&trade; Language Specification</cite>: any fractional part of this
+	 * {@link Rational} will be discarded, and if the resulting "
+	 * {@link BigInteger}" is too big to fit in an {@code int}, only the
+	 * low-order 32 bits are returned.
+	 * <p>
+	 * Note that this conversion can lose information about the overall
+	 * magnitude and precision of this {@link Rational} value as well as return
+	 * a result with the opposite sign.
+	 *
+	 * @return This {@link Rational} converted to an {@code int}.
+	 */
+	@Override
+	public int intValue() {
+		return new BigDecimal(reducedNumerator).divide(new BigDecimal(reducedDenominator), RoundingMode.DOWN).intValue();
+	}
+
+	/**
+	 *
+	 * Converts this {@link Rational} to a {@code long}. This conversion is
+	 * analogous to the <i>narrowing primitive conversion</i> from
+	 * {@code double} to {@code long} as defined in section 5.1.3 of <cite>The
+	 * Java&trade; Language Specification</cite>: any fractional part of this
+	 * {@link Rational} will be discarded, and if the resulting "
+	 * {@link BigInteger}" is too big to fit in a {@code long}, only the
+	 * low-order 64 bits are returned.
+	 * <p>
+	 * Note that this conversion can lose information about the overall
+	 * magnitude and precision of this {@link Rational} value as well as return
+	 * a result with the opposite sign.
+	 *
+	 * @return This {@link Rational} converted to a {@code long}.
+	 */
+	@Override
+	public long longValue() {
+		return new BigDecimal(reducedNumerator).divide(new BigDecimal(reducedDenominator), RoundingMode.DOWN).longValue();
+	}
+
+	/**
+	 * Converts this {@link Rational} to a {@link BigInteger}. This conversion
+	 * is analogous to the <i>narrowing primitive conversion</i> from
+	 * {@code double} to {@code long} as defined in section 5.1.3 of <cite>The
+	 * Java&trade; Language Specification</cite>: any fractional part of this
+	 * {@link Rational} will be discarded.
+	 *
+	 * @return This {@link Rational} converted to a {@link BigInteger}.
+	 */
+	public BigInteger bigIntegerValue() {
+		return new BigDecimal(reducedNumerator).divide(new BigDecimal(reducedDenominator), RoundingMode.DOWN).toBigInteger();
+	}
+
+	/**
+	 * Converts this {@link Rational} to a {@code float}. This conversion is
+	 * similar to the <i>narrowing primitive conversion</i> from {@code double}
+	 * to {@code float} as defined in section 5.1.3 of <cite>The Java&trade;
+	 * Language Specification</cite>: if this {@link Rational} has too great a
+	 * magnitude to represent as a {@code float}, it will be converted to
+	 * {@link Float#NEGATIVE_INFINITY} or {@link Float#POSITIVE_INFINITY} as
+	 * appropriate.
+	 * <p>
+	 * Note that even when the return value is finite, this conversion can lose
+	 * information about the precision of the {@link Rational} value.
+	 *
+	 * @return This {@link Rational} converted to a {@code float}.
+	 */
+	@Override
+	public float floatValue() {
+		return new BigDecimal(reducedNumerator).divide(new BigDecimal(reducedDenominator), MathContext.DECIMAL32).floatValue();
+	}
+
+	/**
+	 * Converts this {@link Rational} to a {@code double}. This conversion is
+	 * similar to the <i>narrowing primitive conversion</i> from {@code double}
+	 * to {@code float} as defined in section 5.1.3 of <cite>The Java&trade;
+	 * Language Specification</cite>: if this {@link Rational} has too great a
+	 * magnitude to represent as a {@code double}, it will be converted to
+	 * {@link Double#NEGATIVE_INFINITY} or {@link Double#POSITIVE_INFINITY} as
+	 * appropriate.
+	 * <p>
+	 * Note that even when the return value is finite, this conversion can lose
+	 * information about the precision of the {@link Rational} value.
+	 *
+	 * @return This {@link Rational} converted to a {@code double}.
+	 */
+	@Override
+	public double doubleValue() {
+		return new BigDecimal(reducedNumerator).divide(new BigDecimal(reducedDenominator), MathContext.DECIMAL64).doubleValue();
+	}
+
+	/**
+	 * Converts this {@link Rational} to a {@link BigDecimal}. This may involve
+	 * rounding. The conversion is limited to 100 decimals and uses
+	 * {@link RoundingMode#HALF_EVEN}.
+	 * <p>
+	 * For explicit control over the conversion, use one of the overloaded
+	 * methods.
+	 *
+	 * @see #bigDecimalValue(MathContext)
+	 * @see #bigDecimalValue(RoundingMode)
+	 * @see #bigDecimalValue(int, RoundingMode)
+	 *
+	 * @return This {@link Rational} converted to a {@link BigDecimal}.
+	 */
+	public BigDecimal bigDecimalValue() {
+		if (BigInteger.ONE.equals(reducedDenominator)) {
+			return new BigDecimal(reducedNumerator);
+		}
+		return new BigDecimal(reducedNumerator).divide(new BigDecimal(reducedDenominator), 100, RoundingMode.HALF_EVEN);
+	}
+
+	/**
+	 * Converts this {@link Rational} to a {@link BigDecimal}. This may involve
+	 * rounding. The conversion is limited to 100 decimals and uses
+	 * {@code roundingMode}.
+	 *
+	 * @see #bigDecimalValue()
+	 * @see #bigDecimalValue(MathContext)
+	 * @see #bigDecimalValue(int, RoundingMode)
+	 *
+	 * @param roundingMode the {@link RoundingMode} to apply.
+	 * @return This {@link Rational} converted to a {@link BigDecimal}.
+	 */
+	public BigDecimal bigDecimalValue(RoundingMode roundingMode) {
+		if (BigInteger.ONE.equals(reducedDenominator)) {
+			return new BigDecimal(reducedNumerator);
+		}
+		return new BigDecimal(reducedNumerator).divide(new BigDecimal(reducedDenominator), 100, roundingMode);
+	}
+
+	/**
+	 * Converts this {@link Rational} to a {@link BigDecimal}. This may involve
+	 * rounding.
+	 * <p>
+	 * Use {@code scale == 0} and
+	 * {@code roundingMode == RoundingMode.UNNECESSARY} to achieve absolute
+	 * precision. This will throw an {@link ArithmeticException} if the exact
+	 * quotient cannot be represented (because it has a non-terminating decimal
+	 * expansion).
+	 *
+	 * @see #bigDecimalValue()
+	 * @see #bigDecimalValue(MathContext)
+	 * @see #bigDecimalValue(RoundingMode)
+	 *
+	 * @param scale the scale of the {@link BigDecimal} quotient to be returned.
+	 * @param roundingMode the {@link RoundingMode} to apply.
+	 * @return This {@link Rational} converted to a {@link BigDecimal}.
+	 * @throws ArithmeticException If
+	 *             {@code roundingMode == RoundingMode.UNNECESSARY} and the
+	 *             specified scale is insufficient to represent the result of
+	 *             the division exactly.
+	 */
+	public BigDecimal bigDecimalValue(int scale, RoundingMode roundingMode) {
+		if (BigInteger.ONE.equals(reducedDenominator)) {
+			return new BigDecimal(reducedNumerator);
+		}
+		return new BigDecimal(reducedNumerator).divide(new BigDecimal(reducedDenominator), scale, roundingMode);
+	}
+
+	/**
+	 * Converts this {@link Rational} to a {@link BigDecimal} using the given
+	 * {@link MathContext}. This may involve rounding.
+	 * <p>
+	 *
+	 * @see #bigDecimalValue()
+	 * @see #bigDecimalValue(RoundingMode)
+	 * @see #bigDecimalValue(int, RoundingMode)
+	 *
+	 * @param mathContext the {@link MathContext} to use.
+	 * @return This {@link Rational} converted to a {@link BigDecimal}.
+	 * @throws ArithmeticException If the result is inexact but the rounding
+	 *             mode is {@code UNNECESSARY} or
+	 *             {@code mathContext.precision == 0} and the quotient has a
+	 *             non-terminating decimal expansion.
+	 */
+	public BigDecimal bigDecimalValue(MathContext mathContext) {
+		if (BigInteger.ONE.equals(reducedDenominator)) {
+			return new BigDecimal(reducedNumerator);
+		}
+		return new BigDecimal(reducedNumerator).divide(new BigDecimal(reducedDenominator), mathContext);
+	}
+
+
+	// Comparison methods
+
+
+	/**
+	 * Compares this {@link Rational} with {@code other}. Two {@link Rational}
+	 * instances that are equal in value but have different numerators and
+	 * denominators are considered equal by this methods (like {@code 1/2} and
+	 * {@code 2/4}).
+	 * <p>
+	 * This method is provided in preference to individual methods for each of
+	 * the six boolean comparison operators ({@literal <}, ==, {@literal >},
+	 * {@literal >=}, !=, {@literal <=}). The suggested idiom for performing
+	 * these comparisons is: {@code (x.compareTo(y)} &lt;<i>op</i>&gt;
+	 * {@code 0)}, where &lt;<i>op</i>&gt; is one of the six comparison
+	 * operators.
+	 *
+	 * @param other the {@link Rational} to which this {@link Rational} is to be
+	 *            compared.
+	 * @return A negative integer, zero, or a positive integer as this
+	 *         {@link Rational} is numerically less than, equal to, or greater
+	 *         than {@code other}.
+	 */
+	@Override
+	public int compareTo(Rational other) {
+		if (signum() != other.signum()) {
+			return signum() - other.signum();
+		}
+		BigInteger[] multipliers = getMultipliers(other);
+		return reducedNumerator.multiply(multipliers[0]).compareTo(other.reducedNumerator.multiply(multipliers[1]));
+	}
+
+	/**
+	 * Compares this {@link Rational} by value with a {@code int}.
+	 * <p>
+	 * This method is provided in preference to individual methods for each of
+	 * the six boolean comparison operators ({@literal <}, ==, {@literal >},
+	 * {@literal >=}, !=, {@literal <=}). The suggested idiom for performing
+	 * these comparisons is: {@code (x.compareTo(y)} &lt;<i>op</i>&gt;
+	 * {@code 0)}, where &lt;<i>op</i>&gt; is one of the six comparison
+	 * operators.
+	 *
+	 * @param value the {@code int} to which this {@link Rational}'s value is to
+	 *            be compared.
+	 * @return A negative integer, zero, or a positive integer as this
+	 *         {@link Rational} is numerically less than, equal to, or greater
+	 *         than {@code value}.
+	 */
+	public int compareTo(int value) {
+		return compareTo(Integer.valueOf(value));
+	}
+
+	/**
+	 * Compares this {@link Rational} by value with a {@code long}.
+	 * <p>
+	 * This method is provided in preference to individual methods for each of
+	 * the six boolean comparison operators ({@literal <}, ==, {@literal >},
+	 * {@literal >=}, !=, {@literal <=}). The suggested idiom for performing
+	 * these comparisons is: {@code (x.compareTo(y)} &lt;<i>op</i>&gt;
+	 * {@code 0)}, where &lt;<i>op</i>&gt; is one of the six comparison
+	 * operators.
+	 *
+	 * @param value the {@code long} to which this {@link Rational}'s value
+	 *            is to be compared.
+	 * @return A negative integer, zero, or a positive integer as this
+	 *         {@link Rational} is numerically less than, equal to, or greater
+	 *         than {@code value}.
+	 */
+	public int compareTo(long value) {
+		return compareTo(Long.valueOf(value));
+	}
+
+	/**
+	 * Compares this {@link Rational} by value with a {@code float}.
+	 * <p>
+	 * This method is provided in preference to individual methods for each of
+	 * the six boolean comparison operators ({@literal <}, ==, {@literal >},
+	 * {@literal >=}, !=, {@literal <=}). The suggested idiom for performing
+	 * these comparisons is: {@code (x.compareTo(y)} &lt;<i>op</i>&gt;
+	 * {@code 0)}, where &lt;<i>op</i>&gt; is one of the six comparison
+	 * operators.
+	 *
+	 * @param value the {@code float} to which this {@link Rational}'s value
+	 *            is to be compared.
+	 * @return A negative integer, zero, or a positive integer as this
+	 *         {@link Rational} is numerically less than, equal to, or greater
+	 *         than {@code value}.
+	 */
+	public int compareTo(float value) {
+		return compareTo(Float.valueOf(value));
+	}
+
+	/**
+	 * Compares this {@link Rational} by value with a {@code double}.
+	 * <p>
+	 * This method is provided in preference to individual methods for each of
+	 * the six boolean comparison operators ({@literal <}, ==, {@literal >},
+	 * {@literal >=}, !=, {@literal <=}). The suggested idiom for performing
+	 * these comparisons is: {@code (x.compareTo(y)} &lt;<i>op</i>&gt;
+	 * {@code 0)}, where &lt;<i>op</i>&gt; is one of the six comparison
+	 * operators.
+	 *
+	 * @param value the {@code double} to which this {@link Rational}'s value
+	 *            is to be compared.
+	 * @return A negative integer, zero, or a positive integer as this
+	 *         {@link Rational} is numerically less than, equal to, or greater
+	 *         than {@code value}.
+	 */
+	public int compareTo(double value) {
+		return compareTo(Double.valueOf(value));
+	}
+
+	/**
+	 * Compares this {@link Rational} by value with any class implementing
+	 * {@link Number}.
+	 * <p>
+	 * This method is provided in preference to individual methods for each of
+	 * the six boolean comparison operators ({@literal <}, ==, {@literal >},
+	 * {@literal >=}, !=, {@literal <=}). The suggested idiom for performing
+	 * these comparisons is: {@code (x.compareTo(y)} &lt;<i>op</i>&gt;
+	 * {@code 0)}, where &lt;<i>op</i>&gt; is one of the six comparison
+	 * operators.
+	 *
+	 * @param number the {@link Number} to which this {@link Rational}'s value
+	 *            is to be compared.
+	 * @return A negative integer, zero, or a positive integer as this
+	 *         {@link Rational} is numerically less than, equal to, or greater
+	 *         than {@code number}.
+	 */
+	public int compareTo(Number number) {
+		// List known integer types for faster and more accurate comparison
+		if (number instanceof BigInteger) {
+			if (isInteger()) {
+				return bigIntegerValue().compareTo((BigInteger) number);
+			}
+			return bigDecimalValue(2, RoundingMode.HALF_EVEN).compareTo(new BigDecimal((BigInteger) number));
+		}
+		if (
+			number instanceof AtomicInteger ||
+			number instanceof AtomicLong ||
+			number instanceof Byte ||
+			number instanceof Integer ||
+			number instanceof Long ||
+			number instanceof Short
+		) {
+			if (isInteger()) {
+				return bigIntegerValue().compareTo(BigInteger.valueOf(number.longValue()));
+			}
+			return bigDecimalValue(2, RoundingMode.HALF_EVEN).compareTo(new BigDecimal(number.longValue()));
+		}
+		if (number instanceof BigDecimal) {
+			Rational other = new Rational((BigDecimal) number);
+			return compareTo(other);
+		}
+		return bigDecimalValue().compareTo(new BigDecimal(number.doubleValue()));
+	}
+
+	@Override
+	public int hashCode() {
+		return hashCode;
+	}
+
+	/**
+	 * Used internally to calculate the {@code hashCode} for caching.
+	 *
+	 * @return The calculated {@code hashCode}.
+	 */
+	protected int calculateHashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((reducedDenominator == null) ? 0 : reducedDenominator.hashCode());
+		result = prime * result + ((reducedNumerator == null) ? 0 : reducedNumerator.hashCode());
+		return result;
+	}
+
+
+	/**
+	 * Indicates whether this instance and {@code object} are mathematically
+	 * equivalent, given that {@code other} implements {@link Number}.
+	 * <p>
+	 * 1/2 and 4/8 are considered equal by this method, as are 4/2 and 2.
+	 * <p>
+	 * Equality is determined by equality of {@code reducedNumerator} and
+	 * {@code reducedDenominator} if {@code object} is another {@link Rational}.
+	 * If not, but {@code object} implements {@link Number},
+	 * {@code compareTo(Number) == 0} is used to determine equality.
+	 * <p>
+	 * To test equal representation, use {@link #equalsExact}.
+	 *
+	 * @param object the reference object with which to compare.
+	 * @return {@code true} if {@code object} is a {@link Rational} and are
+	 *         mathematically equivalent, {@code false} otherwise.
+	 */
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (object == null) {
+			return false;
+		}
+		if (!(object instanceof Number)) {
+			return false;
+		}
+		if (object instanceof Rational) {
+			Rational other = (Rational) object;
+			if (reducedDenominator == null) {
+				if (other.reducedDenominator != null) {
+					return false;
+				}
+			} else if (!reducedDenominator.equals(other.reducedDenominator)) {
+				return false;
+			}
+			if (reducedNumerator == null) {
+				if (other.reducedNumerator != null) {
+					return false;
+				}
+			} else if (!reducedNumerator.equals(other.reducedNumerator)) {
+				return false;
+			}
+		} else {
+			if (reducedNumerator == null || reducedDenominator == null) {
+				// Should be impossible
+				return false;
+			}
+			return compareTo((Number) object) == 0;
+		}
+		return true;
+	}
+
+	/**
+	 * Indicates whether this instance and {@code other} have identical
+	 * numerator and denominator.
+	 * <p>
+	 * 1/2, 4/8, 4/2 and 2 are all considered non-equal by this method.
+	 * <p>
+	 * To test mathematically equivalence, use {@link #equals}.
+	 *
+	 * @param other the {@link Rational} with which to compare.
+	 * @return {@code true} if this instance and {@code other} have an identical
+	 *         representation.
+	 */
+	public boolean equalsExact(Rational other) {
+		return other != null && numerator.equals(other.numerator) && denominator.equals(other.denominator);
+	}
+
+	/**
+	 * Used internally to find by which factor to multiply the reduced
+	 * numerators when comparing two {@link Rational}s.
+	 *
+	 * @param other the {@link Rational} to which this {@link Rational}'s value
+	 *            is to be compared.
+	 * @return An array of {@link BigInteger} multipliers.
+	 */
+	protected BigInteger[] getMultipliers(Rational other) {
+		BigInteger[] result = new BigInteger[2];
+		BigInteger lcm = calculateLeastCommonMultiple(reducedDenominator, other.reducedDenominator);
+		result[0] = lcm.divide(reducedDenominator);
+		result[1] = lcm.divide(other.reducedDenominator);
+		return result;
+	}
+
+
+	// Static methods
+
+
+	/**
+	 * Calculates the greatest common divisor for two {@link Long}s using
+	 * "binary GDC" with some optimizations borrowed from
+	 * {@link org.apache.commons.lang.math.Fraction#greatestCommonDivisor}.
+	 *
+	 * @param u the first number.
+	 * @param v the second number.
+	 * @return The GDC, always 1 or greater.
+	 */
+	public static long calculateGreatestCommonDivisor(long u, long v) {
+		if (Math.abs(u) <= 1 || Math.abs(v) <= 1) {
+			return 1;
+		}
+		// keep u and v negative, as negative integers range down to
+		// -2^63, while positive numbers can only be as large as 2^63-1.
+		if (u > 0) {
+			u = -u;
+		}
+		if (v > 0) {
+			v = -v;
+		}
+		int k = 0;
+		while ((u & 1) == 0 && (v & 1) == 0 && k < 63) {
+			u >>= 1;
+			v >>= 1;
+			k++;
+		}
+		if (k == 63) {
+			throw new ArithmeticException("Overflow: gcd is 2^63");
+		}
+		long t = ((u & 1) == 1) ? v : -(u >> 1);
+		do {
+			while ((t & 1) == 0) {
+				t >>= 1;
+			}
+			if (t > 0) {
+				u = -t;
+			} else {
+				v = t;
+			}
+			t = (v - u) >> 1;
+		} while (t != 0);
+
+		return -u * (1 << k);
+	}
+
+	/**
+	 * Calculates the greatest common divisor for two {@link BigInteger}s using
+	 * {@link BigInteger#gcd}.
+	 *
+	 * @param u the first number.
+	 * @param v the second number.
+	 * @return The GDC, always 1 or greater.
+	 */
+	public static BigInteger calculateGreatestCommonDivisor(BigInteger u, BigInteger v) {
+		if (u.abs().compareTo(BigInteger.ONE) <= 0 || v.abs().compareTo(BigInteger.ONE) <= 0) {
+			return BigInteger.ONE;
+		}
+		return u.gcd(v);
+	}
+
+	/**
+	 * Calculates the least common multiple for two {@link BigInteger}s using the formula
+	 * {@code u * v / gcd(u, v)} where {@code gcd} is the greatest common divisor for the two.
+	 *
+	 * @param u the first number.
+	 * @param v the second number.
+	 * @return The LCM, always 1 or greater.
+	 */
+	public static BigInteger calculateLeastCommonMultiple(BigInteger u, BigInteger v) {
+		if (u == null) {
+			u = BigInteger.ZERO;
+		}
+		if (v == null) {
+			v = BigInteger.ZERO;
+		}
+		if (u.signum() == 0 && v.signum() == 0) {
+			return BigInteger.ONE;
+		}
+		u = u.abs();
+		v = v.abs();
+		if (u.signum() == 0) {
+			return v;
+		}
+		if (v.signum() == 0) {
+			return u;
+		}
+		return u.divide(calculateGreatestCommonDivisor(u, v)).multiply(v);
+	}
+
+	/**
+	 * Used internally to generate a hexadecimal rational string representation
+	 * from two {@link BigInteger}s.
+	 *
+	 * @param numerator the numerator.
+	 * @param denominator the denominator.
+	 * @return The hexadecimal rational string representation.
+	 */
+	protected static String generateRationalHexString(BigInteger numerator, BigInteger denominator) {
+		if (BigInteger.ONE.equals(denominator)) {
+			return numerator.toString(16);
+		}
+		return numerator.toString(16) + "/" + denominator.toString(16);
+	}
+
+	/**
+	 * Used internally to generate a rational string representation from two
+	 * {@link BigInteger}s.
+	 *
+	 * @param numerator the numerator.
+	 * @param denominator the denominator.
+	 * @return The rational string representation.
+	 */
+	protected static String generateRationalString(BigInteger numerator, BigInteger denominator) {
+		if (BigInteger.ONE.equals(denominator)) {
+			return numerator.toString();
+		}
+		return numerator.toString() + "/" + denominator.toString();
+	}
+
+	/**
+	 * Used internally to generate a decimal string representation from two
+	 * {@link BigInteger}s. The decimal representation is limited to 20
+	 * decimals.
+	 *
+	 * @param numerator the numerator.
+	 * @param denominator the denominator.
+	 * @return The string representation.
+	 */
+	protected static String generateDecimalString(BigInteger numerator, BigInteger denominator) {
+		if (BigInteger.ONE.equals(denominator)) {
+			return numerator.toString();
+		}
+		BigDecimal decimalValue = new BigDecimal(numerator).divide(new BigDecimal(denominator), 20, RoundingMode.HALF_EVEN);
+		return DECIMALFORMAT.format(decimalValue);
+	}
+}

--- a/src/main/java/net/pms/util/StringUtil.java
+++ b/src/main/java/net/pms/util/StringUtil.java
@@ -341,9 +341,8 @@ public class StringUtil {
 		Matcher matcher = pattern.matcher(html);
 		if (matcher.find()) {
 			return matcher.group(1).replaceAll("\n    ", "").trim().replaceAll("(?i)<br>", "\n").replaceAll("<.*?>","");
-		} else {
-			throw new IllegalArgumentException("HTML text not as expected, must have <body> section");
 		}
+		throw new IllegalArgumentException("HTML text not as expected, must have <body> section");
 	}
 
 	/**
@@ -430,7 +429,7 @@ public class StringUtil {
 		return sb.toString();
 	}
 
-	public static String prettifyXML(String xml, int indentWidth) {
+	public static String prettifyXML(String xml, int indentWidth) throws SAXException, ParserConfigurationException, XPathExpressionException, TransformerException {
 		try {
 			// Turn XML string into a document
 			Document xmlDocument =
@@ -464,8 +463,8 @@ public class StringUtil {
 			StringWriter stringWriter = new StringWriter();
 			transformer.transform(new DOMSource(xmlDocument), new StreamResult(stringWriter));
 			return stringWriter.toString();
-		} catch (SAXException | IOException | ParserConfigurationException | XPathExpressionException | TransformerException e) {
-			LOGGER.warn("Failed to prettify XML document, returning the source document: {}", e.getMessage());
+		} catch (IOException e) {
+			LOGGER.warn("Failed to read XML document, returning the source document: {}", e.getMessage());
 			LOGGER.trace("", e);
 			return xml;
 		}

--- a/src/test/java/net/pms/util/RationalTest.java
+++ b/src/test/java/net/pms/util/RationalTest.java
@@ -1,0 +1,388 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class RationalTest {
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testDefaultConstructor() {
+		assertEquals(Rational.ZERO, new Rational());
+		assertEquals(BigInteger.ZERO, Rational.ZERO.numerator);
+		assertEquals(BigInteger.ONE, Rational.ZERO.denominator);
+		assertEquals(BigInteger.ONE, Rational.ZERO.greatestCommonDivisor);
+		assertEquals(BigInteger.ZERO, Rational.ZERO.reducedNumerator);
+		assertEquals(BigInteger.ONE, Rational.ZERO.reducedDenominator);
+		assertEquals("0", Rational.ZERO.stringValue);
+		assertEquals("0", Rational.ZERO.reducedStringValue);
+		assertEquals("0", Rational.ZERO.decimalStringValue);
+
+	}
+
+	@Test
+	public void testDoubleConstructor() {
+		assertEquals(0.342, new Rational(0.342).doubleValue(), 0.0);
+		assertEquals(10000d, new Rational(10000d).doubleValue(), 0.0);
+		assertEquals(1d/3, new Rational(1d/3).doubleValue(), 0.0);
+	}
+
+	@Test
+	public void testBigDecimalConstructor() {
+		assertEquals(0, new Rational(BigDecimal.ZERO).intValue());
+		assertEquals(BigDecimal.ONE, new Rational(BigDecimal.ONE).bigDecimalValue());
+		assertEquals(BigDecimal.valueOf(Long.MAX_VALUE), new Rational(BigDecimal.valueOf(Long.MAX_VALUE)).bigDecimalValue());
+		assertEquals(BigDecimal.valueOf(Long.MIN_VALUE), new Rational(BigDecimal.valueOf(Long.MIN_VALUE)).bigDecimalValue());
+		assertEquals(
+			new BigDecimal("398427545234132213.4398023478543978313289043509400000000000000000000000000000000000000000000000000000000000000000000000"),
+			new Rational(new BigDecimal("398427545234132213.43980234785439783132890435094")).bigDecimalValue()
+		);
+		assertEquals(
+			0,
+			new BigDecimal("398427545234132213.43980234785439783132890435094")
+				.compareTo(new Rational(new BigDecimal("398427545234132213.43980234785439783132890435094")).bigDecimalValue())
+		);
+	}
+
+	@Test
+	public void testStringConstructor() {
+		assertEquals(Rational.ZERO, new Rational(""));
+		assertEquals(Rational.ZERO, new Rational((String) null));
+		assertEquals(4, new Rational("16 /4").intValue());
+		assertEquals(5, new Rational("20/4 ").intValue());
+		assertEquals(6d, new Rational("  24 / 4").doubleValue(), 0.0);
+		assertEquals(-6d, new Rational("-24/4").doubleValue(), 0.0);
+		assertEquals(-6d, new Rational("24/ -4").doubleValue(), 0.0);
+		assertEquals(6d, new Rational("-24/-4").doubleValue(), 0.0);
+		assertEquals(0.5625, new Rational("9/16").doubleValue(), 0.0);
+		assertEquals(-2194d, new Rational("-2194").doubleValue(), 0.0);
+	}
+
+	@Test
+	public void testIntConstructor() {
+		assertEquals(Rational.ZERO, new Rational(0));
+		assertEquals(-4096, new Rational(-4096).intValue());
+		assertEquals(Integer.MAX_VALUE, new Rational(Integer.MAX_VALUE).intValue());
+		assertEquals(Integer.MIN_VALUE, new Rational(Integer.MIN_VALUE).intValue());
+	}
+
+	@Test
+	public void testLongConstructor() {
+		assertEquals(Rational.ZERO, new Rational(0L));
+		assertEquals(-4096, new Rational(-4096L).intValue());
+		assertEquals(Long.MAX_VALUE, new Rational(Long.MAX_VALUE).longValue());
+		assertEquals(Long.MIN_VALUE, new Rational(Long.MIN_VALUE).longValue());
+		assertEquals(BigInteger.ONE, new Rational(Long.MIN_VALUE).greatestCommonDivisor);
+		assertEquals(BigInteger.ONE, new Rational(Long.MIN_VALUE).denominator);
+		assertEquals(BigInteger.ONE, new Rational(Long.MIN_VALUE).reducedDenominator);
+	}
+
+	@Test
+	public void testBigIntegerConstructor() {
+		assertEquals(Rational.ZERO, new Rational(BigInteger.valueOf(0)));
+		assertEquals("987933205489029348556903", new Rational(new BigInteger("987933205489029348556903")).stringValue);
+		assertEquals(Long.MAX_VALUE, new Rational(BigInteger.valueOf(Long.MAX_VALUE)).longValue());
+		assertEquals(Long.MIN_VALUE, new Rational(BigInteger.valueOf(Long.MIN_VALUE)).longValue());
+		assertEquals(BigInteger.ONE, new Rational(BigInteger.valueOf(Long.MIN_VALUE)).greatestCommonDivisor);
+		assertEquals(BigInteger.ONE, new Rational(BigInteger.valueOf(Long.MIN_VALUE)).denominator);
+		assertEquals(BigInteger.ONE, new Rational(BigInteger.valueOf(Long.MIN_VALUE)).reducedDenominator);
+	}
+
+	@Test
+	public void testTwoIntsConstructor() {
+		assertEquals(Rational.ZERO, new Rational(0, 30));
+		assertEquals(-1, new Rational(-1, 30).signum());
+		assertEquals(-1, new Rational(1, -30).signum());
+		assertEquals(1, new Rational(-1, -30).signum());
+		assertEquals(Rational.ONE, new Rational(Integer.MAX_VALUE, Integer.MAX_VALUE));
+		assertEquals(Rational.ONE.negate(), new Rational(Integer.MAX_VALUE, -Integer.MAX_VALUE));
+		assertEquals("18/32", new Rational(18, 32).toString());
+		assertEquals("9/16", new Rational(18, 32).toReducedString());
+		assertEquals(0.5625, new Rational(18, 32).doubleValue(), 0.0);
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("denominator can't be zero");
+		assertEquals(Rational.ZERO, new Rational(0, 0));
+	}
+
+	@Test
+	public void testTwoLongsConstructor() {
+		assertEquals(Rational.ZERO, new Rational(0L, 30L));
+		assertEquals(-1, new Rational(-1L, 30L).signum());
+		assertEquals(-1, new Rational(1L, -30L).signum());
+		assertEquals(1, new Rational(-1L, -30L).signum());
+		assertEquals(Rational.ONE, new Rational(Long.MAX_VALUE, Long.MAX_VALUE));
+		assertEquals(Rational.ONE.negate(), new Rational(Long.MAX_VALUE, -Long.MAX_VALUE));
+		assertEquals("36/64", new Rational(36L, 64L).toString());
+		assertEquals("9/16", new Rational(36L, 64L).toReducedString());
+		assertEquals(0.5625, new Rational(36L, 64L).doubleValue(), 0.0);
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("denominator can't be zero");
+		assertEquals(Rational.ZERO, new Rational(0L, 0L));
+	}
+
+	@Test
+	public void testTwoBigIntegersConstructor() {
+		assertEquals(Rational.ZERO, new Rational(null, BigInteger.TEN));
+		assertEquals(-1, new Rational(BigInteger.ONE.negate(), BigInteger.valueOf(30)).signum());
+		assertEquals(-1, new Rational(BigInteger.ONE, BigInteger.valueOf(-30)).signum());
+		assertEquals(1, new Rational(BigInteger.ONE.negate(), BigInteger.valueOf(-30)).signum());
+		assertEquals(Rational.ONE, new Rational(
+			BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(Long.MAX_VALUE)),
+			BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(Long.MAX_VALUE))
+		));
+		assertEquals(Rational.ONE.negate(), new Rational(
+			BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(Long.MAX_VALUE)),
+			BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(Long.MAX_VALUE)).negate()
+		));
+		assertEquals(
+			"42391158275216203514294433201/75362059155939917358745659024",
+			new Rational(new BigInteger("42391158275216203514294433201"), new BigInteger("75362059155939917358745659024")).toString()
+		);
+		assertEquals("9/16", new Rational(
+			new BigInteger("42391158275216203514294433201"), new BigInteger("75362059155939917358745659024")
+		).toReducedString());
+		assertEquals(0.5625, new Rational(
+			new BigInteger("42391158275216203514294433201"), new BigInteger("75362059155939917358745659024")
+		).doubleValue(), 0.0);
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("denominator can't be zero");
+		assertEquals(Rational.ZERO, new Rational(BigInteger.ZERO, null));
+	}
+
+	@Test
+	public void testMultiplyOperator() {
+		assertEquals(new Rational(30), new Rational(5).multiply(6));
+		assertEquals(new Rational(60), new Rational(5).multiply(12L));
+		assertEquals(new Rational(90), new Rational(5).multiply(BigInteger.valueOf(18)));
+		assertEquals(new Rational("15/2"), new Rational(5).multiply(1.5));
+		assertEquals(new Rational("627989997/125000000"), new Rational(5).multiply(new BigDecimal("1.00478399520")));
+		assertEquals(new Rational("180/37"), new Rational("24/37").multiply(new Rational(15, 2)));
+	}
+
+	@Test
+	public void testSubtractOperator() {
+		assertEquals(Rational.ONE.negate(), new Rational(5).subtract(6));
+		assertEquals(new Rational(-7), new Rational(5).subtract(12L));
+		assertEquals(new Rational(-13), new Rational(5).subtract(BigInteger.valueOf(18)));
+		assertEquals(new Rational("7/2"), new Rational(5).subtract(1.5));
+		assertEquals(new Rational("2497010003/625000000"), new Rational(5).subtract(new BigDecimal("1.00478399520")));
+		assertEquals(new Rational("-507/74"), new Rational("24/37").subtract(new Rational(15, 2)));
+	}
+
+	@Test
+	public void testAddOperator() {
+		assertEquals(new Rational(11), new Rational(5).add(6));
+		assertEquals(new Rational(17), new Rational(5).add(12L));
+		assertEquals(new Rational(23), new Rational(5).add(BigInteger.valueOf(18)));
+		assertEquals(new Rational("13/2"), new Rational(5).add(1.5));
+		assertEquals(new Rational("3752989997/625000000"), new Rational(5).add(new BigDecimal("1.00478399520")));
+		assertEquals(new Rational("603/74"), new Rational("24/37").add(new Rational(15, 2)));
+	}
+
+	@Test
+	public void testDivideOperator() {
+		assertEquals(new Rational(5, 6), new Rational(5).divide(6));
+		assertEquals(new Rational("5 / 12"), new Rational(5).divide(12L));
+		assertEquals(new Rational("5/18"), new Rational(5).divide(BigInteger.valueOf(18)));
+		assertEquals(new Rational("10/3"), new Rational(5).divide(1.5));
+		assertEquals(new Rational("3125000000/627989997"), new Rational(5).divide(new BigDecimal("1.00478399520")));
+		assertEquals(new Rational("16/185"), new Rational("24/37").divide(new Rational(15, 2)));
+	}
+
+	@Test
+	public void testReciprocalOperator() {
+		assertEquals(new Rational("1/5"), new Rational(5).reciprocal());
+		assertEquals(new Rational("1/50"), new Rational(50L).reciprocal());
+		assertEquals(new Rational("1/238903247898923"), new Rational(new BigInteger("238903247898923")).reciprocal());
+		assertEquals(new Rational("2/13"), new Rational("13/2").reciprocal());
+		assertEquals(new Rational("625000000/3752989997"), new Rational("3752989997/625000000").reciprocal());
+		assertEquals(new Rational(37, 24), new Rational(24, 37).reciprocal());
+		assertEquals(Rational.ZERO, Rational.ZERO.reciprocal());
+	}
+
+	@Test
+	public void testNegateOperator() {
+		assertEquals(new Rational("-5"), new Rational(5).negate());
+		assertEquals(new Rational("-4/5"), new Rational("32/40").negate());
+		assertEquals(Rational.ZERO, Rational.ZERO.negate());
+	}
+
+	@Test
+	public void testAbsOperator() {
+		assertEquals(new Rational("5"), new Rational(5).abs());
+		assertEquals(new Rational("5"), new Rational(-5).abs());
+		assertEquals(new Rational("32/40"), new Rational("32/-40").negate());
+		assertEquals(Rational.ZERO, Rational.ZERO.abs());
+	}
+
+	@Test
+	public void testPowOperator() {
+		assertEquals(Rational.ONE, new Rational(5).pow(0));
+		assertEquals(new Rational("-5"), new Rational(-5).pow(1));
+		assertEquals(new Rational("-1073741824/30517578125"), new Rational("32/-40").pow(15));
+		assertEquals(new Rational("268435456/6103515625"), new Rational("32/-40").pow(14));
+		assertEquals(new Rational("1/9765625"), new Rational(-5).pow(-10));
+		assertEquals(Rational.ZERO, Rational.ZERO.pow(4));
+	}
+
+	@Test
+	public void testSignum() {
+		assertEquals(1, new Rational(5).signum());
+		assertEquals(-1, new Rational(-15).signum());
+		assertEquals(0, new Rational(null, BigInteger.valueOf(3)).signum());
+		assertEquals(0, Rational.ZERO.signum());
+		assertEquals(-1, new Rational("32/-40").pow(15).signum());
+		assertEquals(1, new Rational("32/-40").pow(14).signum());
+	}
+
+	@Test
+	public void testIsInteger() {
+		assertTrue(new Rational(5).isInteger());
+		assertTrue(new Rational(0).isInteger());
+		assertTrue(new Rational(-5).isInteger());
+		assertFalse(new Rational(5.5).isInteger());
+		assertFalse(new Rational(5, 2).isInteger());
+	}
+
+	@Test
+	public void testGetters() {
+		Rational rational = new Rational(22, 6);
+		assertEquals(22, rational.getNumerator().intValue());
+		assertEquals(6, rational.getDenominator().intValue());
+		assertEquals(11, rational.getReducedNumerator().intValue());
+		assertEquals(3, rational.getReducedDenominator().intValue());
+		assertEquals(2, rational.getGreatestCommonDivisor().intValue());
+	}
+
+	@Test
+	public void testStringOutputs() {
+		Rational rational = new Rational(22, 6);
+		assertEquals("22/6", rational.toString());
+		assertEquals("11/3", rational.toReducedString());
+		assertEquals("3.66666666666666666667", rational.toDecimalString());
+		assertEquals("16/6", rational.toHexString());
+		assertEquals("b/3", rational.toReducedHexString());
+		assertEquals("Value: 22/6, Reduced: 11/3, Decimal: 3.66666666666666666667", rational.toDebugString());
+	}
+
+	@Test
+	public void testNumberInterface() {
+		Rational rational = new Rational(22, 6);
+		assertEquals(3, rational.intValue());
+		assertEquals(3L, rational.longValue());
+		assertEquals(-3L, rational.negate().longValue());
+		assertEquals(BigInteger.valueOf(3), rational.bigIntegerValue());
+		assertEquals(3.666667f, rational.floatValue(), 0.0f);
+		assertEquals(3.666666666666667, rational.doubleValue(), 0.0);
+		assertEquals(
+			new BigDecimal("3.6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666667"),
+			rational.bigDecimalValue()
+		);
+		assertEquals(
+			new BigDecimal("3.6666666666666666666"),
+			rational.bigDecimalValue(new MathContext(20, RoundingMode.FLOOR))
+		);
+		assertEquals(
+			new BigDecimal("3.6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666"),
+			rational.bigDecimalValue(RoundingMode.FLOOR)
+		);
+		assertEquals(
+			new BigDecimal("3.66666666666666666666666666666666666666666666666667"),
+			rational.bigDecimalValue(50, RoundingMode.CEILING)
+		);
+
+
+		exception.expect(ArithmeticException.class);
+		exception.expectMessage("Non-terminating decimal expansion; no exact representable decimal result.");
+		assertEquals(
+			new BigDecimal("3.6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666667"),
+			rational.bigDecimalValue(MathContext.UNLIMITED)
+		);
+	}
+
+	@Test
+	public void testComparison() {
+		assertEquals(0, new Rational(22, 6).compareTo(new Rational(11, 3)));
+		assertEquals(1, new Rational(22, 6).compareTo(new Rational(11, 4)));
+		assertEquals(-1, new Rational(22, 6).compareTo(new Rational(12, 3)));
+		assertEquals(1, new Rational(22, 6).compareTo((byte) 3));
+		assertEquals(-1, new Rational(22, 6).compareTo((byte) 4));
+		assertEquals(1, new Rational(22, 6).compareTo((short) 3));
+		assertEquals(-1, new Rational(22, 6).compareTo((short) 4));
+		assertEquals(1, new Rational(22, 6).compareTo(3));
+		assertEquals(-1, new Rational(22, 6).compareTo(4));
+		assertEquals(0, new Rational(24, 6).compareTo(4));
+		assertEquals(1, new Rational(22, 6).compareTo(3L));
+		assertEquals(-1, new Rational(22, 6).compareTo(4L));
+		assertEquals(1, new Rational(22, 6).compareTo(3f));
+		assertEquals(1, new Rational(22, 6).compareTo(3.6f));
+		assertEquals(-1, new Rational(22, 6).compareTo(3.7f));
+		assertEquals(1, new Rational(22, 6).compareTo(3.666666f));
+		assertEquals(-1, new Rational(22, 6).compareTo(3.666667f));
+		assertEquals(1, new Rational(22, 6).compareTo(3.666666666666666));
+		assertEquals(-1, new Rational(22, 6).compareTo(3.666666666666667));
+		assertEquals(1, new Rational(22, 6).compareTo(new BigDecimal("3.6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666")));
+		assertEquals(-1, new Rational(22, 6).compareTo(new BigDecimal("3.6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666667")));
+		assertTrue(new Rational(22, 6).equalsExact(new Rational(22, 6)));
+		assertFalse(new Rational(22, 6).equalsExact(new Rational(11, 3)));
+	}
+
+	@Test
+	public void testGetMultipliers() {
+		Rational a = new Rational(22, 6);
+		Rational b = new Rational(-5, 34);
+		BigInteger[] array = a.getMultipliers(b);
+		assertArrayEquals(new BigInteger[] {BigInteger.valueOf(34), BigInteger.valueOf(3)}, array);
+		assertEquals(a.reducedDenominator.multiply(array[0]), b.reducedDenominator.multiply(array[1]));
+
+		a = new Rational(4.235);
+		b = new Rational(78, -14);
+		array = a.getMultipliers(b);
+		assertArrayEquals(new BigInteger[] {BigInteger.valueOf(7), BigInteger.valueOf(200)}, array);
+		assertEquals(a.reducedDenominator.multiply(array[0]), b.reducedDenominator.multiply(array[1]));
+	}
+
+	@Test
+	public void testCalculateGreatestCommonDivisor() {
+		assertEquals(5L, Rational.calculateGreatestCommonDivisor(40, 5));
+		assertEquals(1L, Rational.calculateGreatestCommonDivisor(40, 7));
+		assertEquals(2L, Rational.calculateGreatestCommonDivisor(-54, 128));
+	}
+
+	@Test
+	public void testCalculateLeastCommonMultiple() {
+		assertEquals(BigInteger.valueOf(40), Rational.calculateLeastCommonMultiple(BigInteger.valueOf(40), BigInteger.valueOf(5)));
+		assertEquals(BigInteger.valueOf(65610), Rational.calculateLeastCommonMultiple(BigInteger.valueOf(270), BigInteger.valueOf(6561)));
+		assertEquals(BigInteger.valueOf(315), Rational.calculateLeastCommonMultiple(BigInteger.valueOf(63), BigInteger.valueOf(35)));
+	}
+
+
+
+}


### PR DESCRIPTION
This implements support for querying the renderers with ```GetProtocolInfo``` and storing the reply with the renderer. While there is no easy way to apply this to audio and video since they currently don't have any DLNA format profile support, I've applied this information as a filter for the DLNA format profiles used for images and thumbnails.

It seems that one cannot trust this information absolutely (my Onkyo doesn't list any profiles for thumbnails or FLAC), and I also suspect there are renderers out there that doesn't support ```GetProtocolInfo``` at all. As a consequence, if the renderer doesn't supply any information about image profiles, all profiles are offered unfiltered.

While I don't expect this to give any noticable results for anything but in rare cases (like @Sami32's preview window), I think it's a nice foundation to build on for better DLNA support in the future also for audio and video media. This also provides additional logging which will make it much easier to determine what profiles a renderer supports, and to debug renderer issues in general.

If this turns out to work well, there is room for optimization as this implementation first adds the unsupported profiles and then filters them.