### PR TITLE
Sanitize invalid paths

### DIFF
--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -2254,7 +2254,12 @@ public class FileUtil {
 
 		String[] paths = osPath.split(File.pathSeparator);
 		for (String path : paths) {
-			result.add(Paths.get(path));
+			try {
+				Path pathToAdd = Paths.get(path);
+				result.add(pathToAdd);
+			} catch (InvalidPathException e) {
+				LOGGER.debug("Skipping invalid path {}", e.getMessage());
+			}
 		}
 
 		return result;


### PR DESCRIPTION
This fixes a bug that causes UMS to not startup since 7.6.0 if there is an invalid section in the OS path. Verified by a user at https://www.universalmediaserver.com/forum/viewtopic.php?f=9&t=13396&start=30#p39948