### PR TITLE
Use H.264 in Chrome web interface

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -1381,11 +1381,6 @@ web_flash =
 # Default: false
 web_subtitles_transcoded =
 
-# web videos MIME types spoofing
-# ------------------------------
-# When Chrome browser is used, send videos with a spoofed WEBM MIME type.
-# Default: false
-web_chrome_mkv_as_webm_spoof =
 # When Firefox is used on Linux, send videos with a spoofed MP4 MIME type.
 # Default: false
 web_firefox_linux_mp4 =

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -341,7 +341,6 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_WEB_AUTHENTICATE = "web_authenticate";
 	protected static final String KEY_WEB_BROWSE_LANG = "web_use_browser_lang";
 	protected static final String KEY_WEB_BROWSE_SUB_LANG = "web_use_browser_sub_lang";
-	protected static final String KEY_WEB_CHROME_TRICK = "web_chrome_mkv_as_webm_spoof";
 	protected static final String KEY_WEB_CONF_PATH = "web_conf";
 	protected static final String KEY_WEB_CONT_AUDIO = "web_continue_audio";
 	protected static final String KEY_WEB_CONT_IMAGE = "web_continue_image";
@@ -4692,10 +4691,6 @@ public class PmsConfiguration extends RendererConfiguration {
 
 	public boolean getWebFlash() {
 		return getBoolean(KEY_WEB_FLASH, false);
-	}
-
-	public boolean getWebChrome() {
-		return getBoolean(KEY_WEB_CHROME_TRICK, false);
 	}
 
 	public boolean getWebFirefoxLinuxMp4() {

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -347,7 +347,6 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_WEB_CONT_VIDEO = "web_continue_video";
 	protected static final String KEY_WEB_CONTROL = "web_control";
 	protected static final String KEY_WEB_ENABLE = "web_enable";
-	protected static final String KEY_WEB_FIREFOX_LINUX_MP4 = "web_firefox_linux_mp4";
 	protected static final String KEY_WEB_FLASH = "web_flash";
 	protected static final String KEY_WEB_HEIGHT = "web_height";
 	protected static final String KEY_WEB_IMAGE_SLIDE = "web_image_show_delay";
@@ -4691,10 +4690,6 @@ public class PmsConfiguration extends RendererConfiguration {
 
 	public boolean getWebFlash() {
 		return getBoolean(KEY_WEB_FLASH, false);
-	}
-
-	public boolean getWebFirefoxLinuxMp4() {
-		return getBoolean(KEY_WEB_FIREFOX_LINUX_MP4, false);
 	}
 
 	public boolean getWebSubs() {

--- a/src/main/java/net/pms/configuration/WebRender.java
+++ b/src/main/java/net/pms/configuration/WebRender.java
@@ -257,14 +257,6 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 		return false;
 	}
 
-	public boolean isChromeTrick() {
-		return browser == CHROME;
-	}
-
-	public boolean isFirefoxLinuxMp4() {
-		return browser == FIREFOX && platform != null && platform.contains("linux") && pmsconfiguration.getWebFirefoxLinuxMp4();
-	}
-
 	public boolean isScreenSizeConstrained() {
 		return (screenWidth != 0 && RemoteUtil.getWidth() > screenWidth) ||
 			(screenHeight != 0 && RemoteUtil.getHeight() > screenHeight);
@@ -279,9 +271,9 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 	}
 
 	public String getVideoMimeType() {
-		if (isChromeTrick()) {
+		if (browser == CHROME) {
 			return HTTPResource.WEBM_TYPEMIME;
-		} else if (isFirefoxLinuxMp4()) {
+		} else if (browser == FIREFOX) {
 			return HTTPResource.MP4_TYPEMIME;
 		}
 		return defaultMime;
@@ -327,7 +319,7 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 							ffMp4Cmd(cmdList);
 							break;
 						case HTTPResource.WEBM_TYPEMIME:
-							if (isChromeTrick()) {
+							if (browser == CHROME) {
 								ffChromeCmd(cmdList);
 							} else {
 								// nothing here yet

--- a/src/main/java/net/pms/configuration/WebRender.java
+++ b/src/main/java/net/pms/configuration/WebRender.java
@@ -258,7 +258,7 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 	}
 
 	public boolean isChromeTrick() {
-		return browser == CHROME && pmsconfiguration.getWebChrome();
+		return browser == CHROME;
 	}
 
 	public boolean isFirefoxLinuxMp4() {

--- a/src/main/java/net/pms/configuration/WebRender.java
+++ b/src/main/java/net/pms/configuration/WebRender.java
@@ -319,11 +319,7 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 							ffMp4Cmd(cmdList);
 							break;
 						case HTTPResource.WEBM_TYPEMIME:
-							if (browser == CHROME) {
-								ffChromeCmd(cmdList);
-							} else {
-								// nothing here yet
-							}
+							ffWebmCmd(cmdList);
 							break;
 					}
 				}
@@ -391,20 +387,20 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 		cmdList.add("libx264");
 		cmdList.add("-preset");
 		cmdList.add("ultrafast");
-		/*cmdList.add("-tune");
+		cmdList.add("-tune");
 		cmdList.add("zerolatency");
-		cmdList.add("-profile:v");
-		cmdList.add("high");
-		cmdList.add("-level:v");
-		cmdList.add("3.1");*/
+//		cmdList.add("-profile:v");
+//		cmdList.add("high");
+//		cmdList.add("-level:v");
+//		cmdList.add("3.1");
 		cmdList.add("-c:a");
 		cmdList.add("aac");
 		cmdList.add("-ab");
 		cmdList.add("16k");
 //		cmdList.add("-ar");
 //		cmdList.add("44100");
-		/*cmdList.add("-pix_fmt");
-		cmdList.add("yuv420p");*/
+		cmdList.add("-pix_fmt");
+		cmdList.add("yuv420p");
 //		cmdList.add("-frag_duration");
 //		cmdList.add("300");
 //		cmdList.add("-frag_size");
@@ -417,7 +413,7 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 		cmdList.add("mp4");
 	}
 
-	private static void ffChromeCmd(List<String> cmdList) {
+	private static void ffWebmCmd(List<String> cmdList) {
 		//-c:v libx264 -profile:v high -level 4.1 -map 0:a -c:a libmp3lame -ac 2 -preset ultrafast -b:v 35000k -bufsize 35000k -f matroska
 		cmdList.add("-c:v");
 		cmdList.add("libx264");
@@ -504,9 +500,15 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 			dlna.getPlayer() instanceof FFMpegVideo;
 	}
 
+	/**
+	 * libvorbis transcodes very slowly, so we scale the video down to
+	 * speed it up.
+	 *
+	 * @return 
+	 */
 	@Override
 	public String getFFmpegVideoFilterOverride() {
-		return "scale=" + getVideoWidth() + ":" + getVideoHeight();
+		return getVideoMimeType() == HTTPResource.OGG_TYPEMIME ? "scale=" + getVideoWidth() + ":" + getVideoHeight() : "";
 	}
 
 	@Override


### PR DESCRIPTION
I have tested this on Chrome and Firefox on macOS and it correctly automatically differentiates the browsers - it uses libvorbis on Firefox still, but uses the Chrome-specific args for Chrome.

I think this can be merged as it is and we can continue to make similar changes for other browsers to make sure they all work.