### PR TITLE
Implemented workaround for JDK-8179014

### DIFF
--- a/src/main/java/net/pms/newgui/LooksFrame.java
+++ b/src/main/java/net/pms/newgui/LooksFrame.java
@@ -184,6 +184,11 @@ public class LooksFrame extends JFrame implements IFrame, Observer {
 			if (selectedLaf != null) {
 				try {
 					UIManager.setLookAndFeel(selectedLaf);
+					// Workaround for JDK-8179014: JFileChooser with Windows look and feel crashes on win 10
+					// https://bugs.openjdk.java.net/browse/JDK-8179014
+					if (selectedLaf instanceof WindowsLookAndFeel) {
+						UIManager.put("FileChooser.useSystemExtensionHiding", false);
+					}
 				} catch (UnsupportedLookAndFeelException e) {
 					LOGGER.warn("Can't change look and feel", e);
 				}
@@ -660,6 +665,7 @@ public class LooksFrame extends JFrame implements IFrame, Observer {
 		getNt().setScanLibraryEnabled(flag);
 	}
 
+	@Override
 	public String getLog() {
 		return getTt().getList().getText();
 	}


### PR DESCRIPTION
There's a bug somewhere between Windows 10 v1703 and Java 8 > u121 which makes Java applications crash when calling ```JFileChooser``` if the computer has a [God mode folder](https://www.techsupportall.com/godmode-windows-10-can-feature/) somewhere, for example when browsing for a folder to share. See [JDK-8179014](https://bugs.openjdk.java.net/browse/JDK-8179014) for more information.

I'm not running Windows 10 so I can't confirm that the workaround works, but I can hardly see any harm in "unhiding file extensions" in ```JFileChooser``` so I think it's worth implementing.

This is based on [this thread](http://www.universalmediaserver.com/forum/viewtopic.php?f=9&t=9976).
