### PR TITLE
Add renderer for Sony UBP-X800 bluray player

### DIFF
--- a/src/main/external-resources/renderers/Sony-Bluray-UBP-X800.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray-UBP-X800.conf
@@ -108,10 +108,11 @@ Supported = f:tiff                                                              
 Supported = f:webp                                                                   m:image/webp
 #--------------------------------------------------------------------------------------------------------------
 
-
-######### Comment/uncomment the sections below according to your region/model-year #########
+# The UBP-X800 definitely supports more video formats than what is currently specified in this configuration file.
+# Identification of supported video formats for this renderer is a Work-In-Progress
+##### (from DefaultRenderer.conf) #### Comment/uncomment the sections below according to your region/model-year #########
 #--------------------------------------------------------------------------------------------------------------
-# Supported video formats:
+# SUPPORTED VIDEO FORMATS
 #--------------------------------------------------------------------------------------------------------------
 Supported = f:mpegps|mpegts   v:mpeg1|mpeg2     a:ac3|dts|lpcm|mpa|mp3                       m:video/mpeg
 #--------------------------------------------------------------------------------------------------------------

--- a/src/main/external-resources/renderers/Sony-Bluray-UBP-X800.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray-UBP-X800.conf
@@ -1,0 +1,160 @@
+#----------------------------------------------------------------------------
+# Profile for Sony Blu-ray Disc Players.
+# See DefaultRenderer.conf for descriptions of all the available options.
+#
+# Renderer for Sony Bluray UBP-X800 (circa 2017 USA model)
+# Created from Sony-Blueray config file
+#
+#
+RendererName = Sony Bluray UBP-X800
+RendererIcon = sonybluray.png
+
+# ============================================================================
+# This renderer has sent the following string/s:
+#
+# User-Agent: UPnP/1.0
+# X-AV-Client-Info: av=5.0; cn="Sony Corporation"; mn="UBP-X800"; mv="2.0";
+# X-AV-Physical-Unit-Info: pa="UBP-X800";
+# ---
+# User-Agent: UPnP/1.0 DLNADOC/1.50
+# X-AV-Client-Info: av=5.0; cn="Sony Corporation"; mn="UBP-X800"; mv="2.0";
+# X-AV-Physical-Unit-Info: pa="UBP-X800";
+# {friendlyName=UBP-X800, address=192.168.1.120, udn=uuid:00000004-0000-1010-80 00-045d4bacfde5, manufacturer=Sony Corporation, modelName=Blu-ray Disc Player, modelDescription=, manufacturerURL=http://www.sony.net/, modelURL=}
+# ---
+#
+# {friendlyName=ubpX800, address=192.168.1.120, udn=uuid:00000000-0000-1010-8000-045d4bacfde5, manufacturer=Sony Corporation, modelName=UBP-X800, modelNumber=BDP-2017, manufacturerURL=http://www.sony.net/}
+# ============================================================================
+#
+
+UserAgentAdditionalHeader = X-AV-Client-Info
+UserAgentAdditionalHeaderSearch = (cn="Sony Corporation"; mn="UBP-X800")
+UpnpDetailsSearch = Sony Corporation UBP-X800 BDP-2017
+DLNALocalizationRequired = true
+TranscodeVideo = MPEGTS-MPEG2-AC3
+DefaultVBVBufSize = true
+ChunkedTransfer = true
+TextWrap = width:52 indent:10 height:3 whitespace:9
+SendDateMetadata = false
+HalveBitrate = true
+MediaInfo = true
+UpnpAllow = postpone
+
+# Specs below taken from http://www.sony.co.uk/product/blu-ray-disc-player/bdp-s370#pageType=TechnicalSpecs
+# then fine-tuned by lengthy trial and error since so much of that advertised spec is inaccurate.
+# US models don't support video/divx mime type but European and Canadian models do.
+# Subtitles in mkv files are only displayed if mime type is video/divx.
+# Vob subtitles are not supported.
+# See also http://forum.serviio.org/viewtopic.php?f=11&t=2004 for more DLNA-related info on these players.
+
+
+#--------------------------------------------------------------------------------------------------------------
+# SUPPORTED AUDIO FORMATS
+#
+# Note: entries footnoted where appropriate
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:3g2a|3ga     n:2     a:aac-lc|he-aac          s:48000                  m:audio/3gpp
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:aac                                           s:48000                  m:audio/mp4
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:ac3                                           s:48000                  m:audio/mp4
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:adts         n:2     a:aac-lc|he-aac          s:48000                  m:audio/vnd.dlna.adts
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:aif          n:2                              s:192000                 m:audio/aiff
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:aiff         n:2                              s:192000                 m:audio/x-aiff
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:ape          n:2                              s:192000                 m:audio/x-ape
+##--------------------------------------------------------------------------------------------------------------
+Supported = f:dff                                                                    m:audio/dsd
+Supported = f:dff                                                                    m:audio/x-dsd
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:dsd                                                                    m:audio/dsd
+Supported = f:dsd                                                                    m:audio/x-dsd
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:dsf                                                                    m:audio/dsd
+Supported = f:dsf                                                                    m:audio/x-dsd
+--------------------------------------------------------------------------------------------------------------
+Supported = f:mp4                                           s:48000                  m:audio/mp4
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:m4a                                           s:48000                  m:audio/x-m4a
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:flac                                          s:192000                 m:audio/x-flac
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:lpcm         n:2                              s:48000                  m:audio/L16
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:mp3                                           s:48000                  m:audio/mpeg
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:mpa          n:2                              s:48000                  m:audio/mpeg
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:ogg          n:2     a:vorbis                 s:48000                  m:audio/x-ogg
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:wav                                           s:192000                 m:audio/wav
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:wma          n:2                              s:48000                  m:audio/x-ms-wma
+#--------------------------------------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------------------------------------
+# SUPPORTED IMAGE FORMATS
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:gif                                                                    m:image/gif
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:jpg|jpeg                                                               m:image/jpeg
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:png                                                                    m:image/png
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:tiff                                                                   m:image/tiff
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:webp                                                                   m:image/webp
+#--------------------------------------------------------------------------------------------------------------
+
+
+######### Comment/uncomment the sections below according to your region/model-year #########
+#--------------------------------------------------------------------------------------------------------------
+# Supported video formats:
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:mpegps|mpegts   v:mpeg1|mpeg2     a:ac3|dts|lpcm|mpa|mp3                       m:video/mpeg
+#--------------------------------------------------------------------------------------------------------------
+Supported = f:mpegts          v:h264|vc1        a:ac3|dts|dtshd|truehd|aac-lc|lpcm|mpa|mp3   m:video/vnd.dlna.mpeg-tts
+#--------------------------------------------------------------------------------------------------------------
+######### 2010-11 US MODELS (Sony BDP-Sx70/80) ONLY:
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:mp4|m4v         v:mp4|h264        a:ac3|dts|dtshd|truehd|aac-lc|lpcm|mpa|mp3   m:video/mpeg
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:avi|divx        v:divx|mp4        a:ac3|lpcm|mpa|mp3                           m:video/mpeg
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:mkv             v:mp4|divx|h264   a:ac3|dts|dtshd|truehd|aac-lc|lpcm|mpa|mp3   m:video/vnd.dlna.mpeg-tts
+#--------------------------------------------------------------------------------------------------------------
+######### 2012 US MODELS (Sony BDP-Sx90) ONLY:
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:mp4|m4v        v:mp4|h264        a:ac3|dts|dtshd|truehd|aac-lc|lpcm|mpa|mp3   m:video/mp4
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:wmv            v:wmv|vc1         a:wma                                        m:video/mp4
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:avi            v:mp4             a:ac3|lpcm|mpa|mp3                           m:video/mp4
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:mkv            v:mp4|h264        a:ac3|dts|dtshd|truehd|aac-lc|lpcm|mpa|mp3   m:video/x-matroska
+#--------------------------------------------------------------------------------------------------------------
+######### NON-US MODELS ONLY:
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:mp4|m4v        v:mp4|h264        a:ac3|dts|dtshd|truehd|aac-lc|lpcm|mpa|mp3   m:video/mpeg
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:avi|divx       v:divx|mp4        a:ac3|lpcm|mpa|mp3                           m:video/divx
+#--------------------------------------------------------------------------------------------------------------
+#Supported = f:mkv            v:mp4|h264        a:ac3|dts|dtshd|truehd|aac-lc|lpcm|mpa|mp3   m:video/divx
+#-------------------------------------------------------------------------------------------------------------
+
+
+#-------------------------------------------------------------------------------------------------------------
+# Miscellaneous / Yet-To-Be-Categorized
+#
+# How to start upnp services (event-monitoring, remote-control) if supported by this renderer
+#
+# Options:
+#    true      Activate normally, as soon as the device is seen
+#    postpone  Wait until the device has sent an http request before activating upnp services
+#              (i.e. use http header recognition procedures first)
+#    false     Don't activate any upnp services for this device
+# Default: true
+
+UpnpAllow = postpone

--- a/src/main/external-resources/renderers/Sony-Bluray-UBP-X800.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray-UBP-X800.conf
@@ -28,7 +28,7 @@ RendererIcon = sonybluray.png
 
 UserAgentAdditionalHeader = X-AV-Client-Info
 UserAgentAdditionalHeaderSearch = (cn="Sony Corporation"; mn="UBP-X800")
-UpnpDetailsSearch = Sony Corporation UBP-X800 BDP-2017
+UpnpDetailsSearch = Sony Corporation , UBP-X800 , BDP-2017
 DLNALocalizationRequired = true
 TranscodeVideo = MPEGTS-MPEG2-AC3
 DefaultVBVBufSize = true

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -197,6 +197,9 @@ public class RendererConfigurationTest {
 
 		testHeaders("Showtime 4", "User-Agent: Showtime PS3 4.2");
 
+		testHeaders("Sony Bluray UBP-X800", "X-AV-Client-Info: av=5.0; cn=\"Sony Corporation\"; mn=\"UBP-X800\"; mv=\"2.0\";");
+		testUPNPDetails("Sony Bluray UBP-X800", "manufacturer=Sony Corporation, modelName=UBP-X800, modelNumber=BDP-2017");
+
 		testHeaders("Sony Bravia EX", "X-AV-Client-Info: av=5.0; cn=\"Sony Corporation\"; mn=\"BRAVIA KDL-32CX520\"; mv=\"1.7\";");
 
 		testHeaders("Sony Bravia HX", "X-AV-Client-Info: av=5.0; cn=\"Sony Corporation\"; mn=\"BRAVIA KDL-55HX750\"; mv=\"1.7\";");


### PR DESCRIPTION
Renderer configuration for Sony UBP-X800.  Emphasis upon audio support.  Caveat: I'm a video format novice.

With respect to configuration variables, I have endeavored to follow the ordering of DefaultRenderer.conf

I have found that addition of row boundary lines can improve readability of supported formats:

```
#--------------------------------------------------------------------------------------------------------------
Supported = f:mpa          n:2                              s:48000     b:320000     m:audio/mpeg
#--------------------------------------------------------------------------------------------------------------
Supported = f:wav                                           s:48000                  m:audio/wav
#--------------------------------------------------------------------------------------------------------------
Supported = f:wma          n:2                              s:48000     b:192000     m:audio/x-ms-wma
#--------------------------------------------------------------------------------------------------------------
```