### PR TITLE
Fix table CoverArtArchive to work with h2db version 1.4.200

### DIFF
--- a/src/main/java/net/pms/database/TableCoverArtArchive.java
+++ b/src/main/java/net/pms/database/TableCoverArtArchive.java
@@ -270,7 +270,7 @@ public final class TableCoverArtArchive extends Tables {
 					"ID IDENTITY PRIMARY KEY, " +
 					"MODIFIED DATETIME, " +
 					"MBID VARCHAR(36), " +
-					"COVER BLOB, " +
+					"COVER BLOB" +
 				")");
 			statement.execute("CREATE INDEX MBID_IDX ON " + TABLE_NAME + "(MBID)");
 		}


### PR DESCRIPTION
The latest version of h2database is more strict to the SQL syntax.