### PR TITLE
Improved MusicBrainz match logic for cover art retrieval

### DIFF
--- a/src/main/java/net/pms/util/CoverArtArchiveUtil.java
+++ b/src/main/java/net/pms/util/CoverArtArchiveUtil.java
@@ -81,6 +81,7 @@ public class CoverArtArchiveUtil extends CoverUtil {
 		String id;
 		int score;
 		String title;
+		String album;
 		List<String> artists = new ArrayList<>();
 		ReleaseType type;
 		String year;
@@ -92,6 +93,7 @@ public class CoverArtArchiveUtil extends CoverUtil {
 			id = source.id;
 			score = source.score;
 			title = source.title;
+			album = source.album;
 			type = source.type;
 			year = source.year;
 			for (String artist : source.artists) {
@@ -486,8 +488,16 @@ public class CoverArtArchiveUtil extends CoverUtil {
 				if (image == null) {
 					image = coverArt.getImages().get(0);
 				}
-				try (InputStream is = image.getLargeThumbnail()) {
-					byte[] cover = IOUtils.toByteArray(is);
+				byte[] cover = null;
+				try {
+					try (InputStream is = image.getLargeThumbnail()) {
+						cover = IOUtils.toByteArray(is);
+					} catch (HttpResponseException e) {
+						// Use the default image if the large thumbnail is not available
+						try (InputStream is = image.getImage()) {
+							cover = IOUtils.toByteArray(is);
+						}
+					}
 					TableCoverArtArchive.writeMBID(mBID, cover);
 					return cover;
 				} catch (HttpResponseException e) {
@@ -534,24 +544,11 @@ public class CoverArtArchiveUtil extends CoverUtil {
 			added = true;
 		}
 
-		if (StringUtil.hasValue(tagInfo.artistId)) {
-			if (added) {
-				query.append(AND);
-			}
-			query.append("arid:").append(tagInfo.artistId);
-			added = true;
-		} else if (StringUtil.hasValue(tagInfo.artist)) {
-			if (added) {
-				query.append(AND);
-			}
-			query.append("artistname:");
-			if (fuzzy) {
-				query.append(urlEncode(fuzzString(tagInfo.artist)));
-			} else {
-				query.append(urlEncode("\"" + StringUtil.luceneEscape(tagInfo.artist) + "\""));
-			}
-			added = true;
-		}
+		/*
+		 * Release (album) artist is usually the music director of the album.
+		 * Track (Recording) artist is usually the singer. Searching release
+		 * with artist here is likely to return no result.
+		 */
 
 		if (
 			StringUtil.hasValue(tagInfo.trackId) && (
@@ -586,7 +583,7 @@ public class CoverArtArchiveUtil extends CoverUtil {
 			added = true;
 		}
 
-		if (StringUtil.hasValue(tagInfo.year)) {
+		if (!fuzzy && StringUtil.hasValue(tagInfo.year) && tagInfo.year.trim().length() > 3) {
 			if (added) {
 				query.append(AND);
 			}
@@ -636,7 +633,7 @@ public class CoverArtArchiveUtil extends CoverUtil {
 			}
 		}
 
-		if (StringUtil.hasValue(tagInfo.year)) {
+		if (!fuzzy && StringUtil.hasValue(tagInfo.year) && tagInfo.year.trim().length() > 3) {
 			if (added) {
 				query.append(AND);
 			}
@@ -765,33 +762,42 @@ public class CoverArtArchiveUtil extends CoverUtil {
 							// matching quality turns out to be to low
 							int maxScore = 0;
 							for (ReleaseRecord release : releaseList) {
+								boolean found = false;
 								if (StringUtil.hasValue(tagInfo.artist)) {
-									boolean found = false;
-									for (String s : release.artists) {
-										if (s.equalsIgnoreCase(tagInfo.artist)) {
-											found = true;
-											break;
+									String[] tagArtists = tagInfo.artist.split("[,&]");
+									for (String artist : release.artists) {
+										for (String tagArtist : tagArtists) {
+											if (StringUtil.isEqual(tagArtist, artist, false, true, true, null)) {
+												release.score += 30;
+												found = true;
+												break;
+											}
 										}
-									}
-									if (found) {
-										release.score += 30;
 									}
 								}
 								if (StringUtil.hasValue(tagInfo.album)) {
-									if (release.type == ReleaseType.Album) {
-										release.score += 20;
-										if (release.title.equalsIgnoreCase(tagInfo.album)) {
+									if (StringUtil.isEqual(tagInfo.album, release.album, false, true, true, null)) {
 											release.score += 30;
-										}
+											found = true;
 									}
-								} else if (StringUtil.hasValue(tagInfo.title)) {
-									if ((round > 2 || release.type == ReleaseType.Single) && release.title.equalsIgnoreCase(tagInfo.title)) {
+								}
+								if (StringUtil.hasValue(tagInfo.title)) {
+									if (StringUtil.isEqual(tagInfo.title, release.title, false, true, true, null)) {
 										release.score += 40;
+										found = true;
 									}
 								}
 								if (StringUtil.hasValue(tagInfo.year) && StringUtil.hasValue(release.year)) {
-									if (tagInfo.year.equals(release.year)) {
+									if (StringUtil.isSameYear(tagInfo.year, release.year)) {
 										release.score += 20;
+									}
+								}
+								// Prefer Single > Album > Compilation
+								if (found) {
+									if (release.type == ReleaseType.Single) {
+										release.score += 20;
+									} else if (release.type == null || release.type == ReleaseType.Album) {
+										release.score += 10;
 									}
 								}
 								maxScore = Math.max(maxScore, release.score);
@@ -858,9 +864,9 @@ public class CoverArtArchiveUtil extends CoverUtil {
 					release.score = 0;
 				}
 				try {
-					release.title = getChildElement(releaseElement, "title").getTextContent();
+					release.album = getChildElement(releaseElement, "title").getTextContent();
 				} catch (NullPointerException e) {
-					release.title = null;
+					release.album = null;
 				}
 				Element releaseGroup = getChildElement(releaseElement, "release-group");
 				if (releaseGroup != null) {
@@ -931,8 +937,6 @@ public class CoverArtArchiveUtil extends CoverUtil {
 					releaseTemplate.score = 0;
 				}
 
-				// A slight misuse of release.title here, we store the track name
-				// here. It is accounted for in the matching logic.
 				try {
 					releaseTemplate.title = getChildElement(recordingElement, "title").getTextContent();
 				} catch (NullPointerException e) {
@@ -972,6 +976,11 @@ public class CoverArtArchiveUtil extends CoverUtil {
 							} catch (IllegalArgumentException | NullPointerException e) {
 								release.type = null;
 							}
+						}
+						try {
+							release.album = getChildElement(releaseElement, "title").getTextContent();
+						} catch (NullPointerException e) {
+							release.album = null;
 						}
 						Element releaseYear = getChildElement(releaseElement, "date");
 						if (releaseYear != null) {

--- a/src/main/java/net/pms/util/StringUtil.java
+++ b/src/main/java/net/pms/util/StringUtil.java
@@ -297,6 +297,409 @@ public class StringUtil {
 	}
 
 	/**
+	 * Returns the first four digit number that can look like a year from the
+	 * specified {@link CharSequence}.
+	 *
+	 * @param date the {@link CharSequence} from which to extract the year.
+	 * @return The extracted year or {@code -1} if no valid year is found.
+	 */
+	public static int getYear(CharSequence date) {
+		if (isBlank(date)) {
+			return -1;
+		}
+		Pattern pattern = Pattern.compile("\\b\\d{4}\\b");
+		Matcher matcher = pattern.matcher(date);
+		while (matcher.find()) {
+			int result = Integer.parseInt(matcher.group());
+			if (result > 1600 && result < 2100) {
+				return result;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Extracts the first four digit number that can look like a year from both
+	 * {@link CharSequence}s and compares them.
+	 *
+	 * @param firstDate the first {@link CharSequence} containing a year.
+	 * @param secondDate the second {@link CharSequence} containing a year.
+	 * @return {@code true} if a year can be extracted from both
+	 *         {@link CharSequence}s and they have the same numerical value,
+	 *         {@code false} otherwise.
+	 */
+	public static boolean isSameYear(CharSequence firstDate, CharSequence secondDate) {
+		int first = getYear(firstDate);
+		if (first < 0) {
+			return false;
+		}
+		int second = getYear(secondDate);
+		if (second < 0) {
+			return false;
+		}
+		return first == second;
+	}
+
+	/**
+	 * Compares the specified {@link String}s for equality. Either
+	 * {@link String} can be {@code null}, and they are considered equal if both
+	 * are {@code null}.
+	 *
+	 * @param first the first {@link String} to compare.
+	 * @param second the second {@link String} to compare.
+	 * @return {@code true} if the two {@link String}s are equal, {@code false}
+	 *         otherwise.
+	 * @throws IllegalArgumentException if an invalid combination of parameters
+	 *             is specified.
+	 * @throws IndexOutOfBoundsException if {@code fromIdx} or {@code toIdx} is
+	 *             positive and outside the bounds of {@code first} or
+	 *             {@code second}.
+	 */
+	public static boolean isEqual(
+		String first,
+		String second
+	) {
+		return isEqual(first, second, false, false, false, null, false, 0, -1, -1);
+	}
+
+	/**
+	 * Compares the specified {@link String}s for equality. Either
+	 * {@link String} can be {@code null}, and they are considered equal if both
+	 * are {@code null}.
+	 *
+	 * @param first the first {@link String} to compare.
+	 * @param second the second {@link String} to compare.
+	 * @param blankIsNull if {@code true} a blank {@link String} will be equal
+	 *            to any other blank {@link String} or {@code null}.
+	 * @return {@code true} if the two {@link String}s are equal according to
+	 *         the rules set by the parameters, {@code false} otherwise.
+	 * @throws IllegalArgumentException if an invalid combination of parameters
+	 *             is specified.
+	 * @throws IndexOutOfBoundsException if {@code fromIdx} or {@code toIdx} is
+	 *             positive and outside the bounds of {@code first} or
+	 *             {@code second}.
+	 */
+	public static boolean isEqual(
+		String first,
+		String second,
+		boolean blankIsNull
+	) {
+		return isEqual(first, second, blankIsNull, false, false, null, false, 0, -1, -1);
+	}
+
+	/**
+	 * Compares the specified {@link String}s for equality according to the
+	 * rules set by the parameters. Either {@link String} can be {@code null},
+	 * and they are considered equal if both are {@code null}.
+	 *
+	 * @param first the first {@link String} to compare.
+	 * @param second the second {@link String} to compare.
+	 * @param blankIsNull if {@code true} a blank {@link String} will be equal
+	 *            to any other blank {@link String} or {@code null}.
+	 * @param trim {@code true} to {@link String#trim()} both {@link String}s
+	 *            before comparison, {@code false} otherwise.
+	 * @param ignoreCase {@code true} to convert both {@link String}s to
+	 *            lower-case using the specified {@link Locale} before
+	 *            comparison, {@code false} otherwise.
+	 * @param locale the {@link Locale} to use when converting both
+	 *            {@link String}s to lower-case if {@code ignoreCase} is
+	 *            {@code true}. Ignored if {@code ignoreCase} is {@code false}.
+	 *            If {@code null}, {@link Locale#ROOT} will be used.
+	 * @return {@code true} if the two {@link String}s are equal according to
+	 *         the rules set by the parameters, {@code false} otherwise.
+	 */
+	public static boolean isEqual(
+		String first,
+		String second,
+		boolean blankIsNull,
+		boolean trim,
+		boolean ignoreCase,
+		Locale locale
+	) {
+		return isEqual(first, second, blankIsNull, trim, ignoreCase, locale, false, 0, -1, -1);
+	}
+
+	/**
+	 * Compares the specified {@link String}s for equality according to the
+	 * rules set by the parameters. Either {@link String} can be {@code null},
+	 * and they are considered equal if both are {@code null}.
+	 *
+	 * @param first the first {@link String} to compare.
+	 * @param second the second {@link String} to compare.
+	 * @param blankIsNull if {@code true} a blank {@link String} will be equal
+	 *            to any other blank {@link String} or {@code null}.
+	 * @param trim {@code true} to {@link String#trim()} both {@link String}s
+	 *            before comparison, {@code false} otherwise.
+	 * @param ignoreCase {@code true} to convert both {@link String}s to
+	 *            lower-case using the specified {@link Locale} before
+	 *            comparison, {@code false} otherwise.
+	 * @param locale the {@link Locale} to use when converting both
+	 *            {@link String}s to lower-case if {@code ignoreCase} is
+	 *            {@code true}. Ignored if {@code ignoreCase} is {@code false}.
+	 *            If {@code null}, {@link Locale#ROOT} will be used.
+	 * @param shortest {@code true} to only compare the length of the shortest
+	 *            of the two {@link String}s.
+	 * @param minLength the minimum length to compare if {@code shortest} is
+	 *            true. If this is zero, an empty {@link String} will equal any
+	 *            {@link String}.
+	 * @return {@code true} if the two {@link String}s are equal according to
+	 *         the rules set by the parameters, {@code false} otherwise.
+	 */
+	public static boolean isEqual(
+		String first,
+		String second,
+		boolean blankIsNull,
+		boolean trim,
+		boolean ignoreCase,
+		Locale locale,
+		boolean shortest,
+		int minLength
+	) {
+		return isEqual(first, second, blankIsNull, trim, ignoreCase, locale, shortest, minLength, -1, -1);
+	}
+
+	/**
+	 * Compares the specified {@link String}s for equality according to the
+	 * rules set by the parameters. Either {@link String} can be {@code null},
+	 * and they are considered equal if both are {@code null}.
+	 *
+	 * @param first the first {@link String} to compare.
+	 * @param second the second {@link String} to compare.
+	 * @param blankIsNull if {@code true} a blank {@link String} will be equal
+	 *            to any other blank {@link String} or {@code null}.
+	 * @param ignoreCase {@code true} to convert both {@link String}s to
+	 *            lower-case using the specified {@link Locale} before
+	 *            comparison, {@code false} otherwise.
+	 * @param locale the {@link Locale} to use when converting both
+	 *            {@link String}s to lower-case if {@code ignoreCase} is
+	 *            {@code true}. Ignored if {@code ignoreCase} is {@code false}.
+	 *            If {@code null}, {@link Locale#ROOT} will be used.
+	 * @param fromIdx compare only from the character of this index.
+	 * @return {@code true} if the two {@link String}s are equal according to
+	 *         the rules set by the parameters, {@code false} otherwise.
+	 * @throws IllegalArgumentException {@code toIdx} is positive and is smaller
+	 *             than {@code fromIdx}.
+	 * @throws IndexOutOfBoundsException if {@code fromIdx} or {@code toIdx} is
+	 *             positive and outside the bounds of {@code first} or
+	 *             {@code second}.
+	 */
+	public static boolean isEqualFrom(
+		String first,
+		String second,
+		boolean blankIsNull,
+		boolean ignoreCase,
+		Locale locale,
+		int fromIdx
+	) {
+		return isEqual(first, second, blankIsNull, false, ignoreCase, locale, false, 0, fromIdx, -1);
+	}
+
+	/**
+	 * Compares the specified {@link String}s for equality according to the
+	 * rules set by the parameters. Either {@link String} can be {@code null},
+	 * and they are considered equal if both are {@code null}.
+	 *
+	 * @param first the first {@link String} to compare.
+	 * @param second the second {@link String} to compare.
+	 * @param blankIsNull if {@code true} a blank {@link String} will be equal
+	 *            to any other blank {@link String} or {@code null}.
+	 * @param ignoreCase {@code true} to convert both {@link String}s to
+	 *            lower-case using the specified {@link Locale} before
+	 *            comparison, {@code false} otherwise.
+	 * @param locale the {@link Locale} to use when converting both
+	 *            {@link String}s to lower-case if {@code ignoreCase} is
+	 *            {@code true}. Ignored if {@code ignoreCase} is {@code false}.
+	 *            If {@code null}, {@link Locale#ROOT} will be used.
+	 * @param toIdx compare only to (not including) the character of this index.
+	 *            To compare to the end of the {@link String}, use {@code -1} or
+	 *            the index position after the last character (the same as the
+	 *            length).
+	 * @return {@code true} if the two {@link String}s are equal according to
+	 *         the rules set by the parameters, {@code false} otherwise.
+	 * @throws IllegalArgumentException {@code toIdx} is positive and is smaller
+	 *             than {@code fromIdx}.
+	 * @throws IndexOutOfBoundsException if {@code fromIdx} or {@code toIdx} is
+	 *             positive and outside the bounds of {@code first} or
+	 *             {@code second}.
+	 */
+	public static boolean isEqualTo(
+		String first,
+		String second,
+		boolean blankIsNull,
+		boolean ignoreCase,
+		Locale locale,
+		int toIdx
+	) {
+		return isEqual(first, second, blankIsNull, false, ignoreCase, locale, false, 0, -1, toIdx);
+	}
+
+
+	/**
+	 * Compares the specified {@link String}s for equality according to the
+	 * rules set by the parameters. Either {@link String} can be {@code null},
+	 * and they are considered equal if both are {@code null}.
+	 *
+	 * @param first the first {@link String} to compare.
+	 * @param second the second {@link String} to compare.
+	 * @param blankIsNull if {@code true} a blank {@link String} will be equal
+	 *            to any other blank {@link String} or {@code null}.
+	 * @param ignoreCase {@code true} to convert both {@link String}s to
+	 *            lower-case using the specified {@link Locale} before
+	 *            comparison, {@code false} otherwise.
+	 * @param locale the {@link Locale} to use when converting both
+	 *            {@link String}s to lower-case if {@code ignoreCase} is
+	 *            {@code true}. Ignored if {@code ignoreCase} is {@code false}.
+	 *            If {@code null}, {@link Locale#ROOT} will be used.
+	 * @param fromIdx compare only from the character of this index.
+	 * @param toIdx compare only to (not including) the character of this index.
+	 *            To compare to the end of the {@link String}, use {@code -1} or
+	 *            the index position after the last character (the same as the
+	 *            length).
+	 * @return {@code true} if the two {@link String}s are equal according to
+	 *         the rules set by the parameters, {@code false} otherwise.
+	 * @throws IllegalArgumentException {@code toIdx} is positive and is smaller
+	 *             than {@code fromIdx}.
+	 * @throws IndexOutOfBoundsException if {@code fromIdx} or {@code toIdx} is
+	 *             positive and outside the bounds of {@code first} or
+	 *             {@code second}.
+	 */
+	public static boolean isEqual(
+		String first,
+		String second,
+		boolean blankIsNull,
+		boolean ignoreCase,
+		Locale locale,
+		int fromIdx,
+		int toIdx
+	) {
+		return isEqual(first, second, blankIsNull, false, ignoreCase, locale, false, 0, fromIdx, toIdx);
+	}
+
+	/**
+	 * Compares the specified {@link String}s for equality according to the
+	 * rules set by the parameters. Either {@link String} can be {@code null},
+	 * and they are considered equal if both are {@code null}.
+	 *
+	 * @param first the first {@link String} to compare.
+	 * @param second the second {@link String} to compare.
+	 * @param blankIsNull if {@code true} a blank {@link String} will be equal
+	 *            to any other blank {@link String} or {@code null}.
+	 * @param trim {@code true} to {@link String#trim()} both {@link String}s
+	 *            before comparison, {@code false} otherwise. Cannot be used
+	 *            together with {@code fromIdx} or {@code toIdx}.
+	 * @param ignoreCase {@code true} to convert both {@link String}s to
+	 *            lower-case using the specified {@link Locale} before
+	 *            comparison, {@code false} otherwise.
+	 * @param locale the {@link Locale} to use when converting both
+	 *            {@link String}s to lower-case if {@code ignoreCase} is
+	 *            {@code true}. Ignored if {@code ignoreCase} is {@code false}.
+	 *            If {@code null}, {@link Locale#ROOT} will be used.
+	 * @param shortest {@code true} to only compare the length of the shortest
+	 *            of the two {@link String}s. Cannot be used together with
+	 *            {@code fromIdx} or {@code toIdx}.
+	 * @param minLength the minimum length to compare if {@code shortest} is
+	 *            true. If this is zero, an empty {@link String} will equal any
+	 *            {@link String}.
+	 * @param fromIdx compare only from the character of this index. Cannot be
+	 *            used together with {@code trim} or {@code shortest}.
+	 * @param toIdx compare only to (not including) the character of this index.
+	 *            To compare to the end of the {@link String}, use {@code -1} or
+	 *            the index position after the last character (the same as the
+	 *            length). Cannot be used together with {@code trim} or
+	 *            {@code shortest}.
+	 * @return {@code true} if the two {@link String}s are equal according to
+	 *         the rules set by the parameters, {@code false} otherwise.
+	 * @throws IllegalArgumentException if an invalid combination of parameters
+	 *             is specified.
+	 * @throws IndexOutOfBoundsException if {@code fromIdx} or {@code toIdx} is
+	 *             positive and outside the bounds of {@code first} or
+	 *             {@code second}.
+	 */
+	protected static boolean isEqual(
+		String first,
+		String second,
+		boolean blankIsNull,
+		boolean trim,
+		boolean ignoreCase,
+		Locale locale,
+		boolean shortest,
+		int minLength,
+		int fromIdx,
+		int toIdx
+	) {
+		if ((trim || shortest) && (fromIdx >= 0 || toIdx >= 0)) {
+			throw new IllegalArgumentException("trim or shortest and index range can't be used together");
+		}
+		if (blankIsNull) {
+			if (first == null) {
+				first = "";
+			}
+			if (second == null) {
+				second = "";
+			}
+		} else {
+			if (first == null || second == null) {
+				return first == null && second == null;
+			}
+		}
+		// No null after this point
+
+		if (trim) {
+			first = first.trim();
+			second = second.trim();
+		}
+
+		if (ignoreCase) {
+			if (locale == null) {
+				locale = Locale.ROOT;
+			}
+			first = first.toLowerCase(locale);
+			second = second.toLowerCase(locale);
+		}
+
+		if (shortest) {
+			if (first.length() != second.length()) {
+				int shortestIdx = Math.max(Math.min(first.length(), second.length()), minLength);
+				first = first.substring(0, Math.min(shortestIdx, first.length()));
+				second = second.substring(0, Math.min(shortestIdx, second.length()));
+			}
+		} else if (fromIdx >= 0 || toIdx >= 0) {
+			if (fromIdx == toIdx) {
+				return true;
+			}
+			if (fromIdx > toIdx && toIdx >= 0) {
+				throw new IllegalArgumentException("fromIdx (" + fromIdx + ") > toIdx (" + toIdx + ")");
+			}
+			if (fromIdx >= first.length() || fromIdx >= second.length()) {
+				throw new IndexOutOfBoundsException(
+					"fromIdx=" + fromIdx + ", first length=" + first.length() + ", second length=" + second.length()
+				);
+			}
+			if (toIdx > first.length() || toIdx > second.length()) {
+				throw new IndexOutOfBoundsException(
+					"toIdx=" + fromIdx + ", first length=" + first.length() + ", second length=" + second.length()
+				);
+			}
+			if (fromIdx < 0) {
+				fromIdx = 0;
+			}
+			if (toIdx < 0) {
+				first = first.substring(fromIdx);
+				second = second.substring(fromIdx);
+			} else {
+				first = first.substring(fromIdx, toIdx);
+				second = second.substring(fromIdx, toIdx);
+			}
+		}
+
+		if (blankIsNull && (isBlank(first) || isBlank(second))) {
+			return isBlank(first) && isBlank(second);
+		}
+
+		return first.equals(second);
+	}
+
+	/**
 	 * A unicode unescaper that translates unicode escapes, e.g. '\u005c', while leaving
 	 * intact any  sequences that can't be interpreted as escaped unicode.
 	 */

--- a/src/test/java/net/pms/util/StringUtilTest.java
+++ b/src/test/java/net/pms/util/StringUtilTest.java
@@ -23,7 +23,10 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import org.apache.commons.configuration.ConfigurationException;
+import static net.pms.util.StringUtil.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -41,18 +44,131 @@ public class StringUtilTest {
 	@Test
 	public void fillStringTest() {
 		char[] chars = { 'a', 'æ' };
-		assertEquals("fillStringCharArray", StringUtil.fillString(chars, 4), "aæaæaæaæ");
-		assertEquals("fillStringCharSpace", StringUtil.fillString(' ', 10), "          ");
-		assertEquals("fillStringCodePoint", StringUtil.fillString(1333 , 3), "\u0535\u0535\u0535");
-		assertEquals("fillStringUnicodeString", StringUtil.fillString("\u0648\u0AA7\u184A", 2), "\u0648\u0AA7\u184A\u0648\u0AA7\u184A");
-		assertEquals("fillStringEmptyString", StringUtil.fillString("", 100), "");
-		assertEquals("FillStringZero", StringUtil.fillString("foo",	0), "");
+		assertEquals("fillStringCharArray", fillString(chars, 4), "aæaæaæaæ");
+		assertEquals("fillStringCharSpace", fillString(' ', 10), "          ");
+		assertEquals("fillStringCodePoint", fillString(1333 , 3), "\u0535\u0535\u0535");
+		assertEquals("fillStringUnicodeString", fillString("\u0648\u0AA7\u184A", 2), "\u0648\u0AA7\u184A\u0648\u0AA7\u184A");
+		assertEquals("fillStringEmptyString", fillString("", 100), "");
+		assertEquals("FillStringZero", fillString("foo",	0), "");
 	}
 
 	@Test(expected=IllegalArgumentException.class)
 	public void stripHTMLTest() {
-		assertEquals("stripHTMLBasicBody", StringUtil.stripHTML("<html><sometag></sometag><someothertag/><body>Sometext</body></html>"), "Sometext");
-		assertEquals("stripHTMLBodyWithTags", StringUtil.stripHTML("<html><sometag></sometag><someothertag/><body>Sometext <strong>someSTRONGtext</strong></body></html>"), "Sometext someSTRONGtext");
-		assertEquals("stripHTMLWithoutBody", StringUtil.stripHTML("<html><header></header>Somecontent</html>"), "");
+		assertEquals("stripHTMLBasicBody", stripHTML("<html><sometag></sometag><someothertag/><body>Sometext</body></html>"), "Sometext");
+		assertEquals("stripHTMLBodyWithTags", stripHTML("<html><sometag></sometag><someothertag/><body>Sometext <strong>someSTRONGtext</strong></body></html>"), "Sometext someSTRONGtext");
+		assertEquals("stripHTMLWithoutBody", stripHTML("<html><header></header>Somecontent</html>"), "");
+	}
+
+	@Test
+	public void getYearTest() {
+		assertEquals(-1, getYear("1600"));
+		assertEquals(1601, getYear("1601"));
+		assertEquals(2099, getYear("2099"));
+		assertEquals(-1, getYear("2100"));
+		assertEquals(-1, getYear(""));
+		assertEquals(-1, getYear("19834"));
+		assertEquals(-1, getYear("91"));
+		assertEquals(-1, getYear("089"));
+		assertEquals(-1, getYear("foo1984"));
+		assertEquals(-1, getYear("1984bar"));
+		assertEquals(1984, getYear("foo 1984 bar 2003"));
+		assertEquals(2011, getYear("2011-09-11"));
+		assertEquals(2011, getYear("2011 September 9"));
+		assertEquals(2011, getYear("2011-Sep-11"));
+		assertEquals(2011, getYear("2011-Sep-11, Someday"));
+		assertEquals(2011, getYear("2011. september 9."));
+		assertEquals(2011, getYear("2011.9.11"));
+		assertEquals(2011, getYear("2011.09.11"));
+		assertEquals(2011, getYear("2011/09/11"));
+		assertEquals(2011, getYear("Someday, September 11, 2011"));
+		assertEquals(2011, getYear("September 11, 2011"));
+		assertEquals(2011, getYear("Sep. 11, 2011"));
+		assertEquals(2011, getYear("9/11/2011"));
+		assertEquals(2011, getYear("9-11-2011"));
+		assertEquals(2011, getYear("9.11.2011"));
+		assertEquals(-1, getYear("09.11.11"));
+		assertEquals(-1, getYear("09/11/11"));
+		assertEquals(2011, getYear("2011 5 April"));
+		assertEquals(2011, getYear("11/9-2011"));
+		assertEquals(-1, getYear(null));
+	}
+
+	@Test
+	public void isSameYearTest() {
+		assertFalse(isSameYear(null, null));
+		assertFalse(isSameYear("1600", null));
+		assertFalse(isSameYear("1601", null));
+		assertFalse(isSameYear(null, "2099"));
+		assertFalse(isSameYear(null, "2100"));
+		assertFalse(isSameYear("foo 1984 bar 2003", "2003"));
+		assertFalse(isSameYear("1984", "1985"));
+		assertTrue(isSameYear("9-11-2011", "2011 September 9"));
+	}
+
+	@Test
+	public void isEqualTest() {
+		// Null
+		assertTrue(isEqual(null, null));
+		assertFalse(isEqual(null, ""));
+		assertTrue(isEqual(null, "", true));
+		assertFalse(isEqual(null, "   "));
+		assertTrue(isEqual(null, "   ", true));
+		assertFalse(isEqual(null, " \t"));
+		assertTrue(isEqual(null, " \t", true));
+		assertFalse(isEqual(null, "foo"));
+		assertFalse(isEqual(null, "bAR", false, false, false, null, false, 0));
+		assertTrue(isEqual("     ", "\t\t    \t", true, true, null, 1, 5));
+
+		// Blank
+		assertFalse(isEqual("          ", " \t"));
+		assertTrue(isEqual("          ", " \t", true));
+		assertTrue(isEqual(" \t", " \t"));
+		assertFalse(isEqual("", "bAR", false, false, false, null, false, 0));
+		assertFalse(isEqual("       \t ", "bAR", false, false, false, null, false, 0));
+
+		// Case
+		assertFalse(isEqual("bar", "bAR", false, false, false, null, false, 0));
+		assertTrue(isEqual("bar", "bAR", false, false, true, null, false, 0));
+		assertTrue(isEqual("bar", "bar", false, false, false, null, false, 0));
+		assertTrue(isEqual("bar", "bar", false, false, true, null, false, 0));
+		assertTrue(isEqual("BAR", "BAR", false, false, false, null, false, 0));
+		assertTrue(isEqual("BAR", "BAR", false, false, true, null, false, 0));
+
+		// Trim
+		assertFalse(isEqual(" bar", "bar", false, false, false, null, false, 0));
+		assertTrue(isEqual(" bar", "bar", false, true, false, null, false, 0));
+		assertTrue(isEqual(" bar", "bar\t", false, true, false, null, false, 0));
+		assertTrue(isEqual("", "   \t", false, true, false, null, false, 0));
+
+		// Shortest
+		assertTrue(isEqual("foobar", "foobar", false, false, false, null, true, 0));
+		assertTrue(isEqual("foobar", "foo", false, false, false, null, true, 0));
+		assertTrue(isEqual("foo", "foobar", false, false, false, null, true, 0));
+		assertTrue(isEqual("foo", "foobar", false, false, false, null, true, 3));
+		assertFalse(isEqual("foo", "foobar", false, false, false, null, true, 4));
+
+		// SubString
+		assertTrue(isEqual("foo", "foobar", false, false, null, 0, 3));
+		assertTrue(isEqual("foo", "foobar", false, false, null, 1, 3));
+		assertTrue(isEqual("foo", "foobar", false, false, null, 2, 3));
+		assertTrue(isEqual("foo", "bar", false, false, null, 2, 2));
+		assertFalse(isEqualTo("foobar", "hoobar", false, false, null, 3));
+		assertTrue(isEqualFrom("foobar", "hoobar", false, false, null, 3));
+
+		// Combined
+		assertTrue(isEqual("   ", "     ", true, false, false, null, true, 4));
+		assertTrue(isEqual("   ", "     ", false, true, false, null, true, 4));
+		assertTrue(isEqual("Foobar", " foobar     ", true, true, true, null, false, 4));
+		assertTrue(isEqual("Foo", " foobar     ", true, true, true, null, true, 3));
+		assertFalse(isEqual("Foo", " foobar     ", true, true, true, null, true, 4));
+		assertTrue(isEqual("Foobar", "", true, false, true, null, true, 0));
+		assertFalse(isEqual("Foobar", "", true, false, true, null, true, 1));
+		assertFalse(isEqual("Foobar", "", true, false, true, null, false, 0));
+		assertTrue(isEqual("Foobar", "fOO", true, false, true, null, true, 0));
+		assertTrue(isEqual("FooBar", "foobar", true, true, null, 3, -1));
+		assertTrue(isEqual("FooBar", "foobar", true, true, null, 2, 5));
+		assertTrue(isEqual("FooBar", "foobar", false, true, null, 2, 5));
+		assertFalse(isEqual("FooBar", "foobar", true, false, null, 2, 5));
+		assertTrue(isEqual("FooBar", "foobar", false, true, null, -1, 5));
 	}
 }


### PR DESCRIPTION
I added some improvement to MusicBrainz match logic. This has helped me retrieve 1000s of cover art for my MP3 collection. Hope it helps others too.

If cover art is still missing , check if the MBID is referring to correct release on MB site.

```
select * from MUSIC_BRAINZ_RELEASES where mbid in (select mbid from COVER_ART_ARCHIVE where cover is null) order by album
```

If release is correct and thumbnail shows "Cover art from Amazon", make sure you update the cover art by uploading a "FRONT" thumbnail for the release.