### PR TITLE
Add examples for all binary tools paths to UMS.conf

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -1130,6 +1130,7 @@ avisynth_script =
 
 # ---< Binary tools paths >---------------------------------------------------
 # Path to mencoder (absolute or relative from project.binaries.dir)
+# Example: /usr/bin/mencoder
 # Default:
 #     Win: win32/mencoder.exe
 #     Mac: osx/mencoder
@@ -1137,6 +1138,7 @@ avisynth_script =
 mencoder_path =
 
 # Path to ffmpeg (absolute or relative from project.binaries.dir)
+# Example: /usr/bin/ffmpeg
 # Default:
 #     Win: win32/ffmpeg.exe
 #     Mac: osx/ffmpeg
@@ -1144,6 +1146,7 @@ mencoder_path =
 ffmpeg_path =
 
 # Path to mplayer (absolute or relative from project.binaries.dir)
+# Example: /usr/bin/mplayer
 # Default:
 #     Win: win32/mplayer.exe
 #     Mac: osx/mplayer
@@ -1151,6 +1154,7 @@ ffmpeg_path =
 mplayer_path =
 
 # Path to tsMuxeR (absolute or relative from project.binaries.dir)
+# Example: /usr/ums/linux/tsMuxeR
 # Default:
 #     Win: win32/tsMuxeR.exe
 #     Mac: osx/tsMuxeR
@@ -1159,6 +1163,7 @@ tsmuxer_path =
 
 # Path to tsMuxeR-new (absolute or relative from project.binaries.dir)
 # This version of tsMuxeR is used on PS3.
+# Example: /usr/ums/linux/tsMuxeR-new
 # Default:
 #     Win: win32/tsMuxeR-new.exe
 #     Mac: osx/tsMuxeR-new
@@ -1166,6 +1171,7 @@ tsmuxer_path =
 tsmuxer_new_path =
 
 # Path to dcraw (absolute or relative from project.binaries.dir)
+# Example: /usr/bin/dcraw
 # Default:
 #     Win: win32/dcrawMS.exe
 #     Mac: osx/dcraw
@@ -1173,6 +1179,7 @@ tsmuxer_new_path =
 dcraw_path =
 
 # Path to FLAC (absolute or relative from project.binaries.dir)
+# Example: /usr/bin/flac
 # Default:
 #     Win: win32/flac.exe
 #     Mac: osx/flac
@@ -1180,6 +1187,7 @@ dcraw_path =
 flac_path =
 
 # Path to VideoLAN (absolute or relative from project.binaries.dir)
+# Example: /usr/bin/vlc
 # Default:
 #     Win: videolan/vlc.exe
 #     Mac: /Applications/VLC.app/Contents/MacOS/VLC


### PR DESCRIPTION
Given the name of the configuration variables, as well as the default values provided, it is easy to assume that the settings for things like "mplayer_path", etc. should be the path only, not the path + the executable name.

I confirmed that the rest of the source is expecting the custom settings to include the binary file name, so I added examples to the UMS.conf file so as to make sure it was obvious that the setting should include the binary file name.

There were other "Examples" in UMS.conf, and they were listed before the "Default" values for the setting, so I duplicated this practice.

Please feel free to edit as desired.   Thanks!