### PR TITLE
Preserve the "sample" flag while prettifying

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
@@ -251,9 +251,10 @@ public class DLNAMediaDatabase implements Runnable {
 							version = 13;
 							break;
 						case 13:
-							// From version 12 to 13, we added 7 indexes
 							try (Statement statement = conn.createStatement()) {
-								statement.execute("ALTER TABLE FILES ADD EXTRAINFORMATION");
+								StringBuilder sb = new StringBuilder();
+								sb.append("ALTER TABLE FILES ADD EXTRAINFORMATION VARCHAR2(").append(SIZE_MAX).append(')');
+								statement.execute(sb.toString());
 							}
 							version = 14;
 							break;

--- a/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
@@ -66,7 +66,7 @@ public class DLNAMediaDatabase implements Runnable {
 	 * The database version should be incremented when we change anything to
 	 * do with the database since the last released version.
 	 */
-	private final int latestVersion = 13;
+	private final int latestVersion = 14;
 
 	// Database column sizes
 	private final int SIZE_CODECV = 32;
@@ -78,22 +78,18 @@ public class DLNAMediaDatabase implements Runnable {
 	private final int SIZE_CONTAINER = 32;
 	private final int SIZE_IMDBID = 16;
 	private final int SIZE_MATRIX_COEFFICIENTS = 16;
-	private final int SIZE_MOVIEORSHOWNAME = 255;
 	private final int SIZE_MUXINGMODE = 32;
 	private final int SIZE_FRAMERATE_MODE = 16;
-	private final int SIZE_STEREOSCOPY = 255;
 	private final int SIZE_LANG = 3;
-	private final int SIZE_TITLE = 255;
 	private final int SIZE_SAMPLEFREQ = 16;
 	private final int SIZE_CODECA = 32;
-	private final int SIZE_ALBUM = 255;
-	private final int SIZE_ARTIST = 255;
-	private final int SIZE_SONGNAME = 255;
 	private final int SIZE_GENRE = 64;
-	private final int SIZE_TVEPISODENAME = 255;
 	private final int SIZE_YEAR = 4;
 	private final int SIZE_TVSEASON = 4;
 	private final int SIZE_TVEPISODENUMBER = 8;
+
+	// Generic constant for the maximum string size: 255 chars
+	private final int SIZE_MAX = 255;
 
 	public DLNAMediaDatabase(String name) {
 		dbName = name;
@@ -254,6 +250,13 @@ public class DLNAMediaDatabase implements Runnable {
 							}
 							version = 13;
 							break;
+						case 13:
+							// From version 12 to 13, we added 7 indexes
+							try (Statement statement = conn.createStatement()) {
+								statement.execute("ALTER TABLE FILES ADD EXTRAINFORMATION");
+							}
+							version = 14;
+							break;
 						default:
 							// Do the dumb way
 							forceReInit = true;
@@ -320,21 +323,22 @@ public class DLNAMediaDatabase implements Runnable {
 				sb.append(", CONTAINER               VARCHAR2(").append(SIZE_CONTAINER).append(')');
 				sb.append(", MUXINGMODE              VARCHAR2(").append(SIZE_MUXINGMODE).append(')');
 				sb.append(", FRAMERATEMODE           VARCHAR2(").append(SIZE_FRAMERATE_MODE).append(')');
-				sb.append(", STEREOSCOPY             VARCHAR2(").append(SIZE_STEREOSCOPY).append(')');
+				sb.append(", STEREOSCOPY             VARCHAR2(").append(SIZE_MAX).append(')');
 				sb.append(", MATRIXCOEFFICIENTS      VARCHAR2(").append(SIZE_MATRIX_COEFFICIENTS).append(')');
-				sb.append(", TITLECONTAINER          VARCHAR2(").append(SIZE_TITLE).append(')');
-				sb.append(", TITLEVIDEOTRACK         VARCHAR2(").append(SIZE_TITLE).append(')');
+				sb.append(", TITLECONTAINER          VARCHAR2(").append(SIZE_MAX).append(')');
+				sb.append(", TITLEVIDEOTRACK         VARCHAR2(").append(SIZE_MAX).append(')');
 				sb.append(", VIDEOTRACKCOUNT         INT");
 				sb.append(", IMAGECOUNT              INT");
 				sb.append(", BITDEPTH                INT");
 				sb.append(", IMDBID                  VARCHAR2(").append(SIZE_IMDBID).append(')');
 				sb.append(", YEAR                    VARCHAR2(").append(SIZE_YEAR).append(')');
-				sb.append(", MOVIEORSHOWNAME         VARCHAR2(").append(SIZE_MOVIEORSHOWNAME).append(')');
-				sb.append(", MOVIEORSHOWNAMESIMPLE   VARCHAR2(").append(SIZE_MOVIEORSHOWNAME).append(')');
+				sb.append(", MOVIEORSHOWNAME         VARCHAR2(").append(SIZE_MAX).append(')');
+				sb.append(", MOVIEORSHOWNAMESIMPLE   VARCHAR2(").append(SIZE_MAX).append(')');
 				sb.append(", TVSEASON                VARCHAR2(").append(SIZE_TVSEASON).append(')');
 				sb.append(", TVEPISODENUMBER         VARCHAR2(").append(SIZE_TVEPISODENUMBER).append(')');
-				sb.append(", TVEPISODENAME           VARCHAR2(").append(SIZE_TVEPISODENAME).append(')');
+				sb.append(", TVEPISODENAME           VARCHAR2(").append(SIZE_MAX).append(')');
 				sb.append(", ISTVEPISODE             BOOLEAN)");
+				sb.append(", EXTRAINFORMATION        VARCHAR2(").append(SIZE_MAX).append(')');
 				if (trace) {
 					LOGGER.trace("Creating table FILES with:\n\n{}\n", sb.toString());
 				}
@@ -346,14 +350,14 @@ public class DLNAMediaDatabase implements Runnable {
 				sb.append("  ID                INT              NOT NULL");
 				sb.append(", FILEID            BIGINT           NOT NULL");
 				sb.append(", LANG              VARCHAR2(").append(SIZE_LANG).append(')');
-				sb.append(", TITLE             VARCHAR2(").append(SIZE_TITLE).append(')');
+				sb.append(", TITLE             VARCHAR2(").append(SIZE_MAX).append(')');
 				sb.append(", NRAUDIOCHANNELS   NUMERIC");
 				sb.append(", SAMPLEFREQ        VARCHAR2(").append(SIZE_SAMPLEFREQ).append(')');
 				sb.append(", CODECA            VARCHAR2(").append(SIZE_CODECA).append(')');
 				sb.append(", BITSPERSAMPLE     INT");
-				sb.append(", ALBUM             VARCHAR2(").append(SIZE_ALBUM).append(')');
-				sb.append(", ARTIST            VARCHAR2(").append(SIZE_ARTIST).append(')');
-				sb.append(", SONGNAME          VARCHAR2(").append(SIZE_SONGNAME).append(')');
+				sb.append(", ALBUM             VARCHAR2(").append(SIZE_MAX).append(')');
+				sb.append(", ARTIST            VARCHAR2(").append(SIZE_MAX).append(')');
+				sb.append(", SONGNAME          VARCHAR2(").append(SIZE_MAX).append(')');
 				sb.append(", GENRE             VARCHAR2(").append(SIZE_GENRE).append(')');
 				sb.append(", YEAR              INT");
 				sb.append(", TRACK             INT");
@@ -370,7 +374,7 @@ public class DLNAMediaDatabase implements Runnable {
 				sb.append("  ID       INT              NOT NULL");
 				sb.append(", FILEID   BIGINT           NOT NULL");
 				sb.append(", LANG     VARCHAR2(").append(SIZE_LANG).append(')');
-				sb.append(", TITLE    VARCHAR2(").append(SIZE_TITLE).append(')');
+				sb.append(", TITLE    VARCHAR2(").append(SIZE_MAX).append(')');
 				sb.append(", TYPE     INT");
 				sb.append(", constraint PKSUB primary key (FILEID, ID))");
 
@@ -581,6 +585,7 @@ public class DLNAMediaDatabase implements Runnable {
 					media.setYear(rs.getString("YEAR"));
 					media.setMovieOrShowName(rs.getString("MOVIEORSHOWNAME"));
 					media.setSimplifiedMovieOrShowName(rs.getString("MOVIEORSHOWNAMESIMPLE"));
+					media.setExtraInformation(rs.getString("EXTRAINFORMATION"));
 
 					if (rs.getBoolean("ISTVEPISODE")) {
 						media.setTVSeason(rs.getString("TVSEASON"));
@@ -680,7 +685,7 @@ public class DLNAMediaDatabase implements Runnable {
 				try (ResultSet rs = updateStatment.executeQuery()) {
 					if (rs.next()) {
 						rs.updateString("LANG", left(subtitleTrack.getLang(), SIZE_LANG));
-						rs.updateString("TITLE", left(subtitleTrack.getSubtitlesTrackTitleFromMetadata(), SIZE_TITLE));
+						rs.updateString("TITLE", left(subtitleTrack.getSubtitlesTrackTitleFromMetadata(), SIZE_MAX));
 						rs.updateInt("TYPE", subtitleTrack.getType().getStableIndex());
 						rs.updateRow();
 					} else {
@@ -688,7 +693,7 @@ public class DLNAMediaDatabase implements Runnable {
 						insertStatement.setLong(1, fileId);
 						insertStatement.setInt(2, subtitleTrack.getId());
 						insertStatement.setString(3, left(subtitleTrack.getLang(), SIZE_LANG));
-						insertStatement.setString(4, left(subtitleTrack.getSubtitlesTrackTitleFromMetadata(), SIZE_TITLE));
+						insertStatement.setString(4, left(subtitleTrack.getSubtitlesTrackTitleFromMetadata(), SIZE_MAX));
 						insertStatement.setInt(5, subtitleTrack.getType().getStableIndex());
 						insertStatement.executeUpdate();
 					}
@@ -732,14 +737,14 @@ public class DLNAMediaDatabase implements Runnable {
 				try (ResultSet rs = updateStatment.executeQuery()) {
 					if (rs.next()) {
 						rs.updateString("LANG", left(audioTrack.getLang(), SIZE_LANG));
-						rs.updateString("TITLE", left(audioTrack.getAudioTrackTitleFromMetadata(), SIZE_TITLE));
+						rs.updateString("TITLE", left(audioTrack.getAudioTrackTitleFromMetadata(), SIZE_MAX));
 						rs.updateInt("NRAUDIOCHANNELS", audioTrack.getAudioProperties().getNumberOfChannels());
 						rs.updateString("SAMPLEFREQ", left(audioTrack.getSampleFrequency(), SIZE_SAMPLEFREQ));
 						rs.updateString("CODECA", left(audioTrack.getCodecA(), SIZE_CODECA));
 						rs.updateInt("BITSPERSAMPLE", audioTrack.getBitsperSample());
-						rs.updateString("ALBUM", left(trimToEmpty(audioTrack.getAlbum()), SIZE_ALBUM));
-						rs.updateString("ARTIST", left(trimToEmpty(audioTrack.getArtist()), SIZE_ARTIST));
-						rs.updateString("SONGNAME", left(trimToEmpty(audioTrack.getSongname()), SIZE_SONGNAME));
+						rs.updateString("ALBUM", left(trimToEmpty(audioTrack.getAlbum()), SIZE_MAX));
+						rs.updateString("ARTIST", left(trimToEmpty(audioTrack.getArtist()), SIZE_MAX));
+						rs.updateString("SONGNAME", left(trimToEmpty(audioTrack.getSongname()), SIZE_MAX));
 						rs.updateString("GENRE", left(trimToEmpty(audioTrack.getGenre()), SIZE_GENRE));
 						rs.updateInt("YEAR", audioTrack.getYear());
 						rs.updateInt("TRACK", audioTrack.getTrack());
@@ -752,14 +757,14 @@ public class DLNAMediaDatabase implements Runnable {
 						insertStatement.setLong(1, fileId);
 						insertStatement.setInt(2, audioTrack.getId());
 						insertStatement.setString(3, left(audioTrack.getLang(), SIZE_LANG));
-						insertStatement.setString(4, left(audioTrack.getAudioTrackTitleFromMetadata(), SIZE_TITLE));
+						insertStatement.setString(4, left(audioTrack.getAudioTrackTitleFromMetadata(), SIZE_MAX));
 						insertStatement.setInt(5, audioTrack.getAudioProperties().getNumberOfChannels());
 						insertStatement.setString(6, left(audioTrack.getSampleFrequency(), SIZE_SAMPLEFREQ));
 						insertStatement.setString(7, left(audioTrack.getCodecA(), SIZE_CODECA));
 						insertStatement.setInt(8, audioTrack.getBitsperSample());
-						insertStatement.setString(9, left(trimToEmpty(audioTrack.getAlbum()), SIZE_ALBUM));
-						insertStatement.setString(10, left(trimToEmpty(audioTrack.getArtist()), SIZE_ARTIST));
-						insertStatement.setString(11, left(trimToEmpty(audioTrack.getSongname()), SIZE_SONGNAME));
+						insertStatement.setString(9, left(trimToEmpty(audioTrack.getAlbum()), SIZE_MAX));
+						insertStatement.setString(10, left(trimToEmpty(audioTrack.getArtist()), SIZE_MAX));
+						insertStatement.setString(11, left(trimToEmpty(audioTrack.getSongname()), SIZE_MAX));
 						insertStatement.setString(12, left(trimToEmpty(audioTrack.getGenre()), SIZE_GENRE));
 						insertStatement.setInt(13, audioTrack.getYear());
 						insertStatement.setInt(14, audioTrack.getTrack());
@@ -798,7 +803,7 @@ public class DLNAMediaDatabase implements Runnable {
 					"ASPECT, ASPECTRATIOCONTAINER, ASPECTRATIOVIDEOTRACK, REFRAMES, AVCLEVEL, IMAGEINFO, THUMB, " +
 					"CONTAINER, MUXINGMODE, FRAMERATEMODE, STEREOSCOPY, MATRIXCOEFFICIENTS, TITLECONTAINER, " +
 					"TITLEVIDEOTRACK, VIDEOTRACKCOUNT, IMAGECOUNT, BITDEPTH, IMDBID, YEAR, MOVIEORSHOWNAME, " +
-					"MOVIEORSHOWNAMESIMPLE, TVSEASON, TVEPISODENUMBER, TVEPISODENAME, ISTVEPISODE " +
+					"MOVIEORSHOWNAMESIMPLE, TVSEASON, TVEPISODENUMBER, TVEPISODENAME, ISTVEPISODE, EXTRAINFORMATION " +
 				"FROM FILES " +
 				"WHERE " +
 					"FILENAME = ?",
@@ -849,21 +854,22 @@ public class DLNAMediaDatabase implements Runnable {
 							rs.updateString("CONTAINER", left(media.getContainer(), SIZE_CONTAINER));
 							rs.updateString("MUXINGMODE", left(media.getMuxingModeAudio(), SIZE_MUXINGMODE));
 							rs.updateString("FRAMERATEMODE", left(media.getFrameRateMode(), SIZE_FRAMERATE_MODE));
-							rs.updateString("STEREOSCOPY", left(media.getStereoscopy(), SIZE_STEREOSCOPY));
+							rs.updateString("STEREOSCOPY", left(media.getStereoscopy(), SIZE_MAX));
 							rs.updateString("MATRIXCOEFFICIENTS", left(media.getMatrixCoefficients(), SIZE_MATRIX_COEFFICIENTS));
-							rs.updateString("TITLECONTAINER", left(media.getFileTitleFromMetadata(), SIZE_TITLE));
-							rs.updateString("TITLEVIDEOTRACK", left(media.getVideoTrackTitleFromMetadata(), SIZE_TITLE));
+							rs.updateString("TITLECONTAINER", left(media.getFileTitleFromMetadata(), SIZE_MAX));
+							rs.updateString("TITLEVIDEOTRACK", left(media.getVideoTrackTitleFromMetadata(), SIZE_MAX));
 							rs.updateInt("VIDEOTRACKCOUNT", media.getVideoTrackCount());
 							rs.updateInt("IMAGECOUNT", media.getImageCount());
 							rs.updateInt("BITDEPTH", media.getVideoBitDepth());
 							rs.updateString("IMDBID", left(media.getIMDbID(), SIZE_IMDBID));
 							rs.updateString("YEAR", left(media.getYear(), SIZE_YEAR));
-							rs.updateString("MOVIEORSHOWNAME", left(media.getMovieOrShowName(), SIZE_MOVIEORSHOWNAME));
-							rs.updateString("MOVIEORSHOWNAMESIMPLE", left(media.getSimplifiedMovieOrShowName(), SIZE_MOVIEORSHOWNAME));
+							rs.updateString("MOVIEORSHOWNAME", left(media.getMovieOrShowName(), SIZE_MAX));
+							rs.updateString("MOVIEORSHOWNAMESIMPLE", left(media.getSimplifiedMovieOrShowName(), SIZE_MAX));
 							rs.updateString("TVSEASON", left(media.getTVSeason(), SIZE_TVSEASON));
 							rs.updateString("TVEPISODENUMBER", left(media.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
-							rs.updateString("TVEPISODENAME", left(media.getTVEpisodeName(), SIZE_TVEPISODENAME));
+							rs.updateString("TVEPISODENAME", left(media.getTVEpisodeName(), SIZE_MAX));
 							rs.updateBoolean("ISTVEPISODE", media.isTVEpisode());
+							rs.updateString("EXTRAINFORMATION", left(media.getExtraInformation(), SIZE_MAX));
 						}
 						rs.updateRow();
 					}
@@ -877,8 +883,8 @@ public class DLNAMediaDatabase implements Runnable {
 						"FRAMERATE, ASPECT, ASPECTRATIOCONTAINER, ASPECTRATIOVIDEOTRACK, REFRAMES, AVCLEVEL, IMAGEINFO, " +
 						"THUMB, CONTAINER, MUXINGMODE, FRAMERATEMODE, STEREOSCOPY, MATRIXCOEFFICIENTS, TITLECONTAINER, " +
 						"TITLEVIDEOTRACK, VIDEOTRACKCOUNT, IMAGECOUNT, BITDEPTH, IMDBID, YEAR, MOVIEORSHOWNAME, " +
-						"MOVIEORSHOWNAMESIMPLE, TVSEASON, TVEPISODENUMBER, TVEPISODENAME, ISTVEPISODE) VALUES " +
-						"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+						"MOVIEORSHOWNAMESIMPLE, TVSEASON, TVEPISODENUMBER, TVEPISODENAME, ISTVEPISODE, EXTRAINFORMATION) VALUES " +
+						"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 				) {
 					ps.setString(1, name);
 					ps.setTimestamp(2, new Timestamp(modified));
@@ -922,21 +928,22 @@ public class DLNAMediaDatabase implements Runnable {
 						ps.setString(18, left(media.getContainer(), SIZE_CONTAINER));
 						ps.setString(19, left(media.getMuxingModeAudio(), SIZE_MUXINGMODE));
 						ps.setString(20, left(media.getFrameRateMode(), SIZE_FRAMERATE_MODE));
-						ps.setString(21, left(media.getStereoscopy(), SIZE_STEREOSCOPY));
+						ps.setString(21, left(media.getStereoscopy(), SIZE_MAX));
 						ps.setString(22, left(media.getMatrixCoefficients(), SIZE_MATRIX_COEFFICIENTS));
-						ps.setString(23, left(media.getFileTitleFromMetadata(), SIZE_TITLE));
-						ps.setString(24, left(media.getVideoTrackTitleFromMetadata(), SIZE_TITLE));
+						ps.setString(23, left(media.getFileTitleFromMetadata(), SIZE_MAX));
+						ps.setString(24, left(media.getVideoTrackTitleFromMetadata(), SIZE_MAX));
 						ps.setInt(25, media.getVideoTrackCount());
 						ps.setInt(26, media.getImageCount());
 						ps.setInt(27, media.getVideoBitDepth());
 						ps.setString(28, left(media.getIMDbID(), SIZE_IMDBID));
 						ps.setString(29, left(media.getYear(), SIZE_YEAR));
-						ps.setString(30, left(media.getMovieOrShowName(), SIZE_MOVIEORSHOWNAME));
-						ps.setString(31, left(media.getSimplifiedMovieOrShowName(), SIZE_MOVIEORSHOWNAME));
+						ps.setString(30, left(media.getMovieOrShowName(), SIZE_MAX));
+						ps.setString(31, left(media.getSimplifiedMovieOrShowName(), SIZE_MAX));
 						ps.setString(32, left(media.getTVSeason(), SIZE_TVSEASON));
 						ps.setString(33, left(media.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
-						ps.setString(34, left(media.getTVEpisodeName(), SIZE_TVEPISODENAME));
+						ps.setString(34, left(media.getTVEpisodeName(), SIZE_MAX));
 						ps.setBoolean(35, media.isTVEpisode());
+						ps.setString(36, left(media.getExtraInformation(), SIZE_MAX));
 					} else {
 						ps.setString(4, null);
 						ps.setInt(5, 0);
@@ -970,6 +977,7 @@ public class DLNAMediaDatabase implements Runnable {
 						ps.setNull(33, Types.VARCHAR);
 						ps.setNull(34, Types.VARCHAR);
 						ps.setBoolean(35, false);
+						ps.setNull(36, Types.VARCHAR);
 					}
 					ps.executeUpdate();
 					try (ResultSet rs = ps.getGeneratedKeys()) {
@@ -1026,7 +1034,7 @@ public class DLNAMediaDatabase implements Runnable {
 			connection.setAutoCommit(false);
 			try (PreparedStatement ps = connection.prepareStatement(
 				"SELECT " +
-					"ID, IMDBID, YEAR, MOVIEORSHOWNAME, MOVIEORSHOWNAMESIMPLE, TVSEASON, TVEPISODENUMBER, TVEPISODENAME, ISTVEPISODE " +
+					"ID, IMDBID, YEAR, MOVIEORSHOWNAME, MOVIEORSHOWNAMESIMPLE, TVSEASON, TVEPISODENUMBER, TVEPISODENAME, ISTVEPISODE, EXTRAINFORMATION " +
 				"FROM FILES " +
 				"WHERE " +
 					"FILENAME = ? AND MODIFIED = ?",
@@ -1039,12 +1047,13 @@ public class DLNAMediaDatabase implements Runnable {
 					if (rs.next()) {
 						rs.updateString("IMDBID", left(media.getIMDbID(), SIZE_IMDBID));
 						rs.updateString("YEAR", left(media.getYear(), SIZE_YEAR));
-						rs.updateString("MOVIEORSHOWNAME", left(media.getMovieOrShowName(), SIZE_MOVIEORSHOWNAME));
-						rs.updateString("MOVIEORSHOWNAMESIMPLE", left(media.getSimplifiedMovieOrShowName(), SIZE_MOVIEORSHOWNAME));
+						rs.updateString("MOVIEORSHOWNAME", left(media.getMovieOrShowName(), SIZE_MAX));
+						rs.updateString("MOVIEORSHOWNAMESIMPLE", left(media.getSimplifiedMovieOrShowName(), SIZE_MAX));
 						rs.updateString("TVSEASON", left(media.getTVSeason(), SIZE_TVSEASON));
 						rs.updateString("TVEPISODENUMBER", left(media.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
-						rs.updateString("TVEPISODENAME", left(media.getTVEpisodeName(), SIZE_TVEPISODENAME));
+						rs.updateString("TVEPISODENAME", left(media.getTVEpisodeName(), SIZE_MAX));
 						rs.updateBoolean("ISTVEPISODE", media.isTVEpisode());
+						rs.updateString("EXTRAINFORMATION", left(media.getExtraInformation(), SIZE_MAX));
 						rs.updateRow();
 					} else {
 						LOGGER.error("Couldn't find \"{}\" in the database when trying to store data from OpenSubtitles", name);
@@ -1063,7 +1072,7 @@ public class DLNAMediaDatabase implements Runnable {
 	 */
 	public void updateMovieOrShowName(String oldName, String newName) {
 		try {
-			updateRowsInFilesTable(oldName, newName, "MOVIEORSHOWNAME", SIZE_MOVIEORSHOWNAME, true);
+			updateRowsInFilesTable(oldName, newName, "MOVIEORSHOWNAME", SIZE_MAX, true);
 		} catch (SQLException e) {
 			LOGGER.error(
 				"Failed to update MOVIEORSHOWNAME from \"{}\" to \"{}\": {}",

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -190,7 +190,7 @@ public class DLNAMediaInfo implements Cloneable {
 	private String tvSeason;
 	private String tvEpisodeNumber;
 	private String tvEpisodeName;
-	private String edition;
+	private String extraInformation;
 	private boolean isTVEpisode;
 
 	private volatile ImageInfo imageInfo = null;
@@ -2374,12 +2374,25 @@ public class DLNAMediaInfo implements Cloneable {
 		this.isTVEpisode = value;
 	}
 
-	public String getEdition() {
-		return edition;
+	/**
+	 * Any extra information like movie edition or whether it is a
+	 * sample video.
+	 *
+	 * Example: "(Director's Cut) (Sample)"
+	 * @return 
+	 */
+	public String getExtraInformation() {
+		return extraInformation;
 	}
 
-	public void setEdition(String value) {
-		this.edition = value;
+	/**
+	 * Any extra information like movie edition or whether it is a
+	 * sample video.
+	 *
+	 * Example: "(Director's Cut) (Sample)"
+	 */
+	public void setExtraInformation(String value) {
+		this.extraInformation = value;
 	}
 
 	/**

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -547,7 +547,7 @@ public class FileUtil {
 
 		formattedName = basicPrettify(filename);
 
-		if (formattedName.toLowerCase().endsWith("sample")) {
+		if (formattedName.toLowerCase(Locale.ENGLISH).endsWith("sample")) {
 			isSample = true;
 		}
 

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -533,6 +533,7 @@ public class FileUtil {
 
 		// These are false unless we recognize that we could use some info on the video from IMDb
 		boolean isMovieWithoutYear = false;
+		boolean isSample = false;
 
 		String movieOrShowName = null;
 		String year            = null;
@@ -545,6 +546,10 @@ public class FileUtil {
 		Matcher matcher;
 
 		formattedName = basicPrettify(filename);
+
+		if (formattedName.toLowerCase().endsWith("sample")) {
+			isSample = true;
+		}
 
 		if (formattedName.matches(".*[sS]\\d\\d[eE]\\d\\d([eE]|-[eE])\\d\\d.*")) {
 			// This matches scene and most p2p TV episodes within the first 9 seasons that are more than one episode
@@ -808,6 +813,16 @@ public class FileUtil {
 				formattedName = formattedName.substring(0, formattedName.length() - 2);
 			}
 			formattedName += " " + edition;
+		}
+
+		// Retain the fact it is a sample clip
+		if (isSample) {
+			if (edition == null) {
+				edition = "";
+			} else {
+				edition += " ";
+			}
+			edition += "(Sample)";
 		}
 
 		return new String[] { movieOrShowName, year, edition, tvSeason, tvEpisodeNumber, tvEpisodeName };

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -449,7 +449,7 @@ public class FileUtil {
 
 		String title;
 		String year;
-		String edition;
+		String extraInformation;
 		String tvSeason;
 		String tvEpisodeNumber;
 		String tvEpisodeName;
@@ -459,21 +459,21 @@ public class FileUtil {
 		if (media != null && getConfiguration().getUseCache() && StringUtils.isNotBlank(media.getMovieOrShowName())) {
 			title = media.getMovieOrShowName();
 
-			year            = StringUtils.isNotBlank(media.getYear())            ? media.getYear()            : "";
-			edition         = StringUtils.isNotBlank(media.getEdition())         ? media.getEdition()         : "";
-			tvSeason        = StringUtils.isNotBlank(media.getTVSeason())        ? media.getTVSeason()        : "";
-			tvEpisodeNumber = StringUtils.isNotBlank(media.getTVEpisodeNumber()) ? media.getTVEpisodeNumber() : "";
-			tvEpisodeName   = StringUtils.isNotBlank(media.getTVEpisodeName())   ? media.getTVEpisodeName()   : "";
-			isTVEpisode     = StringUtils.isNotBlank(media.getTVSeason());
+			year             = StringUtils.isNotBlank(media.getYear())             ? media.getYear()             : "";
+			extraInformation = StringUtils.isNotBlank(media.getExtraInformation()) ? media.getExtraInformation() : "";
+			tvSeason         = StringUtils.isNotBlank(media.getTVSeason())         ? media.getTVSeason()         : "";
+			tvEpisodeNumber  = StringUtils.isNotBlank(media.getTVEpisodeNumber())  ? media.getTVEpisodeNumber()  : "";
+			tvEpisodeName    = StringUtils.isNotBlank(media.getTVEpisodeName())    ? media.getTVEpisodeName()    : "";
+			isTVEpisode      = StringUtils.isNotBlank(media.getTVSeason());
 		} else {
 			String[] metadataFromFilename = getFileNameMetadata(f);
 
-			title           = StringUtils.isNotBlank(metadataFromFilename[0]) ? metadataFromFilename[0] : "";
-			year            = StringUtils.isNotBlank(metadataFromFilename[1]) ? metadataFromFilename[1] : "";
-			edition         = StringUtils.isNotBlank(metadataFromFilename[2]) ? metadataFromFilename[2] : "";
-			tvSeason        = StringUtils.isNotBlank(metadataFromFilename[3]) ? metadataFromFilename[3] : "";
-			tvEpisodeNumber = StringUtils.isNotBlank(metadataFromFilename[4]) ? metadataFromFilename[4] : "";
-			tvEpisodeName   = StringUtils.isNotBlank(metadataFromFilename[5]) ? metadataFromFilename[5] : "";
+			title            = StringUtils.isNotBlank(metadataFromFilename[0]) ? metadataFromFilename[0] : "";
+			year             = StringUtils.isNotBlank(metadataFromFilename[1]) ? metadataFromFilename[1] : "";
+			extraInformation = StringUtils.isNotBlank(metadataFromFilename[2]) ? metadataFromFilename[2] : "";
+			tvSeason         = StringUtils.isNotBlank(metadataFromFilename[3]) ? metadataFromFilename[3] : "";
+			tvEpisodeNumber  = StringUtils.isNotBlank(metadataFromFilename[4]) ? metadataFromFilename[4] : "";
+			tvEpisodeName    = StringUtils.isNotBlank(metadataFromFilename[5]) ? metadataFromFilename[5] : "";
 
 			if (StringUtils.isNotBlank(tvSeason)) {
 				isTVEpisode = true;
@@ -509,8 +509,8 @@ public class FileUtil {
 			}
 		}
 
-		if (StringUtils.isNotBlank(edition)) {
-			formattedName += " " + edition;
+		if (StringUtils.isNotBlank(extraInformation)) {
+			formattedName += " " + extraInformation;
 		}
 
 		return formattedName;
@@ -541,6 +541,9 @@ public class FileUtil {
 		String tvEpisodeName   = null;
 		String tvEpisodeNumber = null;
 		String edition         = null;
+		
+		// This can contain editions and "Sample" for now
+		String extraInformation = null;
 
 		Pattern pattern;
 		Matcher matcher;
@@ -806,26 +809,19 @@ public class FileUtil {
 			}
 		}
 
-		// Add the edition information if it exists
-		if (edition != null) {
-			String substr = formattedName.substring(Math.max(0, formattedName.length() - 2));
-			if (" -".equals(substr)) {
-				formattedName = formattedName.substring(0, formattedName.length() - 2);
-			}
-			formattedName += " " + edition;
-		}
-
 		// Retain the fact it is a sample clip
 		if (isSample) {
 			if (edition == null) {
-				edition = "";
+				extraInformation = "";
 			} else {
-				edition += " ";
+				extraInformation = edition + " ";
 			}
-			edition += "(Sample)";
+			extraInformation += "(Sample)";
+		} else {
+			extraInformation = edition;
 		}
 
-		return new String[] { movieOrShowName, year, edition, tvSeason, tvEpisodeNumber, tvEpisodeName };
+		return new String[] { movieOrShowName, year, extraInformation, tvSeason, tvEpisodeNumber, tvEpisodeName };
 	}
 
 	/**

--- a/src/main/java/net/pms/util/OpenSubtitle.java
+++ b/src/main/java/net/pms/util/OpenSubtitle.java
@@ -558,12 +558,12 @@ public class OpenSubtitle {
 			final boolean overTheTopLogging = false;
 			String[] metadataFromFilename = FileUtil.getFileNameMetadata(file.getName());
 
-			String titleFromFilename           = metadataFromFilename[0];
-			String yearFromFilename            = metadataFromFilename[1];
-			String editionFromFilename         = metadataFromFilename[2];
-			String tvSeasonFromFilename        = metadataFromFilename[3];
-			String tvEpisodeNumberFromFilename = metadataFromFilename[4];
-			String tvEpisodeNameFromFilename   = metadataFromFilename[5];
+			String titleFromFilename            = metadataFromFilename[0];
+			String yearFromFilename             = metadataFromFilename[1];
+			String extraInformationFromFilename = metadataFromFilename[2];
+			String tvSeasonFromFilename         = metadataFromFilename[3];
+			String tvEpisodeNumberFromFilename  = metadataFromFilename[4];
+			String tvEpisodeNameFromFilename    = metadataFromFilename[5];
 
 			String titleFromFilenameSimplified = PMS.get().getSimplifiedShowName(titleFromFilename);
 
@@ -607,8 +607,8 @@ public class OpenSubtitle {
 			if (yearFromFilename != null) {
 				media.setYear(yearFromFilename);
 			}
-			if (editionFromFilename != null) {
-				media.setEdition(editionFromFilename);
+			if (extraInformationFromFilename != null) {
+				media.setExtraInformation(extraInformationFromFilename);
 			}
 
 			try {
@@ -731,7 +731,6 @@ public class OpenSubtitle {
 										media.setMovieOrShowName(titleFromOpenSubtitles);
 										media.setSimplifiedMovieOrShowName(titleFromOpenSubtitlesSimplified);
 										media.setYear(metadataFromOpenSubtitles[5]);
-										media.setEdition(editionFromFilename);
 
 										// If the filename has indicated this is a TV episode
 										if (StringUtils.isNotBlank(tvSeasonFromFilename)) {

--- a/src/test/java/net/pms/util/FileUtilTest.java
+++ b/src/test/java/net/pms/util/FileUtilTest.java
@@ -128,6 +128,9 @@ public class FileUtilTest {
 		assertThat(FileUtil.getFileNamePrettified("Universal.Media.Server.Special.Edition.2015.720p.mkv")).isEqualTo("Universal Media Server (2015) (Special Edition)");
 		assertThat(FileUtil.getFileNamePrettified("Universal.Media.Server.2015.Special.Edition.720p.mkv")).isEqualTo("Universal Media Server (2015) (Special Edition)");
 
+		// Video of a sample of a movie
+		assertThat(FileUtil.getFileNamePrettified("Universal.Media.Server.2015.720p.Sample.mkv")).isEqualTo("Universal Media Server (2015) (Sample)");
+
 		// Video of an anime episode
 		assertThat(FileUtil.getFileNamePrettified("Universal Media Server - 02 [BD.1080p] [700D423E].mkv")).isEqualTo("Universal Media Server - 102");
 		assertThat(FileUtil.getFileNamePrettified("[FanSubbers]_Universal_Media_Server_02_[700D423E].mp4")).isEqualTo("Universal Media Server - 102");


### PR DESCRIPTION
This fixes a bug where:

```
Movie.2011.1080p.BluRay.DTS.x264-Releasers.mkv
Movie.2011.1080p.BluRay.DTS.x264-Releasers.Sample.mkv
```

Both show up in the server as "Movie (2011)" when prettified