### PR TITLE
Ignored folder list

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -1271,6 +1271,13 @@ itunes_library_path =
 # Default: ""
 folders_ignored =
 
+# Ignored folder names
+# --------------------
+# A comma-separated list of folder names (regardless of their location) to ignore.
+# Example: IgnoredFolder1,IgnoredFolder2
+# Default: ".unwanted"
+folder_names_ignored =
+
 # Ping path
 # ---------
 # The path to PsPing on Windows.

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -3113,6 +3113,7 @@ public class PmsConfiguration extends RendererConfiguration {
 				return folders;
 			}
 			String[] foldersArray = ignoredFolderNamesString.trim().split("\\s*,\\s*");
+			ignoredFolderNames = new ArrayList<>();
 
 			for (String folder : foldersArray) {
 				/*

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -177,6 +177,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_FFMPEG_SOX = "ffmpeg_sox";
 	protected static final String KEY_FIX_25FPS_AV_MISMATCH = "fix_25fps_av_mismatch";
 	protected static final String KEY_FOLDER_LIMIT = "folder_limit";
+	protected static final String KEY_FOLDER_NAMES_IGNORED = "folder_names_ignored";
 	protected static final String KEY_FOLDERS = "folders";
 	protected static final String KEY_FOLDERS_IGNORED = "folders_ignored";
 	protected static final String KEY_FOLDERS_MONITORED = "folders_monitored";
@@ -3027,6 +3028,13 @@ public class PmsConfiguration extends RendererConfiguration {
 	@GuardedBy("sharedFoldersLock")
 	private ArrayList<Path> ignoredFolders;
 
+	private ArrayList<String> ignoredFolderNames;
+
+	/**
+	 * Whether folder_names_ignored has been read.
+	 */
+	private boolean ignoredFolderNamesRead;
+
 	private void readSharedFolders() {
 		synchronized (sharedFoldersLock) {
 			if (!sharedFoldersRead) {
@@ -3090,6 +3098,37 @@ public class PmsConfiguration extends RendererConfiguration {
 			}
 			return ignoredFolders;
 		}
+	}
+
+	/**
+	 * @return The {@link List} of {@link Path}s of ignored folder names.
+	 */
+	@Nonnull
+	public ArrayList<String> getIgnoredFolderNames() {
+		if (!ignoredFolderNamesRead) {
+			String ignoredFolderNamesString = configuration.getString(KEY_FOLDER_NAMES_IGNORED, ".unwanted");
+
+			ArrayList<String> folders = new ArrayList<>();
+			if (ignoredFolderNamesString == null || ignoredFolderNamesString.length() == 0) {
+				return folders;
+			}
+			String[] foldersArray = ignoredFolderNamesString.trim().split("\\s*,\\s*");
+
+			for (String folder : foldersArray) {
+				/*
+				 * Unescape embedded commas. Note: Backslashing isn't safe as it
+				 * conflicts with the Windows path separator.
+				 */
+				folder = folder.replaceAll("&comma;", ",");
+
+				// add the path even if there are problems so that the user can update the shared folders as required.
+				ignoredFolderNames.add(folder);
+			}
+
+			ignoredFolderNamesRead = true;
+		}
+
+		return ignoredFolderNames;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/MapFile.java
+++ b/src/main/java/net/pms/dlna/MapFile.java
@@ -32,7 +32,6 @@ import net.pms.formats.Format;
 import net.pms.formats.FormatFactory;
 import net.pms.util.FileUtil;
 import net.pms.util.UMSUtils;
-import net.pms.util.StringUtil.LetterCase;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -254,6 +253,8 @@ public class MapFile extends DLNAResource {
 						addChild(d, true, isAddGlobally);
 					}
 				} else {
+					ArrayList<String> ignoredFolderNames = configuration.getIgnoredFolderNames();
+
 					/* Optionally ignore empty directories */
 					if (f.isDirectory() && configuration.isHideEmptyFolders() && !FileUtil.isFolderRelevant(f, configuration)) {
 						LOGGER.debug("Ignoring empty/non-relevant directory: " + f.getName());
@@ -265,7 +266,10 @@ public class MapFile extends DLNAResource {
 						if (!emptyFoldersToRescan.contains(f)) {
 							emptyFoldersToRescan.add(f);
 						}
-					} else { // Otherwise add the file
+					} else if (f.isDirectory() && !ignoredFolderNames.isEmpty() && ignoredFolderNames.contains(f.getName())) {
+						LOGGER.debug("Ignoring {} because it is in the ignored folders list", f.getName());
+					} else {
+						// Otherwise add the file
 						RealFile rf = new RealFile(f);
 						if (searchList != null) {
 							searchList.add(rf);

--- a/src/main/java/net/pms/dlna/MapFile.java
+++ b/src/main/java/net/pms/dlna/MapFile.java
@@ -286,6 +286,7 @@ public class MapFile extends DLNAResource {
 			filename = file.getName() == null ? "unnamed" : file.getName();
 			if (file == null || !file.isDirectory()) {
 				LOGGER.trace("Ignoring {} because it is not a valid directory", filename);
+				continue;
 			}
 
 			// Skip if ignored

--- a/src/main/java/net/pms/dlna/MapFile.java
+++ b/src/main/java/net/pms/dlna/MapFile.java
@@ -279,20 +279,31 @@ public class MapFile extends DLNAResource {
 
 	private List<File> getFileList() {
 		List<File> out = new ArrayList<>();
+		ArrayList<String> ignoredFolderNames = configuration.getIgnoredFolderNames();
+		String filename;
 
 		for (File file : this.conf.getFiles()) {
-			if (file != null && file.isDirectory()) {
-				if (file.canRead()) {
-					File[] files = file.listFiles();
+			filename = file.getName() == null ? "unnamed" : file.getName();
+			if (file == null || !file.isDirectory()) {
+				LOGGER.trace("Ignoring {} because it is not a valid directory", filename);
+			}
 
-					if (files == null) {
-						LOGGER.warn("Can't read files from directory: {}", file.getAbsolutePath());
-					} else {
-						out.addAll(Arrays.asList(files));
-					}
+			// Skip if ignored
+			if (!ignoredFolderNames.isEmpty() && ignoredFolderNames.contains(filename)) {
+				LOGGER.debug("Ignoring {} because it is in the ignored folders list", file.getName());
+				continue;
+			}
+
+			if (file.canRead()) {
+				File[] files = file.listFiles();
+
+				if (files == null) {
+					LOGGER.warn("Can't read files from directory: {}", file.getAbsolutePath());
 				} else {
-					LOGGER.warn("Can't read directory: {}", file.getAbsolutePath());
+					out.addAll(Arrays.asList(files));
 				}
+			} else {
+				LOGGER.warn("Can't read directory: {}", file.getAbsolutePath());
 			}
 		}
 


### PR DESCRIPTION
Adds a simple config setting to ignore folders with certain names, useful to avoid parsing partially-downloaded content folders such as the `.unwanted` folder used by `qBittorrent`.

I have tested and it works for me. It speeds up my initial scan