### PR TITLE
Make global ID repository memory-aware

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -142,7 +142,6 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_ASS_OUTLINE = "subtitles_ass_outline";
 	protected static final String KEY_ASS_SCALE = "subtitles_ass_scale";
 	protected static final String KEY_ASS_SHADOW = "subtitles_ass_shadow";
-	protected static final String KEY_BUFFER_MAX = "buffer_max";
 	protected static final String KEY_BUMP_ADDRESS = "bump";
 	protected static final String KEY_BUMP_IPS = "allowed_bump_ips";
 	protected static final String KEY_BUMP_JS = "bump.js";

--- a/src/main/java/net/pms/dlna/GlobalIdRepo.java
+++ b/src/main/java/net/pms/dlna/GlobalIdRepo.java
@@ -44,18 +44,18 @@ public class GlobalIdRepo {
 				/**
 				 * Before adding a new global ID, check whether
 				 * we have a comfortable amount of room in
-				 * memory, and if there isn't, remove the oldest
-				 * ID to make room.
+				 * memory, and if there isn't, remove the
+				 * 2nd-oldest ID to make room.
 				 *
 				 * The math is inexact; current memory plus 1x
-				 * maximum transcoding buffer memory plus 100 MB
+				 * maximum transcoding buffer memory plus 150 MB
 				 * for a general buffer.
 				 */
 				if (debounceCounter == DEBOUNCE_AMOUNT) {
 					long maximumComfortableMemoryUseInMB = (UMSUtils.getCurrentRuntimeMemoryInMB() + PMS.getConfiguration().getMaxMemoryBufferSize() + 150);
 					if (maximumComfortableMemoryUseInMB > UMSUtils.getMaximumRuntimeMemoryInMB()) {
 						for (int i = 0; i <= DEBOUNCE_AMOUNT; i++) {
-							ids.remove(1);
+							remove(ids.get(1).dlnaResource);
 						}
 					}
 					debounceCounter = 0;

--- a/src/main/java/net/pms/dlna/GlobalIdRepo.java
+++ b/src/main/java/net/pms/dlna/GlobalIdRepo.java
@@ -52,7 +52,7 @@ public class GlobalIdRepo {
 				 * for a general buffer.
 				 */
 				if (debounceCounter == DEBOUNCE_AMOUNT) {
-					long maximumComfortableMemoryUseInMB = (UMSUtils.getCurrentRuntimeMemoryInMB() + PMS.getConfiguration().getMaxMemoryBufferSize() + 100);
+					long maximumComfortableMemoryUseInMB = (UMSUtils.getCurrentRuntimeMemoryInMB() + PMS.getConfiguration().getMaxMemoryBufferSize() + 150);
 					if (maximumComfortableMemoryUseInMB > UMSUtils.getMaximumRuntimeMemoryInMB()) {
 						for (int i = 0; i <= DEBOUNCE_AMOUNT; i++) {
 							ids.remove(1);

--- a/src/main/java/net/pms/newgui/StatusTab.java
+++ b/src/main/java/net/pms/newgui/StatusTab.java
@@ -37,8 +37,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import javax.imageio.ImageIO;
 import javax.swing.*;
@@ -47,7 +45,6 @@ import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.newgui.components.AnimatedIcon;
-import net.pms.newgui.components.AnimatedIcon.AnimatedIconFrame;
 import net.pms.newgui.components.AnimatedIcon.AnimatedIconStage;
 import net.pms.newgui.components.AnimatedIcon.AnimatedIconType;
 import net.pms.newgui.components.JAnimatedButton;
@@ -68,7 +65,6 @@ public class StatusTab {
 		public ImagePanel icon;
 		public JLabel label;
 		public GuiUtil.MarqueeLabel playingLabel;
-//		public GuiUtil.ScrollLabel playingLabel;
 		public GuiUtil.FixedPanel playing;
 		public JLabel time;
 		public JFrame frame;
@@ -82,7 +78,6 @@ public class StatusTab {
 			icon.enableRollover();
 			label = new JLabel(renderer.getRendererName());
 			playingLabel = new GuiUtil.MarqueeLabel(" ");
-//			playingLabel = new GuiUtil.ScrollLabel(" ");
 			playingLabel.setForeground(Color.gray);
 			int h = (int) playingLabel.getSize().getHeight();
 			playing = new GuiUtil.FixedPanel(0, h);
@@ -519,25 +514,23 @@ public class StatusTab {
 	}
 
 	private int getTickMarks() {
-		int mb = (int) (Runtime.getRuntime().maxMemory() / 1048576);
+		int mb = (int) UMSUtils.getMaximumRuntimeMemoryInMB();
 		return mb < 1000 ? 100 : mb < 2500 ? 250 : mb < 5000 ? 500 : 1000;
 	}
 
 	public void updateMemoryUsage() {
-		final long max = Runtime.getRuntime().maxMemory() / 1048576;
-		final long used = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1048576;
-		long buf = 0;
-		List<RendererConfiguration> foundRenderers = PMS.get().getFoundRenderers();
-		synchronized (foundRenderers) {
-			for (RendererConfiguration r : PMS.get().getFoundRenderers()) {
-				buf += (r.getBuffer());
-			}
-		}
-		final long buffer = buf;
+		final long maxMemoryInMB = UMSUtils.getMaximumRuntimeMemoryInMB();
+		final long usedMemoryTotalInMB = UMSUtils.getCurrentRuntimeMemoryInMB();
+		final long usedMemoryByBufferInMB = UMSUtils.getCurrentBufferMemoryInMB();
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				memBarUI.setValues(0, (int) max, (int) (used - buffer), (int) buffer);
+				memBarUI.setValues(
+					0,
+					(int) maxMemoryInMB,
+					(int) (usedMemoryTotalInMB - usedMemoryByBufferInMB),
+					(int) usedMemoryByBufferInMB
+				);
 			}
 		});
 	}

--- a/src/main/java/net/pms/util/UMSUtils.java
+++ b/src/main/java/net/pms/util/UMSUtils.java
@@ -593,4 +593,26 @@ public class UMSUtils {
 		configuration.setFFmpegAvailableGPUDecodingAccelerationMethods(availableMethods);
 		configuration.save();
 	}
+
+	private static final int MEGABYTE_IN_BYTES = 1048576;
+	
+	public static long getMaximumRuntimeMemoryInMB() {
+		return Runtime.getRuntime().maxMemory() / MEGABYTE_IN_BYTES;
+	}
+	
+	public static long getCurrentRuntimeMemoryInMB() {
+		return (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / MEGABYTE_IN_BYTES;
+	}
+	
+	public static long getCurrentBufferMemoryInMB() {
+		long buf = 0;
+		List<RendererConfiguration> foundRenderers = PMS.get().getFoundRenderers();
+		synchronized (foundRenderers) {
+			for (RendererConfiguration r : PMS.get().getFoundRenderers()) {
+				buf += (r.getBuffer());
+			}
+		}
+
+		return buf;
+	}
 }


### PR DESCRIPTION
I have just tested this by disabling the changes in https://github.com/UniversalMediaServer/UniversalMediaServer/pull/1486 and scanning my whole computer, and UMS didn't run out of memory, so this works.

It's not an ideal fix - but it is much better than crashing and it will combine nicely with other fixes to come