### PR TITLE
Prevent false-positive for XBMC

### DIFF
--- a/src/main/external-resources/renderers/XBMC.conf
+++ b/src/main/external-resources/renderers/XBMC.conf
@@ -14,7 +14,7 @@ RendererIcon = xbmc.png
 # ============================================================================
 #
 
-UserAgentSearch = Neptune|Platinum|XBMC
+UserAgentSearch = Neptune|Platinum/0|XBMC
 UpnpDetailsSearch = XBMC Media Center - Media Renderer
 
 TranscodeAudio = WAV


### PR DESCRIPTION
Detecting it by `Platinum` isn't ideal so this is more of a hack. XBMC renamed themselves to Kodi and that has its own renderer config, so this profile is historic anyway