### PR TITLE
Update the VieraTXL32V10E.conf

### DIFF
--- a/src/main/external-resources/renderers/Panasonic-VieraTXL32V10E.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraTXL32V10E.conf
@@ -36,7 +36,7 @@ MediaInfo = true
 Supported = f:mpegps     v:mpeg2|mp4|h264   a:ac3|lpcm|aac-lc|mpa   m:video/mpeg   gop:static
 # By default the more widely-supported "video/divx" is used but feel free to
 # test "video/x-msvideo" which might be better choice
-Supported = f:avi|divx   v:mp4|divx         a:mp3|ac3            m:video/divx   qpel:yes   gmc:0
+Supported = f:avi|divx   v:mp4|divx         a:mp3|ac3            m:video/divx
 
 # Supported subtitles formats:
 SupportedExternalSubtitlesFormats = SUBRIP, MICRODVD


### PR DESCRIPTION
This is conf for my TV and I have no idea why I not tested those parameters long time ago. This allow to stream all videos with the DIVX/XVID video codec.