### PR TITLE
Implement the XXE restrictions for the UMS Xml code.

### DIFF
--- a/src/main/java/net/pms/network/UPNPControl.java
+++ b/src/main/java/net/pms/network/UPNPControl.java
@@ -9,7 +9,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.Map.Entry;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import net.pms.PMS;
 import static net.pms.network.UPNPHelper.sleep;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -17,6 +16,7 @@ import net.pms.dlna.protocolinfo.DeviceProtocolInfo;
 import net.pms.dlna.protocolinfo.PanasonicDmpProfiles;
 import net.pms.util.BasicPlayer;
 import net.pms.util.StringUtil;
+import net.pms.util.XmlUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fourthline.cling.DefaultUpnpServiceConfiguration;
 import org.fourthline.cling.UpnpService;
@@ -284,7 +284,7 @@ public class UPNPControl {
 
 	public void init() {
 		try {
-			db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+			db = XmlUtils.xxeDisabledDocumentBuilderFactory().newDocumentBuilder();
 			UMSHeaders = new UpnpHeaders();
 			UMSHeaders.add(UpnpHeader.Type.USER_AGENT.getHttpName(), "UMS/" + PMS.getVersion() + " " + new ServerClientTokens());
 

--- a/src/main/java/net/pms/util/CoverArtArchiveUtil.java
+++ b/src/main/java/net/pms/util/CoverArtArchiveUtil.java
@@ -68,7 +68,7 @@ public class CoverArtArchiveUtil extends CoverUtil {
 	private static final Logger LOGGER = LoggerFactory.getLogger(CoverArtArchiveUtil.class);
 	private static final long WAIT_TIMEOUT_MS = 30000;
 	private static final long EXPIRATION_TIME = 24 * 60 * 60 * 1000; // 24 hours
-	private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+	private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = XmlUtils.xxeDisabledDocumentBuilderFactory();
 
 	private static enum ReleaseType {
 		Single,

--- a/src/main/java/net/pms/util/StringUtil.java
+++ b/src/main/java/net/pms/util/StringUtil.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 import javax.swing.JEditorPane;
 import javax.swing.JTextPane;
 import javax.swing.text.html.HTMLEditorKit;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -895,10 +895,8 @@ public class StringUtil {
 	) throws SAXException, ParserConfigurationException, XPathExpressionException, TransformerException {
 		try {
 			// Turn XML string into a document
-			Document xmlDocument =
-				DocumentBuilderFactory.newInstance().
-				newDocumentBuilder().
-				parse(new InputSource(new ByteArrayInputStream(xml.getBytes("utf-8"))));
+			Document xmlDocument = XmlUtils.xxeDisabledDocumentBuilderFactory().newDocumentBuilder()
+				.parse(new InputSource(new ByteArrayInputStream(xml.getBytes("utf-8"))));
 
 			// Remove whitespaces outside tags
 			xmlDocument.normalize();
@@ -915,7 +913,7 @@ public class StringUtil {
 			}
 
 			// Setup pretty print options
-			TransformerFactory transformerFactory = TransformerFactory.newInstance();
+			TransformerFactory transformerFactory = XmlUtils.xxeDisabledTransformerFactory();
 			transformerFactory.setAttribute("indent-number", indentWidth);
 			Transformer transformer = transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");

--- a/src/main/java/net/pms/util/StringUtil.java
+++ b/src/main/java/net/pms/util/StringUtil.java
@@ -32,7 +32,6 @@ import java.util.regex.Pattern;
 import javax.swing.JEditorPane;
 import javax.swing.JTextPane;
 import javax.swing.text.html.HTMLEditorKit;
-import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;

--- a/src/main/java/net/pms/util/XmlUtils.java
+++ b/src/main/java/net/pms/util/XmlUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.pms.util;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class XmlUtils {
+	private static final Logger LOGGER = LoggerFactory.getLogger(XmlUtils.class);
+
+	/**
+	 * Returns a new {@code DocumentBuilderFactory} instance with XML External Entity (XXE) processing disabled.
+	 *
+	 * @return the new {@code DocumentBuilderFactory} instance with XXE processing disabled
+	 * @throws ParserConfigurationException if an error occurred while disabling XXE processing
+	 * @see DocumentBuilderFactory
+	 */
+	public static DocumentBuilderFactory xxeDisabledDocumentBuilderFactory() {
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		String FEATURE = null;
+		try {
+			FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+			dbf.setFeature(FEATURE, true);    
+			FEATURE = "http://xml.org/sax/features/external-general-entities";
+			dbf.setFeature(FEATURE, false);   
+			FEATURE = "http://xml.org/sax/features/external-parameter-entities";
+			dbf.setFeature(FEATURE, false);
+			FEATURE = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+			dbf.setFeature(FEATURE, false);
+		} catch (ParserConfigurationException e) {
+			LOGGER.info("ParserConfigurationException was thrown. The feature '{}' is probably not supported by the XML processor.", FEATURE);
+		}
+
+		dbf.setXIncludeAware(false);
+		dbf.setExpandEntityReferences(false);
+		return dbf;
+	}
+
+	/**
+	 * Returns a new {@code TransformerFactory} instance with XML External Entity (XXE) processing disabled.
+	 *
+	 * @return the new {@code TransformerFactory} instance with XXE processing disabled
+	 * @see TransformerFactory
+	 */
+	public static TransformerFactory xxeDisabledTransformerFactory() {
+		TransformerFactory transformerFactory = TransformerFactory.newInstance();
+		transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+		return transformerFactory;
+	}
+}


### PR DESCRIPTION
Based on recommendations from the https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet. 
