### PR TITLE
Change the database trace level to 3

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
@@ -125,7 +125,7 @@ public class DLNAMediaDatabase implements Runnable {
 		File profileDirectory = new File(configuration.getProfileDirectory());
 		dbDir = new File(PMS.isRunningTests() || profileDirectory.isDirectory() ? configuration.getProfileDirectory() : null, "database").getAbsolutePath();
 		boolean logDB = configuration.getDatabaseLogging();
-		url = Constants.START_URL + dbDir + File.separator + dbName + (logDB ? ";TRACE_LEVEL_FILE=4" : "");
+		url = Constants.START_URL + dbDir + File.separator + dbName + (logDB ? ";TRACE_LEVEL_FILE=3" : "");
 		LOGGER.debug("Using database URL: {}", url);
 		LOGGER.info("Using database located at: \"{}\"", dbDir);
 		if (logDB) {


### PR DESCRIPTION
I have found that the trace level 4 doesn't create the `medias.trace.db`. Tested by deleting the database folder.