### PR TITLE
Trace the GlobalIdRepo add

### DIFF
--- a/src/main/java/net/pms/dlna/GlobalIdRepo.java
+++ b/src/main/java/net/pms/dlna/GlobalIdRepo.java
@@ -37,6 +37,7 @@ public class GlobalIdRepo {
 			}
 
 			ids.add(new ID(dlnaResource, curGlobalId++));
+			LOGGER.trace("GlobalIdRepo$ID size {}, added {} for renderer {}", ids.size(), dlnaResource.getDisplayName(), dlnaResource.getDefaultRenderer());
 		} finally {
 			lock.writeLock().unlock();
 		}


### PR DESCRIPTION
This is only for testing purpose because there is a bug when all renderers are adding their own GlobalIdResource IDs for the same media. The DLNAResource is added for renderer `null` which is OK but after that it is added again for particular renderer during browsing which is a bug.