### PR TITLE
Avoid downloading a JRE if user has already installed **ONLY** JDK

### DIFF
--- a/src/main/external-resources/nsis/pms.nsi
+++ b/src/main/external-resources/nsis/pms.nsi
@@ -153,6 +153,34 @@ Function GetJRE
 		ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
 		ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$R1" "JavaHome"
 		StrCpy $R0 "$R0\bin\${JAVAEXE}"
+		IfErrors CheckRegistryJDK1
+		IfFileExists $R0 0 CheckRegistryJDK1
+		Call CheckJREVersion
+		IfErrors CheckRegistryJDK1 JreFound
+
+    ; 7) Check the registry for JDK
+    CheckRegistryJDK1:
+        ClearErrors
+        ${If} ${RunningX64}
+            SetRegView 64
+        ${EndIf}
+        ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\Java Development Kit" "CurrentVersion"
+        ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\Java Development Kit\$R1" "JavaHome"
+        StrCpy $R0 "$R0\bin\${JAVAEXE}"
+        IfErrors CheckRegistryJDK2
+        IfFileExists $R0 0 CheckRegistryJDK2
+        Call CheckJREVersion
+        IfErrors CheckRegistryJDK2 JreFound
+
+    ; 8) Check the registry for JDK (location used by JDK 9+)
+	CheckRegistryJDK2:
+		ClearErrors
+		${If} ${RunningX64}
+			SetRegView 64
+		${EndIf}
+		ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\JDK" "CurrentVersion"
+		ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\JDK\$R1" "JavaHome"
+		StrCpy $R0 "$R0\bin\${JAVAEXE}"
 		IfErrors DownloadJRE
 		IfFileExists $R0 0 DownloadJRE
 		Call CheckJREVersion


### PR DESCRIPTION
I've noticed that running UMS in an environment where you've installed **only** the JDK but not a standalone JRE, there were always a prompt that notified the user to install a "newer" version of Java.

I digged through the code and found that, checks were made only for presence of a _Java Runtime Environment_ and not for a _Java Development Kit_.

I managed to add those checks... because a JDK has a JRE inside and so it should't have any problems running UMS.