### PR TITLE
Fix Sleep Manager NPE on Linux

### DIFF
--- a/src/main/java/net/pms/util/SleepManager.java
+++ b/src/main/java/net/pms/util/SleepManager.java
@@ -73,7 +73,7 @@ public class SleepManager {
 	 */
 	public synchronized void startPlaying() {
 		playingCount++;
-		if (!sleepPrevented && mode == PreventSleepMode.PLAYBACK) {
+		if (isPreventSleepSupported() && !sleepPrevented && mode == PreventSleepMode.PLAYBACK) {
 			preventSleep();
 		}
 	}
@@ -88,7 +88,7 @@ public class SleepManager {
 			return;
 		}
 		playingCount--;
-		if (playingCount == 0 && sleepPrevented && mode == PreventSleepMode.PLAYBACK) {
+		if (isPreventSleepSupported() && playingCount == 0 && sleepPrevented && mode == PreventSleepMode.PLAYBACK) {
 			allowSleep();
 		}
 	}
@@ -97,7 +97,7 @@ public class SleepManager {
 	 * Resets the system sleep timer if configured and necessary.
 	 */
 	public synchronized void postponeSleep() {
-		if (mode == PreventSleepMode.PLAYBACK && !sleepPrevented) {
+		if (isPreventSleepSupported() && mode == PreventSleepMode.PLAYBACK && !sleepPrevented) {
 			resetSleepTimer();
 		}
 	}
@@ -162,7 +162,7 @@ public class SleepManager {
 				preventSleep();
 			}
 		} else {
-			LOGGER.debug("SleepManager doesn't support current Platform");
+			LOGGER.debug("SleepManager doesn't support current platform");
 		}
 	}
 


### PR DESCRIPTION
It seems that I forgot to test ```SleepManager``` on Linux, and that ```isPreventSleepSupported()``` wasn't checked every place it needed, making any media playback crash on Linux when ```startPlaying()``` is called.

A workaround is setting ```prevent_sleep = never``` in ```UMS.conf```, but since ```prevent_sleep = playback``` is the default, this is a very bad bug that will affect as good as all Linux installations.

I'm very sorry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1296)
<!-- Reviewable:end -->
