### PR TITLE
Force interface on multicast socket

### DIFF
--- a/src/main/java/net/pms/network/UPNPHelper.java
+++ b/src/main/java/net/pms/network/UPNPHelper.java
@@ -290,7 +290,23 @@ public class UPNPHelper extends UPNPControl {
 
 		InetSocketAddress localAddress = new InetSocketAddress(usableAddresses.get(0), 0);
 		MulticastSocket ssdpSocket = new MulticastSocket(localAddress);
-		ssdpSocket.setNetworkInterface(networkInterface);
+
+        try {
+            LOGGER.trace("Setting SSDP network interface: {}", networkInterface);
+            ssdpSocket.setNetworkInterface(networkInterface);
+        } catch (SocketException ex) {
+            LOGGER.warn("Setting SSDP network interface failed: {}", ex);
+            NetworkInterface confIntf = NetworkConfiguration.getInstance().getNetworkInterfaceByServerName();
+            if (confIntf != null) {
+                LOGGER.trace("Setting SSDP network interface from configuration: {}", confIntf);
+                try {
+                    ssdpSocket.setNetworkInterface(confIntf);
+                } catch (SocketException ex2){
+                    LOGGER.warn("Setting SSDP network interface failed: {}", ex2);
+                }
+            }
+        }
+
 		ssdpSocket.setReuseAddress(true);
 		ssdpSocket.setTimeToLive(32);
 

--- a/src/main/java/net/pms/network/UPNPHelper.java
+++ b/src/main/java/net/pms/network/UPNPHelper.java
@@ -290,6 +290,7 @@ public class UPNPHelper extends UPNPControl {
 
 		InetSocketAddress localAddress = new InetSocketAddress(usableAddresses.get(0), 0);
 		MulticastSocket ssdpSocket = new MulticastSocket(localAddress);
+		ssdpSocket.setNetworkInterface(networkInterface);
 		ssdpSocket.setReuseAddress(true);
 		ssdpSocket.setTimeToLive(32);
 


### PR DESCRIPTION
On macOS (at least) multicast binds to 0.0.0.0 and first available interface despite passing specific address, this is causing ALIVE not being sent and, eventually, playback disconnect. Setting previously calculated interface on the socket fixes that.