### PR TITLE
Adding render config for Sony BluRay BDP-S3700

### DIFF
--- a/src/main/external-resources/renderers/Sony-Bluray-BDP-S3700.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray-BDP-S3700.conf
@@ -1,0 +1,47 @@
+#----------------------------------------------------------------------------
+# Profile for Sony Blu-ray Disc Players.
+# See DefaultRenderer.conf for descriptions of all the available options.
+#
+# 7 September, 2019
+# Erik H. Beck
+#
+# Renderer for Sony Bluray BDP-S3700 (circa 2018 USA model)
+# Created from Sony-Bluray2013 config file
+#
+#
+RendererName = Sony Bluray BDP-S3700
+RendererIcon = Sony-Bluray2013.png
+
+# ============================================================================
+# This renderer has sent the following string/s:
+#
+# modelNumber=BDP-S3700
+# X-AV-Physical-Unit-Info: pa="BDP-S3700";
+#
+# ============================================================================
+#
+
+UserAgentSearch= BDP-S3700
+LoadingPriority = 2
+
+DLNALocalizationRequired = true
+TranscodeVideo = MPEGTS-MPEG2-AC3
+DefaultVBVBufSize = true
+ChunkedTransfer = true
+TextWrap = width:52 indent:10 height:3 whitespace:9
+SendDateMetadata = false
+HalveBitrate = true
+MediaInfo = true
+
+# Supported video formats:
+Supported = f:avi             v:mp4           a:ac3|lpcm|mp3|mpa                          m:video/mp4
+Supported = f:mkv             v:h264|mp4      a:aac-lc|ac3|dts|dtshd|lpcm|mp3|mpa|truehd  m:video/x-matroska
+Supported = f:mp4             v:h264|mp4      a:aac-lc|ac3|dts|dtshd|lpcm|mp3|mpa|truehd  m:video/mp4
+Supported = f:mpegps|mpegts   v:mpeg1|mpeg2   a:ac3|dts|lpcm|mp3|mpa                      m:video/mpeg
+Supported = f:mpegts          v:h264|vc1      a:aac-lc|ac3|dts|dtshd|lpcm|mp3|mpa|truehd  m:video/vnd.dlna.mpeg-tts
+Supported = f:wmv             v:wmv|vc1       a:wma                                       m:video/mp4
+
+# Supported audio formats:
+Supported = f:lpcm   n:2   m:audio/L16    s:48000
+Supported = f:mp3    n:2   m:audio/mpeg
+Supported = f:wma    n:2   m:audio/mpeg

--- a/src/main/external-resources/renderers/Sony-Bluray-BDP-S3700.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray-BDP-S3700.conf
@@ -2,7 +2,9 @@
 # Profile for Sony Blu-ray Disc Players.
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
-# 7 September, 2019
+# 7 September, 2019: First Version
+# 9 September, 2019: Suggested Revisions
+#
 # Erik H. Beck
 #
 # Renderer for Sony Bluray BDP-S3700 (circa 2018 USA model)
@@ -25,12 +27,13 @@ UserAgentSearch= BDP-S3700
 LoadingPriority = 2
 
 DLNALocalizationRequired = true
-TranscodeVideo = MPEGTS-MPEG2-AC3
+# TranscodeVideo = MPEGTS-MPEG2-AC3
+TranscodeVideo = MPEGTS-H264-AC3
 DefaultVBVBufSize = true
 ChunkedTransfer = true
 TextWrap = width:52 indent:10 height:3 whitespace:9
 SendDateMetadata = false
-HalveBitrate = true
+# HalveBitrate = true
 MediaInfo = true
 
 # Supported video formats:

--- a/src/main/external-resources/renderers/Sony-Bluray-BDP-S3700.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray-BDP-S3700.conf
@@ -3,7 +3,7 @@
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 # 7 September, 2019: First Version
-# 9 September, 2019: Suggested Revisions
+# 9 September, 2019: Suggested Revisions Implemented
 #
 # Erik H. Beck
 #
@@ -25,15 +25,13 @@ RendererIcon = Sony-Bluray2013.png
 
 UserAgentSearch= BDP-S3700
 LoadingPriority = 2
-
+#
 DLNALocalizationRequired = true
-# TranscodeVideo = MPEGTS-MPEG2-AC3
 TranscodeVideo = MPEGTS-H264-AC3
 DefaultVBVBufSize = true
 ChunkedTransfer = true
 TextWrap = width:52 indent:10 height:3 whitespace:9
 SendDateMetadata = false
-# HalveBitrate = true
 MediaInfo = true
 
 # Supported video formats:


### PR DESCRIPTION
Created a new rendering config file for a Sony Blu-Ray BDP-S3700.
Made from the render config file for Sony-Bluray-2013 by adding the correct user agent strings.