### PR TITLE
Use move instead of renameTo

### DIFF
--- a/src/main/java/net/pms/dlna/MediaMonitor.java
+++ b/src/main/java/net/pms/dlna/MediaMonitor.java
@@ -232,15 +232,15 @@ public class MediaMonitor extends VirtualFolder {
 						String newDirectory = FileUtil.appendPathSeparator(configuration.getFullyPlayedOutputDirectory());
 						if (!StringUtils.isBlank(newDirectory) && !newDirectory.equals(oldDirectory)) {
 							// Move the video to a different folder
-							boolean moved = true;
+							boolean moved = false;
 							File newFile = null;
 
 							try {
 								Files.move(Paths.get(playedFile.getAbsolutePath()), Paths.get(newDirectory + playedFile.getName()), StandardCopyOption.REPLACE_EXISTING);
 								LOGGER.debug("Moved {} because it has been fully played", playedFile.getName());
 								newFile = new File(newDirectory + playedFile.getName());
+								moved = true;
 							} catch (IOException e) {
-								moved = false;
 								LOGGER.debug("Moving {} failed, trying again in 3 seconds: {}", playedFile.getName(), e.getMessage());
 
 								try {
@@ -248,8 +248,8 @@ public class MediaMonitor extends VirtualFolder {
 									Files.move(Paths.get(playedFile.getAbsolutePath()), Paths.get(newDirectory + playedFile.getName()), StandardCopyOption.REPLACE_EXISTING);
 									LOGGER.debug("Moved {} because it has been fully played", playedFile.getName());
 									newFile = new File(newDirectory + playedFile.getName());
+									moved = true;
 								} catch (InterruptedException e2) {
-									moved = false;
 									LOGGER.debug(
 										"Abandoning moving of {} because the thread was interrupted, probably due to program shutdown: {}",
 										playedFile.getName(),
@@ -257,7 +257,6 @@ public class MediaMonitor extends VirtualFolder {
 									);
 									Thread.currentThread().interrupt();
 								} catch (IOException e3) {
-									moved = false;
 									LOGGER.debug("Moving {} failed a second time: {}", playedFile.getName(), e3.getMessage());
 								}
 							}

--- a/src/main/java/net/pms/dlna/MediaMonitor.java
+++ b/src/main/java/net/pms/dlna/MediaMonitor.java
@@ -4,7 +4,10 @@ import com.sun.jna.Platform;
 import com.sun.jna.platform.FileUtils;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -229,33 +232,33 @@ public class MediaMonitor extends VirtualFolder {
 						String newDirectory = FileUtil.appendPathSeparator(configuration.getFullyPlayedOutputDirectory());
 						if (!StringUtils.isBlank(newDirectory) && !newDirectory.equals(oldDirectory)) {
 							// Move the video to a different folder
-							boolean moved = false;
+							boolean moved = true;
 							File newFile = null;
 
-							if (playedFile.renameTo(new File(newDirectory + playedFile.getName()))) {
+							try {
+								Files.move(Paths.get(playedFile.getAbsolutePath()), Paths.get(newDirectory + playedFile.getName()), StandardCopyOption.REPLACE_EXISTING);
 								LOGGER.debug("Moved {} because it has been fully played", playedFile.getName());
 								newFile = new File(newDirectory + playedFile.getName());
-								moved = true;
-							} else {
-								LOGGER.debug("Moving {} failed, trying again in 3 seconds", playedFile.getName());
+							} catch (IOException e) {
+								moved = false;
+								LOGGER.debug("Moving {} failed, trying again in 3 seconds: {}", playedFile.getName(), e.getMessage());
 
 								try {
 									Thread.sleep(3000);
-
-									if (playedFile.renameTo(new File(newDirectory + playedFile.getName()))) {
-										LOGGER.debug("Moved {} because it has been fully played", playedFile.getName());
-										newFile = new File(newDirectory + playedFile.getName());
-										moved = true;
-									} else {
-										LOGGER.info("Failed to move {}", playedFile.getName());
-									}
-								} catch (InterruptedException e) {
-									LOGGER.warn(
-										"Abandoning moving of {} because the thread was interrupted, probably due to UMS shutdown",
-										e.getMessage()
+									Files.move(Paths.get(playedFile.getAbsolutePath()), Paths.get(newDirectory + playedFile.getName()), StandardCopyOption.REPLACE_EXISTING);
+									LOGGER.debug("Moved {} because it has been fully played", playedFile.getName());
+									newFile = new File(newDirectory + playedFile.getName());
+								} catch (InterruptedException e2) {
+									moved = false;
+									LOGGER.debug(
+										"Abandoning moving of {} because the thread was interrupted, probably due to program shutdown: {}",
+										playedFile.getName(),
+										e2.getMessage()
 									);
-									LOGGER.trace("", e);
 									Thread.currentThread().interrupt();
+								} catch (IOException e3) {
+									moved = false;
+									LOGGER.debug("Moving {} failed a second time: {}", playedFile.getName(), e3.getMessage());
 								}
 							}
 


### PR DESCRIPTION
The other way doesn't give any useful errors to log, just a boolean. This is also more readable since we aren't renaming, we are moving.