### PR TITLE
Fix XVID recognition

### DIFF
--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -477,12 +477,6 @@ public class LibMediaInfoParser {
 		media.getSubtitleTracksList().add(currentSubTrack);
 	}
 
-	@Deprecated
-	// FIXME this is obsolete (replaced by the private method below) and isn't called from anywhere outside this class
-	public static void getFormat(MediaInfo.StreamType streamType, DLNAMediaInfo media, DLNAMediaAudio audio, String value) {
-		setFormat(streamType, media, audio, value, null);
-	}
-
 	/**
 	 * Sends the correct information to media.setContainer(),
 	 * media.setCodecV() or media.setCodecA, depending on streamType.

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -528,8 +528,7 @@ public class LibMediaInfoParser {
 			value.equals("isml") ||
 			(value.startsWith("m4a") && !value.startsWith("m4ae")) ||
 			value.startsWith("m4v") ||
-			value.equals("mpeg-4 visual") ||
-			value.equals("xvid")
+			value.equals("mpeg-4 visual")
 		) {
 			format = FormatConfiguration.MP4;
 		} else if (value.contains("mpeg-ps")) {
@@ -591,6 +590,7 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.VP9;
 		} else if (
 				value.startsWith("div") ||
+				value.startsWith("xvid") ||
 				value.equals("dx50") ||
 				value.equals("dvx1")
 			) {

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -86,8 +86,8 @@ public class LibMediaInfoParser {
 			String value;
 
 			// set General
-			getFormat(general, media, currentAudioTrack, MI.Get(general, 0, "Format"), file);
-			getFormat(general, media, currentAudioTrack, MI.Get(general, 0, "CodecID").trim(), file);
+			setFormat(general, media, currentAudioTrack, MI.Get(general, 0, "Format"), file);
+			setFormat(general, media, currentAudioTrack, MI.Get(general, 0, "CodecID").trim(), file);
 			media.setDuration(parseDuration(MI.Get(general, 0, "Duration")));
 			media.setBitrate(getBitrate(MI.Get(general, 0, "OverallBitRate")));
 			media.setStereoscopy(MI.Get(general, 0, "StereoscopicLayout"));
@@ -138,9 +138,9 @@ public class LibMediaInfoParser {
 						currentSubTrack.setId(media.getSubtitleTracksList().size());
 						addSub(currentSubTrack, media);
 					} else {
-						getFormat(video, media, currentAudioTrack, MI.Get(video, i, "Format"), file);
-						getFormat(video, media, currentAudioTrack, MI.Get(video, i, "Format_Version"), file);
-						getFormat(video, media, currentAudioTrack, MI.Get(video, i, "CodecID"), file);
+						setFormat(video, media, currentAudioTrack, MI.Get(video, i, "Format"), file);
+						setFormat(video, media, currentAudioTrack, MI.Get(video, i, "Format_Version"), file);
+						setFormat(video, media, currentAudioTrack, MI.Get(video, i, "CodecID"), file);
 						media.setWidth(getPixelValue(MI.Get(video, i, "Width")));
 						media.setHeight(getPixelValue(MI.Get(video, i, "Height")));
 						media.setMatrixCoefficients(MI.Get(video, i, "matrix_coefficients"));
@@ -205,10 +205,10 @@ public class LibMediaInfoParser {
 				if (audioTracks > 0) {
 					for (int i = 0; i < audioTracks; i++) {
 						currentAudioTrack = new DLNAMediaAudio();
-						getFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "Format"), file);
-						getFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "Format_Version"), file);
-						getFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "Format_Profile"), file);
-						getFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "CodecID"), file);
+						setFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "Format"), file);
+						setFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "Format_Version"), file);
+						setFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "Format_Profile"), file);
+						setFormat(audio, media, currentAudioTrack, MI.Get(audio, i, "CodecID"), file);
 						value = MI.Get(audio, i, "CodecID_Description");
 						if (isNotBlank(value) && value.startsWith("Windows Media Audio 10")) {
 							currentAudioTrack.setCodecA(FormatConfiguration.WMA10);
@@ -307,7 +307,7 @@ public class LibMediaInfoParser {
 					}
 
 				if (parseByMediainfo) {
-					getFormat(image, media, currentAudioTrack, MI.Get(image, 0, "Format"), file);
+					setFormat(image, media, currentAudioTrack, MI.Get(image, 0, "Format"), file);
 					media.setWidth(getPixelValue(MI.Get(image, 0, "Width")));
 					media.setHeight(getPixelValue(MI.Get(image, 0, "Height")));
 				}
@@ -480,14 +480,12 @@ public class LibMediaInfoParser {
 	@Deprecated
 	// FIXME this is obsolete (replaced by the private method below) and isn't called from anywhere outside this class
 	public static void getFormat(MediaInfo.StreamType streamType, DLNAMediaInfo media, DLNAMediaAudio audio, String value) {
-		getFormat(streamType, media, audio, value, null);
+		setFormat(streamType, media, audio, value, null);
 	}
 
 	/**
 	 * Sends the correct information to media.setContainer(),
 	 * media.setCodecV() or media.setCodecA, depending on streamType.
-	 *
-	 * TODO: Rename to something like setFormat - this is not a getter.
 	 *
 	 * @param streamType
 	 * @param media
@@ -495,7 +493,7 @@ public class LibMediaInfoParser {
 	 * @param value
 	 * @param file
 	 */
-	private static void getFormat(StreamType streamType, DLNAMediaInfo media, DLNAMediaAudio audio, String value, File file) {
+	protected static void setFormat(StreamType streamType, DLNAMediaInfo media, DLNAMediaAudio audio, String value, File file) {
 		if (isBlank(value)) {
 			return;
 		}

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -497,7 +497,7 @@ public class RequestV2 extends HTTPResource {
 						if (dlna.getMedia() != null && !configuration.isDisableSubtitles() && dlna.getMediaSubtitle() != null && dlna.getMediaSubtitle().isStreamable()) {
 							// Some renderers (like Samsung devices) allow a custom header for a subtitle URL
 							String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
-							if (isNotBlank(subtitleHttpHeader)) {
+							if (isNotBlank(subtitleHttpHeader) && !configuration.streamSubsForTranscodedVideo()) {
 								// Device allows a custom subtitle HTTP header; construct it
 								DLNAMediaSubtitle sub = dlna.getMediaSubtitle();
 								String subtitleUrl;

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -497,7 +497,7 @@ public class RequestV2 extends HTTPResource {
 						if (dlna.getMedia() != null && !configuration.isDisableSubtitles() && dlna.getMediaSubtitle() != null && dlna.getMediaSubtitle().isStreamable()) {
 							// Some renderers (like Samsung devices) allow a custom header for a subtitle URL
 							String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
-							if (isNotBlank(subtitleHttpHeader) && !mediaRenderer.streamSubsForTranscodedVideo()) {
+							if (isNotBlank(subtitleHttpHeader) && mediaRenderer.streamSubsForTranscodedVideo()) {
 								// Device allows a custom subtitle HTTP header; construct it
 								DLNAMediaSubtitle sub = dlna.getMediaSubtitle();
 								String subtitleUrl;

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -497,8 +497,8 @@ public class RequestV2 extends HTTPResource {
 						if (dlna.getMedia() != null && !configuration.isDisableSubtitles() && dlna.getMediaSubtitle() != null && dlna.getMediaSubtitle().isStreamable()) {
 							// Some renderers (like Samsung devices) allow a custom header for a subtitle URL
 							String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
-							if (isNotBlank(subtitleHttpHeader) && !configuration.streamSubsForTranscodedVideo()) {
-								// Device allows a custom subtitle HTTP header; construct it
+							if (isNotBlank(subtitleHttpHeader) && !mediaRenderer.streamSubsForTranscodedVideo()) {
+								// Device allows a custom subtitlmediaRenderere HTTP header; construct it
 								DLNAMediaSubtitle sub = dlna.getMediaSubtitle();
 								String subtitleUrl;
 								String subExtension = sub.getType().getExtension();

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -498,7 +498,7 @@ public class RequestV2 extends HTTPResource {
 							// Some renderers (like Samsung devices) allow a custom header for a subtitle URL
 							String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
 							if (isNotBlank(subtitleHttpHeader) && !mediaRenderer.streamSubsForTranscodedVideo()) {
-								// Device allows a custom subtitlmediaRenderere HTTP header; construct it
+								// Device allows a custom subtitle HTTP header; construct it
 								DLNAMediaSubtitle sub = dlna.getMediaSubtitle();
 								String subtitleUrl;
 								String subExtension = sub.getType().getExtension();

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -497,7 +497,7 @@ public class RequestV2 extends HTTPResource {
 						if (dlna.getMedia() != null && !configuration.isDisableSubtitles() && dlna.getMediaSubtitle() != null && dlna.getMediaSubtitle().isStreamable()) {
 							// Some renderers (like Samsung devices) allow a custom header for a subtitle URL
 							String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
-							if (isNotBlank(subtitleHttpHeader) && (dlna.getPlayer() == null || dlna.getPlayer() != null && mediaRenderer.streamSubsForTranscodedVideo())) {
+							if (isNotBlank(subtitleHttpHeader) && (dlna.getPlayer() == null || mediaRenderer.streamSubsForTranscodedVideo())) {
 								// Device allows a custom subtitle HTTP header; construct it
 								DLNAMediaSubtitle sub = dlna.getMediaSubtitle();
 								String subtitleUrl;

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -497,7 +497,7 @@ public class RequestV2 extends HTTPResource {
 						if (dlna.getMedia() != null && !configuration.isDisableSubtitles() && dlna.getMediaSubtitle() != null && dlna.getMediaSubtitle().isStreamable()) {
 							// Some renderers (like Samsung devices) allow a custom header for a subtitle URL
 							String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
-							if (isNotBlank(subtitleHttpHeader) && mediaRenderer.streamSubsForTranscodedVideo()) {
+							if (isNotBlank(subtitleHttpHeader) && (dlna.getPlayer() == null || dlna.getPlayer() != null && mediaRenderer.streamSubsForTranscodedVideo())) {
 								// Device allows a custom subtitle HTTP header; construct it
 								DLNAMediaSubtitle sub = dlna.getMediaSubtitle();
 								String subtitleUrl;

--- a/src/test/java/net/pms/dlna/LibMediaInfoParserTest.java
+++ b/src/test/java/net/pms/dlna/LibMediaInfoParserTest.java
@@ -19,13 +19,15 @@
 package net.pms.dlna;
 
 import static org.assertj.core.api.Assertions.*;
-
+import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import net.pms.PMS;
+import net.pms.configuration.FormatConfiguration;
+import net.pms.dlna.MediaInfo.StreamType;
 
-public class LibMediaInfoParserTest {
+public class LibMediaInfoParserTest extends LibMediaInfoParser {
 	@BeforeClass
 	public static void SetUPClass() {
 		PMS.configureJNA();
@@ -111,5 +113,22 @@ public class LibMediaInfoParserTest {
 		assertThat(LibMediaInfoParser.getLang("enUS")).isEqualTo("enUS");
 		assertThat(LibMediaInfoParser.getLang("ptBR (Brazil)")).isEqualTo("ptBR");
 		assertThat(LibMediaInfoParser.getLang("enUS/GB")).isEqualTo("enUS");
+	}
+
+	@Test
+	public void testSetFormat() throws Exception {
+		DLNAMediaInfo media = new DLNAMediaInfo();
+		DLNAMediaAudio audio = new DLNAMediaAudio();
+		LibMediaInfoParser.setFormat(StreamType.General, media, audio, "XVID", null);
+		assertEquals(FormatConfiguration.DIVX, media.getContainer());
+		LibMediaInfoParser.setFormat(StreamType.Video, media, audio, "XVID", null);
+		assertEquals(FormatConfiguration.DIVX, media.getCodecV());
+		media.setContainer("");
+		LibMediaInfoParser.setFormat(StreamType.General, media, audio, "mp42 (mp42/isom)", null);
+		assertEquals(FormatConfiguration.MP4, media.getContainer());
+		media.setCodecV("");
+		LibMediaInfoParser.setFormat(StreamType.Video, media, audio, "DIVX", null);
+		assertEquals(FormatConfiguration.DIVX, media.getCodecV());
+		// TODO this can continue with other container, video and audio formats
 	}
 }

--- a/src/test/java/net/pms/dlna/LibMediaInfoParserTest.java
+++ b/src/test/java/net/pms/dlna/LibMediaInfoParserTest.java
@@ -119,15 +119,15 @@ public class LibMediaInfoParserTest extends LibMediaInfoParser {
 	public void testSetFormat() throws Exception {
 		DLNAMediaInfo media = new DLNAMediaInfo();
 		DLNAMediaAudio audio = new DLNAMediaAudio();
-		LibMediaInfoParser.setFormat(StreamType.General, media, audio, "XVID", null);
+		setFormat(StreamType.General, media, audio, "XVID", null);
 		assertEquals(FormatConfiguration.DIVX, media.getContainer());
-		LibMediaInfoParser.setFormat(StreamType.Video, media, audio, "XVID", null);
+		setFormat(StreamType.Video, media, audio, "XVID", null);
 		assertEquals(FormatConfiguration.DIVX, media.getCodecV());
 		media.setContainer("");
-		LibMediaInfoParser.setFormat(StreamType.General, media, audio, "mp42 (mp42/isom)", null);
+		setFormat(StreamType.General, media, audio, "mp42 (mp42/isom)", null);
 		assertEquals(FormatConfiguration.MP4, media.getContainer());
 		media.setCodecV("");
-		LibMediaInfoParser.setFormat(StreamType.Video, media, audio, "DIVX", null);
+		setFormat(StreamType.Video, media, audio, "DIVX", null);
 		assertEquals(FormatConfiguration.DIVX, media.getCodecV());
 		// TODO this can continue with other container, video and audio formats
 	}


### PR DESCRIPTION
The XVID video codec is not properly recognized. This change I tested on my new Samsung TV and also on my old Panasonic TV which is capable to support only MPEG and DIVX format.