### PR TITLE
Added ability to overlay texts under the renderer icon.

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -30,6 +30,12 @@ RendererName =
 # Default: unknown.png
 RendererIcon = 
 
+# Determines the text/s that will overlaying the renderer icon
+# Use TEXT@X,Y,FONTSIZE and separate multiples entries by a |
+# Exemple: SAMSUNG@35,65,24|UHD@132,25,17
+# Default: ""
+RendererIconOverlays = 
+
 #-----------------------------------------------------------------------------
 # RENDERER RECOGNITION
 #

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -159,6 +159,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String PUSH_METADATA = "PushMetadata";
 	protected static final String REMOVE_TAGS_FROM_SRT_SUBS = "RemoveTagsFromSRTSubtitles";
 	protected static final String RENDERER_ICON = "RendererIcon";
+	protected static final String RENDERER_ICON_OVERLAYS = "RendererIconOverlays";
 	protected static final String RENDERER_NAME = "RendererName";
 	protected static final String RESCALE_BY_RENDERER = "RescaleByRenderer";
 	protected static final String SEEK_BY_TIME = "SeekByTime";
@@ -1666,6 +1667,16 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 			deviceIcon = UPNPHelper.getDeviceIcon(this, 140);
 		}
 		return deviceIcon == null ? icon : deviceIcon;
+	}
+
+	/**
+	 * Returns the the text/s that is displayed on the renderer icon
+	 * as defined in the renderer configurations. Default value is "".
+	 *
+	 * @return The renderer text.
+	 */
+	public String getRendererIconOverlays() {
+		return getString(RENDERER_ICON_OVERLAYS, "");
 	}
 
 	/**

--- a/src/main/java/net/pms/newgui/StatusTab.java
+++ b/src/main/java/net/pms/newgui/StatusTab.java
@@ -28,6 +28,7 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.Graphics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
@@ -75,7 +76,7 @@ public class StatusTab {
 		private JPanel _panel = null;
 
 		public RendererItem(RendererConfiguration renderer) {
-			icon = addRendererIcon(renderer.getRendererIcon());
+			icon = addRendererIcon(renderer.getRendererIcon(), renderer.getRendererIconOverlays());
 			icon.enableRollover();
 			label = new JLabel(renderer.getRendererName());
 			playingLabel = new GuiUtil.MarqueeLabel(" ");
@@ -426,7 +427,7 @@ public class StatusTab {
 			@Override
 			public void run() {
 				if (renderer.gui != null) {
-					renderer.gui.icon.set(getRendererIcon(renderer.getRendererIcon()));
+					renderer.gui.icon.set(getRendererIcon(renderer.getRendererIcon(), renderer.getRendererIconOverlays()));
 					renderer.gui.label.setText(renderer.getRendererName());
 					// Update the popup panel if it's been opened
 					if (renderer.gui.panel != null) {
@@ -437,9 +438,36 @@ public class StatusTab {
 		});
 	}
 
-	public static ImagePanel addRendererIcon(String icon) {
-		BufferedImage bi = getRendererIcon(icon);
+	public static ImagePanel addRendererIcon(String icon, String overlays) {
+		BufferedImage bi = getRendererIcon(icon, overlays);
 		return bi != null ? new ImagePanel(bi) : null;
+	}
+
+	public static BufferedImage getRendererIcon(String icon, String overlays) {
+		BufferedImage bi = getRendererIcon(icon);
+		if (bi != null && StringUtils.isNotBlank(overlays)) {
+			Graphics g = bi.getGraphics();
+			g.setColor(Color.DARK_GRAY);
+			for (String overlay : overlays.split("[\u007c]")){
+				String text = null;
+				int x, y, size;
+				if (overlay.contains("@"))
+				{
+					text = overlay.substring(0, overlay.indexOf("@"));
+					String[] values = overlay.substring(overlay.indexOf("@") + 1).split(",");
+					if (values.length == 3)
+					{
+						x=Integer.parseInt(values[0]);
+						y=Integer.parseInt(values[1]);
+						size=Integer.parseInt(values[2]);
+						g.setFont(new Font("Courier", Font.BOLD, size));
+						g.drawString(text, x, y);
+					}
+				}
+			}
+			g.dispose();
+		}
+		return bi;
 	}
 
 	public static BufferedImage getRendererIcon(String icon) {


### PR DESCRIPTION
A small added option on the renderer configuration file that allow underlaying some text on the renderer icon.
It draw the text/s directly on the BufferedImage at icon creation, so no undesired side effect.

This can avoid using alot of base renderer's png image in the jar file.
It allow the renderer icon to be more precise, by adding a year, "UHD", wathever you want directly on the icon. 

The option on the renderer configuration file is **`RendererIconOverlays`**.
The value is formated **`TEXT@X,Y,FONTSIZE`** and multiple entries can be used by separate them with a **`|`**.

Exemple :
`RendererIconOverlays = SAMSUNG@35,65,24|UHD@132,25,17`

DefaultRenderer.conf was updated to show users the option exists and how to use it.
