### PR TITLE
- restarting system idle timer in doAllowSleep

### DIFF
--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -53,6 +53,7 @@ import net.pms.formats.v2.SubtitleType;
 import net.pms.image.ImagesUtil;
 import net.pms.io.OutputParams;
 import net.pms.io.ProcessWrapper;
+import net.pms.service.Services;
 import net.pms.util.FullyPlayed;
 import net.pms.util.StringUtil;
 import net.pms.util.SubtitleUtils;
@@ -365,6 +366,7 @@ public class Request extends HTTPResource {
 					appendToHeader(responseHeader, "Connection: keep-alive");
 				} else if (dlna.getMedia() != null && dlna.getMedia().getMediaType() == MediaType.IMAGE && dlna.isCodeValid(dlna)) {
 					// This is a request for an image
+					Services.sleepManager().postponeSleep();
 					DLNAImageProfile imageProfile = ImagesUtil.parseImageRequest(fileName, null);
 					if (imageProfile == null) {
 						// Parsing failed for some reason, we'll have to pick a profile

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -53,6 +53,7 @@ import net.pms.image.ImageInfo;
 import net.pms.image.ImagesUtil;
 import net.pms.io.OutputParams;
 import net.pms.io.ProcessWrapper;
+import net.pms.service.Services;
 import net.pms.network.message.BrowseRequest;
 import net.pms.network.message.BrowseSearchRequest;
 import net.pms.network.message.SamsungBookmark;
@@ -329,6 +330,7 @@ public class RequestV2 extends HTTPResource {
 				iStream = dlnaThumbnailHandler(output, dlna, fileName);
 			} else if (dlna.getMedia() != null && dlna.getMedia().getMediaType() == MediaType.IMAGE) {
 				// This is a request for an image
+				Services.sleepManager().postponeSleep();
 				iStream = dlnaImageHandler(output, dlna, fileName);
 			} else if (dlna.getMedia() != null && fileName.contains("subtitle0000")) {
 				// This is a request for a subtitles file

--- a/src/main/java/net/pms/service/SleepManager.java
+++ b/src/main/java/net/pms/service/SleepManager.java
@@ -108,6 +108,12 @@ public class SleepManager {
 		playingCount--;
 		if (isPreventSleepSupported() && playingCount == 0 && sleepPrevented && mode == PreventSleepMode.PLAYBACK) {
 			allowSleep();
+			/* 
+			 * Between ES_SYSTEM_REQUIRED|ES_CONTINUOUS and ES_CONTINUOUS the Windows does not go to sleep.
+			 * But both do not restart the system idle timer. In worst case Windows goes
+			 * to sleep short after ES_CONTINUOUS. To avoid this the system idle timer gets restarted here.
+			 */
+			postponeSleep();
 		}
 	}
 
@@ -445,12 +451,6 @@ public class SleepManager {
 		protected synchronized void doAllowSleep() {
 			LOGGER.trace("Calling SetThreadExecutionState ES_CONTINUOUS to allow Windows to go to sleep");
 			Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_CONTINUOUS);
-			/* 
-			 * Between ES_SYSTEM_REQUIRED|ES_CONTINUOUS and ES_CONTINUOUS the Windows does not go to sleep.
-			 * But both do not restart the system idle timer. In worst case Windows goes
-			 * to sleep short after ES_CONTINUOUS. To avoid this the system idle timer gets restarted here.
-			 */
-			Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_SYSTEM_REQUIRED);
 
 			sleepPrevented = false;
 		}

--- a/src/main/java/net/pms/service/SleepManager.java
+++ b/src/main/java/net/pms/service/SleepManager.java
@@ -445,6 +445,12 @@ public class SleepManager {
 		protected synchronized void doAllowSleep() {
 			LOGGER.trace("Calling SetThreadExecutionState ES_CONTINUOUS to allow Windows to go to sleep");
 			Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_CONTINUOUS);
+			/* 
+			 * Between ES_SYSTEM_REQUIRED|ES_CONTINUOUS and ES_CONTINUOUS the Windows does not go to sleep.
+			 * But both do not restart the system idle timer. In worst case Windows goes
+			 * to sleep short after ES_CONTINUOUS. To avoid this the system idle timer gets restarted here.
+			 */
+			Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_SYSTEM_REQUIRED);
 
 			sleepPrevented = false;
 		}


### PR DESCRIPTION
Hi all,

First at all: UMS is the best media server I could find. I tried many free and commercial products and only UMS was satisfying me. Thank you all for providing this software!!!!

The correct handling of the Windows power management is essential for me. 

My setup is:
- Media server: PC with Windows 10 (32bit)
  - runs MediaPortal for watching and recording TV
  - runs UMS for music streaming
  - Windows power management is configured to hibernate after 20 minutes inactivity
  - has an USB connected IR remote control which allows to control the MediaPortal
- UPnP/DLNA control point: Android tablet with BubbleUPnP
- UPnP/DLNA rederer: same Android tablet with BubbleUPnP; alternatively a Samsung blue-ray player that allows streaming

My typical use case for music listening is:
1. wake up the media server PC from hibernate with the remote control
2. start BubbleUPnP on tablet and listen to music
3. stop BubbleUPnP when I do not want to listen to music anymore
4. 20 minutes after stopping the music the media server must automatically go to hibernate (I am too lazy to switch off the PC!)

UMS has already implemented the functionality for preventing hibernate during playback. Unfortunately it is not working on my computer! After analyzing the debug log file ([debug-ErrorAt10h16m.log](https://github.com/UniversalMediaServer/UniversalMediaServer/files/3037669/debug-ErrorAt10h16m.log)) I found 2 issues:

1. When playing a 6 minutes song from a playlist the StopPlaying event comes 5 seconds after the StartPlaying event. The StartPlaying for the next song comes 6 minutes later:
`INFO  2019-03-17 09:54:25.334 [StartPlaying Event] Started playing M83 - Oblivion (Original Motion Picture Soundtrack) - 00 04 - M83 - Tech 49.mp3 on your BubbleUPnP`
...
`INFO  2019-03-17 09:54:30.729 [StopPlaying Event] Stopped playing M83 - Oblivion (Original Motion Picture Soundtrack) - 00 04 - M83 - Tech 49.mp3 on your BubbleUPnP`
...
`INFO  2019-03-17 10:00:29.325 [StartPlaying Event] Started playing M83 - Oblivion (Original Motion Picture Soundtrack) - 00 05 - M83 - The Library.mp3 on your BubbleUPnP (STV100-4)`
It seams that the BubbleUPnP renderer loads the stream within 5 seconds in a cache. The problem is that after the StopPlaying UMS is not aware that the renderer is still in playback. If BubbleUPnP caches more than 20 minutes stream the server PC will go to hibernate while the renderer is still playing. I am not sure if other renderer also have such a large cache.

2. About 20 minutes after my last mouse action the PC went to hibernate! This happened 2 minutes after starting a playback:
`INFO  2019-03-17 10:14:25.242 [StartPlaying Event] Started playing M83 - Oblivion (Original Motion Picture Soundtrack) - 00 10 - M83 - Unidentified Object.mp3 on your BubbleUPnP (STV100-4)
`
...
`INFO  2019-03-17 10:14:36.385 [StopPlaying Event] Stopped playing M83 - Oblivion (Original Motion Picture Soundtrack) - 00 10 - M83 - Unidentified Object.mp3 on your BubbleUPnP (STV100-4)`
...
`TRACE 2019-03-17 10:16:47.766 [UPNP-AliveMessageSender] Setting SSDP network interface: name:eth5 (NVIDIA nForce-Netzwerkcontroller)`
This was the last log message before hibernate!
...
`DEBUG 2019-03-17 10:26:02.622 [UPNP-AliveMessageSender] Sending ALIVE...`
This is the first log message after I woke up the PC again!


I do not see a solution for issue 1. It is likely that other renderer do not have such a large cache. Furthermore I do not have so many songs longer than 20 minutes. I can easily live with issue 1.

More critical is issue 2. It seems to me that the StartPlaying and StopPlaying events do not reset the system idle timer. In the code both events execute the `doPreventSleep` and `doAllowSleep` methods of the `SleepManager`. There is done:
1. `KERNEL32.SetThreadExecutionState(Kernel32.ES_SYSTEM_REQUIRED | Kernel32.ES_CONTINUOUS);` at StartPlaying and
2. `Kernel32.INSTANCE.SetThreadExecutionState(Kernel32.ES_CONTINUOUS);` at StopPlaying.

The Windows documentation is not clear for that. A possible interpretation that fits to my observation is that sleep is prevented for the time between `ES_SYSTEM_REQUIRED|ES_CONTINUOUS`  and `ES_CONTINUOUS` but the system idle timer does not get restarted. In worst case the PC hibernates immediately after `ES_CONTINUOUS`!

My proposed fix is to add send a `ES_SYSTEM_REQUIRED` in the `doAllowSleep` method. This restarts the system sleep timer and solved issue 2. I have this modification running since weeks and have no problems anymore.

