### PR TITLE
Fix exception in GetProtocolInfo

### DIFF
--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -722,13 +722,14 @@ public class UPNPControl {
 				new ActionCallback(actionInvocation, upnpService.getControlPoint()) {
 					@Override
 					public void success(ActionInvocation invocation) {
-						String sink = invocation.getOutput("Sink").toString();
-						rendererMap.get(uuid, "0").deviceProtocolInfo.add(DeviceProtocolInfo.GET_PROTOCOLINFO_SINK, sink);
+						Map<String, ActionArgumentValue<RemoteService>> outputs = invocation.getOutputMap();
+						ActionArgumentValue<RemoteService> sink = outputs.get("Sink");
+						if (sink != null) {
+							rendererMap.get(uuid, "0").deviceProtocolInfo.add(DeviceProtocolInfo.GET_PROTOCOLINFO_SINK, sink.toString());
+						}
 						if (LOGGER.isTraceEnabled()) {
 							StringBuilder sb = new StringBuilder();
-							for (Object element : invocation.getOutputMap().entrySet()) {
-								@SuppressWarnings("unchecked")
-								Entry<String, ActionArgumentValue<?>> entry = (Entry<String, ActionArgumentValue<?>>) element;
+							for (Entry<String, ActionArgumentValue<RemoteService>> entry : outputs.entrySet()) {
 								if (entry.getValue() != null) {
 									String value = entry.getValue().toString();
 									if (isNotBlank(value)) {


### PR DESCRIPTION
It turns out that Cling throws and ```IllegalArgumentException``` if you ask for an "action" that doesn't exist in the output. Usually, and per UPnP specification AFAICR, ```Sink``` will be among the actions, but I've just studied a user log where that wasn't the case - resulting in an unhandled (runtime) ```Exception```.

I've rewritten the parsing slightly to avoid that situation.