### PR TITLE
Fixed maximum memory setting in JRE9+

### DIFF
--- a/src/main/external-resources/nsis/setup.nsi
+++ b/src/main/external-resources/nsis/setup.nsi
@@ -118,8 +118,11 @@ Function AdvancedSettings
 		SetRegView 64
 	${EndIf}
 	ReadRegStr $0 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
-	IfErrors SetMinMem
 	IfErrors 0 CheckMemAmnt
+
+	; This is where the registry entries go in JRE9+
+	ReadRegStr $0 HKLM "SOFTWARE\JavaSoft\JRE" "CurrentVersion"
+	IfErrors SetLowMemoryLimit CheckMemAmnt
 
 	; Get the amount of RAM on the computer
 	CheckMemAmnt:
@@ -132,16 +135,15 @@ Function AdvancedSettings
 	System::Int64Op $4 / 1048576
 	Pop $4
 
-	; Choose the maximum amount of RAM we want to use based on installed ram
+	; Choose the maximum amount of RAM we want to use based on installed RAM
 	${If} $4 > 4000 
 		StrCpy $MaximumMemoryJava "1280"
-		Goto NSDContinue
 	${Else}
 		StrCpy $MaximumMemoryJava "768"
-		Goto NSDContinue
 	${EndIf}
+	Goto NSDContinue
 
-	SetMinMem:
+	SetLowMemoryLimit:
 	StrCpy $MaximumMemoryJava "768" 
 
 	NSDContinue:


### PR DESCRIPTION
Currently if a user has JRE9+ installed, and not JRE8- installed, NSIS will always default their maximum memory to 768MB. This restores our previous functionality of defaulting to 1280MB if they have higher than 4000GB of RAM.
Also some minor formatting to make the code more readable