### PR TITLE
Add getting aspect ratio by ffmpeg

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -210,7 +210,7 @@ ByteToTimeseekRewindSeconds =
 MaxVolume = 
 
 #-----------------------------------------------------------------------------
-# MEDIAINFO
+# MEDIAINFOMATION
 #
 
 # Whether UMS should parse files with MediaInfo. This will give UMS more
@@ -224,6 +224,14 @@ MediaInfo =
 # not supported by some renderers and violates UPnP specifications.
 # Default: false
 CreateDLNATreeFaster = 
+
+# Get exatct display aspect ratio by FFmpeg.
+# When set this to false,
+# 1.77 < display aspect ratio <= 1.78 -> 16:9
+# 1.33 < display aspect ratio < 1.34 -> 4:3
+# 1.22 < display aspect ratio < 1.23 -> 5:4
+# Default: false
+GetExactAspectRatioByFFmpeg =
 
 #-----------------------------------------------------------------------------
 # TRANSCODING AND MUXING CAPABILITIES

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -145,6 +145,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String EMBEDDED_SUBS_SUPPORTED = "InternalSubtitlesSupported";
 	protected static final String HALVE_BITRATE = "HalveBitrate";
 	protected static final String H264_L41_LIMITED = "H264Level41Limited";
+	protected static final String GET_EXACT_ASPECT_RATIO_BY_FFMPEG = "GetExactAspectRatioByFFmpeg";
 	protected static final String IGNORE_TRANSCODE_BYTE_RANGE_REQUEST = "IgnoreTranscodeByteRangeRequests";
 	protected static final String IMAGE = "Image";
 	protected static final String KEEP_ASPECT_RATIO = "KeepAspectRatio";
@@ -2128,6 +2129,10 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 
 	public boolean isMediaInfoThumbnailGeneration() {
 		return getBoolean(MEDIAPARSERV2_THUMB, false) && LibMediaInfoParser.isValid();
+	}
+
+	public boolean isGetExactAspectRatioByFFmpeg() {
+		return getBoolean(GET_EXACT_ASPECT_RATIO_BY_FFMPEG, false);
 	}
 
 	public boolean isShowAudioMetadata() {

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1462,7 +1462,7 @@ public class DLNAMediaInfo implements Cloneable {
 								LOGGER.debug("Could not parse height from \"" + aspectRatioContainer.replaceFirst("[0-9]+:", ""));
 							}
 			
-							double exactaspectRatioContainer = tmp_width / tmp_height ;
+							double exactAspectRatioVideoTrack = tmp_width / tmp_height ;
 							if (exactAspectRatioVideoTrack > 1.77 && exactAspectRatioVideoTrack <= 1.78) {
 								aspectRatioVideoTrack = "16:9";
 							} else if (exactAspectRatioVideoTrack > 1.33 && exactAspectRatioVideoTrack < 1.34) {

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -78,7 +78,8 @@ import org.slf4j.LoggerFactory;
 public class DLNAMediaInfo implements Cloneable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(DLNAMediaInfo.class);
 	private static final PmsConfiguration configuration = PMS.getConfiguration();
-
+	private static RendererConfiguration mediaRenderer = PMS.getConfiguration();
+	
 	public static final long ENDFILE_POS = 99999475712L;
 
 	/**
@@ -1371,6 +1372,106 @@ public class DLNAMediaInfo implements Cloneable {
 								}
 							}
 						}
+
+						/** Get aspect ratio
+						 * A movie can have the info of display aspect ratio in a video stream and a container, respetively
+						 * The former is as sample (pixel) aspect ratio and the latter is as display aspect ratio.
+						 * Display aspect ratio = Resolution ratio x Sample aspect ratio
+						 * Both of them can be gotten by ffmpeg. ffmpeg displays the below four kinds on aspect ratio
+						 * 1st:  sample aspect ratio and display aspect ratio do not exist in a video stream and a container, respectively.
+						 *  ..., 720x480, ...
+						 * 2nd:  sample aspect ratio does not exist in a video stream but display aspect ratio does in a container.
+						 *  ..., 720x480, ..., SAR 40:33 DAR 20:11, ...
+						 * 3rd:  sample aspect ratio exists in a video stream and cannot know whether or not display aspect ratio does in a container.
+						 *  ..., 720x480 [SAR 32:27 DAR 16:9], ...
+						 * 4th:  sample aspect ratio and display aspect ratio exist in a video stream and a container, respectively.
+						 *  ..., 720x480 [SAR 1:1 DAR 3:2], ..., SAR 32:27 DAR 16:9, ...
+						 */
+						// Get the display aspect ratio of a video stream
+						if (line.matches(".*\\[SAR [0-9]+:[0-9]+ DAR [0-9]+:[0-9]+\\],.*")) {
+							// 3rd and 4th
+							aspectRatioVideoTrack = line.replaceFirst(".*\\[SAR [0-9]+:[0-9]+ DAR ", "").replaceFirst("\\].*", "").trim();
+						} else {
+							// 1st and 2nd
+							// Resolution ratio is used as display aspect ratio of a video stream/
+							// Greatest common divisor of resolution
+							int GCD = 1;
+							if (width != 0 && height != 0) {
+								int a;
+								int b;
+								int remainder;
+								if (width > height) {
+									a = width;
+									b = height;
+								} else {
+									a = height;
+									b = width;
+								}
+								while ((remainder = a % b) != 0) {
+									a = b;
+									b = remainder;
+								}
+								GCD = b;
+							}
+							aspectRatioVideoTrack =String.valueOf( width / GCD) + ":" + String.valueOf(height / GCD).trim();
+						}
+						if (!mediaRenderer.isGetExactAspectRatioByFFmpeg()) {
+							Double tmp_width = 0.0;
+							Double tmp_height = 0.0;
+							try {
+								tmp_width = Double.parseDouble(aspectRatioVideoTrack.replaceFirst(":[0-9]+", ""));
+							} catch (NumberFormatException nfe) {
+								LOGGER.debug("Could not parse width from \"" + aspectRatioVideoTrack.replaceFirst(":[0-9]+", ""));
+							}
+							try {
+								tmp_height = Double.parseDouble(aspectRatioVideoTrack.replaceFirst("[0-9]+:", ""));
+							} catch (NumberFormatException nfe) {
+								LOGGER.debug("Could not parse height from \"" + aspectRatioVideoTrack.replaceFirst("[0-9]+:", ""));
+							}
+			
+							double exactAspectRatioVideoTrack = tmp_width / tmp_height ;
+							if (exactAspectRatioVideoTrack > 1.77 && exactAspectRatioVideoTrack <= 1.78) {
+								aspectRatioVideoTrack = "16:9";
+							} else if (exactAspectRatioVideoTrack > 1.33 && exactAspectRatioVideoTrack < 1.34) {
+								aspectRatioVideoTrack = "4:3";
+							} else if (exactAspectRatioVideoTrack > 1.22 && exactAspectRatioVideoTrack < 1.23) {
+								aspectRatioVideoTrack = "5:4";
+							}
+						}
+
+						// Get the display aspect ratio of a ccontainer
+						if (line.matches(".*, SAR [0-9]+:[0-9]+ DAR [0-9]+:[0-9]+, .*")) {
+							// 2nd and 4th
+							aspectRatioContainer = line.replaceFirst(".* SAR [0-9]+:[0-9]+ DAR ", "").replaceFirst(",.*", "").trim();
+						} else {
+							// 1st and 3rd
+							// In these case, the display aspect rate of the above video stream is used.
+							aspectRatioContainer = aspectRatioVideoTrack;
+						}
+						if (!mediaRenderer.isGetExactAspectRatioByFFmpeg()) {
+							Double tmp_width = 0.0;
+							Double tmp_height = 0.0;
+							try {
+								tmp_width = Double.parseDouble(aspectRatioContainer.replaceFirst(":[0-9]+", ""));
+							} catch (NumberFormatException nfe) {
+								LOGGER.debug("Could not parse width from \"" + aspectRatioContainer.replaceFirst(":[0-9]+", ""));
+							}
+							try {
+								tmp_height = Double.parseDouble(aspectRatioContainer.replaceFirst("[0-9]+:", ""));
+							} catch (NumberFormatException nfe) {
+								LOGGER.debug("Could not parse height from \"" + aspectRatioContainer.replaceFirst("[0-9]+:", ""));
+							}
+			
+							double exactaspectRatioContainer = tmp_width / tmp_height ;
+							if (exactAspectRatioVideoTrack > 1.77 && exactAspectRatioVideoTrack <= 1.78) {
+								aspectRatioVideoTrack = "16:9";
+							} else if (exactAspectRatioVideoTrack > 1.33 && exactAspectRatioVideoTrack < 1.34) {
+								aspectRatioVideoTrack = "4:3";
+							} else if (exactAspectRatioVideoTrack > 1.22 && exactAspectRatioVideoTrack < 1.23) {
+								aspectRatioVideoTrack = "5:4";
+							}
+						}
+
 					} else if (line.contains("Subtitle:")) {
 						DLNAMediaSubtitle lang = new DLNAMediaSubtitle();
 
@@ -2451,7 +2552,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * @param aspect the aspect ratio to set
 	 */
 	public void setAspectRatioContainer(String aspect) {
-		this.aspectRatioContainer = getFormattedAspectRatio(aspect);
+		this.aspectRatioContainer = aspectRatioContainer != null && aspectRatioContainer.contains(":") ? aspectRatioContainer : getFormattedAspectRatio(aspect);
 	}
 
 	/**
@@ -2470,7 +2571,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * @param aspect the aspect ratio to set
 	 */
 	public void setAspectRatioVideoTrack(String aspect) {
-		this.aspectRatioVideoTrack = getFormattedAspectRatio(aspect);
+		this.aspectRatioVideoTrack = aspectRatioVideoTrack != null && aspectRatioVideoTrack.contains(":") ? aspectRatioVideoTrack : getFormattedAspectRatio(aspect);
 	}
 
 	/**

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -129,6 +129,10 @@ public class FFMpegVideo extends Player {
 
 		boolean is3D = media.is3d() && !media.stereoscopyIsAnaglyph();
 
+	// LOGGER for tesr and review. This is deleted soon.
+	LOGGER.trace("media.getAspectRatioContainer() " + media.getAspectRatioContainer());
+	LOGGER.trace("media.getAspectRatioVideoTrack " + media.getAspectRatioVideoTrack());
+
 		// Make sure the aspect ratio is 16/9 if the renderer needs it.
 		boolean keepAR = (renderer.isKeepAspectRatio() || renderer.isKeepAspectRatioTranscoding()) &&
 				!media.is3dFullSbsOrOu() &&


### PR DESCRIPTION
Display aspect ratio is not gotten by ffmpeg in the present UMS.
This PR makes it possible.

Also, this PR is the preparation for new PRs, which are the addition of  video remux mode and the modfications of rescale and keep display aspect ratio.