### PR TITLE
Unquote macOS menu name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1463,7 +1463,7 @@
 											<option value="-Xss16M"/>
 											<option value="-Dfile.encoding=UTF-8"/>
 											<option value="-Djava.net.preferIPv4Stack=true"/>
-											<option value="-Xdock:name=&quot;UMS&quot;"/>
+											<option value="-Xdock:name=UMS"/>
 										</bundleapp>
 									</target>
 								</configuration>
@@ -1644,7 +1644,7 @@
 											<option value="-Xss16M"/>
 											<option value="-Dfile.encoding=UTF-8"/>
 											<option value="-Djava.net.preferIPv4Stack=true"/>
-											<option value="-Xdock:name=&quot;UMS&quot;"/>
+											<option value="-Xdock:name=UMS"/>
 										</bundleapp>
 									</target>
 								</configuration>


### PR DESCRIPTION
This is a correction of #1353 as pointed out by @esabol in #1352.

I've tested it and found no problems, I'm bewildered as to why I put the quotes there in the first place.

Fixes #1352.