### PR TITLE
Rollback h2database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>1.4.200</version>
+			<version>1.4.199</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
+			<!-- Versions above 1.4.199 should only be used when https://github.com/UniversalMediaServer/UniversalMediaServer/issues/2030 is done -->
 			<version>1.4.199</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
It was sometimes failing to load databases created by previous versions. A better strategy should be done for upgrades in the future