### PR TITLE
Remove crossorigin from webui

### DIFF
--- a/src/main/external-resources/web/browse.html
+++ b/src/main/external-resources/web/browse.html
@@ -34,7 +34,7 @@
 		<script src="/files/util/keycode.js"></script>
 		<script src="/files/util/keycontroller.js"></script>
 		<link rel="stylesheet" href="/files/util/remoteui.css" type="text/css" media="screen">
-		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css" crossorigin="anonymous">
+		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css">
 		<link rel="stylesheet" href="/files/util/jQKeyboard.css" type="text/css">
 		<title>{{name}}</title>
 	</head>
@@ -123,7 +123,7 @@
 			</nav>
 		</div>
 	</body>
-	<script defer src="/files/util/fontawesome/js/all.min.js" crossorigin="anonymous"></script>
+	<script src="/files/util/fontawesome/js/all.min.js"></script>
 	{{#hasFile}}
 	<script src="/files/util/searchclassie.js"></script>
 	<script src="/files/util/search.js"></script>

--- a/src/main/external-resources/web/doc.html
+++ b/src/main/external-resources/web/doc.html
@@ -14,7 +14,7 @@
 		<script src="/files/util/keycode.js"></script>
 		<script src="/files/util/keycontroller.js"></script>
 		<link rel="stylesheet" href="/files/util/remoteui.css" type="text/css" media="screen">
-		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css" crossorigin="anonymous">
+		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css">
 		<!-- Mobile-friendly -->
 		<meta name="viewport" content="width=device-width, initial-scale=1"> 
 		<title>Documentation</title>
@@ -60,6 +60,6 @@
 				</div>
 			</div>
 		</div>
-	<script defer src="/files/util/fontawesome/js/all.min.js" crossorigin="anonymous"></script>
+	<script src="/files/util/fontawesome/js/all.min.js"></script>
 	</body>
 </html>

--- a/src/main/external-resources/web/flow.html
+++ b/src/main/external-resources/web/flow.html
@@ -19,7 +19,7 @@
 		<script src="/files/util/keycode.js"></script>
 		<script src="/files/util/keycontroller.js"></script>
 		<link rel="stylesheet" href="/files/util/remoteui.css" type="text/css" media="screen">
-		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css" crossorigin="anonymous">
+		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css">
 		<!--VideoJS Support -->
 		<link href="/files/util/video-js/video-js.min.css" rel="stylesheet">
 		<script src="/files/util/video-js/video.min.js"></script>
@@ -124,6 +124,6 @@
 		</div>
 	<input type="hidden" class="jQKeyboard" name="dummy">
 	</body>
-	<script defer src="/files/util/fontawesome/js/all.min.js" crossorigin="anonymous"></script>
+	<script src="/files/util/fontawesome/js/all.min.js"></script>
 </html>
 

--- a/src/main/external-resources/web/image.html
+++ b/src/main/external-resources/web/image.html
@@ -15,7 +15,7 @@
 		<script src="/files/util/keycode.js"></script>
 		<script src="/files/util/keycontroller.js"></script>
 		<link rel="stylesheet" href="/files/util/remoteui.css" type="text/css" media="screen">
-		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css" crossorigin="anonymous">
+		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css">
 		<!-- Mobile-friendly -->
 		<meta name="viewport" content="width=device-width, initial-scale=1"> 
 		<title>{{name}}</title>
@@ -102,7 +102,7 @@
 				<button id="next" onclick="next()"{{nextAttr}}>>></button>
 			</div>
 		</div>
-		<script defer src="/files/util/fontawesome/js/all.min.js" crossorigin="anonymous"></script>
+		<script src="/files/util/fontawesome/js/all.min.js"></script>
 	</body>
 </html>
 

--- a/src/main/external-resources/web/play.html
+++ b/src/main/external-resources/web/play.html
@@ -17,7 +17,7 @@
 		<script src="/files/util/keycode.js"></script>
 		<script src="/files/util/keycontroller.js"></script>
 		<link rel="stylesheet" href="/files/util/remoteui.css" type="text/css" media="screen">
-		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css" crossorigin="anonymous">
+		<link rel="stylesheet" href="/files/util/fontawesome/css/all.min.css">
 		<!--VideoJS 7.2.3 Support -->
 		<link href="/files/util/video-js/video-js.min.css" rel="stylesheet">
 		<script src="/files/util/video-js/video.min.js"></script>
@@ -137,7 +137,7 @@
 {{/push}}			
 		</script>
 		<input type="hidden" class="jQKeyboard" name="dummy">
-		<script defer src="/files/util/fontawesome/js/all.min.js" crossorigin="anonymous"></script>
+		<script src="/files/util/fontawesome/js/all.min.js"></script>
 	</body>
 </html>
 


### PR DESCRIPTION
The html tag "crossorigin" means that the file is retrieved without user authentication, this means that the configuration option "web_authentication=true" should cause constant popups for browsers retrieving a file.
In practice Firefox and Chrome ignores this tag, and in my testing only Safari complies with it, meaning that for each refresh it request a user logon, which is annoying and unpractical.