### PR TITLE
Extend media receiver registrar compatibility

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -839,3 +839,11 @@ PushMetadata =
 SupportedVideoBitDepths = 
 
 
+# Whether to advertise and provide to a renderer the MSDRM (Digital Rights Management)
+# authorization service, X_AV_MS_MediaReceiverRegistrar (MRR).  Some renderers require such
+# authorization. UMS only -simulates- the part of the service in order to convince
+# renderers of their authorization.
+# Default: true
+SimulateMRR =
+
+

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -856,19 +856,6 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	}
 
 	/**
-	 * @return whether this renderer will be allowed to participate in MS-DRMND protocol via
-	 * interaction with a 'simulation' of the associated service, X_AV_MS_MediaReceiverRegistrar or
-	 * 'MRR' for short. Some renderers require authorization to access content to be granted via
-	 * interaction with MRR.  UMS will only simulate the part of API which will convince
-	 * a renderer of its authorization.
-	 * 
-	 * Legacy behavior for the Xbox 360 is preserved, since the default value is 'true'
-	 */
-	public boolean isMRRSimulated() {
-		return getBoolean(SIMULATE_MRR, true);
-	}
-
-	/**
 	 * @see #isXbox360()
 	 * @deprecated
 	 */

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -180,6 +180,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String SHOW_AUDIO_METADATA = "ShowAudioMetadata";
 	protected static final String SHOW_DVD_TITLE_DURATION = "ShowDVDTitleDuration"; // Ditlew
 	protected static final String SHOW_SUB_METADATA = "ShowSubMetadata";
+	protected static final String SIMULATE_MRR = "SimulateMRR";
 	protected static final String STREAM_EXT = "StreamExtensions";
 	protected static final String STREAM_SUBS_FOR_TRANSCODED_VIDEO = "StreamSubsForTranscodedVideo";
 	protected static final String SUBTITLE_HTTP_HEADER = "SubtitleHttpHeader";
@@ -852,6 +853,19 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 
 	public int getRank() {
 		return rank;
+	}
+
+	/**
+	 * @return whether this renderer will be allowed to participate in MS-DRMND protocol via
+	 * interaction with a 'simulation' of the associated service, X_AV_MS_MediaReceiverRegistrar or
+	 * 'MRR' for short. Some renderers require authorization to access content to be granted via
+	 * interaction with MRR.  UMS will only simulate the part of API which will convince
+	 * a renderer of its authorization.
+	 * 
+	 * Legacy behavior for the Xbox 360 is preserved, since the default value is 'true'
+	 */
+	public boolean isMRRSimulated() {
+		return getBoolean(SIMULATE_MRR, true);
 	}
 
 	/**

--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -637,20 +637,11 @@ public class Request extends HTTPResource {
 				}
 
 				String friendlyName = configuration.getServerDisplayName();
-				if (mediaRenderer.isMRRSimulated()) {
-					LOGGER.debug("Including X_AV_MS_MediaReceiverRegistrar service in UMS spec");
-					if (xbox360) {
-						friendlyName += " : Windows Media Connect";
-					    s = s.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
-      				}
-					s = s.replace("<serviceList>", "<serviceList>" + CRLF + "<service>" + CRLF +
-						"<serviceType>urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1</serviceType>" + CRLF +
-						"<serviceId>urn:microsoft.com:serviceId:X_MS_MediaReceiverRegistrar</serviceId>" + CRLF +
-						"<SCPDURL>/UPnP_AV_X_MS_MediaReceiverRegistrar_1.0.xml</SCPDURL>" + CRLF +
-						"<controlURL>/upnp/control/x_ms_mediareceiverregistrar</controlURL>" + CRLF +
-						"<eventSubURL>/upnp/event/x_ms_mediareceiverregistrar</eventSubURL>" + CRLF +
-						"</service>" + CRLF);
-				}
+				if (xbox360) {
+					friendlyName += " : Windows Media Connect";
+					   s = s.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
+      			}
+
 				s = s.replace("Universal Media Server", friendlyName);
 
 				inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -636,12 +636,13 @@ public class Request extends HTTPResource {
 					s = s.replace("[port]", "" + PMS.get().getServer().getPort());
 				}
 
+				String friendlyName = configuration.getServerDisplayName();
 				if (mediaRenderer.isMRRSimulated()) {
 					LOGGER.debug("Including X_AV_MS_MediaReceiverRegistrar service in UMS spec");
 					if (xbox360) {
-					    s = s.replace("Universal Media Server", configuration.getServerDisplayName() + " : Windows Media Connect");
+						friendlyName += " : Windows Media Connect";
 					    s = s.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
-					}
+      				}
 					s = s.replace("<serviceList>", "<serviceList>" + CRLF + "<service>" + CRLF +
 						"<serviceType>urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1</serviceType>" + CRLF +
 						"<serviceId>urn:microsoft.com:serviceId:X_MS_MediaReceiverRegistrar</serviceId>" + CRLF +
@@ -649,9 +650,8 @@ public class Request extends HTTPResource {
 						"<controlURL>/upnp/control/x_ms_mediareceiverregistrar</controlURL>" + CRLF +
 						"<eventSubURL>/upnp/event/x_ms_mediareceiverregistrar</eventSubURL>" + CRLF +
 						"</service>" + CRLF);
-				} else {
-					s = s.replace("Universal Media Server", configuration.getServerDisplayName());
 				}
+				s = s.replace("Universal Media Server", friendlyName);
 
 				inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
 			}

--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -637,9 +637,11 @@ public class Request extends HTTPResource {
 				}
 
 				if (mediaRenderer.isMRRSimulated()) {
-					LOGGER.debug("DLNA changes for MS-DRMND");
-					s = s.replace("Universal Media Server", configuration.getServerDisplayName() + " : Windows Media Connect");
-					s = s.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
+					LOGGER.debug("Including X_AV_MS_MediaReceiverRegistrar service in UMS spec");
+					if (xbox360) {
+					    s = s.replace("Universal Media Server", configuration.getServerDisplayName() + " : Windows Media Connect");
+					    s = s.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
+					}
 					s = s.replace("<serviceList>", "<serviceList>" + CRLF + "<service>" + CRLF +
 						"<serviceType>urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1</serviceType>" + CRLF +
 						"<serviceId>urn:microsoft.com:serviceId:X_MS_MediaReceiverRegistrar</serviceId>" + CRLF +

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -851,10 +851,11 @@ public class RequestV2 extends HTTPResource {
 			result = result.replace("[port]", "" + PMS.get().getServer().getPort());
 		}
 
+		String friendlyName = configuration.getServerDisplayName();
 		if (mediaRenderer.isMRRSimulated()) {
 			LOGGER.debug("Including X_AV_MS_MediaReceiverRegistrar service in UMS spec");
 			if (mediaRenderer.isXbox360()) {
-				result = result.replace("Universal Media Server", configuration.getServerDisplayName() + " : Windows Media Connect");
+				friendlyName += " : Windows Media Connect";
 				result = result.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
 			}
 			result = result.replace("<serviceList>", "<serviceList>" + CRLF + "<service>" + CRLF +
@@ -865,7 +866,6 @@ public class RequestV2 extends HTTPResource {
 				"<eventSubURL>/upnp/event/x_ms_mediareceiverregistrar</eventSubURL>" + CRLF +
 				"</service>" + CRLF);
 		} else {
-			result = result.replace("Universal Media Server", configuration.getServerDisplayName());
 			if (mediaRenderer.isSamsung()) {
 				// register UMS as a AllShare service and enable built-in resume functionality (bookmark) on Samsung devices
 				result = result.replace("<serialNumber/>", "<serialNumber/>" + CRLF
@@ -873,6 +873,7 @@ public class RequestV2 extends HTTPResource {
 						+ "<sec:X_ProductCap>smi,DCM10,getMediaInfo.sec,getCaptionInfo.sec</sec:X_ProductCap>");
 			}
 		}
+		result = result.replace("Universal Media Server", friendlyName);
 		return result;
 	}
 

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -852,9 +852,11 @@ public class RequestV2 extends HTTPResource {
 		}
 
 		if (mediaRenderer.isMRRSimulated()) {
-			LOGGER.debug("DLNA changes for Xbox 360");
-			result = result.replace("Universal Media Server", configuration.getServerDisplayName() + " : Windows Media Connect");
-			result = result.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
+			LOGGER.debug("Including X_AV_MS_MediaReceiverRegistrar service in UMS spec");
+			if (mediaRenderer.isXbox360()) {
+				result = result.replace("Universal Media Server", configuration.getServerDisplayName() + " : Windows Media Connect");
+				result = result.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
+			}
 			result = result.replace("<serviceList>", "<serviceList>" + CRLF + "<service>" + CRLF +
 				"<serviceType>urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1</serviceType>" + CRLF +
 				"<serviceId>urn:microsoft.com:serviceId:X_MS_MediaReceiverRegistrar</serviceId>" + CRLF +

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -643,7 +643,7 @@ public class RequestV2 extends HTTPResource {
 		} else if ((GET.equals(method) || HEAD.equals(method)) && (uri.equals("description/fetch") || uri.endsWith("1.0.xml"))) {
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/xml; charset=\"utf-8\"");
 			response.append(serverSpecHandler(output));
-		} else if (POST.equals(method) && (uri.contains("MS_MediaReceiverRegistrar_control") || uri.contains("mrr/control"))) {
+		} else if (POST.equals(method) && (uri.contains("MS_MediaReceiverRegistrar_control") || uri.contains("control/x_ms_mediareceiverregistrar"))) {
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/xml; charset=\"utf-8\"");
 			response.append(msMediaReceiverRegistrarHandler());
 		} else if (POST.equals(method) && uri.endsWith("upnp/control/connection_manager")) {
@@ -851,15 +851,16 @@ public class RequestV2 extends HTTPResource {
 			result = result.replace("[port]", "" + PMS.get().getServer().getPort());
 		}
 
-		if (mediaRenderer.isXbox360()) {
+		if (mediaRenderer.isMRRSimulated()) {
 			LOGGER.debug("DLNA changes for Xbox 360");
 			result = result.replace("Universal Media Server", configuration.getServerDisplayName() + " : Windows Media Connect");
 			result = result.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
 			result = result.replace("<serviceList>", "<serviceList>" + CRLF + "<service>" + CRLF +
 				"<serviceType>urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1</serviceType>" + CRLF +
 				"<serviceId>urn:microsoft.com:serviceId:X_MS_MediaReceiverRegistrar</serviceId>" + CRLF +
-				"<SCPDURL>/upnp/mrr/scpd</SCPDURL>" + CRLF +
-				"<controlURL>/upnp/mrr/control</controlURL>" + CRLF +
+				"<SCPDURL>/UPnP_AV_X_MS_MediaReceiverRegistrar_1.0.xml</SCPDURL>" + CRLF +
+				"<controlURL>/upnp/control/x_ms_mediareceiverregistrar</controlURL>" + CRLF +
+				"<eventSubURL>/upnp/event/x_ms_mediareceiverregistrar</eventSubURL>" + CRLF +
 				"</service>" + CRLF);
 		} else {
 			result = result.replace("Universal Media Server", configuration.getServerDisplayName());
@@ -929,6 +930,15 @@ public class RequestV2 extends HTTPResource {
 			response.append(HTTPXMLHelper.eventProp("TransferIDs"));
 			response.append(HTTPXMLHelper.eventProp("ContainerUpdateIDs"));
 			response.append(HTTPXMLHelper.eventProp("SystemUpdateID", "" + DLNAResource.getSystemUpdateId()));
+			response.append(HTTPXMLHelper.EVENT_FOOTER);
+		} else if (uri.contains("x_ms_mediareceiverregistrar")) {
+			response.append(HTTPXMLHelper.eventHeader("urn:schemas-upnp-org:service:ContentDirectory:1"));
+			// though this is only a 'potemkin' implementation of an MRR,
+			// keep the MMR-related update ids in-sync with the system update id
+			response.append(HTTPXMLHelper.eventProp("AuthorizationGrantedUpdateID", "" + DLNAResource.getSystemUpdateId()));
+			response.append(HTTPXMLHelper.eventProp("AuthorizationDeniedUpdateID", "" + DLNAResource.getSystemUpdateId()));
+			response.append(HTTPXMLHelper.eventProp("ValidationSucceededUpdateID", "" + DLNAResource.getSystemUpdateId()));
+			response.append(HTTPXMLHelper.eventProp("ValidationRevokedUpdateID", "" + DLNAResource.getSystemUpdateId()));
 			response.append(HTTPXMLHelper.EVENT_FOOTER);
 		}
 		return response.toString();

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -852,19 +852,9 @@ public class RequestV2 extends HTTPResource {
 		}
 
 		String friendlyName = configuration.getServerDisplayName();
-		if (mediaRenderer.isMRRSimulated()) {
-			LOGGER.debug("Including X_AV_MS_MediaReceiverRegistrar service in UMS spec");
-			if (mediaRenderer.isXbox360()) {
-				friendlyName += " : Windows Media Connect";
-				result = result.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
-			}
-			result = result.replace("<serviceList>", "<serviceList>" + CRLF + "<service>" + CRLF +
-				"<serviceType>urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1</serviceType>" + CRLF +
-				"<serviceId>urn:microsoft.com:serviceId:X_MS_MediaReceiverRegistrar</serviceId>" + CRLF +
-				"<SCPDURL>/UPnP_AV_X_MS_MediaReceiverRegistrar_1.0.xml</SCPDURL>" + CRLF +
-				"<controlURL>/upnp/control/x_ms_mediareceiverregistrar</controlURL>" + CRLF +
-				"<eventSubURL>/upnp/event/x_ms_mediareceiverregistrar</eventSubURL>" + CRLF +
-				"</service>" + CRLF);
+		if (mediaRenderer.isXbox360()) {
+			friendlyName += " : Windows Media Connect";
+			result = result.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
 		} else {
 			if (mediaRenderer.isSamsung()) {
 				// register UMS as a AllShare service and enable built-in resume functionality (bookmark) on Samsung devices
@@ -873,6 +863,7 @@ public class RequestV2 extends HTTPResource {
 						+ "<sec:X_ProductCap>smi,DCM10,getMediaInfo.sec,getCaptionInfo.sec</sec:X_ProductCap>");
 			}
 		}
+
 		result = result.replace("Universal Media Server", friendlyName);
 		return result;
 	}

--- a/src/main/resources/PMS.xml
+++ b/src/main/resources/PMS.xml
@@ -87,6 +87,13 @@
 				<controlURL>/upnp/control/connection_manager</controlURL>
 				<eventSubURL>/upnp/event/connection_manager</eventSubURL>
 			</service>
+			<service>
+				<serviceType>urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1</serviceType>
+				<serviceId>urn:microsoft.com:serviceId:X_MS_MediaReceiverRegistrar</serviceId>
+				<SCPDURL>/UPnP_AV_X_MS_MediaReceiverRegistrar_1.0.xml</SCPDURL>
+				<controlURL>/upnp/control/x_ms_mediareceiverregistrar</controlURL>
+				<eventSubURL>/upnp/event/x_ms_mediareceiverregistrar</eventSubURL>
+			</service>
 		</serviceList>
 	</device>
 </root>

--- a/src/main/resources/UPnP_AV_X_MS_MediaReceiverRegistrar_1.0.xml
+++ b/src/main/resources/UPnP_AV_X_MS_MediaReceiverRegistrar_1.0.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" ?>
+<scpd xmlns="urn:schemas-upnp-org:service-1-0">
+	<specVersion>
+		<major>1</major>
+		<minor>0</minor>
+	</specVersion>
+	<actionList>
+		<action>
+			<name>IsAuthorized</name>
+			<argumentList>
+				<argument>
+					<name>DeviceID</name>
+					<direction>in</direction>
+					<relatedStateVariable>A_ARG_TYPE_DeviceID</relatedStateVariable>
+				</argument>
+				<argument>
+					<name>Result</name>
+					<direction>out</direction>
+					<relatedStateVariable>A_ARG_TYPE_Result</relatedStateVariable>
+				</argument>
+			</argumentList>
+		</action>
+		<action>
+			<name>RegisterDevice</name>
+			<argumentList>
+				<argument>
+					<name>RegistrationReqMsg</name>
+					<direction>in</direction>
+					<relatedStateVariable>A_ARG_TYPE_RegistrationReqMsg</relatedStateVariable>
+				</argument>
+				<argument>
+					<name>RegistrationRespMsg</name>
+					<direction>out</direction>
+					<relatedStateVariable>A_ARG_TYPE_RegistrationRespMsg</relatedStateVariable>
+				</argument>
+			</argumentList>
+		</action>
+		<action>
+			<name>IsValidated</name>
+			<argumentList>
+				<argument>
+					<name>DeviceID</name>
+					<direction>in</direction>
+					<relatedStateVariable>A_ARG_TYPE_DeviceID</relatedStateVariable>
+				</argument>
+				<argument>
+					<name>Result</name>
+					<direction>out</direction>
+					<relatedStateVariable>A_ARG_TYPE_Result</relatedStateVariable>
+				</argument>
+			</argumentList>
+		</action>
+	</actionList>
+	<serviceStateTable>
+		<stateVariable sendEvents="no">
+			<name>A_ARG_TYPE_DeviceID</name>
+			<dataType>string</dataType>
+		</stateVariable>
+		<stateVariable sendEvents="no">
+			<name>A_ARG_TYPE_Result</name>
+			<dataType>int</dataType>
+		</stateVariable>
+		<stateVariable sendEvents="no">
+			<name>A_ARG_TYPE_RegistrationReqMsg</name>
+			<dataType>bin.base64</dataType>
+		</stateVariable>
+		<stateVariable sendEvents="no">
+			<name>A_ARG_TYPE_RegistrationRespMsg</name>
+			<dataType>bin.base64</dataType>
+		</stateVariable>
+		<stateVariable sendEvents="yes">
+			<name>AuthorizationGrantedUpdateID</name>
+			<dataType>ui4</dataType>
+		</stateVariable>
+		<stateVariable sendEvents="yes">
+			<name>AuthorizationDeniedUpdateID</name>
+			<dataType>ui4</dataType>
+		</stateVariable>
+		<stateVariable sendEvents="yes">
+			<name>ValidationSucceededUpdateID</name>
+			<dataType>ui4</dataType>
+		</stateVariable>
+		<stateVariable sendEvents="yes">
+			<name>ValidationRevokedUpdateID</name>
+			<dataType>ui4</dataType>
+		</stateVariable>
+	</serviceStateTable>
+</scpd>
+


### PR DESCRIPTION
Certain media renderers require greater adherence to the MS-DRMND protocol than is provided by UMS' current simulation of X_AV_MS_MediaReceiverRegistrar service.  I discovered this when attempting to connect a Denon AVR-4311CI to my UMS server version 9.2.

I investigated the problem, determined the cause, and implemented a solution.  My investigation is documented in [this UMS forum topic](https://www.universalmediaserver.com/forum/viewtopic.php?f=5&t=13984&start=10#p40872).

To fix the connection problem by MSDRM-shackled renderers, this PR does the following:
- Extend the simulation of MS-DRM service, X_AV_MS_MediaReceiverRegistear (MRR), to event subscription.
- Change the parent upnp event and control paths to the MRR service such that they match the other two services. (/upnp/event, /upnp/control).
- Add provision of a service description file on the same path as other service description file
- Change default renderer behavior to include the MRR service in the UMS descriptor (i.e. _description/fetch_).  A renderer configuration option (next item) is provided in order to allow this behavior to be disabled.  
- Add a new renderer configuration option, simulateMRR, which enables/disables exposure of MRR to a renderer (default: true)
- Retain renderer predicate function, isXbox360(), due to specialized service which extends beyond the scope of MRR

This PR _does not add a renderer configuration file for the Denon AVR-4311CI_.  I assume that incorporation of a new renderer is preferred to be done as a separate issue. 
