### PR TITLE
Reload renderer configurations when "Restart Server" button is pressed (#564)

### DIFF
--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -970,7 +970,7 @@ public class PMS {
 					UPNPHelper.sendByeBye();
 					server.stop();
 					server = null;
-					RendererConfiguration.resetAllRenderers();
+					RendererConfiguration.loadRendererConfigurations(configuration);
 
 					try {
 						Thread.sleep(1000);


### PR DESCRIPTION
This will fix #564 and possibly other issues too. The renderer configurations use the ```PmsConfiguration```s that exists the moment they are created. These configurations doesn't reflect changes to the "main configuration". Although I don't like this solution very much (there should only be one shared configuration instance which was always updated in my view), I guess it's better than nothing.

I have only tested the bug in #564 and haven't tested if this has other side effects, but since this only applies when the "Restart Server" button is pressed I doubt there are many negative side effects.