### PR TITLE
Fixed support for external subtitles with the se syntax

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -716,20 +716,6 @@ CharMap =
 # Default: ""
 SupportedExternalSubtitlesFormats =
 
-# Some renderers like Panasonic TVs support streaming subtitles together with
-# the streamed video only for some video formats(codecs). This is a
-# comma-separated list of supported video formats for which supported external
-# subtitles formats listed in the "SupportedExternalSubtitlesFormats" are
-# streamed together with streaming (not transcoded) videos.
-# If empty, all subtitles listed in "SupportedExternalSubtitlesFormats" will be
-# streamed.
-# If not empty, we only stream external subtitles for the formats in this list.
-#
-# Example: VideoFormatsSupportingStreamedExternalSubtitles = divx,mp4
-# Default: ""
-VideoFormatsSupportingStreamedExternalSubtitles =
-
-
 # A comma-separated list of supported embedded subtitles formats.
 # This should not be used when embedded subtitles are defined in "Supported" lines
 # because this definition is too general and could not be always working.

--- a/src/main/external-resources/renderers/Panasonic-VieraTXL32V10E.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraTXL32V10E.conf
@@ -35,7 +35,5 @@ Supported = f:mpegps     v:mpeg2|mp4|h264   a:ac3|lpcm|aac-lc|mpa   m:video/mpeg
 Supported = f:avi|divx	v:mp4|divx		a:mp3|ac3	se:SUBRIP|MICRODVD	si:SUBRIP|MICRODVD|DIVX		m:video/divx   qpel:yes|no   gmc:0
 
 # Supported subtitles formats:
-SupportedExternalSubtitlesFormats = SUBRIP, MICRODVD
-VideoFormatsSupportingStreamedExternalSubtitles = divx, mp4
 SupportedInternalSubtitlesFormats = SUBRIP, MICRODVD, DIVX
 

--- a/src/main/external-resources/renderers/Panasonic-VieraVT60.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraVT60.conf
@@ -47,3 +47,4 @@ Supported = f:flac   m:audio/flac
 Supported = f:mp3    m:audio/mpeg
 
 SupportedInternalSubtitlesFormats = ASS,SUBRIP
+SupportedExternalSubtitlesFormats = SUBRIP

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -206,7 +206,6 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String USE_CLOSED_CAPTION = "UseClosedCaption";
 	protected static final String USE_SAME_EXTENSION = "UseSameExtension";
 	protected static final String VIDEO = "Video";
-	protected static final String VIDEO_FORMATS_SUPPORTING_STREAMED_EXTERNAL_SUBTITLES = "VideoFormatsSupportingStreamedExternalSubtitles";
 	protected static final String WRAP_DTS_INTO_PCM = "WrapDTSIntoPCM";
 	protected static final String WRAP_ENCODED_AUDIO_INTO_PCM = "WrapEncodedAudioIntoPCM";
 
@@ -1279,29 +1278,29 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 			// Use the supported information in the configuration to determine the transcoding mime type.
 			if (HTTPResource.VIDEO_TRANSCODE.equals(mimeType)) {
 				if (isTranscodeToMPEGTSH264AC3()) {
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGTS, FormatConfiguration.H264, FormatConfiguration.AC3);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.MPEGTS, FormatConfiguration.H264, FormatConfiguration.AC3);
 				} else if (isTranscodeToMPEGTSH264AAC()) {
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGTS, FormatConfiguration.H264, FormatConfiguration.AAC_LC);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.MPEGTS, FormatConfiguration.H264, FormatConfiguration.AAC_LC);
 				} else if (isTranscodeToMPEGTSH265AC3()) {
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGTS, FormatConfiguration.H265, FormatConfiguration.AC3);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.MPEGTS, FormatConfiguration.H265, FormatConfiguration.AC3);
 				} else if (isTranscodeToMPEGTSH265AAC()) {
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGTS, FormatConfiguration.H265, FormatConfiguration.AAC_LC);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.MPEGTS, FormatConfiguration.H265, FormatConfiguration.AAC_LC);
 				} else if (isTranscodeToMPEGTSMPEG2AC3()) {
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGTS, FormatConfiguration.MPEG2, FormatConfiguration.AC3);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.MPEGTS, FormatConfiguration.MPEG2, FormatConfiguration.AC3);
 				} else if (isTranscodeToWMV()) {
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.WMV, FormatConfiguration.WMV, FormatConfiguration.WMA);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.WMV, FormatConfiguration.WMV, FormatConfiguration.WMA);
 				} else {
 					// Default video transcoding mime type
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MPEGPS, FormatConfiguration.MPEG2, FormatConfiguration.AC3);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.MPEGPS, FormatConfiguration.MPEG2, FormatConfiguration.AC3);
 				}
 			} else if (HTTPResource.AUDIO_TRANSCODE.equals(mimeType)) {
 				if (isTranscodeToWAV()) {
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.WAV, null, null);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.WAV, null, null);
 				} else if (isTranscodeToMP3()) {
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.MP3, null, null);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.MP3, null, null);
 				} else {
 					// Default audio transcoding mime type
-					matchedMimeType = getFormatConfiguration().match(FormatConfiguration.LPCM, null, null);
+					matchedMimeType = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.LPCM, null, null);
 
 					if (matchedMimeType != null) {
 						if (pmsConfiguration.isAudioResample()) {
@@ -1722,7 +1721,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	public boolean isMuxH264MpegTS() {
 		boolean muxCompatible = getBoolean(MUX_H264_WITH_MPEGTS, true);
 		if (isUseMediaInfo()) {
-			muxCompatible = getFormatConfiguration().match(FormatConfiguration.MPEGTS, FormatConfiguration.H264, null) != null;
+			muxCompatible = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.MPEGTS, FormatConfiguration.H264, null) != null;
 		}
 
 		if (Platform.isMac() && System.getProperty("os.version") != null && System.getProperty("os.version").contains("10.4.")) {
@@ -2226,7 +2225,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 
 		// Use the configured "Supported" lines in the renderer.conf
 		// to see if any of them match the MediaInfo library
-		if (isUseMediaInfo() && mediaInfo != null && getFormatConfiguration().match(dlna) != null) {
+		if (isUseMediaInfo() && mediaInfo != null && getFormatConfiguration().getMatchedMIMEtype(dlna) != null) {
 			return true;
 		}
 
@@ -2407,24 +2406,13 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 
 	/**
 	 * List of the renderer supported external subtitles formats
-	 * for streaming together with streaming (not transcoded) video.
+	 * for streaming together with streaming (not transcoded) video, for all
+	 * file types.
 	 *
 	 * @return A comma-separated list of supported text-based external subtitles formats.
 	 */
-	public String getSupportedExternalSubtitles() {
+	public String getExternalSubtitlesFormatsSupportedForAllFiletypes() {
 		return getString(SUPPORTED_EXTERNAL_SUBTITLES_FORMATS, "");
-	}
-
-	/**
-	 * List of video formats for which supported external subtitles formats
-	 * are set for streaming together with streaming (not transcoded) video.
-	 * If empty all subtitles listed in "SupportedExternalSubtitlesFormats" will be streamed.
-	 * When specified only for listed video formats subtitles will be streamed.
-	 *
-	 * @return A comma-separated list of supported video formats listed in "Supported" section.
-	 */
-	public String getVideoFormatsSupportingStreamedExternalSubtitles() {
-		return getString(VIDEO_FORMATS_SUPPORTING_STREAMED_EXTERNAL_SUBTITLES, "");
 	}
 
 	/**
@@ -2448,8 +2436,15 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		return getBoolean(OFFER_SUBTITLES_BY_PROTOCOL_INFO, true);
 	}
 
-	public boolean isSubtitlesStreamingSupported() {
-		return StringUtils.isNotBlank(getSupportedExternalSubtitles());
+	/**
+	 * Note: This can return false even when the renderer config has defined
+	 * external subtitles support for individual filetypes.
+	 *
+	 * @return whether this renderer supports streaming external subtitles
+	 * for all video formats.
+	 */
+	public boolean isSubtitlesStreamingSupportedForAllFiletypes() {
+		return StringUtils.isNotBlank(getExternalSubtitlesFormatsSupportedForAllFiletypes());
 	}
 
 	/**
@@ -2457,39 +2452,28 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 *
 	 * @param subtitle Subtitles for checking
 	 * @param media Played media
+	 * @param dlna
 	 *
 	 * @return True if the renderer specifies support for the subtitles and
 	 * renderer supports subs streaming for the given media video.
 	 */
-	public boolean isExternalSubtitlesFormatSupported(DLNAMediaSubtitle subtitle, DLNAMediaInfo media) {
-		if (subtitle == null || media == null) {
+	public boolean isExternalSubtitlesFormatSupported(DLNAMediaSubtitle subtitle, DLNAMediaInfo media, DLNAResource dlna) {
+		if (subtitle == null || media == null || dlna == null) {
 			return false;
 		}
 
-		if (isSubtitlesStreamingSupported()) {
-			String[] supportedFormats = null;
-			if (StringUtils.isNotBlank(getVideoFormatsSupportingStreamedExternalSubtitles())) {
-				supportedFormats = getVideoFormatsSupportingStreamedExternalSubtitles().split(",");
-			}
-
-			String[] supportedSubs = getSupportedExternalSubtitles().split(",");
+		// First, check if this subtitles format is supported for all filetypes
+		if (isSubtitlesStreamingSupportedForAllFiletypes()) {
+			String[] supportedSubs = getExternalSubtitlesFormatsSupportedForAllFiletypes().split(",");
 			for (String supportedSub : supportedSubs) {
 				if (subtitle.getType().toString().equals(supportedSub.trim().toUpperCase())) {
-					if (supportedFormats != null) {
-						for (String supportedFormat : supportedFormats) {
-							if (media.getCodecV() != null && media.getCodecV().equals(supportedFormat.trim())) {
-								return true;
-							}
-						}
-					} else {
-						return true;
-					}
-
+					return true;
 				}
 			}
 		}
 
-		return false;
+		// We still didn't get a match, so now check for "se" entries in the "Supported" lines
+		return getFormatConfiguration().getMatchedMIMEtype(dlna) != null;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -852,7 +852,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				}
 				if (media_subtitle != null) {
 					if (media_subtitle.isExternal()) {
-						if (renderer != null && renderer.isExternalSubtitlesFormatSupported(media_subtitle, media)) {
+						if (renderer != null && renderer.isExternalSubtitlesFormatSupported(media_subtitle, media, this)) {
 							LOGGER.trace("This video has external subtitles that can be streamed");
 						} else {
 							LOGGER.trace("This video has external subtitles that must be transcoded");
@@ -1011,11 +1011,9 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		boolean parserV2 = media != null && renderer != null && renderer.isUseMediaInfo();
 		if (parserV2 && (format == null || !format.isImage())) {
 			// See which MIME type the renderer prefers in case it supports the media
-			String preferred = renderer.getFormatConfiguration().match(this);
+			String preferred = renderer.getFormatConfiguration().getMatchedMIMEtype(this);
 			if (preferred != null) {
-				/**
-				 * Use the renderer's preferred MIME type for this file.
-				 */
+				// Use the renderer's preferred MIME type for this file
 				if (!FormatConfiguration.MIMETYPE_AUTO.equals(preferred)) {
 					media.setMimeType(preferred);
 				}
@@ -1630,7 +1628,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 					media_subtitle.isExternal() &&
 					renderer != null &&
 					(player == null || renderer.streamSubsForTranscodedVideo()) &&
-					renderer.isExternalSubtitlesFormatSupported(media_subtitle, media);
+					renderer.isExternalSubtitlesFormatSupported(media_subtitle, media, this);
 
 				if (media_audio != null) {
 					String audioLanguage = media_audio.getLang();
@@ -2214,7 +2212,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 					(player == null || mediaRenderer.streamSubsForTranscodedVideo()) &&
 					media_subtitle != null &&
 					media_subtitle.isExternal() &&
-					mediaRenderer.isExternalSubtitlesFormatSupported(media_subtitle, media)
+					mediaRenderer.isExternalSubtitlesFormatSupported(media_subtitle, media, this)
 				) {
 					subsAreValidForStreaming = true;
 					LOGGER.trace("External subtitles \"{}\" can be streamed to {}", media_subtitle.getName(), mediaRenderer);

--- a/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
+++ b/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
@@ -295,12 +295,12 @@ public class FileTranscodeVirtualFolder extends TranscodeVirtualFolder {
 				}
 			}
 
-			if (renderer != null && renderer.isSubtitlesStreamingSupported()) {
+			if (renderer != null && renderer.isSubtitlesStreamingSupportedForAllFiletypes()) {
 				// Add a no-transcode entry for each streamable external subtitles
 				for (DLNAMediaSubtitle subtitlesTrack : subtitlesTracks) {
 					if (
 						subtitlesTrack != null && subtitlesTrack.isExternal() &&
-						renderer.isExternalSubtitlesFormatSupported(subtitlesTrack, originalResource.getMedia())
+						renderer.isExternalSubtitlesFormatSupported(subtitlesTrack, originalResource.getMedia(), originalResource)
 					) {
 						DLNAResource copy = createResourceWithAudioSubtitlePlayer(originalResource, singleAudioTrack, subtitlesTrack, null);
 						entries.add(copy);

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -215,7 +215,7 @@ public class FFMpegVideo extends Player {
 					if (params.sid.getExternalFile() != null) {
 						if (
 							!renderer.streamSubsForTranscodedVideo() ||
-							!renderer.isExternalSubtitlesFormatSupported(params.sid, media)
+							!renderer.isExternalSubtitlesFormatSupported(params.sid, media, dlna)
 						) {
 							// Only transcode subtitles if they aren't streamable
 							originalSubsFilename = params.sid.getExternalFile().getPath();

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -1700,7 +1700,7 @@ public class MEncoderVideo extends Player {
 					cmdList.add("" + params.sid.getLang());
 				} else if (
 					!params.mediaRenderer.streamSubsForTranscodedVideo() ||
-					!params.mediaRenderer.isExternalSubtitlesFormatSupported(params.sid, media)
+					!params.mediaRenderer.isExternalSubtitlesFormatSupported(params.sid, media, dlna)
 				) {
 					// Only transcode subtitles if they aren't streamable
 					cmdList.add("-sub");

--- a/src/main/java/net/pms/encoders/VLCVideo.java
+++ b/src/main/java/net/pms/encoders/VLCVideo.java
@@ -552,7 +552,7 @@ public class VLCVideo extends Player {
 					LOGGER.error("External subtitles file \"{}\" is unavailable", params.sid.getName());
 				} else if (
 					!params.mediaRenderer.streamSubsForTranscodedVideo() ||
-					!params.mediaRenderer.isExternalSubtitlesFormatSupported(params.sid, media)
+					!params.mediaRenderer.isExternalSubtitlesFormatSupported(params.sid, media, dlna)
 				) {
 					String externalSubtitlesFileName;
 

--- a/src/main/java/net/pms/network/Request.java
+++ b/src/main/java/net/pms/network/Request.java
@@ -504,7 +504,7 @@ public class Request extends HTTPResource {
 								dlna.getMediaSubtitle() != null &&
 								dlna.getMediaSubtitle().isExternal() &&
 								!configuration.isDisableSubtitles() &&
-								mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia())
+								mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia(), dlna)
 							) {
 								// Some renderers (like Samsung devices) allow a custom header for a subtitle URL
 								String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
@@ -539,7 +539,7 @@ public class Request extends HTTPResource {
 									reasons.add("dlna.getMediaSubtitle() is null");
 								} else if (!dlna.getMediaSubtitle().isExternal()) {
 									reasons.add("the subtitles are internal/embedded");
-								} else if (!mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia())) {
+								} else if (!mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia(), dlna)) {
 									reasons.add("the external subtitles format isn't supported by the renderer");
 								}
 								LOGGER.trace("Did not send subtitle headers because {}", StringUtil.createReadableCombinedString(reasons));

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -524,7 +524,7 @@ public class RequestV2 extends HTTPResource {
 								dlna.getMediaSubtitle() != null &&
 								dlna.getMediaSubtitle().isExternal() &&
 								!configuration.isDisableSubtitles() &&
-								mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia())
+								mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia(), dlna)
 							) {
 
 								String subtitleHttpHeader = mediaRenderer.getSubtitleHttpHeader();
@@ -559,7 +559,7 @@ public class RequestV2 extends HTTPResource {
 									reasons.add("dlna.getMediaSubtitle() is null");
 								} else if (!dlna.getMediaSubtitle().isExternal()) {
 									reasons.add("the subtitles are internal/embedded");
-								} else if (!mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia())) {
+								} else if (!mediaRenderer.isExternalSubtitlesFormatSupported(dlna.getMediaSubtitle(), dlna.getMedia(), dlna)) {
 									reasons.add("the external subtitles format isn't supported by the renderer");
 								}
 								LOGGER.trace("Did not send subtitle headers because {}", StringUtil.createReadableCombinedString(reasons));


### PR DESCRIPTION
Also removes `VideoFormatsSupportingStreamedExternalSubtitles` since that is no longer needed, and renames some things to be more readable.
It makes another change that we had just been discussing on the forum, which is that a file only needs one supported audio format to pass the match, while currently all audio codecs must be supported to match. In my testing, that has been a good change, as the renderers ignore streams they can't read.
It is possible that some renderers will not accept that but I think that will be more rare.

I have tested it with both syntaxed (`SupportedExternalSubtitlesFormats` and `se:`) on an external SRT file and it works with both, while before it only worked with `SupportedExternalSubtitlesFormats`.