### PR TITLE
fix checking the internal UMS Cling requests

### DIFF
--- a/src/main/java/net/pms/network/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/RequestHandlerV2.java
@@ -420,8 +420,9 @@ public class RequestHandlerV2 extends SimpleChannelInboundHandler<FullHttpReques
 	}
 
 	private boolean isLocalClingRequest(InetAddress ia, String userAgent) {
-		// FIXME: this would also block an external cling-based client running on the same host
-		return userAgent != null && userAgent.contains("Cling/") &&
+		return userAgent != null &&
+			userAgent.contains("UMS/") &&
+			userAgent.contains("Cling/") &&
 			ia.getHostAddress().equals(PMS.get().getServer().getHost());
 	}
 


### PR DESCRIPTION
This fix the Netty4 PR and allow to run locally e.g. `cling-workbench-2.1.0-standalone.jar` for testing or to run other external cling-based client running on the same host.