### PR TITLE
attempt to fix PrependTrackNumbers not working

### DIFF
--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -268,9 +268,24 @@ public class LibMediaInfoParser {
 					currentAudioTrack.getAudioProperties().setNumberOfChannels(MI.Get(audio, i, "Channel(s)"));
 					currentAudioTrack.setSampleFrequency(getSampleFrequency(MI.Get(audio, i, "SamplingRate")));
 					currentAudioTrack.setBitRate(getBitrate(MI.Get(audio, i, "BitRate")));
+
 					currentAudioTrack.setSongname(MI.Get(general, 0, "Track"));
+					currentAudioTrack.setAlbum(MI.Get(general, 0, "Album"));
+					currentAudioTrack.setAlbumArtist(MI.Get(general, 0, "Album/Performer"));
+					currentAudioTrack.setArtist(MI.Get(general, 0, "Performer"));
+					currentAudioTrack.setGenre(MI.Get(general, 0, "Genre"));
+
+					value = MI.Get(general, 0, "Track/Position");
+					if (!value.isEmpty()) {
+						try {
+							currentAudioTrack.setTrack(Integer.parseInt(value));
+						} catch (NumberFormatException nfe) {
+							LOGGER.debug("Could not parse track \"" + value + "\"");
+						}
+					}
 
 					if (
+						renderer != null &&
 						renderer.isPrependTrackNumbers() &&
 						currentAudioTrack.getTrack() > 0 &&
 						currentAudioTrack.getSongname() != null &&
@@ -278,11 +293,6 @@ public class LibMediaInfoParser {
 					) {
 						currentAudioTrack.setSongname(currentAudioTrack.getTrack() + ": " + currentAudioTrack.getSongname());
 					}
-
-					currentAudioTrack.setAlbum(MI.Get(general, 0, "Album"));
-					currentAudioTrack.setAlbumArtist(MI.Get(general, 0, "Album/Performer"));
-					currentAudioTrack.setArtist(MI.Get(general, 0, "Performer"));
-					currentAudioTrack.setGenre(MI.Get(general, 0, "Genre"));
 
 					// Try to parse the year from the stored date
 					String recordedDate = MI.Get(general, 0, "Recorded_Date");
@@ -302,15 +312,6 @@ public class LibMediaInfoParser {
 							currentAudioTrack.setId(getSpecificID(value));
 						} else {
 							currentAudioTrack.setId(media.getAudioTracksList().size());
-						}
-					}
-
-					value = MI.Get(general, i, "Track/Position");
-					if (!value.isEmpty()) {
-						try {
-							currentAudioTrack.setTrack(Integer.parseInt(value));
-						} catch (NumberFormatException nfe) {
-							LOGGER.debug("Could not parse track \"" + value + "\"");
 						}
 					}
 


### PR DESCRIPTION
I believe this was an ordering problem.
setTrack() needing to happen before getTrack()

While I'm changing this, check that `renderer` is not `null` before trying to call a function with it.