### PR TITLE
Fix image ContentFeatures header

### DIFF
--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -66,7 +66,7 @@ public class RealFile extends MapFile {
 		}
 
 		boolean valid = file.exists() && (getFormat() != null || file.isDirectory());
-		if (valid && getParent().getDefaultRenderer() != null && getParent().getDefaultRenderer().isUseMediaInfo()) {
+		if (valid && getParent() != null && getParent().getDefaultRenderer() != null && getParent().getDefaultRenderer().isUseMediaInfo()) {
 			// we need to resolve the DLNA resource now
 			run();
 

--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -351,10 +351,10 @@ public class Request extends HTTPResource {
 						thumbInputStream = FullyPlayed.addFullyPlayedOverlay(thumbInputStream);
 					}
 					inputStream = thumbInputStream.transcode(imageProfile, mediaRenderer != null ? mediaRenderer.isThumbnailPadding() : false);
-					if (contentFeatures != null && inputStream instanceof DLNAThumbnailInputStream) {
+					if (contentFeatures != null) {
 						appendToHeader(
 							responseHeader,
-							"ContentFeatures.DLNA.ORG: " + dlna.getDlnaContentFeatures(((DLNAThumbnailInputStream) inputStream).getDLNAImageProfile())
+							"ContentFeatures.DLNA.ORG: " + dlna.getDlnaContentFeatures(imageProfile, true)
 						);
 					}
 					if (inputStream != null && (lowRange > 0 || highRange > 0)) {
@@ -401,10 +401,10 @@ public class Request extends HTTPResource {
 							LOGGER.warn("Input stream returned for \"{}\" was null, no image will be sent to renderer", fileName);
 						} else {
 							inputStream = DLNAImageInputStream.toImageInputStream(imageInputStream, imageProfile, false);
-							if (contentFeatures != null && inputStream instanceof DLNAImageInputStream) {
+							if (contentFeatures != null) {
 								appendToHeader(
 									responseHeader,
-									"ContentFeatures.DLNA.ORG: " + dlna.getDlnaContentFeatures(((DLNAImageInputStream) inputStream).getDLNAImageProfile())
+									"ContentFeatures.DLNA.ORG: " + dlna.getDlnaContentFeatures(imageProfile, false)
 								);
 							}
 							if (inputStream != null && (lowRange > 0 || highRange > 0)) {

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -340,10 +340,10 @@ public class RequestV2 extends HTTPResource {
 						thumbInputStream = FullyPlayed.addFullyPlayedOverlay(thumbInputStream);
 					}
 					inputStream = thumbInputStream.transcode(imageProfile, mediaRenderer != null ? mediaRenderer.isThumbnailPadding() : false);
-					if (contentFeatures != null && inputStream instanceof DLNAThumbnailInputStream) {
+					if (contentFeatures != null) {
 						output.headers().set(
 							"ContentFeatures.DLNA.ORG",
-							dlna.getDlnaContentFeatures(((DLNAThumbnailInputStream) inputStream).getDLNAImageProfile())
+							dlna.getDlnaContentFeatures(imageProfile, true)
 						);
 					}
 					if (inputStream != null && (lowRange > 0 || highRange > 0)) {
@@ -394,10 +394,10 @@ public class RequestV2 extends HTTPResource {
 							LOGGER.warn("Input stream returned for \"{}\" was null, no image will be sent to renderer", fileName);
 						} else {
 							inputStream = DLNAImageInputStream.toImageInputStream(imageInputStream, imageProfile, false);
-							if (contentFeatures != null && inputStream instanceof DLNAImageInputStream) {
+							if (contentFeatures != null) {
 								output.headers().set(
 									"ContentFeatures.DLNA.ORG",
-									dlna.getDlnaContentFeatures(((DLNAImageInputStream) inputStream).getDLNAImageProfile())
+									dlna.getDlnaContentFeatures(imageProfile, false)
 								);
 							}
 							if (inputStream != null && (lowRange > 0 || highRange > 0)) {

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -798,7 +798,7 @@ public class FileUtil {
 
 		boolean found = false;
 		if (file.exists()) {
-			found = browseFolderForSubtitles(file.getParentFile(), file, media, usecache);
+			found = browseFolderForSubtitles(file.getAbsoluteFile().getParentFile(), file, media, usecache);
 		}
 		String alternate = PMS.getConfiguration().getAlternateSubtitlesFolder();
 

--- a/src/test/java/net/pms/util/PlayerUtilTest.java
+++ b/src/test/java/net/pms/util/PlayerUtilTest.java
@@ -20,6 +20,7 @@ package net.pms.util;
 
 import ch.qos.logback.classic.LoggerContext;
 import java.io.File;
+import java.util.Random;
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.RealFile;
 import net.pms.dlna.WebStream;
@@ -29,30 +30,27 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
 public class PlayerUtilTest {
-	private DLNAResource video;
-	private DLNAResource audio;
-	private DLNAResource image;
-	private DLNAResource webImage;
-	private DLNAResource webVideo;
-	private DLNAResource webAudio;
+	private static DLNAResource video;
+	private static DLNAResource audio;
+	private static DLNAResource image;
+	private static DLNAResource webImage;
+	private static DLNAResource webVideo;
+	private static DLNAResource webAudio;
 
-	@Before
-	public void setUp() {
-		// Silence all log messages from the PMS code that is being tested
-		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-		context.reset();
-
+	@BeforeClass
+	public static void setUpClass() {
 		// initialise the fixtures
 		// XXX we need to call isValid to call checktype(), which is needed to initialise the format
-		image = new RealFile(new File("test.jpg"));
+		image = new RealFile(getNonExistingFile("test.jpg"));
 		image.isValid();
-		audio = new RealFile(new File("test.mp3"));
+		audio = new RealFile(getNonExistingFile("test.mp3"));
 		audio.isValid();
-		video = new RealFile(new File("test.mpg"));
+		video = new RealFile(getNonExistingFile("test.mpg"));
 		video.isValid();
 		webImage = new WebStream("", "http://example.com/test.jpg", "", Format.IMAGE);
 		webImage.isValid();
@@ -60,6 +58,13 @@ public class PlayerUtilTest {
 		webAudio.isValid();
 		webVideo = new WebStream("", "http://example.com/test.mpg", "", Format.VIDEO);
 		webVideo.isValid();
+	}
+
+	@Before
+	public void setUp() {
+		// Silence all log messages from the PMS code that is being tested
+		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+		context.reset();
 	}
 
 	@Test
@@ -174,5 +179,16 @@ public class PlayerUtilTest {
 		assertFalse(isWebVideo(webImage));
 		assertFalse(isWebVideo(webAudio));
 		assertTrue(isWebVideo(webVideo));
+	}
+
+	private static File getNonExistingFile(String initialname) {
+		String basename = FileUtil.getFileNameWithoutExtension(initialname);
+		String extension = FileUtil.getExtension(initialname);
+		Random random = new Random();
+		File result = new File(initialname);
+		while (result.exists()) {
+			result = new File(basename + random.nextInt() + "." + extension);
+		}
+		return result;
 	}
 }


### PR DESCRIPTION
I don't know what I was thinking when I implemented ```getContentFeatures()``` for images and thumbnails, but there were several things I hadn't taken into consideration. One of the things was simply that I don't seem to have considered that this applied to thumbnails at all.

This is quite a bad bug, as it will throw NPEs for most thumbnails and images for all renderers that request ```ContentFeatures``` (mostly older/DLNA 1.0 renderers). I have no idea how this passed testing without being revealed.

I have some problems testing this properly because I don't have a suitable renderer, but I think this fixes it. **Testing with appropriate renderers is needed**. I think this both fixes #1366 and fixes #1379.

While working on this I also came across some bugs in and related to ```PlayerUtiltest```. My tests kept failing and I checked out commits back to 6.5.3 with the same tests failing. After a lot of digging it turned out that the tests would fail if you happen to have a file with the same name as one of the file names used in the test (```test.jpg```, ```test.mp3``` and ```test.mpg```) in your repository root. I happened to have a ```test.mpg``` file from some FFmpeg testing.

I fixed this by making sure that the file names used in the test don't exist. A couple of NPEs were also revealed and fixed.