### PR TITLE
Display thumbnails for playlists.

### DIFF
--- a/src/main/java/net/pms/dlna/PlaylistFolder.java
+++ b/src/main/java/net/pms/dlna/PlaylistFolder.java
@@ -100,6 +100,37 @@ public class PlaylistFolder extends DLNAResource {
 	}
 
 	@Override
+	protected DLNAThumbnailInputStream getThumbnailInputStream() throws IOException
+	{
+		File thumbnailImage = null;
+		if (!isweb) {
+			 thumbnailImage = new File(FilenameUtils.removeExtension(uri) + ".png");
+			 if (!thumbnailImage.exists() || thumbnailImage.isDirectory()) {
+				 thumbnailImage = new File(FilenameUtils.removeExtension(uri) + ".jpg");
+			 }
+			 if (!thumbnailImage.exists() || thumbnailImage.isDirectory()) {
+				 thumbnailImage = new File(FilenameUtils.getFullPath(uri) + "folder.png");
+			 }
+			 if (!thumbnailImage.exists() || thumbnailImage.isDirectory()) {
+				 thumbnailImage = new File(FilenameUtils.getFullPath(uri) + "folder.jpg");
+			 }
+			 if (!thumbnailImage.exists() || thumbnailImage.isDirectory()) {
+				 return super.getThumbnailInputStream();
+			 }
+			 DLNAThumbnailInputStream result = null;
+			 try {
+				 LOGGER.debug("PlaylistFolder albumart path : " + thumbnailImage.getAbsolutePath());
+				 result = DLNAThumbnailInputStream.toThumbnailInputStream(new FileInputStream(thumbnailImage));
+			 } catch (IOException e) {
+				 LOGGER.debug("An error occurred while getting thumbnail for \"{}\", using generic thumbnail instead: {}", getName(), e.getMessage());
+				 LOGGER.trace("", e);
+			 }
+			 return result != null ? result : super.getThumbnailInputStream();
+		}
+		return null;
+	}	
+
+	@Override
 	protected void resolveOnce() {
 		ArrayList<Entry> entries = new ArrayList<>();
 		boolean m3u = false;


### PR DESCRIPTION
Display thumbnails for playlists. The thumbnail image has to be named as the playlist file with replaced extension to "png" or "jpg". If an individual image is not found, a general folder image named "folder.png" or "folder.jpg" is searched for.

So if we have a playlist named "myPlaylist.m3u8" an image placed in the same directory named "myPlaylist.png" will be used as thumbnail, instead of the default one.