### PR TITLE
Fixed regression in folder thumbnails on non-Windows platforms

### DIFF
--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -281,11 +281,7 @@ public class RealFile extends MapFile {
 		}
 
 		if (file.isDirectory()) {
-			cachedThumbnail = FileUtil.replaceExtension(file, "/folder.jpg", true, false);
-
-			if (cachedThumbnail == null) {
-				cachedThumbnail = FileUtil.replaceExtension(file, "/folder.png", true, false);
-			}
+			cachedThumbnail = MapFile.getFolderThumbnail(file);
 		}
 
 		boolean hasAlreadyEmbeddedCoverArt = getType() == Format.AUDIO && getMedia() != null && getMedia().getThumb() != null;


### PR DESCRIPTION
It seems I forgot to refactor parts of the involved code in #1385, which broke folder thumbnails on Linux and macOS. Thanks to @sammyrc34 for discovering this in #1391.

@SubJunk I think this should be in before 6.7.4 as well, since you didn't release it this weekend.