### PR TITLE
Fix problem when the TotalMatches for the FileTranscodeVirtualFolder is changed during browsing

### DIFF
--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -43,6 +43,7 @@ import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAMediaSubtitle;
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.DLNAThumbnailInputStream;
+import net.pms.dlna.FileTranscodeVirtualFolder;
 import net.pms.dlna.MediaType;
 import net.pms.dlna.Range;
 import net.pms.dlna.RealFile;
@@ -757,8 +758,12 @@ public class Request extends HTTPResource {
 						if (xbox360 && containerID != null) {
 							uf.setFakeParentId(containerID);
 						}
-						if (uf.isCompatible(mediaRenderer) && (uf.getPlayer() == null || uf.getPlayer().isPlayerCompatible(mediaRenderer))) {
-							response.append(uf.getDidlString(mediaRenderer));
+						if (uf.isCompatible(mediaRenderer) && (uf.getPlayer() == null
+							|| uf.getPlayer().isPlayerCompatible(mediaRenderer))
+							// do not check compatibility of the media for items in the FileTranscodeVirtualFolder because we need
+							 // all possible combination not only those supported by renderer because the renderer setting could be wrong. 
+							|| files.get(0).getParent() instanceof FileTranscodeVirtualFolder) {
+								response.append(uf.getDidlString(mediaRenderer));
 						} else {
 							minus++;
 						}

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -802,7 +802,8 @@ public class RequestV2 extends HTTPResource {
 
 						if (uf.isCompatible(mediaRenderer) && (uf.getPlayer() == null
 							|| uf.getPlayer().isPlayerCompatible(mediaRenderer))
-							 // do not check compatibility of the media when it is in the FileTranscodeVirtualFolder because the renderer setting could be wrong 
+							 // do not check compatibility of the media for items in the FileTranscodeVirtualFolder because we need
+							 // all possible combination not only those supported by renderer because the renderer setting could be wrong. 
 							|| files.get(0).getParent() instanceof FileTranscodeVirtualFolder) {
 								response.append(uf.getDidlString(mediaRenderer));
 						} else {

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -802,7 +802,7 @@ public class RequestV2 extends HTTPResource {
 
 						if (uf.isCompatible(mediaRenderer) && (uf.getPlayer() == null || uf.getPlayer().isPlayerCompatible(mediaRenderer))) {
 							response.append(uf.getDidlString(mediaRenderer));
-						} else {
+						} else if (!(files.get(0).getParent() instanceof FileTranscodeVirtualFolder)) {
 							minus++;
 						}
 					}

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -800,9 +800,12 @@ public class RequestV2 extends HTTPResource {
 							uf.setFakeParentId(containerID);
 						}
 
-						if (uf.isCompatible(mediaRenderer) && (uf.getPlayer() == null || uf.getPlayer().isPlayerCompatible(mediaRenderer))) {
-							response.append(uf.getDidlString(mediaRenderer));
-						} else if (!(files.get(0).getParent() instanceof FileTranscodeVirtualFolder)) {
+						if (uf.isCompatible(mediaRenderer) && (uf.getPlayer() == null
+							|| uf.getPlayer().isPlayerCompatible(mediaRenderer))
+							 // do not check compatibility of the media when it is in the FileTranscodeVirtualFolder because the renderer setting could be wrong 
+							|| files.get(0).getParent() instanceof FileTranscodeVirtualFolder) {
+								response.append(uf.getDidlString(mediaRenderer));
+						} else {
 							minus++;
 						}
 					}


### PR DESCRIPTION
in the FileTranscodeVirtualFolder. The problem should be in the FileTranscodeVirtualFolder when all players, audio and subtitles combinations are made but I could't find it.