### PR TITLE
fix maven lifecycle mapping in Eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -746,7 +746,9 @@
 										<artifactId>
 											maven-antrun-plugin
 										</artifactId>
-										<version>${maven-antrun-plugin-version}</version>
+										<versionRange>
+											[1.7,)
+										</versionRange>
 										<goals>
 											<goal>run</goal>
 										</goals>


### PR DESCRIPTION
broken in ab709cac650532a07a5799c756c9b881d38450f6