### PR TITLE
Implemented byte-range support and sustained rendering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -848,10 +848,10 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-					<testSource>1.7</testSource>
-					<testTarget>1.7</testTarget>
+					<source>1.8</source>
+					<target>1.8</target>
+					<testSource>1.8</testSource>
+					<testTarget>1.8</testTarget>
 					<compilerArgument>${compilerArgument}</compilerArgument>
 				</configuration>
 			</plugin>

--- a/src/main/java/net/pms/configuration/WebRender.java
+++ b/src/main/java/net/pms/configuration/WebRender.java
@@ -278,7 +278,7 @@ public class WebRender extends DeviceConfiguration implements RendererConfigurat
 	public String getVideoMimeType() {
 		if (browser == CHROME) {
 			return HTTPResource.WEBM_TYPEMIME;
-		} else if (browser == FIREFOX) {
+		} else if (browser == FIREFOX || browser == SAFARI) {
 			return HTTPResource.MP4_TYPEMIME;
 		}
 		return defaultMime;

--- a/src/main/java/net/pms/remote/RemoteBrowseHandler.java
+++ b/src/main/java/net/pms/remote/RemoteBrowseHandler.java
@@ -112,7 +112,7 @@ public class RemoteBrowseHandler implements HttpHandler {
 				HashMap<String, String> item = new HashMap<>();
 				sb.append("<a href=\"#\" onclick=\"umsAjax('/play/").append(idForWeb)
 						.append("', true);return false;\" title=\"").append(name).append("\">")
-						.append("<img class=\"thumb\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
+						.append("<img class=\"thumb\" loading=\"lazy\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
 						.append("</a>");
 				item.put("thumb", sb.toString());
 				sb.setLength(0);
@@ -185,7 +185,7 @@ public class RemoteBrowseHandler implements HttpHandler {
 				if (WebRender.supports(resource) || resource.isResume() || resource.getType() == Format.IMAGE) {
 					sb.append("<a href=\"/play/").append(idForWeb)
 						.append("\" title=\"").append(name).append("\">")
-						.append("<img class=\"thumb\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
+						.append("<img class=\"thumb\" loading=\"lazy\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
 						.append("</a>");
 					item.put("thumb", sb.toString());
 					sb.setLength(0);
@@ -199,7 +199,7 @@ public class RemoteBrowseHandler implements HttpHandler {
 					sb.append("<a class=\"webdisabled\" href=\"javascript:notify('warn','")
 						.append(RemoteUtil.getMsgString("Web.6", t)).append("')\"")
 						.append(" title=\"").append(name).append(' ').append(RemoteUtil.getMsgString("Web.7", t)).append("\">")
-						.append("<img class=\"thumb\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
+						.append("<img class=\"thumb\" loading=\"lazy\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
 						.append("</a>");
 					item.put("thumb", sb.toString());
 					sb.setLength(0);


### PR DESCRIPTION
This was done to try and fix #977 , but it doesn't fix Safari support.
What i've done is add byte-range support to RemoteMediaHandler.java. 
However, the default implementation stopped and started ffmpeg with each refresh, which is unsustainable for byte-range requests.
So i created a media resource dictionary, which has the last access time, and is scanned by a timer every 2 minutes to check if it has been left alone for 5 minutes, and then deletes it.
I also set the java version to 8 instead of 7 to use lambdas, i don't quite get why it was version 7, since i didn't notice anything breaking, and most operating systems use atleast java 8.

The reason this doesn't fix Safari support is because of the content length, when supplied with a fixed length via Content-Range, Safari starts by scanning this range to find the end, and then sets what it thinks the video length is, meaning playback stops unless you refresh.
To actually support Safari i would recommend using HLS instead, as it can be used by ffmpeg to generate a "playlist" file and a vod file. That is however not supported with the current setup, as this requires safari to access atleast 2 files, which is possible using "hls_flags single_file". But it does work, as i have tried serving via nginx while transcoding, which Safari sees as live.

The does also need more extensive testing.
Dont merge as there are playback bugs, that i have yet to track down.