### PR TITLE
Implemented latest JNA, Chromecast, OSHI and other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 			Check the org.slf4j:slf4j-api version of the other libraries before upgrading
 		-->
 		<logback-version>1.2.3</logback-version>
-		<surefire-version>2.20</surefire-version>
+		<surefire-version>2.22.2</surefire-version>
 
 		<!--
 			net.java.dev.jna:jna-platform is shared with
@@ -106,7 +106,7 @@
 
 			Check the net.java.dev.jna:jna-platform version of the other library before upgrading
 		-->
-		<jna-version>4.4.0</jna-version>
+		<jna-version>5.3.1</jna-version>
 
 		<!--
 			 use the Windows makensis.exe for Windows builds unless
@@ -449,12 +449,12 @@
 
 				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
 			-->
-			<version>0.10.0</version>
+			<version>0.11.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
 			<artifactId>icu4j</artifactId>
-			<version>59.1</version>
+			<version>64.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
@@ -483,7 +483,7 @@
 
 				Check the commons-io:commons-io version before upgrading
 			-->
-			<version>2.1.0</version>
+			<version>2.1.1</version>
 			<exclusions>
 				<!-- This should never have been a dependency in the first place -->
 				<exclusion>
@@ -501,6 +501,10 @@
 				<exclusion>
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpclient</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -520,7 +524,7 @@
 
 				Check the net.java.dev.jna:jna-platform version before upgrading
 			-->
-			<version>3.4.3</version>
+			<version>3.13.3</version>
 		</dependency>
 		<!-- FIX ERROR:  java.lang.NoSuchMethodError: org.codehaus.plexus.util.xml.pull.MXParser -->
 		<dependency>

--- a/src/main/java/net/pms/util/jna/PointerArrayByReference.java
+++ b/src/main/java/net/pms/util/jna/PointerArrayByReference.java
@@ -18,6 +18,7 @@
  */
 package net.pms.util.jna;
 
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
 
@@ -56,7 +57,7 @@ public class PointerArrayByReference extends ArrayByReference<Pointer> {
 
 	@Override
 	public int getElementSize() {
-		return Pointer.SIZE;
+		return Native.POINTER_SIZE;
 	}
 
 	/**

--- a/src/main/java/net/pms/util/jna/macos/corefoundation/CFTypeArrayRef.java
+++ b/src/main/java/net/pms/util/jna/macos/corefoundation/CFTypeArrayRef.java
@@ -19,7 +19,6 @@
 package net.pms.util.jna.macos.corefoundation;
 
 import com.sun.jna.Native;
-//import com.sun.jna.Pointer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.pms.util.jna.ArrayByReference;
 import net.pms.util.jna.macos.corefoundation.CoreFoundation.CFTypeRef;

--- a/src/main/java/net/pms/util/jna/macos/corefoundation/CFTypeArrayRef.java
+++ b/src/main/java/net/pms/util/jna/macos/corefoundation/CFTypeArrayRef.java
@@ -18,7 +18,8 @@
  */
 package net.pms.util.jna.macos.corefoundation;
 
-import com.sun.jna.Pointer;
+import com.sun.jna.Native;
+//import com.sun.jna.Pointer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.pms.util.jna.ArrayByReference;
 import net.pms.util.jna.macos.corefoundation.CoreFoundation.CFTypeRef;
@@ -45,7 +46,7 @@ public class CFTypeArrayRef extends ArrayByReference<CFTypeRef> {
 	 * @param size the number of {@link CFTypeRef}'s in the array.
 	 */
 	public CFTypeArrayRef(long size) {
-		setSize(Pointer.SIZE * size, 0);
+		setSize(Native.POINTER_SIZE * size, 0);
 	}
 
 	/**
@@ -133,7 +134,7 @@ public class CFTypeArrayRef extends ArrayByReference<CFTypeRef> {
 
 	@Override
 	public int getElementSize() {
-		return Pointer.SIZE;
+		return Native.POINTER_SIZE;
 	}
 
 	@Override

--- a/src/test/java/net/pms/util/jna/JNATypesTest.java
+++ b/src/test/java/net/pms/util/jna/JNATypesTest.java
@@ -8,6 +8,7 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import com.sun.jna.Memory;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
 
@@ -132,7 +133,7 @@ public class JNATypesTest {
 	public void testPointerArrayByReference() throws Throwable {
 		assertNull(new PointerArrayByReference(0L).getArray());
 		assertEquals("NULL", new PointerArrayByReference().toString());
-		assertEquals(Pointer.SIZE, new PointerArrayByReference().getElementSize());
+		assertEquals(Native.POINTER_SIZE, new PointerArrayByReference().getElementSize());
 		assertEquals(0L, new PointerArrayByReference().getSize());
 		assertEquals(5L, new PointerArrayByReference(5).getSize());
 		assertEquals(0L, new PointerArrayByReference(-9).getSize());


### PR DESCRIPTION
Need testing on MAC OS because of changes in the Nadahar's code.
I think it should work because all JNA versions since 5.0.0 removed `Pointer.SIZE` and use `Native.POINTER_SIZE` for all calculation of the arrays size and memory location.