### PR TITLE
Fixed FileWatcher not working for Device Configuration file

### DIFF
--- a/src/main/java/net/pms/util/FileWatcher.java
+++ b/src/main/java/net/pms/util/FileWatcher.java
@@ -99,13 +99,14 @@ public class FileWatcher {
 			String match;
 			String globChar;
 			final String[] globCharsToEscape = {  
-					"[",
-					"]",
-					"{",
-					"}",
-					"?",
-					"*",
-					"," };
+				"[",
+				"]",
+				"{",
+				"}",
+				"?",
+				"*",
+				","
+			};
 
 			if (fspec.startsWith("glob:") || fspec.startsWith("regex:")) {
 				match = fspec; //assume fspec is valid glob or regex pattern, not just a file path

--- a/src/main/java/net/pms/util/FileWatcher.java
+++ b/src/main/java/net/pms/util/FileWatcher.java
@@ -100,13 +100,12 @@ public class FileWatcher {
 			String globChar;
 			final String[] globCharsToEscape = {  
 					"[",
-                    "]",
-                    "{",
-                    "}",
-                    "?",
-                    "*",
-                    "," };
-
+					"]",
+					"{",
+					"}",
+					"?",
+					"*",
+					"," };
 
 			if (fspec.startsWith("glob:") || fspec.startsWith("regex:")) {
 				match = fspec; //assume fspec is valid glob or regex pattern, not just a file path

--- a/src/main/java/net/pms/util/FileWatcher.java
+++ b/src/main/java/net/pms/util/FileWatcher.java
@@ -96,8 +96,28 @@ public class FileWatcher {
 		}
 
 		public void init(Path dir) {
-			// Assume glob pattern if no prefix
-			String match = (fspec.startsWith("glob:") || fspec.startsWith("regex:")) ? fspec : ("glob:" + fspec);
+			String match;
+			String globChar;
+			final String[] globCharsToEscape = {  
+					"[",
+                    "]",
+                    "{",
+                    "}",
+                    "?",
+                    "*",
+                    "," };
+
+
+			if (fspec.startsWith("glob:") || fspec.startsWith("regex:")) {
+				match = fspec; //assume fspec is valid glob or regex pattern, not just a file path
+			} else { // Default to glob pattern if no prefix. fspec is a file path with double-backslashes
+				match = "glob:" + fspec;
+				// escape glob chars that could occur in a file path and would be interpreted as pattern in getPathMatcher()
+				for (int i = 0; i < globCharsToEscape.length; i++) {
+					globChar = globCharsToEscape[i];
+					match = match.replace(globChar, "\\" + globChar);
+				}
+			}
 			matcher = dir.getFileSystem().getPathMatcher(match);
 		}
 


### PR DESCRIPTION
**Issue:**
Device Configuration files have the following name: for me, e.g. [TV]UE55JU6450-c02aa3.conf
Changes in the file will be ignored until next restart of UMS, although a Filewatcher entry is added for the file.

**Reason:**
Filewatcher is creating a matcher for the file path. But because of the special chars `[` and `]` the `getPathMatcher()` methods interpretes them as glob commands and transforms them to regex expressions, which is leading to a misformed matcher. 

**Solution:**
I changed the `init() `method of the Filewatcher, where the matcher is created. 
The `getPathMatcher()` methods expects a glob or regex pattern string. The existing coding assumed a valid glob syntax and added the respective syntax prefix to the file path. 
So now, instead of assuming valid input, we are defaulting to glob with the prefix, but also escaping all glob specific special characters that could occur in the file path.

This is my first pull request on github and I am not a "productive" Java developer. So if you have any feedback, improvements, better ideas to solve it or just questions I would gladly hear it. Let me hear/see what you think about this.