### PR TITLE
AVI / MJPEG support enhancement

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -566,13 +566,13 @@ CharMap =
 #    3gp      3rd Generation Partnership Project            video/3gpp
 #    3g2a     3rd Generation Partnership Project 2 Audio    audio/3gpp2
 #    3g2      3rd Generation Partnership Project 2          video/3gpp2
-#    aac-lc   Advanced Audio Coding (Low Complexity)        audio/aac
+#    aac-lc   Advanced Audio Coding (Low Complexity)
 #    ac3      Audio Codec 3 (Dolby Digital)                 audio/vnd.dolby.dd-raw
 #    acelp    Algebraic Code Excited Linear Prediction                                     Audio codec
-#    adpcm    Adaptive differential pulse-code modulation   audio/x-adpcm
+#    adpcm    Adaptive differential pulse-code modulation
 #    adts     Audio Data Transport Stream                   audio/vnd.dlna.adts
-#    aiff     Audio Interchange File Format                 audio/L16
-#    alac     Apple Lossless Audio Codec                    audio/m4a
+#    aiff     Audio Interchange File Format                 audio/L16                      Also audio/aiff or audio/x-aiff
+#    alac     Apple Lossless Audio Codec                                                   Need audio/x-m4a or audio/m4a
 #    als      Audio Lossless Coding (MPEG-4 ALS)
 #    amr      Adaptive Multi-Rate audio codec               audio/amr
 #    ape      Monkey's Audio                                audio/x-ape
@@ -593,13 +593,17 @@ CharMap =
 #    flv      Flash Video                                   video/x-flv
 #    g729     G.729                                                                         Also known as Coding of speech-ACELP
 #    gif      Graphics Interchange Format                   image/gif
-#    h263     H.263 video compression standard              video/h263
-#    h264     H.264/MPEG-4 Part 10 (AVC)                    video/h264
-#    h265     High Efficiency Video Coding (HEVC)           video/h265
-#    he-aac   Advanced Audio Coding (High-Efficiency)       audio/aacp
-#    jpg      JPEG                                          image/jpeg
+#    h261     H.261 video compression standard
+#    h263     H.263 video compression standard
+#    h264     H.264/MPEG-4 Part 10 (AVC)
+#    h265     High Efficiency Video Coding (HEVC)
+#    he-aac   Advanced Audio Coding (High-Efficiency)
+#    indeo    Intel Indeo Video                                                             IV31, IV32, IV41 and IV50
+#    jpg      Joint Photographic Experts Group              image/jpeg
+#    jpeg     Motion JPEG A
+#    jpeg2000 Motion JPEG 2000
 #    lpcm     Linear Pulse-Code Modulation                  audio/L16
-#    mjpeg    Motion JPEG                                   video/x-motion-jpeg
+#    mjpeg    Motion JPEG B
 #    mka      Matroska Audio                                audio/x-matroska
 #    mkv      Matroska Video                                video/x-matroska
 #    mlp      Meridian Lossless Packing                     audio/vnd.dolby.mlp
@@ -619,35 +623,37 @@ CharMap =
 #    ogg      Ogg container                                 video/ogg                          Applies for Vorbis I files only, use with FLAC and Theora should use oga and ogv respectively
 #    ogv      Ogg container with video content              video/ogg
 #    ogx      Ogg container                                 application/ogg
-#    opus     Ogg Opus                                      audio/ogg
+#    opus     Ogg Opus                                                                         Need audio/ogg or audio/opus
 #    png      Portable Network Graphics                     image/png
 #    qdmc     QDesign Music Codec (RaveSound)
 #    ralf     RealAudio Lossless Format                     audio/vnd.rn-realaudio
+#    rgb      Uncompressed video (Red, Green and Blue)
 #    rm       RealMedia (RMVB)                              application/vnd.rn-realmedia-vbr
 #    shn      Shorten                                       audio/x-shorten
 #    sipro    Sipro Lab Telecom
-#    sls      Scalable to Lossless                          audio/mp4                          Also known as MPEG-4 SLS
-#    sor      Sorenson Spark                                video/x-sorenson-spark
+#    sls      Scalable to Lossless                                                             Also known as MPEG-4 SLS
+#    sor      Sorenson Spark
 #    tiff     Tagged Image File Format                      image/tiff
-#    theora   Ogg Theora                                    video/ogg
+#    theora   Ogg Theora
 #    tta      True Audio codec                              audio/x-tta
 #    truehd   Dolby TrueHD                                  audio/vnd.dolby.mlp
-#    vc1      Microsoft VC-1 (WMV 9)                        video/vc1                          Also known as WMV 9 and WMV3
-#    vorbis   Ogg Vorbis                                    audio/ogg
+#    vc1      Microsoft VC-1                                                                   Also known as WMV 9 and WMV3
+#    vorbis   Ogg Vorbis
 #    vp6      On2 TrueMotion VP6
 #    vp7      On2 TrueMotion VP7
-#    vp8      Google VP8                                    video/webm
-#    vp9      Google VP9                                    video/webm
+#    vp8      Google VP8
+#    vp9      Google VP9
 #    wavpack  WavPack                                       audio/wavpack
 #    wav      Waveform Audio File Format                    audio/x-wav
 #    weba     Webm Audio                                    audio/webm
 #    webm     WebM Video                                    video/webm
 #    wma      Windows Media Audio                           audio/x-ms-wma
-#    wma10    Windows Media Audio 10 Professional           audio/x-ms-wma
-#    wmalossless      ""          Lossless                  audio/x-ms-wma
-#    wmapro           ""          Pro                       audio/x-ms-wma
-#    wmavoice         ""          Voice                     audio/x-ms-wma
+#    wma10    Windows Media Audio 10 Professional
+#    wmalossless      ""          Lossless
+#    wmapro           ""          Pro
+#    wmavoice         ""          Voice
 #    wmv      Windows Media Video                           video/x-ms-wmv                     Matches WMV1, WMV2, WMV7 and WMV8 (see "vc1" above for more). Tag also used for asf files
+#    yuv      Uncompressed video                                                               Luminance (Y) and two chrominance (UV)
 #
 #    und      Undetermined, if the parser did not recognize one of above
 #

--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -72,14 +72,18 @@ public class FormatConfiguration {
 	public static final String FLV = "flv";
 	public static final String G729 = "g729";
 	public static final String GIF = "gif";
+	public static final String H261 = "h261";
 	public static final String H263 = "h263";
 	public static final String H264 = "h264";
 	public static final String H265 = "h265";
 	public static final String HE_AAC = "he-aac";
 	public static final String ICNS = "icns";
 	public static final String ICO = "ico";
+	public static final String INDEO = "indeo";
 	public static final String ISO = "iso";
 	public static final String JPG = "jpg";
+	public static final String JPEG = "jpeg";
+	public static final String JPEG2000 = "jpeg2000";
 	public static final String LPCM = "lpcm";
 	public static final String M4A = "m4a";
 	public static final String MKV = "mkv";
@@ -115,6 +119,8 @@ public class FormatConfiguration {
 	public static final String RAW = "raw";
 	public static final String REALAUDIO_14_4 = "ra14.4";
 	public static final String REALAUDIO_28_8 = "ra28.8";
+	/** Used as a "video codec" when sequences of raw, uncompressed RGB or RGBA is used as a video stream in AVI, MP4 or MOV files */
+	public static final String RGB = "rgb";
 	public static final String RM = "rm";
 	public static final String SHORTEN = "shn";
 	public static final String SIPRO = "sipro";
@@ -143,6 +149,8 @@ public class FormatConfiguration {
 	public static final String WMAPRO = "wmapro";
 	public static final String WMAVOICE = "wmavoice";
 	public static final String WMV = "wmv";
+	/** Used as a "video codec" when sequences of raw, uncompressed YUV is used as a video stream in AVI, MP4 or MOV files */
+	public static final String YUV = "yuv";
 	public static final String MIMETYPE_AUTO = "MIMETYPE_AUTO";
 	public static final String und = "und";
 

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -470,15 +470,16 @@ public class LibMediaInfoParser {
 		} else if (value.equals("qt") || value.equals("quicktime")) {
 			format = FormatConfiguration.MOV;
 		} else if (
-			value.equals("isom") ||
-			value.startsWith("mp4") ||
-			value.equals("20") ||
-			value.equals("m4v") ||
-			value.startsWith("mpeg-4") ||
-			value.contains("m4a") ||
-			value.contains("xvid")
-		) {
-			format = FormatConfiguration.MP4;
+				value.contains("isom") ||
+				value.startsWith("mp4") ||
+				value.equals("20") ||
+				value.equals("isml") ||
+				value.startsWith("m4a") ||
+				value.startsWith("m4v") ||
+				value.equals("mpeg-4 visual") ||
+				value.equals("xvid")
+			) {
+				format = FormatConfiguration.MP4;
 		} else if (value.contains("mpeg-ps")) {
 			format = FormatConfiguration.MPEGPS;
 		} else if (value.contains("mpeg-ts") || value.equals("bdav")) {
@@ -495,12 +496,31 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.RM;
 		} else if (value.startsWith("theora")) {
 			format = FormatConfiguration.THEORA;
-		} else if (value.contains("windows media") || value.equals("wmv1") || value.equals("wmv2") || value.equals("wmv7") || value.equals("wmv8")) {
-			format = FormatConfiguration.WMV;
-		} else if (value.contains("mjpg") || value.contains("m-jpeg")) {
-			format = FormatConfiguration.MJPEG;
-		} else if (value.startsWith("h263") || value.startsWith("s263") || value.startsWith("u263")) {
-			format = FormatConfiguration.H263;
+		} else if (
+				value.startsWith("windows media") ||
+				value.equals("wmv1") ||
+				value.equals("wmv2")
+			) {
+				format = FormatConfiguration.WMV;
+		} else if (streamType == StreamType.Video &&
+				(
+					value.contains("mjpg") ||
+					value.startsWith("mjpeg") ||
+					value.equals("mjpa") ||
+					value.equals("mjpb") ||
+					value.equals("jpeg") ||
+					value.equals("jpeg2000")
+				)
+			) {
+				format = FormatConfiguration.MJPEG;
+		} else if (value.equals("h261")) {
+			format = FormatConfiguration.H261;
+		} else if (
+				value.equals("h263") ||
+				value.equals("s263") ||
+				value.equals("u263")
+			) {
+				format = FormatConfiguration.H263;
 		} else if (value.startsWith("avc") || value.startsWith("h264")) {
 			format = FormatConfiguration.H264;
 		} else if (value.startsWith("hevc")) {
@@ -519,14 +539,30 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.MP4;
 		} else if (value.contains("mjpg") || value.contains("m-jpeg")) {
 			format = FormatConfiguration.MJPEG;
-		} else if (value.contains("div") || value.contains("dx")) {
-			format = FormatConfiguration.DIVX;
+		} else if (
+				value.startsWith("div") ||
+				value.equals("dx50") ||
+				value.equals("dvx1")
+			) {
+				format = FormatConfiguration.DIVX;
+		} else if (value.startsWith("indeo")) { // Intel Indeo Video: IV31, IV32, IV41 and IV50
+			format = FormatConfiguration.INDEO;
+		} else if (streamType == StreamType.Video && value.equals("yuv")) {
+			format = FormatConfiguration.YUV;
+		} else if (streamType == StreamType.Video && (value.equals("rgb") || value.equals("rgba"))) {
+			format = FormatConfiguration.RGB;
 		} else if (value.matches("(?i)(dv)|(cdv.?)|(dc25)|(dcap)|(dvc.?)|(dvs.?)|(dvrs)|(dv25)|(dv50)|(dvan)|(dvh.?)|(dvis)|(dvl.?)|(dvnm)|(dvp.?)|(mdvf)|(pdvc)|(r411)|(r420)|(sdcc)|(sl25)|(sl50)|(sldv)")) {
 			format = FormatConfiguration.DV;
 		} else if (value.contains("mpeg video")) {
 			format = FormatConfiguration.MPEG2;
-		} else if (value.equals("vc-1") || value.equals("vc1") || value.equals("wvc1") || value.equals("wmv3") || value.equals("wmv9") || value.equals("wmva")) {
-			format = FormatConfiguration.VC1;
+		} else if (
+				value.equals("vc-1") ||
+				value.equals("wvc1") ||
+				value.equals("wmv3") ||
+				value.equals("wmvp") ||
+				value.equals("wmva")
+			) {
+				format = FormatConfiguration.VC1;
 		} else if (value.startsWith("version 1")) {
 			if (media.getCodecV() != null && media.getCodecV().equals(FormatConfiguration.MPEG2) && audio.getCodecA() == null) {
 				format = FormatConfiguration.MPEG1;
@@ -556,8 +592,12 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.ADTS;
 		} else if (value.startsWith("amr")) {
 			format = FormatConfiguration.AMR;
-		} else if (value.equals("ac-3") || value.equals("a_ac3") || value.equals("2000")) {
-			format = FormatConfiguration.AC3;
+		} else if (
+				value.equals("ac-3") ||
+				value.equals("a_ac3") ||
+				value.equals("2000")
+			) {
+				format = FormatConfiguration.AC3;
 		} else if (value.startsWith("cook")) {
 			format = FormatConfiguration.COOK;
 		} else if (value.startsWith("qdesign")) {

--- a/src/main/java/net/pms/formats/MPG.java
+++ b/src/main/java/net/pms/formats/MPG.java
@@ -49,6 +49,8 @@ public class MPG extends Format {
 			"m2t",
 			"m2ts",
 			"m4v",
+			"mj2",
+			"mjp2",
 			"mod",
 			"mp4",
 			"mpe",

--- a/src/test/java/net/pms/configuration/FormatConfigurationRegressionTest0.java
+++ b/src/test/java/net/pms/configuration/FormatConfigurationRegressionTest0.java
@@ -721,4 +721,41 @@ public class FormatConfigurationRegressionTest0 {
     org.junit.Assert.assertTrue("'" + str0 + "' != '" + "wma10"+ "'", str0.equals("wma10"));
 
   }
+
+  @Test
+  public void testH261() throws Throwable {
+    java.lang.String str0 = net.pms.configuration.FormatConfiguration.H261;
+
+    // Regression assertion (captures the current behavior of the code)
+    org.junit.Assert.assertTrue("'" + str0 + "' != '" + "h261"+ "'", str0.equals("h261"));
+
+  }
+
+  @Test
+  public void testINDEO() throws Throwable {
+    java.lang.String str0 = net.pms.configuration.FormatConfiguration.INDEO;
+
+    // Regression assertion (captures the current behavior of the code)
+    org.junit.Assert.assertTrue("'" + str0 + "' != '" + "indeo"+ "'", str0.equals("indeo"));
+
+  }
+
+  @Test
+  public void testRGB() throws Throwable {
+    java.lang.String str0 = net.pms.configuration.FormatConfiguration.RGB;
+
+    // Regression assertion (captures the current behavior of the code)
+    org.junit.Assert.assertTrue("'" + str0 + "' != '" + "rgb"+ "'", str0.equals("rgb"));
+
+  }
+
+  @Test
+  public void testYUV() throws Throwable {
+    java.lang.String str0 = net.pms.configuration.FormatConfiguration.YUV;
+
+    // Regression assertion (captures the current behavior of the code)
+    org.junit.Assert.assertTrue("'" + str0 + "' != '" + "yuv"+ "'", str0.equals("yuv"));
+
+  }
+
 }

--- a/src/test/java/net/pms/test/formats/FormatFactoryTest.java
+++ b/src/test/java/net/pms/test/formats/FormatFactoryTest.java
@@ -148,6 +148,8 @@ public class FormatFactoryTest {
 		testSingleFormat("test.m2t", "MPG", Format.VIDEO);
 		testSingleFormat("test.m2ts", "MPG", Format.VIDEO);
 		testSingleFormat("test.m4v", "MPG", Format.VIDEO);
+		testSingleFormat("test.mj2", "MPG", Format.VIDEO);
+		testSingleFormat("test.mjp2", "MPG", Format.VIDEO);
 		testSingleFormat("test.mod", "MPG", Format.VIDEO);
 		testSingleFormat("test.mp4", "MPG", Format.VIDEO);
 		testSingleFormat("test.mpe", "MPG", Format.VIDEO);


### PR DESCRIPTION
Following [this user report](http://www.universalmediaserver.com/forum/viewtopic.php?f=9&t=10097&p=31696#p31696) on the forum, that tried to play his family AVI videos, taken from cameras and phones years ago, without success.
It give me the idea that he should not be the only one, and that our AVI / MJPEG support was poor, so i did this PR.
```logtalk
DEBUG 2017-06-16 20:21:01.494 [New I/O worker #13] net.pms.dlna.DLNAResource Starting transcode/remux of 2004-jonathansroomjanuary1.avi with media info: container: avi, bitrate: 9217159, size: 122127360, video tracks: 1, video codec: und, duration: 00:01:46.00, width: 320, height: 240, frame rate: 5.000, thumb size: 26502, mime type: video/avi
```
```logtalk
DEBUG 2017-06-16 20:21:01.869 [ffmpeg64.exe-25-2] net.pms.io.OutputTextLogger     ISBJ            : JPGVideo
DEBUG 2017-06-16 20:21:01.869 [ffmpeg64.exe-25-2] net.pms.io.OutputTextLogger   Duration: 00:01:46.00, start: 0.000000, bitrate: 9217 kb/s
DEBUG 2017-06-16 20:21:01.869 [ffmpeg64.exe-25-2] net.pms.io.OutputTextLogger     Stream #0:0: Video: rawvideo, bgr24, 320x240, 9233 kb/s, 5 fps, 5 tbr, 5 tbn, 5 tbc
DEBUG 2017-06-16 20:21:01.869 [ffmpeg64.exe-25-2] net.pms.io.OutputTextLogger Codec AVOption b (set bitrate (in bits/s)) specified for output file #0 (\\.\pipe\ffmpegvideo_65_1497669661510) has not been used for any stream. The most likely reason is either wrong type (e.g. a video option with no video streams) or that it is a private option of some encoder which was not actually used for any stream.
```

Documentation of reference:
- https://en.wikipedia.org/wiki/Motion_JPEG_2000
- https://en.wikipedia.org/wiki/Motion_JPEG
- https://en.wikipedia.org/wiki/Indeo
- https://en.wikipedia.org/wiki/H.261
- [DIVX](https://support.divx.com/s/article/ka140000000bmIcAAI/Genuine-DivX-and-Diagnosing-Playback-Problems?language=en_US)
- [WMV](https://github.com/MediaArea/MediaInfoLib/blob/725929c736412576308cd024f7e585c88cfa2494/Source/Resource/Text/DataBase/CodecID_Video_Riff.csv#L650-L654), also from [Microsoft](https://msdn.microsoft.com/en-us/library/windows/desktop/bb970509(v=vs.85).aspx)
- [ISML](https://github.com/MediaArea/MediaInfoLib/blob/f9e3216447eba7c7dc435e602f1c5c88cae1680e/Source/Resource/Text/DataBase/CodecID_General_Mpeg4.csv#L26), also from [Microsoft](https://blogs.iis.net/samzhang/live-smooth-streaming-publishing-point-advanced-settings)

Can also be found in MOV container:
- [RGB](https://en.wikipedia.org/wiki/Uncompressed_video), [here](https://github.com/MediaArea/MediaInfoLib/blob/182baa2b699b0d24b3647094c8f07368a9369d86/Source/Resource/Text/DataBase/Codec.csv#L1-L8) and [there](https://github.com/MediaArea/MediaInfoLib/blob/31cbb6661f7121e8af7c10ac3cae4abece5a207d/Source/Resource/Text/DataBase/CodecID_Video_Matroska.csv#L1).
- [YUV](https://en.wikipedia.org/wiki/YUV), [here](https://github.com/MediaArea/MediaInfoLib/blob/4468063f90bdf485a2d43b9fe66878dc37b9a15a/Source/Resource/Text/DataBase/Format.csv#L61)

**Note**: Samples are availables on request.