### PR TITLE
NPE in RendererConfiguration.calculatedSpeed()

### DIFF
--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -2542,7 +2542,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		String max = getString(MAX_VIDEO_BITRATE, "");
 		for (Entry<InetAddress, RendererConfiguration> entry : addressAssociation.entrySet()) {
 			if (entry.getValue() == this) {
-				Future<Integer> speed = SpeedStats.getInstance().getSpeedInMBitsStored(entry.getKey(), getRendererName());
+				Future<Integer> speed = SpeedStats.getInstance().getSpeedInMBitsStored(entry.getKey());
 				if (speed != null) {
 					if (max == null) {
 						return String.valueOf(speed.get());

--- a/src/main/java/net/pms/io/BasicSystemUtils.java
+++ b/src/main/java/net/pms/io/BasicSystemUtils.java
@@ -223,6 +223,11 @@ public class BasicSystemUtils implements SystemUtils {
 		return timeString;
 	}
 
+	@Override
+	public int getPingPacketFragments(int packetSize) {
+		return ((packetSize + 8) / 1500) + 1;
+	}
+
 	/**
 	 * Return the proper tray icon for the operating system.
 	 *

--- a/src/main/java/net/pms/io/MacSystemUtils.java
+++ b/src/main/java/net/pms/io/MacSystemUtils.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -51,7 +52,7 @@ public class MacSystemUtils extends BasicSystemUtils {
 		try {
 			Process process = Runtime.getRuntime().exec(new String[] { "ifconfig", ni.getName(), "ether" });
 			inputStream = process.getInputStream();
-			List<String> lines = IOUtils.readLines(inputStream);
+			List<String> lines = IOUtils.readLines(inputStream, StandardCharsets.UTF_8);
 			String aMacStr = null;
 			Pattern aMacPattern = Pattern.compile("\\s*ether\\s*([a-d0-9]{2}:[a-d0-9]{2}:[a-d0-9]{2}:[a-d0-9]{2}:[a-d0-9]{2}:[a-d0-9]{2})");
 
@@ -80,5 +81,69 @@ public class MacSystemUtils extends BasicSystemUtils {
 		}
 
 		return aHardwareAddress;
+	}
+
+	/**
+	 * Return the platform specific ping command for the given host address,
+	 * ping count and packet size. macOS has a maximum UDP packet size of ~8400
+	 * bytes, so this method will divide packets of larger sizes into multiple
+	 * packets to "simulate" the effect.
+	 *
+	 * @param hostAddress the host address.
+	 * @param count the ping count.
+	 * @param packetSize the packet size.
+	 * @return The ping command.
+	 */
+	@Override
+	public String[] getPingCommand(String hostAddress, int count, int packetSize) {
+		if (packetSize > 8000) {
+			int divisor = getPingPacketDivisor(packetSize);
+			packetSize /= divisor;
+			count *= divisor;
+		}
+		return new String[] {
+			"ping", /* count */ "-c", Integer.toString(count),
+			/* delay */ "-i", "0.1",
+			/* size */ "-s", Integer.toString(packetSize),
+			hostAddress
+		};
+	}
+
+	@Override
+	public String parsePingLine(String line) {
+		int msPos = line.indexOf("ms");
+		String timeString = null;
+
+		if (msPos > -1) {
+			if (line.lastIndexOf('<', msPos) > -1){
+				timeString = "0.5";
+			} else {
+				timeString = line.substring(line.lastIndexOf('=', msPos) + 1, msPos).trim();
+
+			}
+		}
+		// Avoid returning the macOS ping statistics
+		return timeString != null && timeString.contains("/") ? null : timeString;
+	}
+
+	@Override
+	public int getPingPacketFragments(int packetSize) {
+		if (packetSize > 8000) {
+			packetSize /= getPingPacketDivisor(packetSize);
+		}
+		return ((packetSize + 8) / 1500) + 1;
+	}
+
+	/**
+	 * macOS has a default maximum UDP packet size of ~8400 bytes. This method
+	 * will divide packets of larger size into multiple packets to "simulate"
+	 * the effect.
+	 *
+	 * @param packetSize the packet size.
+	 * @return The divisor with which to device the packet size and multiply the
+	 *         count.
+	 */
+	private static int getPingPacketDivisor(int packetSize) {
+		return (int) Math.ceil(packetSize / 8000.0);
 	}
 }

--- a/src/main/java/net/pms/io/SystemUtils.java
+++ b/src/main/java/net/pms/io/SystemUtils.java
@@ -70,4 +70,12 @@ public interface SystemUtils {
 	String[] getPingCommand(String hostAddress, int count, int packetSize);
 
 	String parsePingLine(String line);
+
+	/**
+	 * This is't an actual but an estimated value assuming default MTU size.
+	 * 
+	 * @param packetSize the size of the packet in bytes.
+	 * @return The estimated number of fragments.
+	 */
+	int getPingPacketFragments(int packetSize);
 }

--- a/src/main/java/net/pms/network/SpeedStats.java
+++ b/src/main/java/net/pms/network/SpeedStats.java
@@ -52,7 +52,33 @@ public class SpeedStats {
 
 	private final Map<String, Future<Integer>> speedStats = new HashMap<>();
 
+	/**
+	 * Returns the estimated networks throughput for the given IP address in
+	 * Mb/s from the cache as a {@link Future}. If no value is cached for
+	 * {@code addr}, {@code null} is returned.
+	 *
+	 * @param addr the {@link InetAddress} to lookup.
+	 * @param rendererName not in use.
+	 * @return The {@link Future} with the estimated network throughput or
+	 *         {@code null}.
+	 * @deprecated Use {@link #getSpeedInMBitsStored(InetAddress)} instead.
+	 */
+	@SuppressWarnings("unused")
+	@Deprecated
 	public Future<Integer> getSpeedInMBitsStored(InetAddress addr, String rendererName) {
+		return getSpeedInMBitsStored(addr);
+	}
+
+	/**
+	 * Returns the estimated networks throughput for the given IP address in
+	 * Mb/s from the cache as a {@link Future}. If no value is cached for
+	 * {@code addr}, {@code null} is returned.
+	 *
+	 * @param addr the {@link InetAddress} to lookup.
+	 * @return The {@link Future} with the estimated network throughput or
+	 *         {@code null}.
+	 */
+	public Future<Integer> getSpeedInMBitsStored(InetAddress addr) {
 		// only look in the store
 		// if no pings are done resort to conf values
 		synchronized (speedStats) {
@@ -102,7 +128,7 @@ public class SpeedStats {
 
 		private Integer doCall() throws Exception {
 			String ip = addr.getHostAddress();
-			LOGGER.info("Checking IP: " + ip + " for " + rendererName);
+			LOGGER.info("Checking IP: {} for {}", ip, rendererName);
 			// calling the canonical host name the first time is slow, so we call it in a separate thread
 			String hostname = addr.getCanonicalHostName();
 			synchronized (speedStats) {
@@ -111,9 +137,9 @@ public class SpeedStats {
 					// wait a little bit
 					try {
 						// probably we are waiting for ourself to finish the work...
-						Integer value = otherTask.get(100, TimeUnit.MILLISECONDS);
+						Integer value = otherTask.get(200, TimeUnit.MILLISECONDS);
 						// if the other task already calculated the speed, we get the result,
-						// unless we do it now 
+						// unless we do it now
 						if (value != null) {
 							return value;
 						}
@@ -124,9 +150,9 @@ public class SpeedStats {
 			}
 
 			if (!ip.equals(hostname)) {
-				LOGGER.info("Renderer " + rendererName + " found on this address: " + hostname + " (" + ip + ")");
+				LOGGER.info("Renderer {} found on address: {} ({})", rendererName, hostname, ip);
 			} else {
-				LOGGER.info("Renderer " + rendererName + " found on this address: " + ip);
+				LOGGER.info("Renderer {} found on address: {}", rendererName, ip);
 			}
 
 			int[] sizes = {512, 1476, 9100, 32000, 64000};
@@ -141,7 +167,7 @@ public class SpeedStats {
 				}
 			}
 			double speedInMbits1 = bps / (cnt * 1000000);
-			LOGGER.info("Renderer " + rendererName + " has an estimated network speed of " + speedInMbits1 + " Mb/s");
+			LOGGER.info("Renderer {} has an estimated network speed of {} Mb/s", rendererName, speedInMbits1);
 			int speedInMbits = (int) speedInMbits1;
 			if (speedInMbits1 < 1.0) {
 				speedInMbits = -1;
@@ -161,7 +187,7 @@ public class SpeedStats {
 			op.log = true;
 			op.maxBufferSize = 1;
 			SystemUtils sysUtil = PMS.get().getRegistry();
-			final ProcessWrapperImpl pw = new ProcessWrapperImpl(sysUtil.getPingCommand(addr.getHostAddress(), 3, size), op, true, false);
+			final ProcessWrapperImpl pw = new ProcessWrapperImpl(sysUtil.getPingCommand(addr.getHostAddress(), 5, size), op, true, false);
 			Runnable r = new Runnable() {
 				@Override
 				public void run() {
@@ -197,8 +223,8 @@ public class SpeedStats {
 
 			if (c > 0) {
 				time /= c;
-				int frags = ((size + 8) / 1500) + 1;
-				LOGGER.debug("est speed for " + size + " " + frags + " is " + ((size + 8 + (frags * 32)) * 8000 * 2) / time);
+				int frags = sysUtil.getPingPacketFragments(size);
+				LOGGER.debug("Estimated speed from ICMP packet size {} in {} fragment(s) is {} bit/s", size, frags, ((size + 8 + (frags * 32)) * 8000 * 2) / time);
 				return ((size + 8 + (frags * 32)) * 8000 * 2) / time;
 			}
 			return time;


### PR DESCRIPTION
While looking at [this output](https://github.com/UniversalMediaServer/UniversalMediaServer/issues/1325#issuecomment-312385834) in #1325, it seems like the NPE is caused by ```getSpeedInMBitsStored()``` returning ```null```. I've tried to avoid that situation. This "fix" will lead to a maximum value of ```0``` being returned if no results are availabe from "speedstats" and no maximum bandwidth is configured on the renderer. That's not ideal, but I don't know what else to return. It's surely better than crashing with a NPE.

The related code is generally extremely fragile and unstructured. I see a lot of potentiel problems, both with thread-safety and missing handling of almost anything "not going according to plan". I won't get involved with another one of those major refactorings now, so this is just an attempt to patch *one of* all the problems with this code.

I've never looked at the "speedstats" code before, but now that I have I'd say it's in so bad shape that I think hiding it until it's fixed would probably be a better option that using it as it is. This isn't the first time I've seen it end up with some very questionable results. The "math" isn't really explained, but I can see from the log that the parsing fails regularly and that all the larger packet sizes are rejected by the underlying OS (macOS) in the log I looked at in #1325. Using only small packet sizes probably means that the results are very inaccurate.

In any case, it can't hurt to prevent a NPE, can it?

