### PR TITLE
Update Travis-CI builds to also use OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,17 @@ addons:
     packages:
     - mediainfo 
 
-jdk:
-  - openjdk7
-  - oraclejdk7
-  - oraclejdk8
+matrix:
+  include:
+    - os: linux
+      jdk: openjdk7
+    - os: linux
+      jdk: oraclejdk7
+    - os: linux
+      jdk: oraclejdk8
+    - os: linux
+      dist: trusty
+      jdk: openjdk8
 
 install: mvn external:install 
 


### PR DESCRIPTION
Travis-CI has a beta platform ```trusty``` (Ubuntu 14.04) that can build using OpenJDK 8. This PR adds that to ```travis.yml```.