### PR TITLE
Memory logging adjustments

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -1517,7 +1517,7 @@ search_recurse_depth=
 log_level = 
 
 # Logfile name
-# ---------------------
+# ------------
 # The name of the standard log file. This is just the file name, 
 # no path information must be given here. The location of the log
 # file is decided by rules that varies by platform and some other
@@ -1526,7 +1526,7 @@ log_level =
 logging_logfile_name =
 
 # Logging Buffered
-# ---------------------
+# ----------------
 # By default the log file(s) are flushed/written to disk after each new log 
 # event. SSD drives can be written to a fixed number of times only, and logging
 # can be a great source of wear on such drives. Buffered logging makes UMS 
@@ -1543,7 +1543,7 @@ logging_logfile_name =
 logging_buffered =
 
 # Logging Filter Console
-# ---------------------
+# ----------------------
 # A separate filter for the console that filters after the root filter have
 # done it's filtering. It's not possible to get back things filtered out by
 # Log Level above, but you can further filter out more before it's written to
@@ -1553,7 +1553,7 @@ logging_buffered =
 logging_filter_console =
 
 # Logging Filter Log Tab
-# ---------------------
+# ----------------------
 # A separate filter for the log window in the "Logs" tab in the GUI that
 # filters after the root filter have done it's filtering. It's not possible to
 # get back things filtered out by Log Level above, but you can further filter
@@ -1563,12 +1563,30 @@ logging_filter_console =
 logging_filter_logs_tab =
 
 # Logging Logs Tab Linebuffer
-# ---------------------
+# ---------------------------
 # Specifies how many lines the log windows on the "Logs" tab in the GUI will
 # store before deleting the oldest entries. This will decide the length of the
 # scrollable area.
 # Default: 1000
 logging_logs_tab_linebuffer = 
+
+# Log System Information
+# ----------------------
+# Specifies if or when to log information about the OS, CPU and memory. This
+# is useful for diagnosing problems, but isn't stricly necessary during normal
+# use. On some platforms, acquiring the information can take some time,
+# although that doesn't mean that it uses a lot of resources. There are three
+# modes:
+#
+# - Never: Never log system information. This is useful it gathering of the
+#   information leads to an error or other problem).
+# - Trace only: Only log system information if the log level is "TRACE". This
+#   is the default which only triggers gathering of system information when
+#   the log level commonly used for diagnostics is activated.
+# - Always: Always log system information.
+#
+# Default: Trace only
+log_system_info = 
 
 #---< Syslog settings >----------------
 #
@@ -1581,7 +1599,7 @@ logging_logs_tab_linebuffer =
 # want to acquire in-depth knowledge about LogBack configuration. 
 
 # Logging Use Syslog
-# ---------------------
+# ------------------
 # Activates syslog logging and disables file logging. That enables you to 
 # send all logging to a differnt computer running a syslog server completely
 # removing all local disk I/O from logging, or to collect logs in a centralized
@@ -1592,7 +1610,7 @@ logging_logs_tab_linebuffer =
 logging_use_syslog = 
 
 # Logging Syslog Host
-# ---------------------
+# -------------------
 # Host name or IP address for the syslog server. Use "localhost" for logging 
 # to a syslog server on the same computer. The name must be resolvable (via
 # DNS, WINS, HOSTS etc.) or be an IP address for syslog logging to be activated.
@@ -1600,13 +1618,14 @@ logging_use_syslog =
 logging_syslog_host =
 
 # Logging Syslog Port
-# ---------------------
+# -------------------
 # UDP port to use for syslog logging. This should normally be left at the 
 # default value.
 # Default: 514
 logging_syslog_port =
 
 # Logging Syslog Facility
+# -----------------------
 # Syslog facility can be specified for filtering purposes, but is limited to
 # one of the following values: AUTH, AUTHPRIV, DAEMON, CRON, FTP, LPR, KERN,
 # MAIL, NEWS, SYSLOG, USER, UUCP, LOCAL1, LOCAL2, LOCAL3, LOCAL4, LOCAL5,

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -415,11 +415,6 @@ public class PMS {
 	 * @throws Exception
 	 */
 	private boolean init() throws Exception {
-		// Splash
-		Splash splash = null;
-		if (!isHeadless()) {
-			splash = new Splash(configuration);
-		}
 
 		// Show the language selection dialog before displayBanner();
 		if (
@@ -434,6 +429,12 @@ public class PMS {
 					return false;
 				}
 			}
+		}
+
+		// Initialize splash screen
+		Splash splash = null;
+		if (!isHeadless()) {
+			splash = new Splash(configuration);
 		}
 
 		// Call this as early as possible
@@ -463,6 +464,10 @@ public class PMS {
 
 		// Wizard
 		if (configuration.isRunWizard() && !isHeadless()) {
+			// Hide splash screen
+			if (splash != null) {
+				splash.setVisible(false);
+			}
 			// Ask the user if they want to run the wizard
 			int whetherToRunWizard = JOptionPane.showConfirmDialog(
 				null,
@@ -566,6 +571,11 @@ public class PMS {
 				configuration.setRunWizard(false);
 				save();
 			}
+
+			// Unhide splash screen
+			if (splash != null) {
+				splash.setVisible(true);
+			}
 		}
 
 		// The public VERSION field is deprecated.
@@ -595,8 +605,10 @@ public class PMS {
 			frame = new DummyFrame();
 		}
 
+		// Close splash screen
 		if (splash != null) {
 			splash.dispose();
+			splash = null;
 		}
 
 		/*

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -47,6 +47,7 @@ import net.pms.util.FileUtil.FileLocation;
 import net.pms.util.FullyPlayedAction;
 import net.pms.util.InvalidArgumentException;
 import net.pms.util.Languages;
+import net.pms.util.LogSystemInformationMode;
 import net.pms.util.PreventSleepMode;
 import net.pms.util.PropertiesUtil;
 import net.pms.util.SubtitleColor;
@@ -185,6 +186,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_LIVE_SUBTITLES_KEEP = "live_subtitles_keep";
 	protected static final String KEY_LIVE_SUBTITLES_LIMIT = "live_subtitles_limit";
 	protected static final String KEY_LIVE_SUBTITLES_TMO = "live_subtitles_timeout";
+	protected static final String KEY_LOG_SYSTEM_INFO = "log_system_info";
 	protected static final String KEY_LOGGING_LOGFILE_NAME = "logging_logfile_name";
 	protected static final String KEY_LOGGING_BUFFERED = "logging_buffered";
 	protected static final String KEY_LOGGING_FILTER_CONSOLE = "logging_filter_console";
@@ -635,7 +637,7 @@ public class PmsConfiguration extends RendererConfiguration {
 		);
 	}
 
-	private String verifyLogFolder(File folder, String fallbackTo) {
+	private static String verifyLogFolder(File folder, String fallbackTo) {
 		try {
 			FilePermissions permissions = FileUtil.getFilePermissions(folder);
 			if (LOGGER.isTraceEnabled()) {
@@ -725,9 +727,8 @@ public class PmsConfiguration extends RendererConfiguration {
 		String s = getString(KEY_LOGGING_LOGFILE_NAME, "debug.log");
 		if (FileUtil.isValidFileName(s)) {
 			return s;
-		} else {
-			return "debug.log";
 		}
+		return "debug.log";
 	}
 
 	public String getDefaultLogFilePath() {
@@ -776,6 +777,13 @@ public class PmsConfiguration extends RendererConfiguration {
 
 	public String getInterFramePath() {
 		return programPaths.getInterFramePath();
+	}
+
+	public LogSystemInformationMode getLogSystemInformation() {
+		LogSystemInformationMode defaultValue = LogSystemInformationMode.TRACE_ONLY;
+		String value = getString(KEY_LOG_SYSTEM_INFO, defaultValue.toString());
+		LogSystemInformationMode result = LogSystemInformationMode.typeOf(value);
+		return result != null ? result : defaultValue;
 	}
 
 	/**

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -3921,7 +3921,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	}
 
 	public boolean isShowSplashScreen() {
-		return getBoolean(KEY_SHOW_SPLASH_SCREEN, false);
+		return getBoolean(KEY_SHOW_SPLASH_SCREEN, true);
 	}
 
 	public void setShowSplashScreen(boolean value) {

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -112,6 +112,7 @@ public class DLNAMediaInfo implements Cloneable {
 		mutableAudioOrVideoContainers.put(FormatConfiguration.THREEGPP2, new AudioVariantInfo(new THREEG2A(), FormatConfiguration.THREEGA));
 		// XXX WEBM Audio is NOT MKA, but it will have to stay this way until WEBM Audio is implemented.
 		mutableAudioOrVideoContainers.put(FormatConfiguration.WEBM, new AudioVariantInfo(new MKA(), FormatConfiguration.WEBA));
+		mutableAudioOrVideoContainers.put(FormatConfiguration.WMV, new AudioVariantInfo(new WMA(), FormatConfiguration.WMA));
 
 		audioOrVideoContainers = Collections.unmodifiableMap(mutableAudioOrVideoContainers);
 	}

--- a/src/main/java/net/pms/newgui/Splash.java
+++ b/src/main/java/net/pms/newgui/Splash.java
@@ -36,8 +36,6 @@ import org.slf4j.LoggerFactory;
 public class Splash extends JFrame implements MouseListener {
 	private static final long serialVersionUID = 2357524127613134620L;
 	private static final Logger LOGGER = LoggerFactory.getLogger(Splash.class);
-	private JLabel imglabel;
-	private ImageIcon img;
 	private PmsConfiguration configuration;
 
 	/**
@@ -53,8 +51,8 @@ public class Splash extends JFrame implements MouseListener {
 			return;
 		}
 
-		img = new ImageIcon(getClass().getResource("/resources/images/splash.png"));
-		imglabel = new JLabel(img);
+		ImageIcon img = new ImageIcon(getClass().getResource("/resources/images/splash.png"));
+		JLabel imglabel = new JLabel(img);
 		imglabel.setBounds(0, 0, img.getIconWidth(), img.getIconHeight());
 		setSize(imglabel.getWidth(), imglabel.getHeight());
 		setUndecorated(true);
@@ -63,6 +61,8 @@ public class Splash extends JFrame implements MouseListener {
 		setLayout(null);
 		add(imglabel);
 		imglabel.addMouseListener(this);
+		img = new ImageIcon(getClass().getResource("/resources/images/icon-32.png"));
+		setIconImage(img.getImage());
 		if (System.getProperty("console") == null) {
 			setVisible(true);
 		}

--- a/src/main/java/net/pms/util/LogSystemInformationMode.java
+++ b/src/main/java/net/pms/util/LogSystemInformationMode.java
@@ -1,0 +1,75 @@
+package net.pms.util;
+
+import java.util.Locale;
+
+/**
+ * This is a representation of the different modes of system information logging.
+ *
+ * @author Nadahar
+ */
+public enum LogSystemInformationMode {
+	/** Never log system information */
+	NEVER,
+
+	/** Only log system information when the log level is trace */
+	TRACE_ONLY,
+
+	/** Always log system information */
+	ALWAYS;
+
+	/**
+	 * Tries to parse a {@link String} value into a
+	 * {@link LogSystemInformationMode}. If the parsing fails, {@code null} is
+	 * returned.
+	 *
+	 * @param logMode the {@link String} representing the mode of system
+	 *            information logging.
+	 * @return The corresponding {@link LogSystemInformationMode} or
+	 *         {@code null}.
+	 */
+	public static LogSystemInformationMode typeOf(String logMode) {
+		if (logMode == null) {
+			return null;
+		}
+		logMode = logMode.trim().toLowerCase(Locale.ROOT);
+		switch (logMode) {
+			case "never":
+			case "off":
+			case "none":
+			case "no":
+			case "false":
+				return NEVER;
+			case "trace":
+			case "trace only":
+			case "trace_only":
+				return TRACE_ONLY;
+			case "always":
+			case "on":
+			case "yes":
+			case "true":
+				return ALWAYS;
+			default: return null;
+		}
+	}
+
+	/**
+	 * @return the {@link Enum} value as a {@link String}.
+	 */
+	public String getValue() {
+		return super.toString();
+	}
+
+	@Override
+	public String toString() {
+		switch (this) {
+			case NEVER:
+				return "Never";
+			case TRACE_ONLY:
+				return "Trace only";
+			case ALWAYS:
+				return "Always";
+			default:
+				throw new IllegalStateException("Unimplemented enum value: " + super.toString());
+		}
+	}
+}

--- a/src/main/java/net/pms/util/SystemInformation.java
+++ b/src/main/java/net/pms/util/SystemInformation.java
@@ -1,0 +1,201 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.util;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import org.slf4j.spi.LocationAwareLogger;
+import com.sun.jna.Platform;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.software.os.OperatingSystem;
+
+
+/**
+ * This class doubles as a utility class for gathering and logging system
+ * information and a {@link Thread} that will do the gathering and logging once
+ * when started.
+ *
+ * @author Nadahar
+ */
+public class SystemInformation extends Thread {
+	private static final Logger LOGGER = LoggerFactory.getLogger(SystemInformation.class);
+
+	/**
+	 * Creates a new system information logger thread.
+	 */
+	public SystemInformation() {
+		super("System Information Logger");
+	}
+
+	/**
+	 * Collects and returns system information.
+	 *
+	 * @return A {@link List} of {@link String}s containing the collected system
+	 *         information.
+	 */
+	public static List<String> getSystemInfo() {
+		List<String> result = new ArrayList<>();
+		StringBuilder sb = new StringBuilder();
+		long jvmMemory = Runtime.getRuntime().maxMemory();
+		OperatingSystem os = null;
+		CentralProcessor processor = null;
+		GlobalMemory memory = null;
+		try {
+			SystemInfo systemInfo = new SystemInfo();
+			HardwareAbstractionLayer hardware = systemInfo.getHardware();
+			os = systemInfo.getOperatingSystem();
+			processor = hardware.getProcessor();
+			memory = hardware.getMemory();
+		} catch (Error e) {
+			LOGGER.debug("Could not retrieve system information: {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+
+		sb.append("JVM: ").append(System.getProperty("java.vm.name")).append(" ")
+			.append(System.getProperty("java.version")).append(" (")
+			.append(System.getProperty("sun.arch.data.model")).append("-bit) by ")
+			.append(System.getProperty("java.vendor"));
+		result.add(sb.toString());
+		sb.setLength(0);
+		sb.append("OS: ");
+		if (os != null && isNotBlank(os.toString())) {
+			sb.append(os.toString()).append(" ").append(getOSBitness()).append("-bit");
+		} else {
+			sb.append(System.getProperty("os.name")).append(" ").append(getOSBitness()).append("-bit ");
+			sb.append(System.getProperty("os.version"));
+		}
+		result.add(sb.toString());
+		sb.setLength(0);
+		if (processor != null) {
+			sb.append("CPU: ").append(processor.getName()).append(" with ")
+				.append(processor.getPhysicalProcessorCount());
+			if (processor.getPhysicalProcessorCount() > 1) {
+				sb.append(" cores");
+			} else {
+				sb.append(" core");
+			}
+			if (processor.getLogicalProcessorCount() != processor.getPhysicalProcessorCount()) {
+				sb.append(" (").append(processor.getLogicalProcessorCount());
+				if (processor.getLogicalProcessorCount() > 1) {
+					sb.append(" virtual cores)");
+				} else {
+					sb.append(" virtual core)");
+				}
+			}
+			result.add(sb.toString());
+			sb.setLength(0);
+		}
+		if (memory != null) {
+			sb.append("Physical Memory: ").append(StringUtil.formatBytes(memory.getTotal(), true));
+			result.add(sb.toString());
+			sb.setLength(0);
+			sb.append("Free Memory: ").append(StringUtil.formatBytes(memory.getAvailable(), true));
+			result.add(sb.toString());
+			sb.setLength(0);
+
+		}
+		sb.append("Maximum JVM Memory: ");
+		if (jvmMemory == Long.MAX_VALUE) {
+			sb.append("Unlimited");
+		} else {
+			sb.append(StringUtil.formatBytes(jvmMemory, true));
+		}
+		result.add(sb.toString());
+		return result;
+	}
+
+	/**
+	 * Logs relevant system information with the specified {@code logLevel}.
+	 *
+	 * @param logLevel the {@link ch.qos.logback.classic.Level} to use when
+	 *            logging.
+	 */
+	public static void logSystemInfo(ch.qos.logback.classic.Level logLevel) {
+		if (logLevel == null) {
+			throw new IllegalArgumentException("logLevel cannot be null");
+		}
+		logSystemInfo(ch.qos.logback.classic.Level.toLocationAwareLoggerInteger(logLevel));
+	}
+
+	/**
+	 * Logs relevant system information with the specified {@code logLevel}.
+	 *
+	 * @param logLevel the {@link Level} to use when logging.
+	 */
+	public static void logSystemInfo(Level logLevel) {
+		if (logLevel == null) {
+			throw new IllegalArgumentException("logLevel cannot be null");
+		}
+		logSystemInfo(logLevel.toInt());
+	}
+
+	/**
+	 * Logs relevant system information with the specified {@code logLevel}.
+	 *
+	 * @param locationAwareLogLevel the {@link LocationAwareLogger} integer
+	 *            constant to use when logging.
+	 */
+	public static void logSystemInfo(int locationAwareLogLevel) {
+		StringBuilder systemInfo = new StringBuilder("System information:\n");
+		for (String s : getSystemInfo()) {
+			systemInfo.append("  ").append(s).append("\n");
+		}
+		((ch.qos.logback.classic.Logger) LOGGER).log(
+			null,
+			SystemInformation.class.getName(),
+			locationAwareLogLevel,
+			systemInfo.toString(),
+			null,
+			null
+		);
+	}
+
+	/**
+	 * Determines whether the operating system is 64-bit or 32-bit.
+	 *
+	 * XXX This will work with Windows and OS X but not necessarily with Linux
+	 * as we're relying on Java's {@code os.arch} which only detects the bitness
+	 * of the JVM, not of the operating system. If <a
+	 * href="https://github.com/oshi/oshi/issues/377">OSHI #377</a> is
+	 * implemented, it could be a reliable source for all OSes.
+	 *
+	 * @return The bitness of the operating system.
+	 */
+	public static int getOSBitness() {
+		if (Platform.isWindows()) {
+			return System.getenv("ProgramFiles(x86)") != null ? 64 : 32;
+		}
+		return Platform.is64Bit() ? 64 : 32;
+	}
+
+	@Override
+	public void run() {
+		LOGGER.trace("Starting gathering of system information");
+		logSystemInfo(Level.INFO);
+		LOGGER.trace("Done logging system information, shutting down thread");
+	}
+}

--- a/src/main/java/net/pms/util/jna/macos/iokit/IOKitUtils.java
+++ b/src/main/java/net/pms/util/jna/macos/iokit/IOKitUtils.java
@@ -110,10 +110,10 @@ public class IOKitUtils {
 	}
 
 	/**
-	 * Determines if the current macOS version has is of a version equal or
-	 * greater to the arguments. Since {@code "10"} is fixed for all versions of
-	 * macOS, only the major and minor versions are needed. The format is
-	 * interpreted as {@code 10.major.minor}.
+	 * Determines if the current macOS version is of a version equal or greater
+	 * to the arguments. Since {@code "10"} is fixed for all versions of macOS,
+	 * only the major and minor versions are needed. The format is interpreted
+	 * as {@code 10.major.minor}.
 	 *
 	 * @param major the second part of the macOS version number.
 	 * @param minor the third part of the macOS version number.


### PR DESCRIPTION
This PR does some adjustments to #1208 based on past-merge experience. It basically "reverts" the logging done in the ```main``` thread to a slightly tweaked version of what it used to be.

All the OSHI logging has been moved into a new class ```SystemInformation```. This class has both utility methods for gathering and logging this information and is a ```Thread``` subclass that will gather and log the same information in a separate thread if instantiated and started. In addition, I've made the system information logging configurable with:
* Never log system information
* Log system information only when log level is ```TRACE```
* Always log system information

I've set the default to ```Trace only```. The benefits of all this are:
* UMS doesn't need to gather and log this information during normal use, when it has no value
* Gathering the information can take considerable time on some platforms. When run in a separate thread nothing will wait for this, and the results will be logged when they are available.
* It is possible to disable this completely if it turns out to be installations where the JNA calls leads to problems/crashes.

I've also added some fixes, and the splash screen is on by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/universalmediaserver/universalmediaserver/1327)
<!-- Reviewable:end -->
