### PR TITLE
Update OSHI to 3.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,17 +507,7 @@
 
 				Check the net.java.dev.jna:jna-platform version before upgrading
 			-->
-			<version>3.4.2</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>net.java.dev.jna</groupId>
-					<artifactId>jna-platform</artifactId>
-				</exclusion>
-			</exclusions>
+			<version>3.4.3</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
This resolves the JNA and slf4j dependency version conflicts between OSHI and UMS.

@Sami32 It would be nice if you could test if this works on your computer without changing the JNA version.
