### PR TITLE
Exclusion of cover/album art from media entries (#1375)

### DIFF
--- a/src/main/java/net/pms/dlna/DVDISOTitle.java
+++ b/src/main/java/net/pms/dlna/DVDISOTitle.java
@@ -345,10 +345,10 @@ public class DVDISOTitle extends DLNAResource {
 				thumbFolder = file.getParentFile();
 			}
 
-			cachedThumbnail = FileUtil.getFileNameWithNewExtension(thumbFolder, file, "jpg");
+			cachedThumbnail = FileUtil.replaceExtension(thumbFolder, file, "jpg", true, true);
 
 			if (cachedThumbnail == null) {
-				cachedThumbnail = FileUtil.getFileNameWithNewExtension(thumbFolder, file, "png");
+				cachedThumbnail = FileUtil.replaceExtension(thumbFolder, file, "png", true, true);
 			}
 
 			if (cachedThumbnail == null) {

--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -342,9 +342,7 @@ public class Request extends HTTPResource {
 					if (!configuration.isShowCodeThumbs() && !dlna.isCodeValid(dlna)) {
 						thumbInputStream = dlna.getGenericThumbnailInputStream(null);
 					} else {
-						if (mediaRenderer.isUseMediaInfo()) {
-							dlna.checkThumbnail();
-						}
+						dlna.checkThumbnail();
 						thumbInputStream = dlna.fetchThumbnailInputStream();
 					}
 					if (dlna instanceof RealFile && FullyPlayed.isFullyPlayedThumbnail(((RealFile) dlna).getFile())) {

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -331,9 +331,7 @@ public class RequestV2 extends HTTPResource {
 					if (!configuration.isShowCodeThumbs() && !dlna.isCodeValid(dlna)) {
 						thumbInputStream = dlna.getGenericThumbnailInputStream(null);
 					} else {
-						if (mediaRenderer.isUseMediaInfo()) {
-							dlna.checkThumbnail();
-						}
+						dlna.checkThumbnail();
 						thumbInputStream = dlna.fetchThumbnailInputStream();
 					}
 					if (dlna instanceof RealFile && FullyPlayed.isFullyPlayedThumbnail(((RealFile) dlna).getFile())) {

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -28,6 +28,7 @@ import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAMediaSubtitle;
 import net.pms.formats.FormatFactory;
 import net.pms.formats.v2.SubtitleType;
+import net.pms.util.StringUtil.LetterCase;
 import static net.pms.util.Constants.*;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.WordUtils;
@@ -193,10 +194,6 @@ public class FileUtil {
 		}
 	}
 
-	public static File isFileExists(String f, String ext) {
-		return isFileExists(new File(f), ext);
-	}
-
 	public static boolean isUrl(String filename) {
 		// We're intentionally avoiding stricter URI() methods, which can throw
 		// URISyntaxException for psuedo-urls (e.g. librtmp-style urls containing spaces)
@@ -227,21 +224,82 @@ public class FileUtil {
 		return getExtension(substringBefore(u, "?"));
 	}
 
-	public static String getExtension(File f) {
-		if (f == null || f.getName() == null) {
-			return null;
-		}
-		return getExtension(f.getName());
+	/**
+	 * Returns the file extension from the specified {@link File} or
+	 * {@code null} if it has no extension.
+	 *
+	 * @param file the {@link File} from which to extract the extension.
+	 * @return The extracted extension or {@code null}.
+	 */
+	public static String getExtension(File file) {
+		return getExtension(file, null, null);
 	}
 
-	public static String getExtension(String f) {
-		int point = f.lastIndexOf('.');
+	/**
+	 * Returns the file extension from the specified {@link File} or
+	 * {@code null} if it has no extension.
+	 *
+	 * @param file the {@link File} from which to extract the extension.
+	 * @param convertTo if {@code null} makes no letter case change to the
+	 *            returned {@link String}, otherwise converts the extracted
+	 *            extension (if any) to the corresponding letter case.
+	 * @param locale the {@link Locale} to use for letter case conversion.
+	 *            Defaults to {@link Locale#ROOT} if {@code null}.
+	 * @return The extracted and potentially letter case converted extension or
+	 *         {@code null}.
+	 */
+	public static String getExtension(File file, LetterCase convertTo, Locale locale) {
+		if (file == null || file.getName() == null) {
+			return null;
+		}
+		return getExtension(file.getName(), convertTo, locale);
+	}
 
+	/**
+	 * Returns the file extension from {@code fileName} or {@code null} if
+	 * {@code fileName} has no extension.
+	 *
+	 * @param fileName the file name from which to extract the extension.
+	 * @return The extracted extension or {@code null}.
+	 */
+	public static String getExtension(String fileName) {
+		return getExtension(fileName, null, null);
+	}
+
+	/**
+	 * Returns the file extension from {@code fileName} or {@code null} if
+	 * {@code fileName} has no extension.
+	 *
+	 * @param fileName the file name from which to extract the extension.
+	 * @param convertTo if {@code null} makes no letter case change to the
+	 *            returned {@link String}, otherwise converts the extracted
+	 *            extension (if any) to the corresponding letter case.
+	 * @param locale the {@link Locale} to use for letter case conversion.
+	 *            Defaults to {@link Locale#ROOT} if {@code null}.
+	 * @return The extracted and potentially letter case converted extension or
+	 *         {@code null}.
+	 */
+	public static String getExtension(String fileName, LetterCase convertTo, Locale locale) {
+		if (fileName == null) {
+			return null;
+		}
+
+		int point = fileName.lastIndexOf('.');
 		if (point == -1) {
 			return null;
 		}
+		if (convertTo != null && locale == null) {
+			locale = Locale.ROOT;
+		}
 
-		return f.substring(point + 1);
+		String extension = fileName.substring(point + 1);
+		if (convertTo == LetterCase.UPPER) {
+			return extension.toUpperCase(locale);
+		}
+		if (convertTo == LetterCase.LOWER) {
+			return extension.toLowerCase(locale);
+		}
+		return extension;
 	}
 
 	public static String getFileNameWithoutExtension(String f) {
@@ -721,16 +779,20 @@ public class FileUtil {
 		return matcher.find() ? matcher.start() : -1;
 	}
 
+	/**
+	 * @deprecated Use {@link #replaceExtension} instead.
+	 */
+	@Deprecated
 	public static File getFileNameWithNewExtension(File parent, File file, String ext) {
-		return isFileExists(new File(parent, file.getName()), ext);
+		return replaceExtension(parent, file, ext, true, true);
 	}
 
 	/**
-	 * @deprecated Use {@link #getFileNameWithNewExtension(File, File, String)}.
+	 * @deprecated Use {@link #replaceExtension} instead.
 	 */
 	@Deprecated
 	public static File getFileNameWitNewExtension(File parent, File f, String ext) {
-		return getFileNameWithNewExtension(parent, f, ext);
+		return replaceExtension(parent, f, ext, true, true);
 	}
 
 	public static File getFileNameWithAddedExtension(File parent, File f, String ext) {
@@ -751,24 +813,159 @@ public class FileUtil {
 		return getFileNameWithAddedExtension(parent, file, ext);
 	}
 
+	/**
+	 * @deprecated Use {@link #replaceExtension} instead.
+	 */
+	@Deprecated
+	public static File isFileExists(String f, String ext) {
+		return replaceExtension(new File(f), ext, true, true);
+	}
+
+	/**
+	 * @deprecated Use {@link #replaceExtension} instead.
+	 */
+	@Deprecated
 	public static File isFileExists(File f, String ext) {
-		int point = f.getName().lastIndexOf('.');
+		return replaceExtension(f, ext, true, true);
+	}
 
+	/**
+	 * Returns a new {@link File} instance where the file extension has been
+	 * replaced.
+	 *
+	 * @param file the {@link File} for which to replace the extension.
+	 * @param extension the new file extension.
+	 * @param nullIfNonExisting whether or not to return {@code null} or a
+	 *            non-existing {@link File} instance if the constructed
+	 *            {@link File} doesn't exist.
+	 * @param adjustExtensionCase whether or not to try upper- and lower-case
+	 *            variants of the extension. If {@code true} and the constructed
+	 *            {@link File} doesn't exist with the given case but does exist
+	 *            with an either upper or lower case version of the extension,
+	 *            the existing {@link File} instance will be returned.
+	 * @return The constructed {@link File} instance or {@code null} if the
+	 *         target file doesn't exist and {@code nullIfNonExisting} is true.
+	 */
+	public static File replaceExtension(
+		File file,
+		String extension,
+		boolean nullIfNonExisting,
+		boolean adjustExtensionCase
+	) {
+		if (file == null) {
+			return null;
+		}
+		return replaceExtension(
+			file.getParentFile(),
+			file.getName(),
+			extension,
+			nullIfNonExisting,
+			adjustExtensionCase
+		);
+	}
+
+	/**
+	 * Returns a new {@link File} instance where the file extension has been
+	 * replaced.
+	 *
+	 * @param folder the {@link File} instance representing the folder for the
+	 *            constructed {@link File}. Use {@code null} or an empty string
+	 *            for the current folder.
+	 * @param file the {@link File} for which to replace the extension. Only the
+	 *            file name will be used, its path will be discarded.
+	 * @param extension the new file extension.
+	 * @param nullIfNonExisting whether or not to return {@code null} or a
+	 *            non-existing {@link File} instance if the constructed
+	 *            {@link File} doesn't exist.
+	 * @param adjustExtensionCase whether or not to try upper- and lower-case
+	 *            variants of the extension. If {@code true} and the constructed
+	 *            {@link File} doesn't exist with the given case but does exist
+	 *            with an either upper or lower case version of the extension,
+	 *            the existing {@link File} instance will be returned.
+	 * @return The constructed {@link File} instance or {@code null} if the
+	 *         target file doesn't exist and {@code nullIfNonExisting} is true.
+	 */
+	public static File replaceExtension(
+		File folder,
+		File file,
+		String extension,
+		boolean nullIfNonExisting,
+		boolean adjustExtensionCase
+	) {
+		if (file == null) {
+			return null;
+		}
+		return replaceExtension(
+			folder,
+			file.getName(),
+			extension,
+			nullIfNonExisting,
+			adjustExtensionCase
+		);
+	}
+
+	/**
+	 * Returns a new {@link File} instance where the file extension has been
+	 * replaced.
+	 *
+	 * @param folder the {@link File} instance representing the folder for the
+	 *            constructed {@link File}. Use {@code null} or an empty string
+	 *            for the current folder.
+	 * @param fileName the {@link String} for which to replace the extension.
+	 * @param extension the new file extension.
+	 * @param nullIfNonExisting whether or not to return {@code null} or a
+	 *            non-existing {@link File} instance if the constructed
+	 *            {@link File} doesn't exist.
+	 * @param adjustExtensionCase whether or not to try upper- and lower-case
+	 *            variants of the extension. If {@code true} and the constructed
+	 *            {@link File} doesn't exist with the given case but does exist
+	 *            with an either upper or lower case version of the extension,
+	 *            the existing {@link File} instance will be returned.
+	 * @return The constructed {@link File} instance or {@code null} if the
+	 *         target file doesn't exist and {@code nullIfNonExisting} is true.
+	 */
+	public static File replaceExtension(
+		File folder,
+		String fileName,
+		String extension,
+		boolean nullIfNonExisting,
+		boolean adjustExtensionCase
+	) {
+		if (isBlank(fileName)) {
+			return null;
+		}
+
+		int point = fileName.lastIndexOf('.');
+
+		String baseFileName;
 		if (point == -1) {
-			point = f.getName().length();
+			baseFileName = fileName;
+		} else {
+			baseFileName = fileName.substring(0, point);
 		}
 
-		File lowerCasedFile = new File(f.getParentFile(), f.getName().substring(0, point) + "." + ext.toLowerCase());
-		if (lowerCasedFile.exists()) {
-			return lowerCasedFile;
+		if (isBlank(extension)) {
+			File result = new File(folder, baseFileName);
+			return !nullIfNonExisting || result.exists() ? result : null;
 		}
 
-		File upperCasedFile = new File(f.getParentFile(), f.getName().substring(0, point) + "." + ext.toUpperCase());
-		if (upperCasedFile.exists()) {
-			return upperCasedFile;
+		File result = new File(folder, baseFileName + "." + extension);
+		if (result.exists() || !nullIfNonExisting && !adjustExtensionCase) {
+			return result;
 		}
 
-		return null;
+		if (!Platform.isWindows() && adjustExtensionCase) {
+			File adjustedResult = new File(folder, baseFileName + "." + extension.toLowerCase(Locale.ROOT));
+			if (adjustedResult.exists()) {
+				return adjustedResult;
+			}
+			adjustedResult = new File(folder, baseFileName + "." + extension.toUpperCase(Locale.ROOT));
+			if (adjustedResult.exists()) {
+				return adjustedResult;
+			}
+		}
+
+		return nullIfNonExisting ? null : result;
 	}
 
 	/**
@@ -851,7 +1048,7 @@ public class FileUtil {
 							if ("sub".equals(ext)) {
 								// Avoid microdvd/vobsub confusion by ignoring sub+idx pairs here since
 								// they'll come in unambiguously as vobsub via the idx file anyway
-								return isFileExists(new File(dir, name), "idx") == null;
+								return replaceExtension(new File(dir, name), "idx", true, true) == null;
 							}
 							return supported.contains(ext);
 						}
@@ -983,14 +1180,13 @@ public class FileUtil {
 				if (Charset.isSupported(match.getName())) {
 					LOGGER.debug("Detected charset \"{}\" in file {}", match.getName(), file.getAbsolutePath());
 					return Charset.forName(match.getName());
-				} else {
-					LOGGER.debug(
-						"Detected charset \"{}\" in file {}, but cannot use it because it's not supported by the Java Virual Machine",
-						match.getName(),
-						file.getAbsolutePath()
-					);
-					return null;
 				}
+				LOGGER.debug(
+					"Detected charset \"{}\" in file {}, but cannot use it because it's not supported by the Java Virual Machine",
+					match.getName(),
+					file.getAbsolutePath()
+				);
+				return null;
 			} catch (IllegalCharsetNameException e) {
 				LOGGER.debug("Illegal charset deteceted \"{}\" in file {}", match.getName(), file.getAbsolutePath());
 			}
@@ -1012,10 +1208,9 @@ public class FileUtil {
 		if (match != null) {
 			LOGGER.debug("Detected charset \"{}\" in file {}", match.getName(), file.getAbsolutePath());
 			return match.getName().toUpperCase(PMS.getLocale());
-		} else {
-			LOGGER.debug("Found no matching charset for file {}", file.getAbsolutePath());
-			return null;
 		}
+		LOGGER.debug("Found no matching charset for file {}", file.getAbsolutePath());
+		return null;
 	}
 
 	/**
@@ -1207,10 +1402,9 @@ public class FileUtil {
 	public static FilePermissions getFilePermissions(String path) throws FileNotFoundException {
 		if (path != null) {
 			return new FilePermissions(new File(path));
-		} else {
-			File file = null;
-			return new FilePermissions(file);
 		}
+		File file = null;
+		return new FilePermissions(file);
 	}
 
 	/**
@@ -1225,9 +1419,8 @@ public class FileUtil {
 			} catch (FileNotFoundException | IllegalArgumentException e) {
 				return null;
 			}
-		} else {
-			return null;
 		}
+		return null;
 	}
 
 	public static boolean isFileRelevant(File f, PmsConfiguration configuration) {
@@ -1546,8 +1739,7 @@ public class FileUtil {
 				}
 				return unixUID;
 			}
-		} else {
-			throw new UnsupportedOperationException("getUnixUID can only be called on Unix based OS'es");
 		}
+		throw new UnsupportedOperationException("getUnixUID can only be called on Unix based OS'es");
 	}
 }

--- a/src/main/java/net/pms/util/GenericIcons.java
+++ b/src/main/java/net/pms/util/GenericIcons.java
@@ -90,7 +90,13 @@ public enum GenericIcons {
 	 *         if one couldn't be generated.
 	 */
 	public DLNAThumbnailInputStream getGenericIcon(DLNAResource resource) {
-		ImageFormat imageFormat = ImageFormat.JPEG;
+		/*
+		 * This should be the same format as the source images since OpenJDK
+		 * will fail to write JPEGs if the cached BufferedImage has 4 color
+		 * components. Alternatively the color model of the cached
+		 * BufferedImages would have to be converted to 3 components first.
+		 */
+		ImageFormat imageFormat = ImageFormat.PNG;
 
 		if (resource == null) {
 			ImageIO.setUseCache(false);

--- a/src/main/java/net/pms/util/StringUtil.java
+++ b/src/main/java/net/pms/util/StringUtil.java
@@ -24,12 +24,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.text.SimpleDateFormat;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Formatter;
 import java.util.Locale;
-import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.JEditorPane;
@@ -676,5 +673,17 @@ public class StringUtil {
 			return String.format(locale, "%d %s", bytes / divisor, unit);
 		}
 		return String.format(locale, "%.1f %s", (double) bytes / divisor, unit);
+	}
+
+	/**
+	 * An enum representing letter cases.
+	 */
+	public static enum LetterCase {
+
+		/** Upper-case, uppercase, capital or majuscule */
+		UPPER,
+
+		/** Lower-case, lowercase or minuscule */
+		LOWER
 	}
 }


### PR DESCRIPTION
This hopefully fixes #1375. Both "folder" images and images that match audio or video file names (either by same name with different extension or by adding ```.cover.jpg``` or ```.cover.png``` to the file name is hidden.

The real changes are in ```MapFile```, the other changes are simply bugfixes and optimizations.