### PR TITLE
Improvements to Windows auto updater:

### DIFF
--- a/src/main/java/net/pms/configuration/Build.java
+++ b/src/main/java/net/pms/configuration/Build.java
@@ -44,19 +44,19 @@ public class Build {
 
 	/**
 	 * the name of the subdirectory under which PMS config files are stored for this build.
-	 * the default value is "PMS" e.g.
+	 * the default value is "UMS" e.g.
 	 *
 	 *     Windows:
 	 *
-	 *         %ALLUSERSPROFILE%\PMS
+	 *         %ALLUSERSPROFILE%\UMS
 	 *
 	 *     Mac OS X:
 	 *
-	 *         /home/<username>/Library/Application Support/PMS
+	 *         /home/<username>/Library/Application Support/UMS
 	 *
 	 *     Linux &c.
 	 *
-	 *         /home/<username>/.config/PMS
+	 *         /home/<username>/.config/UMS
 	 *
 	 * a custom build can change this to avoid interfering with the config files of other
 	 * builds e.g.:
@@ -64,7 +64,7 @@ public class Build {
 	 *     PROFILE_DIRECTORY_NAME = "PMS Rendr Edition";
 	 *     PROFILE_DIRECTORY_NAME = "pms-mlx";
 	 *
-	 * Note: custom Windows builds that change this value should change the corresponding "$ALLUSERSPROFILE\PMS"
+	 * Note: custom Windows builds that change this value should change the corresponding "$ALLUSERSPROFILE\UMS"
 	 * value in nsis/setup.nsi
 	 *
 	 * @return The profile directory name

--- a/src/main/java/net/pms/newgui/update/AutoUpdateDialog.java
+++ b/src/main/java/net/pms/newgui/update/AutoUpdateDialog.java
@@ -11,9 +11,13 @@ import java.util.Observable;
 import java.util.Observer;
 import javax.swing.*;
 import net.pms.Messages;
+import net.pms.PMS;
+import net.pms.configuration.PmsConfiguration;
 import net.pms.update.AutoUpdater;
 import net.pms.update.AutoUpdater.State;
 import net.pms.util.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AutoUpdateDialog extends JDialog implements Observer {
 	private static final long serialVersionUID = 3809427933990495309L;
@@ -23,6 +27,8 @@ public class AutoUpdateDialog extends JDialog implements Observer {
 	private JButton cancelButton = new CancelButton();
 	private JProgressBar downloadProgressBar = new JProgressBar();
 	private static AutoUpdateDialog instance;
+	private static final Logger LOGGER = LoggerFactory.getLogger(AutoUpdateDialog.class);
+	private static final PmsConfiguration configuration = PMS.getConfiguration();
 	public synchronized static void showIfNecessary(Window parent, AutoUpdater autoUpdater, boolean isStartup) {
 		if (autoUpdater.isUpdateAvailable() || !isStartup) {
 			if (instance == null) {
@@ -37,10 +43,8 @@ public class AutoUpdateDialog extends JDialog implements Observer {
 		this.autoUpdater = autoUpdater;
 		autoUpdater.addObserver(this);
 		initComponents();
-		setResizable(false);
-		setMinimumSize(new Dimension(0, 120));
+		setMinimumSize(new Dimension(0, 140));
 		setLocationRelativeTo(parent);
-		setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
 		update();
 	}
 
@@ -172,12 +176,12 @@ public class AutoUpdateDialog extends JDialog implements Observer {
 
 				// See if we have write permission in the program folder. We don't necessarily
 				// need admin rights here.
-				File file = new File(System.getProperty("user.dir"));
+				File file = new File(configuration.getProfileDirectory());
 				try {
 					if (!FileUtil.getFilePermissions(file).isWritable()) {
-						permissionsReminder = Messages.getString("AutoUpdate.12");
+						permissionsReminder = Messages.getString("AutoUpdate.NoPermissions");
 						if (Platform.isWindows()) {
-							permissionsReminder += "\n" + Messages.getString("AutoUpdate.13");
+							permissionsReminder += "<br>" + Messages.getString("AutoUpdate.13");
 						}
 						cancelButton.setText(Messages.getString("Dialog.Close"));
 						okButton.setEnabled(false);
@@ -191,7 +195,7 @@ public class AutoUpdateDialog extends JDialog implements Observer {
 					okButton.setVisible(false);
 				}
 
-				return Messages.getString("AutoUpdate.7") + permissionsReminder;
+				return "<html>" + String.format(Messages.getString("AutoUpdate.VersionXIsAvailable"), autoUpdater.serverProperties.getLatestVersion()) + permissionsReminder + "</html>";
 			default:
 				return Messages.getString("AutoUpdate.8");
 		}

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -4,13 +4,14 @@ AutoUpdate.2=Download finished
 AutoUpdate.3=Download in progress
 AutoUpdate.4=No update available
 AutoUpdate.5=Connecting to server
-AutoUpdate.7=An update is available
 AutoUpdate.8=Unknown state
 AutoUpdate.9=No auto updater
 AutoUpdate.10=Download
 AutoUpdate.11=Not Now
-AutoUpdate.12=, but you do not have permission to modify the application folder.
 AutoUpdate.13=Try running UMS as administrator.
+AutoUpdate.VersionXIsAvailable=Version %s is available
+AutoUpdate.NoPermissions=, but UMS can't write to the profile folder.
+AutoUpdate.UnableToRunUpdate=Unable to run update. You may need to manually download it.
 AviSynthMEncoder.3=Enable AviSynth variable framerate change into a constant framerate (convertfps=true)
 AviSynthMEncoder.4=AviSynth script is fully customizable\n
 AviSynthMEncoder.5=The following variables are available:\n


### PR DESCRIPTION
 - Stop disabling close button
 - Stop disabling resizing
 - Set better minimum size
 - Save updated file to profile directory to get around most common permission problem
 - Update English translations
 - Fixed newline character not working
 - Updated javadocs
 - Attempt to run previously-downloaded file instead of saying "Must download before run"
 - Allow the whole process to happen without UMS being elevated
 - Added logging