### PR TITLE
Fix bug with JPEG_LRG profile check

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2880,7 +2880,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 						));
 					}
 					if (!DLNAImageProfile.JPEG_MED.isResolutionCorrect(imageInfo)) {
-						if (DLNAImageResElement.isImageProfileSupported(DLNAImageProfile.PNG_LRG, renderer)) {
+						if (DLNAImageResElement.isImageProfileSupported(DLNAImageProfile.JPEG_LRG, renderer)) {
 							resElements.add(new DLNAImageResElement(
 								DLNAImageProfile.JPEG_LRG, imageInfo,
 								DLNAImageProfile.JPEG_LRG.useThumbnailSource(imageInfo, thumbnailImageInfo)
@@ -2901,7 +2901,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			if (DLNAImageResElement.isImageProfileSupported(DLNAImageProfile.PNG_LRG, renderer)) {
 				resElements.add(new DLNAImageResElement(DLNAImageProfile.PNG_LRG, null, false));
 			}
-			LOGGER.debug("Warning: Image \"{}\" isn't parsed when DIDL-Lite is generated", this.getName());
+			LOGGER.debug("Warning: Image \"{}\" wasn't parsed when DIDL-Lite was generated", this.getName());
 		}
 
 		// Sort the elements by priority
@@ -2923,7 +2923,6 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			}
 		}
 	}
-
 
 	/**
 	 * Generate and append the thumbnail {@code res} and


### PR DESCRIPTION
I've made a little typo in the ```JPEG_LRG``` evaluation so that support for ```PNG_LRG``` is checked. That means that renderers that doesn't support ```PNG_LRG``` won't be offered ```JPEG_LRG```.

This originates from [this thread](http://www.universalmediaserver.com/forum/viewtopic.php?f=9&t=11617&start=20). Testing has been done by both my and the affected user, and the error is quite obvious. Thus, I don't think any further testing is needed.