### PR TITLE
Revert the maven checkstyle plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -953,7 +953,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.1.0</version>
 				<configuration>
 					<configLocation>CheckStyle.xml</configLocation>
 				</configuration>


### PR DESCRIPTION
The checkstyle version 3.1.0 is the last version which works with the maven site plugin 3.9.0 (tested)