### PR TITLE
More MediaInfo testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,6 @@ matrix:
     - os: osx
       osx_image: xcode9.3
     - os: osx
-      osx_image: xcode9.4
-    - os: osx
-      osx_image: xcode10.3
-    - os: osx
       osx_image: xcode11.3
 
 install: mvn external:install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       dist: trusty
       jdk: oraclejdk8
       before_install:
-        - sudo apt-get -y install libmms0 libzen0v5
+        - sudo apt-get -y install libmms0
         - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
         - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
@@ -19,7 +19,7 @@ matrix:
       dist: xenial
       jdk: openjdk8
       before_install:
-        - sudo apt-get -y install libmms0 libzen0v5
+        - sudo apt-get -y install libmms0
         - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
         - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
@@ -28,7 +28,7 @@ matrix:
       dist: bionic
       jdk: openjdk8
       before_install:
-        - sudo apt-get -y install libmms0 libzen0v5
+        - sudo apt-get -y install libmms0
         - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
         - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
       jdk: openjdk8
       before_install:
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+        - sudo apt-get -y install libmms0 libzen0v5
         - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ matrix:
       jdk: openjdk8
       before_install:
         - sudo apt-get -y install libmms0
-        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
+        - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
+        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_18.04.deb
+        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_18.04.deb
     - os: osx
       osx_image: xcode9.3
     - os: osx
@@ -41,4 +41,4 @@ matrix:
 
 install: mvn external:install
 
-script: mvn verify -B -V -P testing -e -X
+script: mvn verify -B -V -P testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ matrix:
       dist: trusty
       jdk: oraclejdk8
       before_install:
-        - apt show mediainfo
+        - sudo apt-get update
+        - sudo apt show mediainfo
+        - sudo apt-cache show mediainfo
+        - sudo apt-get show mediainfo
         - sudo apt-get -y install mediainfo=18.12
     - os: osx
       osx_image: xcode9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,14 @@ matrix:
         - sudo apt show mediainfo
         - sudo apt-cache show mediainfo
         - sudo apt-get -y install mediainfo=18.12
+    - os: linux
+      dist: bionic
+      jdk: openjdk8
+      before_install:
+        - sudo apt-get update
+        - sudo apt show mediainfo
+        - sudo apt-cache show mediainfo
+        - sudo apt-get -y install mediainfo=18.12
     - os: osx
       osx_image: xcode9.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
         - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
         - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/20.03/libmediainfo0v5_20.03-1_amd64.xUbuntu_18.04.deb
-        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_18.04.deb
+        - sudo dpkg -i libmediainfo0v5_20.03-1_amd64.xUbuntu_18.04.deb
     - os: osx
       osx_image: xcode9.3
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ matrix:
       jdk: oraclejdk8
       before_install:
         - sudo apt-get -y install libmms0
-        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb
+        - sudo dpkg -i libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb
+        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
+        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_14.04.deb
     - os: linux
       dist: xenial
       jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,16 @@
-dist: trusty
-
 language: java
 
 cache:
   directories:
   - $HOME/.m2
 
-addons:
-  apt:
-    packages: mediainfo=18.12
-
 matrix:
   include:
     - os: linux
+      dist: trusty
       jdk: oraclejdk8
+      before_install:
+        - sudo apt-get -y install mediainfo=18.12
     - os: osx
       osx_image: xcode9.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb
         - sudo dpkg -i libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
-        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_14.04.deb
+        - sudo dpkg -i libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
     - os: linux
       dist: xenial
       jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ matrix:
       dist: xenial
       jdk: openjdk8
       before_install:
-        - sudo apt-get update
-        - sudo apt show mediainfo
-        - sudo apt-cache show mediainfo
-        - sudo apt-get -y install mediainfo=18.12
+        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: linux
       dist: bionic
       jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ matrix:
         - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: osx
       osx_image: xcode9.3
+    - os: osx
+      osx_image: xcode9.4
+    - os: osx
+      osx_image: xcode10.3
 
 install: mvn external:install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       dist: trusty
       jdk: oraclejdk8
       before_install:
-        - apt policy mediainfo
+        - apt show mediainfo
         - sudo apt-get -y install mediainfo=18.12
     - os: osx
       osx_image: xcode9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,13 @@ matrix:
         - sudo apt-get update
         - sudo apt show mediainfo
         - sudo apt-cache show mediainfo
-        - sudo apt-get show mediainfo
+        - sudo apt-get -y install mediainfo=18.12
+    - os: linux
+      dist: xenial
+      jdk: openjdk8
+      before_install:
+        - sudo apt show mediainfo
+        - sudo apt-cache show mediainfo
         - sudo apt-get -y install mediainfo=18.12
     - os: osx
       osx_image: xcode9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ matrix:
       dist: xenial
       jdk: openjdk8
       before_install:
-        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
         - sudo apt-get -y install libmms0 libzen0v5
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
         - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ matrix:
 
 install: mvn external:install
 
-script: mvn verify -B -V -P testing
+script: mvn verify -B -V -P testing -e -X

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ cache:
   directories:
   - $HOME/.m2
 
+# The strategy with these matrixes are to test both old and new versions of operating systems
+# and Java, to ensure we don't break old things and that newer things continue to work
 matrix:
   include:
     - os: linux
@@ -16,15 +18,6 @@ matrix:
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
         - sudo dpkg -i libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
     - os: linux
-      dist: xenial
-      jdk: openjdk8
-      before_install:
-        - sudo apt-get -y install libmms0
-        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-    - os: linux
       dist: bionic
       jdk: openjdk8
       before_install:
@@ -32,6 +25,14 @@ matrix:
         - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
         - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_18.04.deb
+        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_18.04.deb
+    - os: linux
+      dist: bionic
+      before_install:
+        - sudo apt-get -y install libmms0
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
+        - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
+        - wget https://mediaarea.net/download/binary/libmediainfo0/20.03/libmediainfo0v5_20.03-1_amd64.xUbuntu_18.04.deb
         - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_18.04.deb
     - os: osx
       osx_image: xcode9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,32 +15,33 @@ matrix:
         - sudo dpkg -i libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
         - sudo dpkg -i libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
-    - os: linux
-      dist: xenial
-      jdk: openjdk8
-      before_install:
-        - sudo apt-get -y install libmms0
-        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-    - os: linux
-      dist: bionic
-      jdk: openjdk8
-      before_install:
-        - sudo apt-get -y install libmms0
-        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+    # Newer packages disabled until the following is resolved: https://github.com/vitalidze/chromecast-java-api-v2/issues/124
+    # - os: linux
+    #   dist: xenial
+    #   jdk: openjdk8
+    #   before_install:
+    #     - sudo apt-get -y install libmms0
+    #     - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+    #     - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+    #     - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+    #     - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+    # - os: linux
+    #   dist: bionic
+    #   jdk: openjdk8
+    #   before_install:
+    #     - sudo apt-get -y install libmms0
+    #     - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+    #     - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+    #     - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+    #     - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: osx
       osx_image: xcode9.3
     - os: osx
       osx_image: xcode9.4
-    - os: osx
-      osx_image: xcode10.3
-    - os: osx
-      osx_image: xcode11.3
+    # - os: osx
+    #   osx_image: xcode10.3
+    # - os: osx
+    #   osx_image: xcode11.3
 
 install: mvn external:install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,10 @@ matrix:
       osx_image: xcode9.3
     - os: osx
       osx_image: xcode9.4
+      jdk: openjdk8
     - os: osx
       osx_image: xcode10.3
+      jdk: openjdk8
 
 install: mvn external:install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,15 @@ matrix:
         - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_18.04.deb
         - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_18.04.deb
-    - os: linux
-      dist: bionic
-      before_install:
-        - sudo apt-get -y install libmms0
-        - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
-        - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
-        - wget https://mediaarea.net/download/binary/libmediainfo0/20.03/libmediainfo0v5_20.03-1_amd64.xUbuntu_18.04.deb
-        - sudo dpkg -i libmediainfo0v5_20.03-1_amd64.xUbuntu_18.04.deb
+    # This section can potentially be enabled when we upgrade MediaInfo to 20.03
+    # - os: linux
+    #   dist: bionic
+    #   before_install:
+    #     - sudo apt-get -y install libmms0
+    #     - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
+    #     - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_18.04.deb
+    #     - wget https://mediaarea.net/download/binary/libmediainfo0/20.03/libmediainfo0v5_20.03-1_amd64.xUbuntu_18.04.deb
+    #     - sudo dpkg -i libmediainfo0v5_20.03-1_amd64.xUbuntu_18.04.deb
     - os: osx
       osx_image: xcode9.3
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
       dist: trusty
       jdk: oraclejdk8
       before_install:
+        - apt policy mediainfo
         - sudo apt-get -y install mediainfo=18.12
     - os: osx
       osx_image: xcode9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
       dist: xenial
       jdk: openjdk8
       before_install:
+        - sudo apt-get update
         - sudo apt show mediainfo
         - sudo apt-cache show mediainfo
         - sudo apt-get -y install mediainfo=18.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ matrix:
       jdk: oraclejdk8
       before_install:
         - sudo apt-get -y install libmms0
-        - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
         - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: linux
@@ -20,8 +20,8 @@ matrix:
       jdk: openjdk8
       before_install:
         - sudo apt-get -y install libmms0
-        - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
         - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: linux
@@ -29,8 +29,8 @@ matrix:
       jdk: openjdk8
       before_install:
         - sudo apt-get -y install libmms0
-        - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
-        - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
         - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ matrix:
       osx_image: xcode9.3
     - os: osx
       osx_image: xcode9.4
-      jdk: openjdk8
     - os: osx
       osx_image: xcode10.3
-      jdk: openjdk8
+    - os: osx
+      osx_image: xcode11.3
 
 install: mvn external:install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,11 @@ matrix:
       dist: trusty
       jdk: oraclejdk8
       before_install:
-        - sudo apt-get update
-        - sudo apt show mediainfo
-        - sudo apt-cache show mediainfo
-        - sudo apt-get -y install mediainfo=18.12
+        - sudo apt-get -y install libmms0 libzen0v5
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: linux
       dist: xenial
       jdk: openjdk8
@@ -27,10 +28,11 @@ matrix:
       dist: bionic
       jdk: openjdk8
       before_install:
-        - sudo apt-get update
-        - sudo apt show mediainfo
-        - sudo apt-cache show mediainfo
-        - sudo apt-get -y install mediainfo=18.12
+        - sudo apt-get -y install libmms0 libzen0v5
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.38/libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libzen0v5_0.4.38-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: osx
       osx_image: xcode9.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ matrix:
       osx_image: xcode9.3
     - os: osx
       osx_image: xcode9.4
-    # - os: osx
-    #   osx_image: xcode10.3
-    # - os: osx
-    #   osx_image: xcode11.3
+    - os: osx
+      osx_image: xcode10.3
+    - os: osx
+      osx_image: xcode11.3
 
 install: mvn external:install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,25 +15,25 @@ matrix:
         - sudo dpkg -i libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
         - sudo dpkg -i libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
-    # Newer packages disabled until the following is resolved: https://github.com/vitalidze/chromecast-java-api-v2/issues/124
-    # - os: linux
-    #   dist: xenial
-    #   jdk: openjdk8
-    #   before_install:
-    #     - sudo apt-get -y install libmms0
-    #     - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-    #     - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-    #     - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-    #     - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-    # - os: linux
-    #   dist: bionic
-    #   jdk: openjdk8
-    #   before_install:
-    #     - sudo apt-get -y install libmms0
-    #     - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-    #     - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
-    #     - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
-    #     - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+    Newer packages disabled until the following is resolved: https://github.com/vitalidze/chromecast-java-api-v2/issues/124
+    - os: linux
+      dist: xenial
+      jdk: openjdk8
+      before_install:
+        - sudo apt-get -y install libmms0
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+    - os: linux
+      dist: bionic
+      jdk: openjdk8
+      before_install:
+        - sudo apt-get -y install libmms0
+        - wget https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb
+        - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
+        - sudo dpkg -i libmediainfo0v5_18.12-1_amd64.xUbuntu_16.04.deb
     - os: osx
       osx_image: xcode9.3
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 addons:
   apt:
-    packages: mediainfo
+    packages: mediainfo=18.12
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
         - sudo dpkg -i libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb
         - wget https://mediaarea.net/download/binary/libmediainfo0/18.12/libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
         - sudo dpkg -i libmediainfo0_18.12-1_amd64.xUbuntu_14.04.deb
-    Newer packages disabled until the following is resolved: https://github.com/vitalidze/chromecast-java-api-v2/issues/124
     - os: linux
       dist: xenial
       jdk: openjdk8

--- a/pom.xml
+++ b/pom.xml
@@ -698,24 +698,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<configuration>
 
-						<!--
-							1) Force language because JUnit tests depend on English language strings
-
-							2) Use our JNA dependency rather than the system's - fixes
-							the following error on Linux (Ubuntu 12.04 with system
-							jna-3.2.7.jar via libjna-java):
-
-							There is an incompatible JNA native library installed on this system.
-
-							3) Xmx and MaxPermSize from https://stackoverflow.com/questions/23260057/the-forked-vm-terminated-without-saying-properly-goodbye-vm-crash-or-system-exi
-						-->
-						<argLine>-Duser.language=en -Djna.nosys=true -XX:-UseSplitVerifier -Xmx1280m -XX:MaxPermSize=256m</argLine> <!-- only one argLine element is processed -->
-						<forkCount>1</forkCount>
-						<reuseForks>true</reuseForks>
-          	<useSystemClassLoader>false</useSystemClassLoader>
-					</configuration>
 					<version>${surefire-version}</version>
 				</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,26 @@
 
 				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
 			-->
-			<version>0.11.0</version>
+			<version>0.11.2</version>
+
+      <exclusions>
+        <!--
+					The exclusions can be removed when https://github.com/vitalidze/chromecast-java-api-v2/issues/124 is resolved.
+					Fix from https://github.com/openhab/openhab-addons/pull/7258/files
+				-->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.icu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -462,27 +462,7 @@
 
 				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
 			-->
-			<version>0.11.2</version>
-
-			<exclusions>
-				<!--
-					The exclusions can be removed when
-					https://github.com/vitalidze/chromecast-java-api-v2/issues/124 is resolved.
-					Fix from https://github.com/openhab/openhab-addons/pull/7258/files
-				-->
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-annotations</artifactId>
-				</exclusion>
-			</exclusions>
+			<version>0.11.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.icu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -372,14 +372,14 @@
 			<version>1.2.11</version>
 		</dependency>
 		<dependency>
-		    <groupId>net.sf.sevenzipjbinding</groupId>
-		    <artifactId>sevenzipjbinding</artifactId>
-		    <version>${sevenzip-version}</version>
+			<groupId>net.sf.sevenzipjbinding</groupId>
+			<artifactId>sevenzipjbinding</artifactId>
+			<version>${sevenzip-version}</version>
 		</dependency>
 		<dependency>
-		    <groupId>net.sf.sevenzipjbinding</groupId>
-		    <artifactId>sevenzipjbinding-all-platforms</artifactId>
-		    <version>${sevenzip-version}</version>
+			<groupId>net.sf.sevenzipjbinding</groupId>
+			<artifactId>sevenzipjbinding-all-platforms</artifactId>
+			<version>${sevenzip-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -464,25 +464,25 @@
 			-->
 			<version>0.11.2</version>
 
-      <exclusions>
-        <!--
+			<exclusions>
+				<!--
 					The exclusions can be removed when
 					https://github.com/vitalidze/chromecast-java-api-v2/issues/124 is resolved.
 					Fix from https://github.com/openhab/openhab-addons/pull/7258/files
 				-->
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-      </exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
@@ -561,33 +561,33 @@
 		</dependency>
 		<!-- FIX ERROR:  java.lang.NoSuchMethodError: org.codehaus.plexus.util.xml.pull.MXParser -->
 		<dependency>
-		    <groupId>org.codehaus.plexus</groupId>
-		    <artifactId>plexus</artifactId>
-		    <version>5.1</version>
-		    <type>pom</type>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus</artifactId>
+			<version>5.1</version>
+			<type>pom</type>
 		</dependency>
 		<dependency>
-		    <groupId>org.codehaus.plexus</groupId>
-		    <artifactId>plexus-utils</artifactId>
-		    <version>3.1.0</version>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>3.1.0</version>
 		</dependency>
 		<!-- FIX ERROR: Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkArgument -->
 		<dependency>
-		    <groupId>com.google.guava</groupId>
-		    <artifactId>guava-parent</artifactId>
-		    <version>26.0-jre</version>
-		    <type>pom</type>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava-parent</artifactId>
+			<version>26.0-jre</version>
+			<type>pom</type>
 		</dependency>
 		<dependency>
-		    <groupId>org.codehaus</groupId>
-		    <artifactId>codehaus-parent</artifactId>
-		    <version>4</version>
-		    <type>pom</type>
+			<groupId>org.codehaus</groupId>
+			<artifactId>codehaus-parent</artifactId>
+			<version>4</version>
+			<type>pom</type>
 		</dependency>
 		<dependency>
-		    <groupId>net.lingala.zip4j</groupId>
-		    <artifactId>zip4j</artifactId>
-		    <version>1.3.2</version>
+			<groupId>net.lingala.zip4j</groupId>
+			<artifactId>zip4j</artifactId>
+			<version>1.3.2</version>
 		</dependency>
 
 		<!-- start of JAXB dependencies -->
@@ -997,7 +997,7 @@
 							<report>plugins</report>
 						</reports>
 					</reportSet>
-		        </reportSets>
+				</reportSets>
 			</plugin>
 
 			<!-- tests report -->
@@ -1769,7 +1769,7 @@
 									<target>
 										<!-- Copy ums-x.x.x-jar-with-dependencies.jar to ums.jar -->
 										<copy file="${project.basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar"
-										      tofile="${project.basedir}/target/ums.jar" overwrite="true" />
+													tofile="${project.basedir}/target/ums.jar" overwrite="true" />
 
 										<!-- MediaInfo library needs to be in the standard library path to be found -->
 										<copy file="${project.binaries}/MediaInfo.dll" todir="${project.basedir}" />
@@ -3294,16 +3294,16 @@
 										<taskdef name="bundleapp" classname="com.oracle.appbundler.AppBundlerTask"
 											classpath="${basedir}/src/main/external-resources/lib/appbundler-1.3.UMS.jar"/>
 										<bundleapp outputdirectory="${project.build.directory}/${project.build.finalName}-distribution"
-										           name="${project.name}"
-										           displayname="${project.name}"
-										           executableName="UMS"
-										           identifier="net.pms.PMS"
-										           shortversion="${project.version.short}"
-										           version="${project.version}"
-										           icon="${project.basedir}/src/main/resources/images/logo.icns"
-										           applicationCategory="public.app-category.entertainment"
-										           workingdirectory="$APP_ROOT/Contents/Resources"
-										           mainclassname="net.pms.PMS">
+															 name="${project.name}"
+															 displayname="${project.name}"
+															 executableName="UMS"
+															 identifier="net.pms.PMS"
+															 shortversion="${project.version.short}"
+															 version="${project.version}"
+															 icon="${project.basedir}/src/main/resources/images/logo.icns"
+															 applicationCategory="public.app-category.entertainment"
+															 workingdirectory="$APP_ROOT/Contents/Resources"
+															 mainclassname="net.pms.PMS">
 											<runtime dir="${env.JAVA_HOME}" />
 											<classpath file="${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar"/>
 											<option value="-Xmx1280M"/>
@@ -3431,7 +3431,7 @@
 								<configuration>
 									<target>
 										<copy file="${project.basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar"
-										      tofile="${project.basedir}/target/pms.jar" overwrite="true" />
+													tofile="${project.basedir}/target/pms.jar" overwrite="true" />
 									</target>
 								</configuration>
 							</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -712,7 +712,7 @@
 							3) Xmx and MaxPermSize from https://stackoverflow.com/questions/23260057/the-forked-vm-terminated-without-saying-properly-goodbye-vm-crash-or-system-exi
 						-->
 						<argLine>-Duser.language=en -Djna.nosys=true -XX:-UseSplitVerifier -Xmx1024m -XX:MaxPermSize=256m</argLine> <!-- only one argLine element is processed -->
-						<forkCount>3</forkCount>
+						<forkCount>1</forkCount>
 						<reuseForks>true</reuseForks>
 					</configuration>
 					<version>${surefire-version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -708,8 +708,12 @@
 							jna-3.2.7.jar via libjna-java):
 
 							There is an incompatible JNA native library installed on this system.
+
+							3) Xmx and MaxPermSize from https://stackoverflow.com/questions/23260057/the-forked-vm-terminated-without-saying-properly-goodbye-vm-crash-or-system-exi
 						-->
 						<argLine>-Duser.language=en -Djna.nosys=true -XX:-UseSplitVerifier -Xmx1024m -XX:MaxPermSize=256m</argLine> <!-- only one argLine element is processed -->
+						<forkCount>3</forkCount>
+						<reuseForks>true</reuseForks>
 					</configuration>
 					<version>${surefire-version}</version>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 			Check the org.slf4j:slf4j-api version of the other libraries before upgrading
 		-->
 		<logback-version>1.2.3</logback-version>
-		<surefire-version>2.22.2</surefire-version>
+		<surefire-version>3.0.0-M4</surefire-version>
 
 		<!--
 			net.java.dev.jna:jna-platform is shared with
@@ -711,9 +711,10 @@
 
 							3) Xmx and MaxPermSize from https://stackoverflow.com/questions/23260057/the-forked-vm-terminated-without-saying-properly-goodbye-vm-crash-or-system-exi
 						-->
-						<argLine>-Duser.language=en -Djna.nosys=true -XX:-UseSplitVerifier -Xmx1024m -XX:MaxPermSize=256m</argLine> <!-- only one argLine element is processed -->
+						<argLine>-Duser.language=en -Djna.nosys=true -XX:-UseSplitVerifier -Xmx1280m -XX:MaxPermSize=256m</argLine> <!-- only one argLine element is processed -->
 						<forkCount>1</forkCount>
 						<reuseForks>true</reuseForks>
+          	<useSystemClassLoader>false</useSystemClassLoader>
 					</configuration>
 					<version>${surefire-version}</version>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 			Check the org.slf4j:slf4j-api version of the other libraries before upgrading
 		-->
 		<logback-version>1.2.3</logback-version>
-		<surefire-version>3.0.0-M4</surefire-version>
+		<surefire-version>2.22.2</surefire-version>
 
 		<!--
 			net.java.dev.jna:jna-platform is shared with

--- a/pom.xml
+++ b/pom.xml
@@ -709,7 +709,7 @@
 
 							There is an incompatible JNA native library installed on this system.
 						-->
-						<argLine>-Duser.language=en -Djna.nosys=true -XX:-UseSplitVerifier</argLine> <!-- only one argLine element is processed -->
+						<argLine>-Duser.language=en -Djna.nosys=true -XX:-UseSplitVerifier -Xmx1024m -XX:MaxPermSize=256m</argLine> <!-- only one argLine element is processed -->
 					</configuration>
 					<version>${surefire-version}</version>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,8 @@
 
       <exclusions>
         <!--
-					The exclusions can be removed when https://github.com/vitalidze/chromecast-java-api-v2/issues/124 is resolved.
+					The exclusions can be removed when
+					https://github.com/vitalidze/chromecast-java-api-v2/issues/124 is resolved.
 					Fix from https://github.com/openhab/openhab-addons/pull/7258/files
 				-->
         <exclusion>

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1814,8 +1814,14 @@ public class DLNAMediaInfo implements Cloneable {
 			if (isNotBlank(getMatrixCoefficients())) {
 				result.append(", Matrix Coefficients: ").append(getMatrixCoefficients());
 			}
+			if (getReferenceFrameCount() > -1) {
+				result.append(", Reference Frame Count: ").append(getReferenceFrameCount());
+			}
 			if (isNotBlank(avcLevel)) {
 				result.append(", AVC Level: ").append(getAvcLevel());
+			}
+			if (isNotBlank(h264Profile)) {
+				result.append(", AVC Profile: ").append(getH264Profile());
 			}
 //			if (isNotBlank(getHevcLevel())) {
 //				result.append(", HEVC Level: ");
@@ -1837,7 +1843,6 @@ public class DLNAMediaInfo implements Cloneable {
 			if (subtitleTracks != null && !subtitleTracks.isEmpty()) {
 				appendSubtitleTracks(result);
 			}
-
 		} else if (getAudioTrackCount() > 0) {
 			result.append(", Bitrate: ").append(getBitrate());
 			result.append(", Duration: ").append(getDurationString());

--- a/src/main/java/net/pms/io/OutputConsumer.java
+++ b/src/main/java/net/pms/io/OutputConsumer.java
@@ -20,7 +20,6 @@ package net.pms.io;
 
 import java.io.InputStream;
 import java.util.List;
-import org.apache.commons.io.IOUtils;
 
 public abstract class OutputConsumer extends Thread {
 	protected InputStream inputStream;
@@ -29,12 +28,6 @@ public abstract class OutputConsumer extends Thread {
 	public OutputConsumer(InputStream inputStream) {
 		this.inputStream = inputStream;
 		this.filtered = false;
-	}
-
-	@Deprecated
-	@Override
-	public void destroy() {
-		IOUtils.closeQuietly(inputStream);
 	}
 
 	public void setInputStream(InputStream inputStream) {

--- a/src/main/java/net/pms/newgui/SharedContentTab.java
+++ b/src/main/java/net/pms/newgui/SharedContentTab.java
@@ -673,19 +673,19 @@ public class SharedContentTab {
 				rowVector.setElementAt(aValue, column);
 			}
 			fireTableCellUpdated(row, column);
-			configuration.setSharedFolders(folderTableModel.getDataVector());
+			configuration.setSharedFolders((Vector) folderTableModel.getDataVector());
 		}
 
 		@Override
 		public void insertRow(int row, Vector rowData) {
 			super.insertRow(row, rowData);
-			configuration.setSharedFolders(folderTableModel.getDataVector());
+			configuration.setSharedFolders((Vector) folderTableModel.getDataVector());
 		}
 
 		@Override
 		public void removeRow(int row) {
 			super.removeRow(row);
-			configuration.setSharedFolders(folderTableModel.getDataVector());
+			configuration.setSharedFolders((Vector) folderTableModel.getDataVector());
 		}
 	}
 


### PR DESCRIPTION
Tests more about MediaInfo (I think it's everything we use now) and updates MediaInfo on Travis to be the same version we actually use and recommend.
It also fixes JDK 11 compilation, not that we officially support that