### PR TITLE
Fix potential errors of video stream ffmpegvideo

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -376,7 +376,7 @@ public class FFMpegVideo extends Player {
 
 			// Output video codec
 			if (renderer.isTranscodeToH264() || renderer.isTranscodeToH265()) {
-				if (!customFFmpegOptions.contains("-(c:v|codec:v|vcodec)")) {
+				if (!customFFmpegOptions.matches(".* -(c:v|codec:v|vcodec) .*")) {
 					transcodeOptions.add("-c:v");
 					if (renderer.isTranscodeToH264()) {
 						transcodeOptions.add("libx264");

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -397,8 +397,8 @@ public class FFMpegVideo extends Player {
 					transcodeOptions.add("31");
 				}
 				if (!customFFmpegOptions.contains("-pix_fmt")) {
-    				transcodeOptions.add("-pix_fmt");
-    				transcodeOptions.add("yuv420p");
+    					transcodeOptions.add("-pix_fmt");
+    					transcodeOptions.add("yuv420p");
 				}
 			} else if (!dtsRemux) {
 				transcodeOptions.add("-c:v");
@@ -462,7 +462,7 @@ public class FFMpegVideo extends Player {
 		boolean isXboxOneWebVideo = params.mediaRenderer.isXboxOne() && purpose() == VIDEO_WEBSTREAM_PLAYER;
 		int maximumBitrate = defaultMaxBitrates[0];
 
-		if (params.mediaRenderer.getCBRVideoBitrate() == 0 && params.timeend == 0) {
+		if ((params.mediaRenderer.getCBRVideoBitrate() == 0 && params.timeend == 0) || (!customFFmpegOptions.matches(".*-(maxrate|bufsize)") && !customFFmpegOptions.matches(".*-(x264opts|x264-params) .*(vbv-maxrate=|vbv-bufsize=).*")) {
 			if (rendererMaxBitrates[0] < 0) {
 				// odd special case here
 				// this is -1 so we guess that 3000 kbps is good
@@ -578,7 +578,7 @@ public class FFMpegVideo extends Player {
 			// Add x264 quality settings
 			String x264CRF = configuration.getx264ConstantRateFactor();
 
-			if (!(customFFmpegOptions.contains("-crf") || customFFmpegOptions.contains("-b:v") || customFFmpegOptions.contains("-b ") || ((customFFmpegOptions.contains("-x264opts") || customFFmpegOptions.contains("-x264-params")) && (customFFmpegOptions.contains("crf=") || customFFmpegOptions.contains("bitrate=") || customFFmpegOptions.contains("B="))))) {
+			if (!customFFmpegOptions.matches(".*-(crf|b:v|b)") && !customFFmpegOptions.matches(".*-(x264opts|x264-params) .*(crf=|bitrate=|B=).*") {
 				// Remove comment from the value
 				if (x264CRF.contains("/*")) {
 					x264CRF = x264CRF.substring(x264CRF.indexOf("/*"));

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -376,7 +376,7 @@ public class FFMpegVideo extends Player {
 
 			// Output video codec
 			if (renderer.isTranscodeToH264() || renderer.isTranscodeToH265()) {
-				if (!(customFFmpegOptions.contains("-c:v") || customFFmpegOptions.contains("-codec:v") || customFFmpegOptions.contains("-vcodec"))) {
+				if (!customFFmpegOptions.contains("-(c:v|codec:v|vcodec)")) {
 					transcodeOptions.add("-c:v");
 					if (renderer.isTranscodeToH264()) {
 						transcodeOptions.add("libx264");

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -462,7 +462,7 @@ public class FFMpegVideo extends Player {
 		boolean isXboxOneWebVideo = params.mediaRenderer.isXboxOne() && purpose() == VIDEO_WEBSTREAM_PLAYER;
 		int maximumBitrate = defaultMaxBitrates[0];
 
-		if ((params.mediaRenderer.getCBRVideoBitrate() == 0 && params.timeend == 0) || (!customFFmpegOptions.matches(".*-(maxrate|bufsize)") && !customFFmpegOptions.matches(".*-(x264opts|x264-params) .*(vbv-maxrate=|vbv-bufsize=).*")) {
+		if ((params.mediaRenderer.getCBRVideoBitrate() == 0 && params.timeend == 0) || (!customFFmpegOptions.matches(".*-(maxrate|bufsize)") && !customFFmpegOptions.matches(".*-(x264opts|x264-params) .*(vbv-maxrate=|vbv-bufsize=).*"))) {
 			if (rendererMaxBitrates[0] < 0) {
 				// odd special case here
 				// this is -1 so we guess that 3000 kbps is good

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -578,7 +578,7 @@ public class FFMpegVideo extends Player {
 			// Add x264 quality settings
 			String x264CRF = configuration.getx264ConstantRateFactor();
 
-			if (!customFFmpegOptions.matches(".*-(crf|b:v|b)") && !customFFmpegOptions.matches(".*-(x264opts|x264-params) .*(crf=|bitrate=|B=).*") {
+			if (!customFFmpegOptions.matches(".*-(crf|b:v|b)") && !customFFmpegOptions.matches(".*-(x264opts|x264-params) .*(crf=|bitrate=|B=).*")) {
 				// Remove comment from the value
 				if (x264CRF.contains("/*")) {
 					x264CRF = x264CRF.substring(x264CRF.indexOf("/*"));

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -385,10 +385,10 @@ public class FFMpegVideo extends Player {
 					}
 					transcodeOptions.add("-tune");
 					transcodeOptions.add("zerolatency");
-				}
-				if (!customFFmpegOptions.contains("-preset")) {
-					transcodeOptions.add("-preset");
-					transcodeOptions.add("ultrafast");
+    				if (!customFFmpegOptions.contains("-preset")) {
+    					transcodeOptions.add("-preset");
+    					transcodeOptions.add("ultrafast");
+    				}
 				}
 				if (!customFFmpegOptions.contains("-level")) {
 					transcodeOptions.add("-level");

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -396,8 +396,10 @@ public class FFMpegVideo extends Player {
 					transcodeOptions.add("-level");
 					transcodeOptions.add("31");
 				}
-				transcodeOptions.add("-pix_fmt");
-				transcodeOptions.add("yuv420p");
+				if (!customFFmpegOptions.contains("-pix_fmt")) {
+    				transcodeOptions.add("-pix_fmt");
+    				transcodeOptions.add("yuv420p");
+				}
 			} else if (!dtsRemux) {
 				transcodeOptions.add("-c:v");
 				transcodeOptions.add("mpeg2video");

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -383,8 +383,10 @@ public class FFMpegVideo extends Player {
 					} else {
 						transcodeOptions.add("libx265");
 					}
-					transcodeOptions.add("-tune");
-					transcodeOptions.add("zerolatency");
+					if (!customFFmpegOptions.contains("-tune")) {
+    					transcodeOptions.add("-tune");
+    					transcodeOptions.add("zerolatency");
+					}
     				if (!customFFmpegOptions.contains("-preset")) {
     					transcodeOptions.add("-preset");
     					transcodeOptions.add("ultrafast");

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -433,7 +433,7 @@ public class FFMpegVideo extends Player {
 	public List<String> getVideoBitrateOptions(DLNAResource dlna, DLNAMediaInfo media, OutputParams params) {
 		List<String> videoBitrateOptions = new ArrayList<>();
 		boolean low = false;
-		String customFFmpegOptions = renderer.getCustomFFmpegOptions();
+		String customFFmpegOptions = params.mediaRenderer.getCustomFFmpegOptions();
 
 		int defaultMaxBitrates[] = getVideoBitrateConfig(configuration.getMaximumBitrate());
 		int rendererMaxBitrates[] = new int[2];

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -433,6 +433,7 @@ public class FFMpegVideo extends Player {
 	public List<String> getVideoBitrateOptions(DLNAResource dlna, DLNAMediaInfo media, OutputParams params) {
 		List<String> videoBitrateOptions = new ArrayList<>();
 		boolean low = false;
+		String customFFmpegOptions = renderer.getCustomFFmpegOptions();
 
 		int defaultMaxBitrates[] = getVideoBitrateConfig(configuration.getMaximumBitrate());
 		int rendererMaxBitrates[] = new int[2];
@@ -577,32 +578,34 @@ public class FFMpegVideo extends Player {
 			// Add x264 quality settings
 			String x264CRF = configuration.getx264ConstantRateFactor();
 
-			// Remove comment from the value
-			if (x264CRF.contains("/*")) {
-				x264CRF = x264CRF.substring(x264CRF.indexOf("/*"));
-			}
-
-			if (x264CRF.contains("Automatic")) {
-				if (x264CRF.contains("Wireless") || maximumBitrate < 70) {
-					x264CRF = "19";
-					// Lower quality for 720p+ content
-					if (media.getWidth() > 1280) {
-						x264CRF = "23";
-					} else if (media.getWidth() > 720) {
-						x264CRF = "22";
-					}
-				} else {
-					x264CRF = "16";
-
-					// Lower quality for 720p+ content
-					if (media.getWidth() > 720) {
+			if (!(customFFmpegOptions.contains("-crf") || customFFmpegOptions.contains("-b:v") || customFFmpegOptions.contains("-b ") || ((customFFmpegOptions.contains("-x264opts") || customFFmpegOptions.contains("-x264-params")) && (customFFmpegOptions.contains("crf=") || customFFmpegOptions.contains("bitrate=") || customFFmpegOptions.contains("B="))))) {
+				// Remove comment from the value
+				if (x264CRF.contains("/*")) {
+					x264CRF = x264CRF.substring(x264CRF.indexOf("/*"));
+				}
+	
+				if (x264CRF.contains("Automatic")) {
+					if (x264CRF.contains("Wireless") || maximumBitrate < 70) {
 						x264CRF = "19";
+						// Lower quality for 720p+ content
+						if (media.getWidth() > 1280) {
+							x264CRF = "23";
+						} else if (media.getWidth() > 720) {
+							x264CRF = "22";
+						}
+					} else {
+						x264CRF = "16";
+	
+						// Lower quality for 720p+ content
+						if (media.getWidth() > 720) {
+							x264CRF = "19";
+						}
 					}
 				}
-			}
-			if (isNotBlank(x264CRF) && !params.mediaRenderer.nox264()) {
-				videoBitrateOptions.add("-crf");
-				videoBitrateOptions.add(x264CRF);
+				if (isNotBlank(x264CRF) && !params.mediaRenderer.nox264()) {
+					videoBitrateOptions.add("-crf");
+					videoBitrateOptions.add(x264CRF);
+				}
 			}
 		}
 

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -376,7 +376,7 @@ public class FFMpegVideo extends Player {
 
 			// Output video codec
 			if (renderer.isTranscodeToH264() || renderer.isTranscodeToH265()) {
-				if (!customFFmpegOptions.contains("-c:v")) {
+				if (!(customFFmpegOptions.contains("-c:v") || customFFmpegOptions.contains("-codec:v") || customFFmpegOptions.contains("-vcodec"))) {
 					transcodeOptions.add("-c:v");
 					if (renderer.isTranscodeToH264()) {
 						transcodeOptions.add("libx264");

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -376,7 +376,7 @@ public class FFMpegVideo extends Player {
 
 			// Output video codec
 			if (renderer.isTranscodeToH264() || renderer.isTranscodeToH265()) {
-				if (!customFFmpegOptions.matches(".* -(c:v|codec:v|vcodec) .*")) {
+				if (!customFFmpegOptions.matches(".*-(c:v|codec:v|vcodec).*")) {
 					transcodeOptions.add("-c:v");
 					if (renderer.isTranscodeToH264()) {
 						transcodeOptions.add("libx264");


### PR DESCRIPTION
This PR fixes potential errors. Not used options can be a cause for errors. Extra options can result in decrease in quality or behavior users unexpect. Needs to consider ffmpeg often changes the behavior of options.