### PR TITLE
Remove Oracle JDK 7 test from Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,8 @@ matrix:
     - os: linux
       jdk: openjdk7
     - os: linux
-      dist: precise
-      jdk: oraclejdk7
-    - os: linux
       jdk: oraclejdk8
     - os: linux
-      dist: trusty
       jdk: openjdk8
     - os: osx
 


### PR DESCRIPTION
It seems that Travis CI is finally decommissioning their Ubuntu Precise containers, which were the last to support Oracle JDK 7. This removes the tests so builds don't fail as a consequence.