### PR TITLE
Fix custom option parsing for ffmpeg_gpu_decoding_acceleration_method

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -831,7 +831,8 @@ public class FFMpegVideo extends Player {
 				cmdList.add(configuration.getFFmpegGPUDecodingAccelerationMethod().trim());
 			} else {
 				if (configuration.getFFmpegGPUDecodingAccelerationMethod().matches(".*-hwaccel +[a-z]+.*")) {
-					cmdList.add(configuration.getFFmpegGPUDecodingAccelerationMethod());
+					String[] hwaccelOptions = StringUtils.split(configuration.getFFmpegGPUDecodingAccelerationMethod());
+					cmdList.addAll(Arrays.asList(hwaccelOptions));
 				} else {
 					cmdList.add("-hwaccel");
 					cmdList.add("auto");


### PR DESCRIPTION
Java's ProcessBuilder quotes arguments with spaces automatically. This affects `ffmpeg_gpu_decoding_acceleration_method`, which breaks the ffmpeg invocation if there are any spaces. This can be puzzling, as some of examples in the documentation don't actually work.

Considering this one:
`-hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format vaapi`

Splitting the commands ensures that this, which is currently live and fails:
`ffmpeg -y -loglevel fatal "-hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format vaapi" (...)`

Becomes this, which is what's expected by ffmpeg:
`ffmpeg -y -loglevel fatal -hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format vaapi (...)`