### PR TITLE
Update AVC profile in the MediaInfo parsing.

### DIFF
--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -191,6 +191,7 @@ public class LibMediaInfoParser {
 						value = MI.Get(video, i, "Format_Profile");
 						if (!value.isEmpty() && media.getCodecV() != null && media.getCodecV().equals(FormatConfiguration.H264)) {
 							media.setAvcLevel(getAvcLevel(value));
+							media.setH264Profile(getAvcProfile(value));
 						}
 
 						if (parseLogger != null) {


### PR DESCRIPTION
Do not use getters for variables defined in the same class.

EDIT: @SubJunk we should check all the code to avoid use getters and setters to be used for variables defined in the classes whose defined them and methods in those classes calls them. It can a little bit speed up the UMS because using getters and setters takes some extra time than using the variables themselfs.