### PR TITLE
Fix samsung subs

### DIFF
--- a/src/main/java/net/pms/network/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/RequestHandlerV2.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Locale;
@@ -60,7 +61,6 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 		Pattern.CASE_INSENSITIVE
 	);
 
-	private volatile HttpRequest nettyRequest;
 	private final ChannelGroup group;
 
 	public RequestHandlerV2(ChannelGroup group) {
@@ -86,15 +86,21 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 
 	@Override
 	public void messageReceived(ChannelHandlerContext ctx, MessageEvent event) throws Exception {
-		HttpRequest nettyRequest = this.nettyRequest = (HttpRequest) event.getMessage();
+		RequestV2 request = null;
+		RendererConfiguration renderer = null;
+		String userAgentString = null;
+		ArrayList<String> identifiers = new ArrayList<>();
+
+		HttpRequest nettyRequest = (HttpRequest) event.getMessage();
+		HttpHeaders headers = nettyRequest.headers();
 
 		InetSocketAddress remoteAddress = (InetSocketAddress) event.getChannel().getRemoteAddress();
 		InetAddress ia = remoteAddress.getAddress();
 
 		// Is the request from our own Cling service, i.e. self-originating?
 		boolean isSelf = ia.getHostAddress().equals(PMS.get().getServer().getHost()) &&
-			nettyRequest.headers().get(HttpHeaders.Names.USER_AGENT) != null &&
-			nettyRequest.headers().get(HttpHeaders.Names.USER_AGENT).contains("UMS/");
+			headers.get(HttpHeaders.Names.USER_AGENT) != null &&
+			headers.get(HttpHeaders.Names.USER_AGENT).contains("UMS/");
 
 		// Filter if required
 		if (isSelf || filterIp(ia)) {
@@ -105,13 +111,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 			return;
 		}
 
-		RequestV2 request = new RequestV2(nettyRequest.getMethod().getName(), nettyRequest.getUri().substring(1));
-
-		if (nettyRequest.getProtocolVersion().getMinorVersion() == 0) {
-			request.setHttp10(true);
-		}
-
-		HttpHeaders headers = nettyRequest.headers();
+		RequestV2 request = new RequestV2(nettyRequest.getMethod(), getUri(nettyRequest.getUri()));
 
 		// The handler makes a couple of attempts to recognize a renderer from its requests.
 		// IP address matches from previous requests are preferred, when that fails request
@@ -119,7 +119,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 		// default renderer.
 
 		// Attempt 1: try to recognize the renderer by its socket address from previous requests
-		RendererConfiguration renderer = RendererConfiguration.getRendererConfigurationBySocketAddress(ia);
+		renderer = RendererConfiguration.getRendererConfigurationBySocketAddress(ia);
 
 		// If the renderer exists but isn't marked as loaded it means it's unrecognized
 		// by upnp and we still need to attempt http recognition here.
@@ -134,8 +134,6 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 
 		Set<String> headerNames = headers.names();
 		Iterator<String> iterator = headerNames.iterator();
-		String userAgentString = null;
-		ArrayList<String> identifiers = new ArrayList<>();
 		while (iterator.hasNext()) {
 			String name = iterator.next();
 			String headerLine = name + ": " + headers.get(name);
@@ -263,6 +261,23 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 		writeResponse(ctx, event, request, ia);
 	}
 
+	/**
+	 * Removes all preceding slashes from uri. Samsung 2012 TVs have a problematic (additional) preceding slash that
+	 * needs to be also removed.
+	 *
+	 * @param rawUri requested uri
+	 * @return uri without preceding slash
+	 */
+	private String getUri(String rawUri) {
+		String uri = rawUri;
+
+		while (uri.startsWith("/")) {
+			LOGGER.trace("Stripping preceding slash from: " + uri);
+			uri = uri.substring(1);
+		}
+		return uri;
+	}
+
 	private static void logMessageReceived(MessageEvent event, String content, RendererConfiguration renderer) {
 		StringBuilder header = new StringBuilder();
 		String soapAction = null;
@@ -292,7 +307,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 		String formattedContent = null;
 		if (StringUtils.isNotBlank(content)) {
 			try {
-				formattedContent = StringUtil.prettifyXML(content, 4);
+				formattedContent = StringUtil.prettifyXML(content, StandardCharsets.UTF_8, 2);
 			} catch (XPathExpressionException | SAXException | ParserConfigurationException | TransformerException e) {
 				LOGGER.trace("XML parsing failed with:\n{}", e);
 				formattedContent = "  Content isn't valid XML, using text formatting: " + e.getMessage()  + "\n";
@@ -351,7 +366,8 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 		return !PMS.getConfiguration().getIpFiltering().allowed(inetAddress);
 	}
 
-	private void writeResponse(ChannelHandlerContext ctx, MessageEvent e, RequestV2 request, InetAddress ia) throws HttpException {
+	private void writeResponse(ChannelHandlerContext ctx, MessageEvent event, RequestV2 request, InetAddress ia) throws HttpException {
+		HttpRequest nettyRequest = (HttpRequest) event.getMessage();
 		// Decide whether to close the connection or not.
 		boolean close = HttpHeaders.Values.CLOSE.equalsIgnoreCase(nettyRequest.headers().get(HttpHeaders.Names.CONNECTION)) ||
 			nettyRequest.getProtocolVersion().equals(HttpVersion.HTTP_1_0) &&
@@ -361,24 +377,22 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 		HttpResponse response;
 		if (request.getLowRange() != 0 || request.getHighRange() != 0) {
 			response = new DefaultHttpResponse(
-				request.isHttp10() ? HttpVersion.HTTP_1_0 : HttpVersion.HTTP_1_1,
+				nettyRequest.getProtocolVersion(),
 				HttpResponseStatus.PARTIAL_CONTENT
 			);
 		} else {
 			response = new DefaultHttpResponse(
-				request.isHttp10() ? HttpVersion.HTTP_1_0 : HttpVersion.HTTP_1_1,
+				nettyRequest.getProtocolVersion(),
 				HttpResponseStatus.OK
 			);
 		}
-
-		response.headers().set(HttpHeaders.Names.SERVER, PMS.get().getServerName());
 
 		StartStopListenerDelegate startStopListenerDelegate = new StartStopListenerDelegate(ia.getHostAddress());
 		// Attach it to the context so it can be invoked if connection is reset unexpectedly
 		ctx.setAttachment(startStopListenerDelegate);
 
 		try {
-			request.answer(response, e, close, startStopListenerDelegate);
+			request.answer(response, event, close, startStopListenerDelegate);
 		} catch (IOException e1) {
 			LOGGER.debug("HTTP request V2 IO error: " + e1.getMessage());
 			LOGGER.trace("", e1);
@@ -393,7 +407,6 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 	@Override
 	public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e)
 		throws Exception {
-		Channel ch = e.getChannel();
 		Throwable cause = e.getCause();
 		if (cause instanceof TooLongFrameException) {
 			sendError(ctx, HttpResponseStatus.BAD_REQUEST);
@@ -412,6 +425,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 				LOGGER.trace("", cause);
 			}
 		}
+		Channel ch = e.getChannel();
 		if (ch.isConnected()) {
 			sendError(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR);
 		}

--- a/src/main/java/net/pms/network/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/RequestHandlerV2.java
@@ -111,7 +111,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 			return;
 		}
 
-		request = new RequestV2(nettyRequest.getMethod().getName(), nettyRequest.getUri().substring(1));
+		request = new RequestV2(nettyRequest.getMethod(), getUri(nettyRequest.getUri()));
 
 		// The handler makes a couple of attempts to recognize a renderer from its requests.
 		// IP address matches from previous requests are preferred, when that fails request

--- a/src/main/java/net/pms/network/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/RequestHandlerV2.java
@@ -111,7 +111,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 			return;
 		}
 
-		RequestV2 request = new RequestV2(nettyRequest.getMethod(), getUri(nettyRequest.getUri()));
+		request = new RequestV2(nettyRequest.getMethod().getName(), nettyRequest.getUri().substring(1));
 
 		// The handler makes a couple of attempts to recognize a renderer from its requests.
 		// IP address matches from previous requests are preferred, when that fails request

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -92,6 +92,7 @@ import net.pms.network.message.BrowseRequest;
 import net.pms.network.message.BrowseSearchRequest;
 import net.pms.network.message.SamsungBookmark;
 import net.pms.network.message.SearchRequest;
+import net.pms.service.Services;
 import net.pms.util.FullyPlayed;
 import net.pms.util.StringUtil;
 import net.pms.util.SubtitleUtils;
@@ -386,6 +387,7 @@ public class RequestV2 extends HTTPResource {
 					output.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
 				} else if (dlna.getMedia() != null && dlna.getMedia().getMediaType() == MediaType.IMAGE && dlna.isCodeValid(dlna)) {
 					// This is a request for an image
+					Services.sleepManager().postponeSleep();
 					DLNAImageProfile imageProfile = ImagesUtil.parseImageRequest(fileName, null);
 					if (imageProfile == null) {
 						// Parsing failed for some reason, we'll have to pick a profile

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -57,6 +57,10 @@ import org.jboss.netty.channel.ChannelFuture;
 import org.jboss.netty.channel.ChannelFutureListener;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import static org.jboss.netty.handler.codec.http.HttpMethod.GET;
+import static org.jboss.netty.handler.codec.http.HttpMethod.HEAD;
+import static org.jboss.netty.handler.codec.http.HttpMethod.POST;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.stream.ChunkedStream;
@@ -107,16 +111,14 @@ public class RequestV2 extends HTTPResource {
 	private static final Pattern DIDL_PATTERN = Pattern.compile("<Result>(&lt;DIDL-Lite.*?)</Result>");
 	private final SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss", Locale.US);
 	private static int BUFFER_SIZE = 8 * 1024;
-	private final String method;
+	private final HttpMethod method;
 	private PmsConfiguration configuration = PMS.getConfiguration();
 
 	/**
-	 * A {@link String} that contains the argument with which this {@link RequestV2} was
-	 * created. It contains a command, a unique resource id and a resource name, all
-	 * separated by slashes. For example: "get/0$0$2$17/big_buck_bunny_1080p_h264.mov" or
-	 * "get/0$0$2$13/thumbnail0000Sintel.2010.1080p.mkv"
+	 * A {@link String} that contains the uri with which this {@link RequestV2} was
+	 * created.
 	 */
-	private String argument;
+	private String uri;
 	private String soapaction;
 	private String content;
 	private int startingIndex;
@@ -135,7 +137,6 @@ public class RequestV2 extends HTTPResource {
 	 * When sending an input stream, the highRange indicates which byte to stop at.
 	 */
 	private long highRange;
-	private boolean http10;
 
 	public RendererConfiguration getMediaRenderer() {
 		return mediaRenderer;
@@ -216,24 +217,16 @@ public class RequestV2 extends HTTPResource {
 		this.highRange = highRange;
 	}
 
-	public boolean isHttp10() {
-		return http10;
-	}
-
-	public void setHttp10(boolean http10) {
-		this.http10 = http10;
-	}
-
 	/**
 	 * This class will construct and transmit a proper HTTP response to a given HTTP request.
 	 * Rewritten version of the {@link Request} class.
 	 * @param method The {@link String} that defines the HTTP method to be used.
-	 * @param argument The {@link String} containing instructions for PMS. It contains a command,
+	 * @param argument The {@link HttpMethod} containing instructions for PMS. It contains a command,
 	 * 		a unique resource id and a resource name, all separated by slashes.
 	 */
-	public RequestV2(String method, String argument) {
+	public RequestV2(HttpMethod method, String uri) {
 		this.method = method;
-		this.argument = argument;
+		this.uri = uri;
 	}
 
 	public String getSoapaction() {
@@ -250,24 +243,6 @@ public class RequestV2 extends HTTPResource {
 
 	public void setTextContent(String content) {
 		this.content = content;
-	}
-
-	/**
-	 * Retrieves the HTTP method with which this {@link RequestV2} was created.
-	 * @return The (@link String} containing the HTTP method.
-	 */
-	public String getMethod() {
-		return method;
-	}
-
-	/**
-	 * Retrieves the argument with which this {@link RequestV2} was created. It contains
-	 * a command, a unique resource id and a resource name, all separated by slashes. For
-	 * example: "get/0$0$2$17/big_buck_bunny_1080p_h264.mov" or "get/0$0$2$13/thumbnail0000Sintel.2010.1080p.mkv"
-	 * @return The {@link String} containing the argument.
-	 */
-	public String getArgument() {
-		return argument;
 	}
 
 	/**
@@ -298,16 +273,16 @@ public class RequestV2 extends HTTPResource {
 		InputStream inputStream = null;
 
 		// Samsung 2012 TVs have a problematic preceding slash that needs to be removed.
-		if (argument.startsWith("/")) {
-			LOGGER.trace("Stripping preceding slash from: " + argument);
-			argument = argument.substring(1);
+		if (uri.startsWith("/")) {
+			LOGGER.trace("Stripping preceding slash from: " + uri);
+			uri = uri.substring(1);
 		}
 
-		if ((method.equals("GET") || method.equals("HEAD")) && argument.startsWith("console/")) {
+		if ((GET.equals(method) || HEAD.equals(method)) && uri.startsWith("console/")) {
 			// Request to output a page to the HTML console.
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/html");
-			response.append(HTMLConsole.servePage(argument.substring(8)));
-		} else if ((method.equals("GET") || method.equals("HEAD")) && argument.startsWith("get/")) {
+			response.append(HTMLConsole.servePage(uri.substring(8)));
+		} else if ((GET.equals(method) || HEAD.equals(method)) && uri.startsWith("get/")) {
 			// Request to retrieve a file
 
 			/**
@@ -321,7 +296,7 @@ public class RequestV2 extends HTTPResource {
 
 			// Note: we intentionally include the trailing filename here because it may
 			// be used to reconstruct lost Temp items.
-			String id = argument.substring(argument.indexOf("get/") + 4);
+			String id = uri.substring(uri.indexOf("get/") + 4);
 
 			// Some clients escape the separators in their request: unescape them.
 			id = id.replace("%24", "$");
@@ -663,20 +638,20 @@ public class RequestV2 extends HTTPResource {
 					}
 				}
 			}
-		} else if ((method.equals("GET") || method.equals("HEAD")) && (argument.toLowerCase().endsWith(".png") || argument.toLowerCase().endsWith(".jpg") || argument.toLowerCase().endsWith(".jpeg"))) {
+		} else if ((GET.equals(method) || HEAD.equals(method)) && (uri.toLowerCase().endsWith(".png") || uri.toLowerCase().endsWith(".jpg") || uri.toLowerCase().endsWith(".jpeg"))) {
 			inputStream = imageHandler(output);
-		} else if ((method.equals("GET") || method.equals("HEAD")) && (argument.equals("description/fetch") || argument.endsWith("1.0.xml"))) {
+		} else if ((GET.equals(method) || HEAD.equals(method)) && (uri.equals("description/fetch") || uri.endsWith("1.0.xml"))) {
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/xml; charset=\"utf-8\"");
 			response.append(serverSpecHandler(output));
-		} else if (method.equals("POST") && (argument.contains("MS_MediaReceiverRegistrar_control") || argument.contains("mrr/control"))) {
+		} else if (POST.equals(method) && (uri.contains("MS_MediaReceiverRegistrar_control") || uri.contains("mrr/control"))) {
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/xml; charset=\"utf-8\"");
 			response.append(msMediaReceiverRegistrarHandler());
-		} else if (method.equals("POST") && argument.endsWith("upnp/control/connection_manager")) {
+		} else if (POST.equals(method) && uri.endsWith("upnp/control/connection_manager")) {
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/xml; charset=\"utf-8\"");
 			if (soapaction != null && soapaction.contains("ConnectionManager:1#GetProtocolInfo")) {
 				response.append(getProtocolInfoHandler());
 			}
-		} else if (method.equals("POST") && argument.endsWith("upnp/control/content_directory")) {
+		} else if (POST.equals(method) && uri.endsWith("upnp/control/content_directory")) {
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/xml; charset=\"utf-8\"");
 			if (soapaction != null && soapaction.contains("ContentDirectory:1#GetSystemUpdateID")) {
 				response.append(getSystemUpdateIdHandler());
@@ -695,9 +670,9 @@ public class RequestV2 extends HTTPResource {
 			} else {
 				LOGGER.debug("Unsupported action received: " + content);
 			}
-		} else if (method.equals("SUBSCRIBE")) {
+		} else if (method.getName().equals("SUBSCRIBE")) {
 			response.append(subscribeHandler(output));
-		} else if (method.equals("NOTIFY")) {
+		} else if (method.getName().equals("NOTIFY")) {
 			response.append(notifyHandler(output));
 		}
 
@@ -710,7 +685,7 @@ public class RequestV2 extends HTTPResource {
 			output.headers().set(HttpHeaders.Names.CONTENT_LENGTH, "" + responseData.length);
 
 			// HEAD requests only require headers to be set, no need to set contents.
-			if (!method.equals("HEAD")) {
+			if (!HEAD.equals(method)) {
 				// Not a HEAD request, so set the contents of the response.
 				ChannelBuffer buf = ChannelBuffers.copiedBuffer(responseData);
 				output.setContent(buf);
@@ -752,7 +727,7 @@ public class RequestV2 extends HTTPResource {
 			// Send the response headers to the client.
 			future = event.getChannel().write(output);
 
-			if (lowRange != DLNAMediaInfo.ENDFILE_POS && !method.equals("HEAD")) {
+			if (lowRange != DLNAMediaInfo.ENDFILE_POS && !HEAD.equals(method)) {
 				// Send the response body to the client in chunks.
 				ChannelFuture chunkWriteFuture = event.getChannel().write(new ChunkedStream(inputStream, BUFFER_SIZE));
 
@@ -839,7 +814,7 @@ public class RequestV2 extends HTTPResource {
 	}
 
 	private InputStream imageHandler(HttpResponse output) {
-		if (argument.toLowerCase().endsWith(".png")) {
+		if (uri.toLowerCase().endsWith(".png")) {
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "image/png");
 		} else {
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "image/jpeg");
@@ -848,7 +823,7 @@ public class RequestV2 extends HTTPResource {
 		output.headers().set(HttpHeaders.Names.ACCEPT_RANGES, HttpHeaders.Values.BYTES);
 		output.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
 		output.headers().set(HttpHeaders.Names.EXPIRES, getFutureDate() + " GMT");
-		return getResourceInputStream(argument);
+		return getResourceInputStream(uri);
 	}
 
 	private String serverSpecHandler(HttpResponse output) throws IOException {
@@ -856,13 +831,13 @@ public class RequestV2 extends HTTPResource {
 		output.headers().set(HttpHeaders.Names.EXPIRES, "0");
 		output.headers().set(HttpHeaders.Names.ACCEPT_RANGES, HttpHeaders.Values.BYTES);
 		output.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
-		InputStream iStream = getResourceInputStream((argument.equals("description/fetch") ? "PMS.xml" : argument));
+		InputStream iStream = getResourceInputStream((uri.equals("description/fetch") ? "PMS.xml" : uri));
 
 		byte b[] = new byte[iStream.available()];
 		iStream.read(b);
 		String s = new String(b, StandardCharsets.UTF_8);
 
-		if (argument.equals("description/fetch")) {
+		if (uri.equals("description/fetch")) {
 			s = prepareUmsSpec(s);
 		}
 		return s;
@@ -922,7 +897,7 @@ public class RequestV2 extends HTTPResource {
 						Socket sock = new Socket(addr, port);
 						OutputStream out = sock.getOutputStream()
 				) {
-					out.write(("NOTIFY /" + argument + " HTTP/1.1").getBytes(StandardCharsets.UTF_8));
+					out.write(("NOTIFY /" + uri + " HTTP/1.1").getBytes(StandardCharsets.UTF_8));
 					out.write(CRLF.getBytes(StandardCharsets.UTF_8));
 					out.write(("SID: " + PMS.get().usn()).getBytes(StandardCharsets.UTF_8));
 					out.write(CRLF.getBytes(StandardCharsets.UTF_8));
@@ -943,13 +918,13 @@ public class RequestV2 extends HTTPResource {
 			LOGGER.debug("Expected soap action in request");
 		}
 
-		if (argument.contains("connection_manager")) {
+		if (uri.contains("connection_manager")) {
 			response.append(HTTPXMLHelper.eventHeader("urn:schemas-upnp-org:service:ConnectionManager:1"));
 			response.append(HTTPXMLHelper.eventProp("SinkProtocolInfo"));
 			response.append(HTTPXMLHelper.eventProp("SourceProtocolInfo"));
 			response.append(HTTPXMLHelper.eventProp("CurrentConnectionIDs"));
 			response.append(HTTPXMLHelper.EVENT_FOOTER);
-		} else if (argument.contains("content_directory")) {
+		} else if (uri.contains("content_directory")) {
 			response.append(HTTPXMLHelper.eventHeader("urn:schemas-upnp-org:service:ContentDirectory:1"));
 			response.append(HTTPXMLHelper.eventProp("TransferIDs"));
 			response.append(HTTPXMLHelper.eventProp("ContainerUpdateIDs"));
@@ -992,7 +967,7 @@ public class RequestV2 extends HTTPResource {
 
 		String rendererName = getRendererName();
 
-		if (method.equals("HEAD")) {
+		if (HEAD.equals(method)) {
 			LOGGER.trace(
 				"HEAD only response sent to {}:\n\nHEADER:\n  {} {}\n{}",
 				rendererName,

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -72,6 +72,7 @@ import net.pms.database.TableFilesStatus;
 import net.pms.dlna.DLNAImageInputStream;
 import net.pms.dlna.DLNAImageProfile;
 import net.pms.dlna.DLNAMediaInfo;
+import net.pms.dlna.DLNAMediaOnDemandSubtitle;
 import net.pms.dlna.DLNAMediaSubtitle;
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.DLNAThumbnailInputStream;
@@ -83,6 +84,7 @@ import net.pms.encoders.ImagePlayer;
 import net.pms.external.StartStopListenerDelegate;
 import net.pms.formats.Format;
 import net.pms.formats.v2.SubtitleType;
+import net.pms.image.BufferedImageFilterChain;
 import net.pms.image.ImagesUtil;
 import net.pms.io.OutputParams;
 import net.pms.io.ProcessWrapper;
@@ -354,10 +356,20 @@ public class RequestV2 extends HTTPResource {
 						dlna.checkThumbnail();
 						thumbInputStream = dlna.fetchThumbnailInputStream();
 					}
-					if (dlna instanceof RealFile && FullyPlayed.isFullyPlayedThumbnail(((RealFile) dlna).getFile())) {
-						thumbInputStream = FullyPlayed.addFullyPlayedOverlay(thumbInputStream);
+					BufferedImageFilterChain filterChain = null;
+					if (
+						dlna instanceof RealFile &&
+						mediaRenderer.isThumbnails() &&
+						FullyPlayed.isFullyPlayedMark(((RealFile) dlna).getFile())
+					) {
+						filterChain = new BufferedImageFilterChain(FullyPlayed.getOverlayFilter());
 					}
-					inputStream = thumbInputStream.transcode(imageProfile, mediaRenderer != null ? mediaRenderer.isThumbnailPadding() : false);
+					filterChain = dlna.addFlagFilters(filterChain);
+					inputStream = thumbInputStream.transcode(
+						imageProfile,
+						mediaRenderer != null ? mediaRenderer.isThumbnailPadding() : false,
+						filterChain
+					);
 					if (contentFeatures != null) {
 						output.headers().set(
 							"ContentFeatures.DLNA.ORG",
@@ -452,22 +464,31 @@ public class RequestV2 extends HTTPResource {
 						// XXX external file is null if the first subtitle track is embedded:
 						// http://www.ps3mediaserver.org/forum/viewtopic.php?f=3&t=15805&p=75534#p75534
 						if (sub.isExternal()) {
-							try {
-								if (sub.getType() == SubtitleType.SUBRIP && mediaRenderer.isRemoveTagsFromSRTsubs()) { // remove tags from .srt subs when renderer doesn't support them
-									inputStream = SubtitleUtils.removeSubRipTags(sub.getExternalFile());
-								} else {
-									inputStream = new FileInputStream(sub.getExternalFile());
+							if (sub.getExternalFile() == null && sub instanceof DLNAMediaOnDemandSubtitle) {
+								// Try to fetch subtitles
+								((DLNAMediaOnDemandSubtitle) sub).fetch();
+							}
+							if (sub.getExternalFile() == null) {
+								LOGGER.error("External subtitles file \"{}\" is unavailable", sub.getName());
+							} else {
+								try {
+									if (sub.getType() == SubtitleType.SUBRIP && mediaRenderer.isRemoveTagsFromSRTsubs()) {
+										// Remove tags from .srt subtitles if the renderer doesn't support them
+										inputStream = SubtitleUtils.removeSubRipTags(sub.getExternalFile());
+									} else {
+										inputStream = new FileInputStream(sub.getExternalFile());
+									}
+									LOGGER.trace("Loading external subtitles file: {}", sub.getName());
+								} catch (IOException ioe) {
+									LOGGER.debug("Couldn't load external subtitles file: {}\nCause: {}", sub.getName(), ioe.getMessage());
+									LOGGER.trace("", ioe);
 								}
-								LOGGER.trace("Loading external subtitles file: {}", sub);
-							} catch (IOException ioe) {
-								LOGGER.debug("Couldn't load external subtitles file: {}\nCause: {}", sub, ioe.getMessage());
-								LOGGER.trace("", ioe);
 							}
 						} else {
-							LOGGER.trace("Not loading external subtitles file because it is embedded: {}", sub);
+							LOGGER.trace("Not sending subtitles because they are embedded: {}", sub);
 						}
 					} else {
-						LOGGER.trace("Not loading external subtitles because dlna.getMediaSubtitle() returned null");
+						LOGGER.trace("Not sending external subtitles because dlna.getMediaSubtitle() returned null");
 					}
 				} else if (dlna.isCodeValid(dlna)) {
 					// This is a request for a regular file.
@@ -511,42 +532,53 @@ public class RequestV2 extends HTTPResource {
 
 					Format format = dlna.getFormat();
 					if (format != null && format.isVideo()) {
-						if (dlna.getMedia() != null && !configuration.isDisableSubtitles() && dlna.getMediaSubtitle() != null && dlna.getMediaSubtitle().isStreamable()) {
-							// Some renderers (like Samsung devices) allow a custom header for a subtitle URL
-							String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
-							if (isNotBlank(subtitleHttpHeader) && (dlna.getPlayer() == null || mediaRenderer.streamSubsForTranscodedVideo())) {
-								// Device allows a custom subtitle HTTP header; construct it
-								DLNAMediaSubtitle sub = dlna.getMediaSubtitle();
-								String subtitleUrl;
-								String subExtension = sub.getType().getExtension();
-								if (isNotBlank(subExtension)) {
-									subExtension = "." + subExtension;
-								}
-								subtitleUrl = "http://" + PMS.get().getServer().getHost() +
-									':' + PMS.get().getServer().getPort() + "/get/" +
-									id.substring(0, id.indexOf('/')) + "/subtitle0000" + subExtension;
+						MediaType mediaType = dlna.getMedia() == null ? null : dlna.getMedia().getMediaType();
+						if (mediaType == MediaType.VIDEO) {
+							if (
+								dlna.getMedia() != null &&
+								dlna.getMediaSubtitle() != null &&
+								dlna.getMediaSubtitle().isExternal() &&
+								!configuration.isDisableSubtitles() &&
+								mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia())
+							) {
 
-								output.headers().set(subtitleHttpHeader, subtitleUrl);
+								String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
+								if (isNotBlank(subtitleHttpHeader)  && (dlna.getPlayer() == null || mediaRenderer.streamSubsForTranscodedVideo())) {
+									// Device allows a custom subtitle HTTP header; construct it
+									DLNAMediaSubtitle sub = dlna.getMediaSubtitle();
+									String subtitleUrl;
+									String subExtension = sub.getType().getExtension();
+									if (isNotBlank(subExtension)) {
+										subExtension = "." + subExtension;
+									}
+									subtitleUrl = "http://" + PMS.get().getServer().getHost() +
+										':' + PMS.get().getServer().getPort() + "/get/" +
+										id.substring(0, id.indexOf('/')) + "/subtitle0000" + subExtension;
+
+										output.headers().set(subtitleHttpHeader, subtitleUrl);
+									} else {
+										LOGGER.trace(
+											"Did not send subtitle headers because mediaRenderer.getSubtitleHttpHeader() returned {}",
+											subtitleHttpHeader == null ? "null" : "\"" + subtitleHttpHeader + "\""
+											);
+									}
 							} else {
-								LOGGER.trace(
-									"Did not send subtitle headers because mediaRenderer.getSubtitleHttpHeader() returned {}",
-									subtitleHttpHeader == null ? "null" : "\"" + subtitleHttpHeader + "\""
-								);
+								ArrayList<String> reasons = new ArrayList<>();
+								if (dlna.getMedia() == null) {
+									reasons.add("dlna.getMedia() is null");
+								}
+								if (configuration.isDisableSubtitles()) {
+									reasons.add("configuration.isDisabledSubtitles() is true");
+								}
+								if (dlna.getMediaSubtitle() == null) {
+									reasons.add("dlna.getMediaSubtitle() is null");
+								} else if (!dlna.getMediaSubtitle().isExternal()) {
+									reasons.add("the subtitles are internal/embedded");
+								} else if (!mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia())) {
+									reasons.add("the external subtitles format isn't supported by the renderer");
+								}
+								LOGGER.trace("Did not send subtitle headers because {}", StringUtil.createReadableCombinedString(reasons));
 							}
-						} else if (LOGGER.isTraceEnabled()) {
-							ArrayList<String> reasons = new ArrayList<>();
-							if (dlna.getMedia() == null) {
-								reasons.add("dlna.getMedia() is null");
-							}
-							if (configuration.isDisableSubtitles()) {
-								reasons.add("configuration.isDisabledSubtitles() is true");
-							}
-							if (dlna.getMediaSubtitle() == null) {
-								reasons.add("dlna.getMediaSubtitle() is null");
-							} else if (!dlna.getMediaSubtitle().isStreamable()) {
-								reasons.add("dlna.getMediaSubtitle().isStreamable() is false");
-							}
-							LOGGER.trace("Did not send subtitle headers because {}", StringUtil.createReadableCombinedString(reasons));
 						}
 					}
 
@@ -970,7 +1002,7 @@ public class RequestV2 extends HTTPResource {
 			String formattedResponse = null;
 			if (isNotBlank(response)) {
 				try {
-					formattedResponse = StringUtil.prettifyXML(response.toString(), 4);
+					formattedResponse = StringUtil.prettifyXML(response.toString(), StandardCharsets.UTF_8, 4);
 				} catch (SAXException | ParserConfigurationException | XPathExpressionException | TransformerException e) {
 					formattedResponse = "  Content isn't valid XML, using text formatting: " + e.getMessage()  + "\n";
 					formattedResponse += "    " + response.toString().replaceAll("\n", "\n    ");
@@ -991,7 +1023,7 @@ public class RequestV2 extends HTTPResource {
 						LOGGER.trace(
 							"The unescaped <Result> sent to {} is:\n{}",
 							rendererName,
-							StringUtil.prettifyXML(StringEscapeUtils.unescapeXml(matcher.group(1)), 2)
+							StringUtil.prettifyXML(StringEscapeUtils.unescapeXml(matcher.group(1)), StandardCharsets.UTF_8, 2)
 						);
 					} catch (SAXException | ParserConfigurationException | XPathExpressionException | TransformerException e) {
 						LOGGER.warn("Failed to prettify DIDL-Lite document: {}", e.getMessage());


### PR DESCRIPTION
This fixes a bug where subtitles broke on older Samsung TVs in 535dafea2a63bcc1c213435baf5bde47592587a2 (or more specifically 6337b21b3d52671fb91ae88178fa568c7fcfe5fa which was merged in #1700)

I tried to fix it in a smaller way but the only way I could get working was to revert that PR and then re-add the changes that have been done since it. Not ideal but it is a serious bug that needs to be fixed.

The fix has been verified by pipin on the forum https://www.universalmediaserver.com/forum/viewtopic.php?f=4&t=13118