### PR TITLE
Dirty fix for testing the issue #1401

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
 		<maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
 		<git-commit-id-plugin-version>2.2.2</git-commit-id-plugin-version>
-		<maven-assembly-plugin-version>3.0.0</maven-assembly-plugin-version>
+		<maven-assembly-plugin-version>3.1.0</maven-assembly-plugin-version>
 
 		<!--
 			org.slf4j:slf4j-api is shared with
@@ -218,7 +218,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.7</version>
+			<version>2.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
@@ -780,7 +780,7 @@
 
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.7.0</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -34,7 +34,6 @@ import net.pms.configuration.FormatConfiguration;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.dlna.DLNAImageProfile.HypotheticalResult;
-import net.pms.dlna.protocolinfo.ProtocolInfo;
 import net.pms.dlna.virtual.TranscodeVirtualFolder;
 import net.pms.dlna.virtual.VirtualFolder;
 import net.pms.dlna.virtual.VirtualVideoAction;
@@ -444,7 +443,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		int localizationValue = 1;
 		String dlnaOrgPnFlags = null;
 		if (getType() == Format.VIDEO || getType() == Format.AUDIO) {
-			String orgPnValue = requestedURL.substring(requestedURL.lastIndexOf("_") + 1, requestedURL.lastIndexOf("."));
+			String orgPnValue = requestedURL.substring(requestedURL.lastIndexOf("/") + 1, requestedURL.indexOf("_"));
 			if (orgPnValue != null) {
 				dlnaOrgPnFlags = "DLNA_ORG_PN=" + orgPnValue;
 			}
@@ -2650,34 +2649,36 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				String transcodedExtension = "";
 				if (player != null && media != null) {
 					// Note: Can't use instanceof below because the audio classes inherit the corresponding video class
-					
-					
 					if (media.isVideo()) {
 						if (mediaRenderer.isTranscodeToMPEGTS()) {
-							transcodedExtension = ".ts";
+							transcodedExtension = "_transcoded_to.ts";
 						} else if (mediaRenderer.isTranscodeToWMV() && !xbox360) {
-							transcodedExtension = ".wmv";
+							transcodedExtension = "_transcoded_to.wmv";
 						} else {
-							transcodedExtension = ".mpg";
+							transcodedExtension = "_transcoded_to.mpg";
 						}
 					} else if (media.isAudio()) {
 						if (mediaRenderer.isTranscodeToMP3()) {
-							transcodedExtension = ".mp3";
+							transcodedExtension = "_transcoded_to.mp3";
 						} else if (mediaRenderer.isTranscodeToWAV()) {
-							transcodedExtension = ".wav";
+							transcodedExtension = "_transcoded_to.wav";
 						} else {
-							transcodedExtension = ".pcm";
+							transcodedExtension = "_transcoded_to.pcm";
 						}
 					}
 				}
 
-				String orgPnFlag = null;
+				StringBuilder updatedFileURL = new StringBuilder();
+				updatedFileURL.append(getFileURL().substring(0, getFileURL().lastIndexOf("/") + 1));
 				if (dlnaOrgPnFlags != null) {
-					orgPnFlag = dlnaOrgPnFlags.substring(dlnaOrgPnFlags.indexOf("=") + 1);
+					updatedFileURL.append(dlnaOrgPnFlags.substring(dlnaOrgPnFlags.indexOf("=") + 1))
+					.append("_");
 				}
 
-				wireshark.append(' ').append(getFileURL()).append("_").append(orgPnFlag).append(transcodedExtension);
-				sb.append(getFileURL()).append("_").append(orgPnFlag).append(transcodedExtension);
+				updatedFileURL.append(getFileURL().substring(getFileURL().lastIndexOf("/") + 1));
+
+				wireshark.append(' ').append(updatedFileURL).append(transcodedExtension);
+				sb.append(updatedFileURL).append(transcodedExtension);
 				LOGGER.trace("Network debugger: " + wireshark.toString());
 				wireshark.setLength(0);
 				closeTag(sb, "res");

--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -557,7 +557,7 @@ public class Request extends HTTPResource {
 						}
 
 						if (contentFeatures != null) {
-							appendToHeader(responseHeader, "ContentFeatures.DLNA.ORG: " + dlna.getDlnaContentFeatures(mediaRenderer));
+							appendToHeader(responseHeader, "ContentFeatures.DLNA.ORG: " + dlna.getDlnaContentFeatures(mediaRenderer, argument));
 						}
 
 						if (dlna.getPlayer() == null || xbox360) {

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -597,7 +597,7 @@ public class RequestV2 extends HTTPResource {
 						highRange = lowRange + CLoverride - (CLoverride > 0 ? 1 : 0);
 
 						if (contentFeatures != null) {
-							output.headers().set("ContentFeatures.DLNA.ORG", dlna.getDlnaContentFeatures(mediaRenderer));
+							output.headers().set("ContentFeatures.DLNA.ORG", dlna.getDlnaContentFeatures(mediaRenderer, argument));
 						}
 
 						output.headers().set(HttpHeaders.Names.ACCEPT_RANGES, HttpHeaders.Values.BYTES);


### PR DESCRIPTION
The DIDL-Lite sends always the MPEG_PS_PALLocalizedValue but it should be determined if renderer is
capable to use it by using ProtocolInfo.