### PR TITLE
Show Splash Screen as early as possible

### DIFF
--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -415,6 +415,12 @@ public class PMS {
 	 * @throws Exception
 	 */
 	private boolean init() throws Exception {
+		// Splash
+		Splash splash = null;
+		if (!isHeadless()) {
+			splash = new Splash(configuration);
+		}
+
 		// Show the language selection dialog before displayBanner();
 		if (
 			!isHeadless() &&
@@ -560,12 +566,6 @@ public class PMS {
 				configuration.setRunWizard(false);
 				save();
 			}
-		}
-
-		// Splash
-		Splash splash = null;
-		if (!isHeadless()) {
-			splash = new Splash(configuration);
 		}
 
 		// The public VERSION field is deprecated.


### PR DESCRIPTION
This could partially solve the problem introduced by @Nadahar in #1208 and show Splash Screen before the oshi is called and could make users wait and not think that UMS doesn't start.