### PR TITLE
Revert "Use network interface names instead of their hardware description"

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -137,11 +137,10 @@ single_instance =
 
 # Force networking on interface
 # -----------------------------
-# Specifies the network interface to attach to, should only be
+# Specifies the (physical) network interface to attach to, should only be
 # relevant when the server has more than one network interface and UMS picks
 # the wrong one. The selector displays all available network interfaces.
-# E.g. network_interface = Intel(R) Dual Band Wireless-AC 3160
-# NOTE: Do not change it directly here but use the selector in the UMS GUI.
+# E.g. network_interface = eth0
 # Default: "", which means UMS will automatically select a network interface.
 network_interface =
 

--- a/src/main/java/net/pms/network/NetworkConfiguration.java
+++ b/src/main/java/net/pms/network/NetworkConfiguration.java
@@ -84,12 +84,11 @@ public class NetworkConfiguration {
 		}
 
 		/**
-		 * Returns the display name of the interface association 
-		 * with IP address if exists.
+		 * Returns the display name of the interface association.
 		 *
 		 * @return The name.
 		 */
-		public String getDisplayNameWithAddress() {
+		public String getDisplayName() {
 			String displayName = iface.getDisplayName();
 
 			if (displayName != null) {
@@ -104,24 +103,7 @@ public class NetworkConfiguration {
 
 			return displayName;
 		}
-
-		/**
-		 * Returns the display name of the interface association.
-		 *
-		 * @return The name.
-		 */
-		public String getDisplayName() {
-			String displayName = iface.getDisplayName();
-
-			if (displayName != null) {
-				displayName = displayName.trim();
-			} else {
-				displayName = iface.getName();
-			}
-
-			return displayName;
-		}
-
+		
 		@Override
 		public String toString() {
 			return "InterfaceAssociation(addr=" + addr + ", iface=" + iface + ", parent=" + parentName + ')';
@@ -142,13 +124,6 @@ public class NetworkConfiguration {
 	 * The list of discovered network interfaces.
 	 */
 	private List<InterfaceAssociation> interfaces = new ArrayList<>();
-
-	/**
-	 * @return The list of discovered network interfaces.
-	 */
-	public List<InterfaceAssociation> getInterfacesList() {
-		return interfaces;
-	}
 
 	/**
 	 * The map of discovered default IP addresses belonging to a network interface.
@@ -312,7 +287,7 @@ public class NetworkConfiguration {
 						LOGGER.trace("found {} -> {}", networkInterface.getName(), address.getHostAddress());
 						final InterfaceAssociation ia = new InterfaceAssociation(address, networkInterface, parentName);
 						interfaces.add(ia);
-						mainAddress.put(networkInterface.getDisplayName(), ia);
+						mainAddress.put(networkInterface.getName(), ia);
 						foundAddress = true;
 					}
 				} else {
@@ -328,18 +303,16 @@ public class NetworkConfiguration {
 		}
 	}
 
-
 	/**
-	 * Returns the list of user friendly names of interfaces with their IP
-	 * address.
+	 * Returns the list of discovered interface names.
 	 *
-	 * @return The list of names.
+	 * @return The interface names.
 	 */
-	public List<String> getDisplayNamesWithAddress() {
+	public List<String> getKeys() {
 		List<String> result = new ArrayList<>(interfaces.size());
 
 		for (InterfaceAssociation i : interfaces) {
-			result.add(i.getDisplayNameWithAddress());
+			result.add(i.getShortName());
 		}
 
 		return result;
@@ -355,7 +328,7 @@ public class NetworkConfiguration {
 		List<String> result = new ArrayList<>(interfaces.size());
 
 		for (InterfaceAssociation i : interfaces) {
-			result.add(i.getDisplayName());
+				result.add(i.getDisplayName());
 		}
 
 		return result;

--- a/src/main/java/net/pms/newgui/GeneralTab.java
+++ b/src/main/java/net/pms/newgui/GeneralTab.java
@@ -35,7 +35,6 @@ import net.pms.configuration.Build;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.network.NetworkConfiguration;
-import net.pms.network.NetworkConfiguration.InterfaceAssociation;
 import net.pms.newgui.components.CustomJButton;
 import net.pms.service.PreventSleepMode;
 import net.pms.service.SleepManager;
@@ -376,24 +375,12 @@ public class GeneralTab {
 
 			final KeyedComboBoxModel<String, String> networkInterfaces = createNetworkInterfacesModel();
 			networkinterfacesCBX = new JComboBox<>(networkInterfaces);
-			String savedNetworkInterface = configuration.getNetworkInterface();
-			// for backwards-compatibility check if the short network interface name is used
-			if (StringUtils.isNotBlank(savedNetworkInterface)) {
-				List<InterfaceAssociation> netInterfaces = NetworkConfiguration.getInstance().getInterfacesList();
-				for (InterfaceAssociation netInterface : netInterfaces) {
-					if (netInterface.getShortName().equals(savedNetworkInterface)) {
-						savedNetworkInterface = netInterface.getDisplayName();
-						break;
-					}
-				}
-			}
-
-			networkInterfaces.setSelectedKey(savedNetworkInterface);
+			networkInterfaces.setSelectedKey(configuration.getNetworkInterface());
 			networkinterfacesCBX.addItemListener(new ItemListener() {
 				@Override
 				public void itemStateChanged(ItemEvent e) {
 					if (e.getStateChange() == ItemEvent.SELECTED) {
-						configuration.setNetworkInterface(networkInterfaces.getSelectedKey());
+						configuration.setNetworkInterface((String) networkInterfaces.getSelectedKey());
 					}
 				}
 			});
@@ -625,8 +612,8 @@ public class GeneralTab {
 	}
 
 	private KeyedComboBoxModel<String, String> createNetworkInterfacesModel() {
-		List<String> keys = NetworkConfiguration.getInstance().getDisplayNames();
-		List<String> names = NetworkConfiguration.getInstance().getDisplayNamesWithAddress();
+		List<String> keys = NetworkConfiguration.getInstance().getKeys();
+		List<String> names = NetworkConfiguration.getInstance().getDisplayNames();
 		keys.add(0, "");
 		names.add(0, "");
 		return new KeyedComboBoxModel<>(


### PR DESCRIPTION
Reverts UniversalMediaServer/UniversalMediaServer#2080

@valib unfortunately I noticed a bug with this so I will re-merge this if that gets fixed - the backwards-compatible change isn't working. I have my wired network selected in the GUI so it appears to work, but then it binds to my wireless interface instead.