### PR TITLE
Fix replaceExtension for usage with directories on non-windows OS

### DIFF
--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -282,7 +282,7 @@ public class RealFile extends MapFile {
 
 		if (file.isDirectory()) {
 			cachedThumbnail = FileUtil.replaceExtension(file, "folder.jpg", true, false);
-			
+
 			if (cachedThumbnail == null) {
 				cachedThumbnail = FileUtil.replaceExtension(file, "folder.png", true, false);
 			}

--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -281,10 +281,10 @@ public class RealFile extends MapFile {
 		}
 
 		if (file.isDirectory()) {
-			cachedThumbnail = FileUtil.replaceExtension(file, "/folder.jpg", true, false);
-
+			cachedThumbnail = FileUtil.replaceExtension(file, "folder.jpg", true, false);
+			
 			if (cachedThumbnail == null) {
-				cachedThumbnail = FileUtil.replaceExtension(file, "/folder.png", true, false);
+				cachedThumbnail = FileUtil.replaceExtension(file, "folder.png", true, false);
 			}
 		}
 

--- a/src/test/java/net/pms/util/FileUtilTest.java
+++ b/src/test/java/net/pms/util/FileUtilTest.java
@@ -390,4 +390,21 @@ public class FileUtilTest {
 		assertEquals("AppendMissingSlash", FileUtil.appendPathSeparator("foo/bar"), "foo/bar/");
 		assertEquals("DontAppendSlash", FileUtil.appendPathSeparator("foo/bar/"), "foo/bar/");
 	}
+	
+	@Test
+	public void testReplaceExtension() throws Exception {
+		File dir1 = FileUtils.getTempDirectory();
+		File file1 = File.createTempFile("ums-test", ".temp", dir1);
+		assertThat( FileUtil.replaceExtension(file1, ".foo", true, false) ).isEqualTo( null );
+		assertThat( FileUtil.replaceExtension(file1, ".foo", false, false) ).isInstanceOf( File.class ).doesNotExist();
+		assertThat( FileUtil.replaceExtension(file1, "bar", false, false) ).isInstanceOf( File.class ).doesNotExist();
+		assertThat( FileUtil.replaceExtension(file1, "", true, false).getAbsolutePath() ).isEqualTo(file1.getAbsolutePath());
+		assertThat( FileUtil.replaceExtension(file1, "", false, false).getAbsolutePath() ).isEqualTo(file1.getAbsolutePath());
+		assertThat( FileUtil.replaceExtension(dir1, "foo", true, false) ).isEqualTo(null);
+		assertThat( FileUtil.replaceExtension(dir1, "foo", false, false) ).isInstanceOf( File.class ).doesNotExist();
+		assertThat( FileUtil.replaceExtension(dir1, file1.getName(), true, false).getAbsolutePath() ).isEqualTo(file1.getAbsolutePath());
+		assertThat( FileUtil.replaceExtension(dir1, file1, "foo", true, true) ).isEqualTo( null );
+		file1.delete();
+	}
+	
 }


### PR DESCRIPTION
On Linux or unix like OSs, previously replaceExtension appended a period before the separator, eg "Dir./folder.jpg". Fixed method for replacement in all cases, files and folders, and added associated unit tests.