### PR TITLE
Add wma10 profile.

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -640,8 +640,13 @@ CharMap =
 #    vp9      Google VP9                                    video/webm
 #    wavpack  WavPack                                       audio/wavpack
 #    wav      Waveform Audio File Format                    audio/x-wav
+#    weba     Webm Audio                                    audio/webm
 #    webm     WebM Video                                    video/webm
 #    wma      Windows Media Audio                           audio/x-ms-wma
+#    wma10    Windows Media Audio 10 Professional           audio/x-ms-wma
+#    wmalossless      ""          Lossless                  audio/x-ms-wma
+#    wmapro           ""          Pro                       audio/x-ms-wma
+#    wmavoice         ""          Voice                     audio/x-ms-wma
 #    wmv      Windows Media Video                           video/x-ms-wmv                     Matches WMV1, WMV2, WMV7 and WMV8 (see "vc1" above for more). Tag also used for asf files
 #
 #    und      Undetermined, if the parser did not recognize one of above

--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -138,6 +138,7 @@ public class FormatConfiguration {
 	public static final String WEBM = "webm";
 	public static final String WEBP = "webp";
 	public static final String WMA = "wma";
+	public static final String WMA10 = "wma10";
 	public static final String WMALOSSLESS = "wmalossless";
 	public static final String WMAPRO = "wmapro";
 	public static final String WMAVOICE = "wmavoice";

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -416,6 +416,13 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	}
 
 	/**
+	 * @return True if the audio codec is WMA10.
+	 */
+	public boolean isWMA10() {
+		return FormatConfiguration.WMA10.equalsIgnoreCase(getCodecA());
+	}
+
+	/**
 	 * @return True if the audio codec is WMA Lossless.
 	 */
 	public boolean isWMALossless() {
@@ -540,6 +547,8 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 			return "WavPack";
 		} else if (isWMA()) {
 			return "WMA";
+		} else if (isWMA10()) {
+			return "WMA 10";
 		} else if (isWMALossless()) {
 			return "WMA Lossless";
 		} else if (isWMAPro()) {

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1563,6 +1563,7 @@ public class DLNAMediaInfo implements Cloneable {
 					mimeType = HTTPResource.AUDIO_WEBM_TYPEMIME;
 					break;
 				case FormatConfiguration.WMA:
+				case FormatConfiguration.WMA10:
 					mimeType = HTTPResource.AUDIO_WMA_TYPEMIME;
 					break;
 			}

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -191,6 +191,10 @@ public class LibMediaInfoParser {
 						getFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "Format_Version"), file);
 						getFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "Format_Profile"), file);
 						getFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "CodecID"), file);
+						value = MI.Get(audio, i, "CodecID_Description");
+						if (isNotBlank(value) && value.startsWith("Windows Media Audio 10")) {
+							currentAudioTrack.setCodecA(FormatConfiguration.WMA10);
+						}
 						currentAudioTrack.setLang(getLang(MI.Get(audio, i, "Language/String")));
 						currentAudioTrack.setAudioTrackTitleFromMetadata((MI.Get(audio, i, "Title")).trim());
 						currentAudioTrack.getAudioProperties().setNumberOfChannels(MI.Get(audio, i, "Channel(s)"));
@@ -613,9 +617,9 @@ public class LibMediaInfoParser {
 		} else if (
 			streamType == StreamType.Audio && media.getCodecV() == null && audio != null && audio.getCodecA() != null &&
 			audio.getCodecA() == FormatConfiguration.WMA &&
-			(value.equals("161") || value.equals("162") || value.equals("163") || value.equalsIgnoreCase("A"))
+			(value.equals("160") || value.equals("161") || value.equals("162") || value.equals("163") || value.equalsIgnoreCase("A") || value.equals("wma10"))
 		) {
-			if (value.equals("161")) {
+			if (value.equals("160") || value.equals("161")) {
 				format = FormatConfiguration.WMA;
 			} else if (value.equals("162")) {
 				format = FormatConfiguration.WMAPRO;
@@ -623,6 +627,8 @@ public class LibMediaInfoParser {
 				format = FormatConfiguration.WMALOSSLESS;
 			} else if (value.equalsIgnoreCase("A")) {
 				format = FormatConfiguration.WMAVOICE;
+			} else if (value.equals("wma10")) {
+				format = FormatConfiguration.WMA10;
 			}
 		} else if (value.equals("flac")) {
 			format = FormatConfiguration.FLAC;

--- a/src/test/java/net/pms/configuration/FormatConfigurationRegressionTest0.java
+++ b/src/test/java/net/pms/configuration/FormatConfigurationRegressionTest0.java
@@ -713,4 +713,12 @@ public class FormatConfigurationRegressionTest0 {
     // Regression assertion (captures the current behavior of the code)
     org.junit.Assert.assertTrue("'" + str0 + "' != '" + "g729"+ "'", str0.equals("g729"));
   }
+  @Test
+  public void testWMA10() throws Throwable {
+    java.lang.String str0 = net.pms.configuration.FormatConfiguration.WMA10;
+
+    // Regression assertion (captures the current behavior of the code)
+    org.junit.Assert.assertTrue("'" + str0 + "' != '" + "wma10"+ "'", str0.equals("wma10"));
+
+  }
 }


### PR DESCRIPTION
Some renderers, doesn't support [WMA 10 Pro](https://msdn.microsoft.com/en-us/library/windows/desktop/gg153556(v=vs.85).aspx), so it'll make them to be transcoded and playable at their full resolution.

I tested it without any issue.

**EDIT**:
PHILIPS PFL-L7605H/12
PHILIPS PUS6561/12
SAMSUNG BD-F5100-ZF
Sony SMP-N100
Sony BDP-590S
Sony STR-DN840
TOSHIBA_39L4300UM
Toshiba L74xx
...

https://en.wikipedia.org/wiki/Windows_Media_Audio

> All versions of WMA released since version 9.0 - namely 9.1, 9.2 and 10 - have been backwards compatible with the original v9 decoder and are therefore not considered separate codecs. The sole exception to this is the WMA 10 Professional codec whose Low Bit Rate (LBR) mode is only backwards compatible with the older WMA Professional decoders at half sampling rate (similar to how HE-AAC is backwards compatible with AAC-LC). Full fidelity decoding of WMA 10 Professional LBR bitstreams requires a WMA version 10 or newer decoder.