### PR TITLE
Fixed bug reported in

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -5132,7 +5132,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		String titleFromDatabaseSimplified;
 
 		// Apply the metadata from the filename.
-		if (StringUtils.isNotBlank(tvSeasonFromFilename) && StringUtils.isNotBlank(tvEpisodeNumberFromFilename)) {
+		if (isNotBlank(titleFromFilename) && isNotBlank(tvSeasonFromFilename) && isNotBlank(tvEpisodeNumberFromFilename)) {
 			/**
 			 * Overwrite the title from the filename if it's very similar to one we
 			 * already have in our database. This is to avoid minor grammatical differences
@@ -5146,7 +5146,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 
 			media.setTVSeason(tvSeasonFromFilename);
 			media.setTVEpisodeNumber(tvEpisodeNumberFromFilename);
-			if (StringUtils.isNotBlank(tvEpisodeNameFromFilename)) {
+			if (isNotBlank(tvEpisodeNameFromFilename)) {
 				media.setTVEpisodeName(tvEpisodeNameFromFilename);
 			}
 


### PR DESCRIPTION
https://www.universalmediaserver.com/forum/viewtopic.php?f=9&p=40144&sid=aa8911e4a3d3bc307724b316f5ac07de#p40144
When are used hyphens in the filename like `tvr-criminal-minds-s09e07-720p.mkv` instead of periods or underscores then the exception is raised.