### PR TITLE
Update the supported formats in web renderers

### DIFF
--- a/src/main/java/net/pms/configuration/WebRender.java
+++ b/src/main/java/net/pms/configuration/WebRender.java
@@ -37,7 +37,9 @@ import net.pms.encoders.FFMpegVideo;
 import net.pms.encoders.Player;
 import net.pms.external.StartStopListenerDelegate;
 import net.pms.formats.*;
+import net.pms.formats.audio.M4A;
 import net.pms.formats.audio.MP3;
+import net.pms.formats.audio.OGA;
 import net.pms.formats.image.BMP;
 import net.pms.formats.image.GIF;
 import net.pms.formats.image.JPG;
@@ -73,7 +75,9 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 	private static final Format[] supportedFormats = {
 		new GIF(),
 		new JPG(),
+		new M4A(),
 		new MP3(),
+		new OGA(),
 		new PNG(),
 		new BMP()
 	};
@@ -120,6 +124,7 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 		configuration.addProperty(SUPPORTED, "f:mp4 m:video/mp4");
 		configuration.addProperty(SUPPORTED, "f:mp3 n:2 m:audio/mpeg");
 		configuration.addProperty(SUPPORTED, "f:ogg v:theora m:video/ogg");
+		configuration.addProperty(SUPPORTED, "f:m4a m:audio/mp4");
 		configuration.addProperty(SUPPORTED, "f:oga a:vorbis|flac m:audio/ogg");
 		configuration.addProperty(SUPPORTED, "f:wav n:2 m:audio/wav");
 		configuration.addProperty(SUPPORTED, "f:webm v:vp8|vp9 m:video/webm");

--- a/src/main/java/net/pms/remote/RemoteUtil.java
+++ b/src/main/java/net/pms/remote/RemoteUtil.java
@@ -177,10 +177,13 @@ public class RemoteUtil {
 				mime.equals(HTTPResource.MP4_TYPEMIME) ||
 				mime.equals(HTTPResource.WEBM_TYPEMIME) ||
 				mime.equals(HTTPResource.OGG_TYPEMIME) ||
-				mime.equals(HTTPResource.AUDIO_OGA_TYPEMIME) ||
+				mime.equals(HTTPResource.AUDIO_M4A_TYPEMIME) ||
 				mime.equals(HTTPResource.AUDIO_MP3_TYPEMIME) ||
+				mime.equals(HTTPResource.AUDIO_OGA_TYPEMIME) ||
+				mime.equals(HTTPResource.AUDIO_WAV_TYPEMIME) ||
+				mime.equals(HTTPResource.BMP_TYPEMIME) ||
 				mime.equals(HTTPResource.PNG_TYPEMIME) ||
-				mime.equals(HTTPResource.JPEG_TYPEMIME) ||
+				mime.equals(HTTPResource.PNG_TYPEMIME) ||
 				mime.equals(HTTPResource.GIF_TYPEMIME)
 			)
 		) {

--- a/src/main/java/net/pms/remote/RemoteUtil.java
+++ b/src/main/java/net/pms/remote/RemoteUtil.java
@@ -183,7 +183,7 @@ public class RemoteUtil {
 				mime.equals(HTTPResource.AUDIO_WAV_TYPEMIME) ||
 				mime.equals(HTTPResource.BMP_TYPEMIME) ||
 				mime.equals(HTTPResource.PNG_TYPEMIME) ||
-				mime.equals(HTTPResource.PNG_TYPEMIME) ||
+				mime.equals(HTTPResource.JPEG_TYPEMIME) ||
 				mime.equals(HTTPResource.GIF_TYPEMIME)
 			)
 		) {


### PR DESCRIPTION
It can partially solve the problem reported in https://www.universalmediaserver.com/forum/viewtopic.php?f=9&t=14171 where the m4a audio is transcoded for the Firefox browser and it finish with the error at the end of the file. This format is actually supported by all relevant browsers. There still persists the problem to auto skip to the next file when the file is fully played. Also files do not start playing automatically when selected. There must be problem in the web impementation.
