### PR TITLE
Removed versions of JDK that are no longer supported by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ addons:
 matrix:
   include:
     - os: linux
-      jdk: openjdk7
-    - os: linux
-      jdk: oraclejdk8
-    - os: linux
       jdk: openjdk8
     - os: osx
       osx_image: xcode9.3


### PR DESCRIPTION
This temporarily reduces our build matrixes until https://github.com/UniversalMediaServer/UniversalMediaServer/pull/1807 is ready