### PR TITLE
Proper escaping of friendly server names

### DIFF
--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -642,7 +642,7 @@ public class Request extends HTTPResource {
 					   s = s.replace("<modelName>UMS</modelName>", "<modelName>Windows Media Connect</modelName>");
       			}
 
-				s = s.replace("Universal Media Server", friendlyName);
+				s = s.replace("Universal Media Server", StringEscapeUtils.escapeXml10(friendlyName));
 
 				inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
 			}

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -864,7 +864,7 @@ public class RequestV2 extends HTTPResource {
 			}
 		}
 
-		result = result.replace("Universal Media Server", friendlyName);
+		result = result.replace("Universal Media Server", StringEscapeUtils.escapeXml10(friendlyName));
 		return result;
 	}
 


### PR DESCRIPTION
Without it, using "&" in the friendly server name did result in UMS producing invalid XML documents, which then allegedly used to break some clients.

This should fix https://github.com/UniversalMediaServer/UniversalMediaServer/issues/1172. I wasn't able to verify it, as my tv is handling these invalid XML documents properly anyway, but I was able to verify that produced XML documents became valid and that it didn't break anything for my tv either.