### PR TITLE
Fixed bug when multiple video streams are transcoded.

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -955,7 +955,7 @@ public class FFMpegVideo extends Player {
 		if (media.getAudioTracksList().size() > 1) {
 			// Set the video stream
 			cmdList.add("-map");
-			cmdList.add("0:v");
+			cmdList.add("0:v:0"); //TODO find a way how to automatically select propper stream when media includes multiple video streams
 
 			// Set the proper audio stream
 			cmdList.add("-map");


### PR DESCRIPTION
Only one video stream should be transcoded but there is not implemented a way how to select this stream. New class like `DLNAMediaVideo` and `List<DLNAMediaVideo> videoTracks` in the DLNAMediaInfo could be implemented to do that. I found the bug where I try to solve the problem reported in http://www.universalmediaserver.com/forum/viewtopic.php?f=9&p=36522#p36522 
For now I set FFmpeg parameter to use the first video stream which should be the primary stream to use.