### PR TITLE
Added lazy-loading to WebUI images

### DIFF
--- a/src/main/java/net/pms/remote/RemoteBrowseHandler.java
+++ b/src/main/java/net/pms/remote/RemoteBrowseHandler.java
@@ -112,7 +112,7 @@ public class RemoteBrowseHandler implements HttpHandler {
 				HashMap<String, String> item = new HashMap<>();
 				sb.append("<a href=\"#\" onclick=\"umsAjax('/play/").append(idForWeb)
 						.append("', true);return false;\" title=\"").append(name).append("\">")
-						.append("<img class=\"thumb\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
+						.append("<img class=\"thumb\" loading=\"lazy\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
 						.append("</a>");
 				item.put("thumb", sb.toString());
 				sb.setLength(0);
@@ -185,7 +185,7 @@ public class RemoteBrowseHandler implements HttpHandler {
 				if (WebRender.supports(resource) || resource.isResume() || resource.getType() == Format.IMAGE) {
 					sb.append("<a href=\"/play/").append(idForWeb)
 						.append("\" title=\"").append(name).append("\">")
-						.append("<img class=\"thumb\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
+						.append("<img class=\"thumb\" loading=\"lazy\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
 						.append("</a>");
 					item.put("thumb", sb.toString());
 					sb.setLength(0);
@@ -199,7 +199,7 @@ public class RemoteBrowseHandler implements HttpHandler {
 					sb.append("<a class=\"webdisabled\" href=\"javascript:notify('warn','")
 						.append(RemoteUtil.getMsgString("Web.6", t)).append("')\"")
 						.append(" title=\"").append(name).append(' ').append(RemoteUtil.getMsgString("Web.7", t)).append("\">")
-						.append("<img class=\"thumb\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
+						.append("<img class=\"thumb\" loading=\"lazy\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
 						.append("</a>");
 					item.put("thumb", sb.toString());
 					sb.setLength(0);


### PR DESCRIPTION
So if you create some, i don't know, 5446 images in one folder, loading because staggeringly slow. Because browsers attempt to download as much as their cache will allow them, and this causes the UMS server to not respond for some 50 seconds.
Instead, what adding loading="lazy" does, is it tells the client, load these when needed on the screen.

So this cuts the loading times from 50 to 5 seconds (in my testing anyway), as the images are just loading in when they appear on-screen.

Note:
It also causes some cover images to appear as black-boxes when you scroll before being loaded (could be lessened by HTTP/2.0), but only if you use firefox (thanks mozilla), chrome and safari doesn't exhibit this problem.