### PR TITLE
Don't use global ID repository during cache scan

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -732,7 +732,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 									fileTranscodeFolder.addChildInternal(newChild, isAddGlobally);
 									LOGGER.trace("Adding \"{}\" to transcode folder for player: \"{}\"", child.getName(), playerTranscoding);
 
-									transcodeFolder.updateChild(fileTranscodeFolder);
+									transcodeFolder.updateChild(fileTranscodeFolder, isAddGlobally);
 								}
 							}
 
@@ -1098,6 +1098,10 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		return null;
 	}
 
+	public void updateChild(DLNAResource child) {
+		updateChild(child, true);
+	}
+
 	/**
 	 * (Re)sets the given DLNA resource as follows:
 	 *    - if it's already one of our children, renew it
@@ -1105,8 +1109,9 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 *    - otherwise add it as a new child.
 	 *
 	 * @param child the DLNA resource to update
+	 * @param isAddGlobally whether to add to the global ID repository
 	 */
-	public void updateChild(DLNAResource child) {
+	public void updateChild(DLNAResource child, boolean isAddGlobally) {
 		DLNAResource found = children.contains(child) ?
 			child : searchByName(child.getName());
 		if (found != null) {
@@ -1117,10 +1122,10 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				children.set(children.indexOf(found), child);
 			}
 			// Renew
-			addChild(child, false);
+			addChild(child, false, isAddGlobally);
 		} else {
 			// Not found, it's new
-			addChild(child, true);
+			addChild(child, true, isAddGlobally);
 		}
 	}
 

--- a/src/main/java/net/pms/dlna/MapFile.java
+++ b/src/main/java/net/pms/dlna/MapFile.java
@@ -512,7 +512,7 @@ public class MapFile extends DLNAResource {
 		emptyFoldersToRescan = null; // Since we're re-scanning, reset this list so it can be built again
 		discoverable = null;
 		discoverChildren(str, isAddGlobally);
-		analyzeChildren(-1);
+		analyzeChildren(-1, isAddGlobally);
 	}
 
 	@Override

--- a/src/main/java/net/pms/dlna/RootFolder.java
+++ b/src/main/java/net/pms/dlna/RootFolder.java
@@ -107,6 +107,10 @@ public class RootFolder extends DLNAResource {
 
 	@Override
 	public void discoverChildren() {
+		discoverChildren(true);
+	}
+
+	public void discoverChildren(boolean isAddGlobally) {
 		if (isDiscovered()) {
 			return;
 		}
@@ -114,7 +118,7 @@ public class RootFolder extends DLNAResource {
 		if (configuration.isShowMediaLibraryFolder()) {
 			DLNAResource libraryRes = PMS.get().getLibrary();
 			if (libraryRes != null) {
-				addChild(libraryRes);
+				addChild(libraryRes, true, isAddGlobally);
 			}
 		}
 
@@ -123,7 +127,7 @@ public class RootFolder extends DLNAResource {
 				PMS.getConfiguration().getDataFile("UMS.last"),
 				PMS.getConfiguration().getInt("last_play_limit", 250),
 				Playlist.PERMANENT|Playlist.AUTOSAVE);
-			addChild(last);
+			addChild(last, true, isAddGlobally);
 		}
 
 		String m = configuration.getFoldersMonitored();
@@ -136,25 +140,25 @@ public class RootFolder extends DLNAResource {
 			mon = new MediaMonitor(dirs);
 
 			if (configuration.isShowNewMediaFolder()) {
-				addChild(mon);
+				addChild(mon, true, isAddGlobally);
 			}
 		}
 
 		if (configuration.getFolderLimit() && getDefaultRenderer() != null && getDefaultRenderer().isLimitFolders()) {
 			lim = new FolderLimit();
-			addChild(lim);
+			addChild(lim, true, isAddGlobally);
 		}
 
 		if (configuration.isDynamicPls()) {
-			addChild(PMS.get().getDynamicPls());
+			addChild(PMS.get().getDynamicPls(), true, isAddGlobally);
 			if (!configuration.isHideSavedPlaylistFolder()) {
 				File plsdir = new File(configuration.getDynamicPlsSavePath());
-				addChild(new RealFile(plsdir, Messages.getString("VirtualFolder.3")));
+				addChild(new RealFile(plsdir, Messages.getString("VirtualFolder.3")), true, isAddGlobally);
 			}
 		}
 
 		for (DLNAResource r : getConfiguredFolders(tags)) {
-			addChild(r);
+			addChild(r, true, isAddGlobally);
 		}
 
 		/**
@@ -181,7 +185,7 @@ public class RootFolder extends DLNAResource {
 		}
 
 		for (DLNAResource r : getVirtualFolders(tags)) {
-			addChild(r);
+			addChild(r, true, isAddGlobally);
 		}
 
 		loadWebConf();
@@ -211,7 +215,7 @@ public class RootFolder extends DLNAResource {
 
 
 		for (DLNAResource r : getAdditionalFoldersAtRoot()) {
-			addChild(r);
+			addChild(r, true, isAddGlobally);
 		}
 
 		if (configuration.isShowServerSettingsFolder()) {
@@ -236,7 +240,7 @@ public class RootFolder extends DLNAResource {
 		running = true;
 
 		if (!isDiscovered()) {
-			discoverChildren();
+			discoverChildren(false);
 		}
 
 		setDefaultRenderer(RendererConfiguration.getDefaultConf());
@@ -282,7 +286,7 @@ public class RootFolder extends DLNAResource {
 							child.syncResolve();
 						}
 						child.discoverChildren();
-						child.analyzeChildren(-1);
+						child.analyzeChildren(-1, false);
 						child.setDiscovered(true);
 					}
 


### PR DESCRIPTION
This resolves the initial memory use problem. It's a simple boolean that disables adding to global repository during a scan