### PR TITLE
Revive parent folder thumbnails

### DIFF
--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -317,10 +317,32 @@ public class RealFile extends MapFile {
 				result = getMedia().getThumbnailInputStream();
 			}
 		} catch (IOException e) {
-			result = null;
-			LOGGER.debug("An error occurred while getting thumbnail for \"{}\", using generic thumbnail instead: {}", getName(), e.getMessage());
+			LOGGER.debug(
+				"An error occurred while getting thumbnail for \"{}\", using generic thumbnail instead: {}",
+				getName(),
+				e.getMessage()
+			);
 			LOGGER.trace("", e);
 		}
+
+		if (
+			result == null &&
+			getParent() != null &&
+			getParent() instanceof RealFile &&
+			((RealFile) getParent()).getPotentialCover() != null)
+		{
+			try {
+			result = DLNAThumbnailInputStream.toThumbnailInputStream(new FileInputStream(((RealFile) getParent()).getPotentialCover()));
+			} catch (IOException e) {
+				LOGGER.debug(
+					"An error occurred while getting parent folder thumbnail for \"{}\", using generic thumbnail instead: {}",
+					getName(),
+					e.getMessage()
+				);
+				LOGGER.trace("", e);
+			}
+		}
+
 		return result != null ? result : super.getThumbnailInputStream();
 	}
 


### PR DESCRIPTION
This is based on [this thread](http://www.universalmediaserver.com/forum/viewtopic.php?t=10592). This is not a bugfix, it's a question of how we want it to work.

There have been complaints in the past that folder thumbnails would override thumbnails for individual items. During #1061 and the introduction of the generic thumbnails, I removed this so that generic thumbnails would be shown instead. Folder thumbnails (```folder.jpg``` and ```folder.png```) is still used as the thumbnail for the folder itself, but not for the media items in the folder.

When I read the above thread, I was thinking that it might be better if a folder thumbnail would be shown if no thumbnail was found for the individual media item instead of a generic icon, if a folder thumbnail exists.

I'm not sure what is the "best" behaviour, ideally I think it should be possible to configure thumbnail priorities as I've mentioned before. This is a small tweak that makes folder thumbnails the "second last" priority only preferred over generic thumbnails, without taking on the larger project of making it configurable.

@UniversalMediaServer/developers Do you think this is an improvement, or is generic thumbnails a better solution?