### PR TITLE
Use new FFmpeg on Windows 7+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 		<project.binaries>${project.basedir}/target/bin</project.binaries>
 
 		<project.binaries-base>http://universalmediaserver.com/svn/binaries</project.binaries-base>
-		<binary-revision>71</binary-revision>
+		<binary-revision>74</binary-revision>
 
 		<maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
 		<git-commit-id-plugin-version>2.2.2</git-commit-id-plugin-version>
@@ -1105,6 +1105,8 @@
 										<get src="${project.binaries-base}/win32/LICENSE-mplayer.txt?p=${binary-revision}" dest="${project.binaries}/win32/LICENSE-mplayer.txt" usetimestamp="true" />
 										<get src="${project.binaries-base}/win32/builds.txt?p=${binary-revision}" dest="${project.binaries}/win32/builds.txt" usetimestamp="true" />
 										<get src="${project.binaries-base}/win32/dcrawMS.exe?p=${binary-revision}" dest="${project.binaries}/win32/dcrawMS.exe" usetimestamp="true" />
+										<get src="${project.binaries-base}/win32/ffmpeg-old.exe?p=${binary-revision}" dest="${project.binaries}/win32/ffmpeg-old.exe" usetimestamp="true" />
+										<get src="${project.binaries-base}/win32/ffmpeg64-old.exe?p=${binary-revision}" dest="${project.binaries}/win32/ffmpeg64-old.exe" usetimestamp="true" />
 										<get src="${project.binaries-base}/win32/ffmpeg.exe?p=${binary-revision}" dest="${project.binaries}/win32/ffmpeg.exe" usetimestamp="true" />
 										<get src="${project.binaries-base}/win32/ffmpeg64.exe?p=${binary-revision}" dest="${project.binaries}/win32/ffmpeg64.exe" usetimestamp="true" />
 										<get src="${project.binaries-base}/win32/flac.exe?p=${binary-revision}" dest="${project.binaries}/win32/flac.exe" usetimestamp="true" />

--- a/src/main/java/net/pms/configuration/WindowsDefaultPaths.java
+++ b/src/main/java/net/pms/configuration/WindowsDefaultPaths.java
@@ -30,12 +30,36 @@ import org.slf4j.LoggerFactory;
 class WindowsDefaultPaths implements ProgramPaths {
 	private static final Logger LOGGER = LoggerFactory.getLogger(WindowsDefaultPaths.class);
 
+	/**
+	 * Our source for FFmpeg binaries has started to disclose the minimum
+	 * version of Windows they work on, on the download page at
+	 * https://ffmpeg.zeranoe.com/builds/
+	 *
+	 * At the time of writing, it is Windows 7+, so we carry on that logic
+	 * here.
+	 *
+	 * Note: This does not mean the "old" version actually works on Vista
+	 * and XP, rather that the new version is guaranteed not to. This note
+	 * should be removed/changed if XP and Vista are tested.
+	 *
+	 * @return the path to the correct FFmpeg version
+	 */
 	@Override
 	public String getFfmpegPath() {
+		String path = getBinariesPath() + "win32/ffmpeg";
+
 		if (Platform.is64Bit()) {
-			return getBinariesPath() + "win32/ffmpeg64.exe";
+			path += "64";
 		}
-		return getBinariesPath() + "win32/ffmpeg.exe";
+
+		if (
+			System.getProperty("os.name") == "Windows Vista" ||
+			System.getProperty("os.name") == "Windows XP"
+		) {
+			path += "-old";
+		}
+
+		return path + ".exe";
 	}
 
 	@Override


### PR DESCRIPTION
It's that time again, to see if FFmpeg will break things

My main reason for wanting the newer version is font/subtitles handling seems to have got faster in the update - with our 2016 version it is timing out for some files but the new one works better