### PR TITLE
Changed upnp:class for PlaylistFolder from storageFolder to playlistContainer

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2449,7 +2449,11 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		if (first != null && media != null && !media.isSecondaryFormatValid()) {
 			uclass = "dummy";
 		} else if (isFolder) {
-			uclass = "object.container.storageFolder";
+		    if (this instanceof PlaylistFolder) {
+	          uclass = "object.container.playlistContainer";
+		    } else {
+			  uclass = "object.container.storageFolder";
+		    }
 			if (xbox360 && getFakeParentId() != null) {
 				switch (getFakeParentId()) {
 					case "7":


### PR DESCRIPTION
Give control points the ability to identify a DLNAResource PlaylistFolder as upnp:class of type object.container.playlistContainer.