### PR TITLE
Fix DTS and AC-3 passthrough regression

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -929,17 +929,33 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			} else if (!format.isCompatible(media, renderer)) {
 				isIncompatible = true;
 				LOGGER.trace(prependTraceReason + "it is not supported by the renderer", getName());
-			} else if (
-				configurationSpecificToRenderer.isEncodedAudioPassthrough() &&
-				getMediaAudio() != null &&
-				(
-					"AC3".equals(getMediaAudio().getAudioCodec()) ||
-					"DTS".equals(getMediaAudio().getAudioCodec())
-				)
-			) {
-				isIncompatible = true;
-				LOGGER.trace(prependTraceReason + "the audio will use the encoded audio passthrough feature", getName());
-			} else if (format.isVideo() && parserV2 && renderer != null) {
+			} else if (configurationSpecificToRenderer.isEncodedAudioPassthrough()) {
+				if (
+					getMediaAudio() != null &&
+					(
+						FormatConfiguration.AC3.equals(getMediaAudio().getAudioCodec()) ||
+						FormatConfiguration.DTS.equals(getMediaAudio().getAudioCodec())
+					)
+				) {
+					isIncompatible = true;
+					LOGGER.trace(prependTraceReason + "the audio will use the encoded audio passthrough feature", getName());
+				} else {
+					for (DLNAMediaAudio audioTrack : media.getAudioTracksList()) {
+						if (
+							audioTrack != null &&
+							(
+								FormatConfiguration.AC3.equals(audioTrack.getAudioCodec()) ||
+								FormatConfiguration.DTS.equals(audioTrack.getAudioCodec())
+							)
+						) {
+							isIncompatible = true;
+							LOGGER.trace(prependTraceReason + "the audio will use the encoded audio passthrough feature", getName());
+							break;
+						}
+					}
+				}
+			}
+			if (!isIncompatible && format.isVideo() && parserV2 && renderer != null) {
 				int maxBandwidth = renderer.getMaxBandwidth();
 
 				if (

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -919,7 +919,6 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			// Should transcoding be forced for this format?
 			boolean forceTranscode = format.skip(configurationForceExtensions, rendererForceExtensions);
 			boolean isIncompatible = false;
-			String audioTracksList = getName() + media.getAudioTracksList().toString();
 
 			String prependTraceReason = "File \"{}\" will not be streamed because ";
 			if (forceTranscode) {
@@ -932,9 +931,10 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				LOGGER.trace(prependTraceReason + "it is not supported by the renderer", getName());
 			} else if (
 				configurationSpecificToRenderer.isEncodedAudioPassthrough() &&
+				getMediaAudio() != null &&
 				(
-					audioTracksList.contains("audio codec: AC3") ||
-					audioTracksList.contains("audio codec: DTS")
+					"AC3".equals(getMediaAudio().getAudioCodec()) ||
+					"DTS".equals(getMediaAudio().getAudioCodec())
 				)
 			) {
 				isIncompatible = true;


### PR DESCRIPTION
This fixes a regressions in c4de4b52b47cd05e5322a78bd9333e5d086ca7ab that was caused by me (while rebasing), although the commit was by @Sami32. I had changed the capitalization of some words in ```DLNAMediaAudio.toString()``` which broke the bad hack made in 5e5338c7ed4d6f6521b574754d88ca5c9f49b8ca. Thanks to @Sami32 for finding this sneaky bug 👍 

The hack made was very unsafe and was bound to break sooner or later. As such I didn't simply "fix" it by correcting the capitalization, as that would just break the next time someone did something with the log output.

@SubJunk Neither your commit message nor your code makes it quite clear to me what the purpose of 5e5338c7ed4d6f6521b574754d88ca5c9f49b8ca was. To correct it I've thus had to guess a bit. It seems to me that the intention was for the video to be transcoded not only if the selected audio track is DTS or AC-3, but if *any* of the audio tracks are. My fix has thus implemented that. If the intention was somewhat different, so please tell me if what I've done is correct or wrong.

I've also added DTSHD to this, although I don't know if DTSHD works with audio passthrough. I assume that some of you already know this, so please let me know if DTSHD should stay or be removed from this condition.