### PR TITLE
Add support for Sony Bravia XF series

### DIFF
--- a/src/main/external-resources/renderers/Sony-BraviaXD.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaXD.conf
@@ -1,8 +1,8 @@
 #---------------------------------------------------------------------------------------------------
-# Profile for Sony Bravia XD 70/75/80/83/85/93/94 series, 4K HDR avec Android TV.
+# Profile for Sony Bravia XD 70/75/80/83/85/93/94 series, 4K HDR with Android TV.
 # See DefaultRenderer.conf for descriptions of all the available options.
 
-RendererName = Sony Bravia XD/XE
+RendererName = Sony Bravia XD/XE/XF
 RendererIcon = Sony-BraviaXD.png
 
 # =================================================================================
@@ -28,8 +28,8 @@ RendererIcon = Sony-BraviaXD.png
 # If a connection issue is encountered, add chromecast_extension=false into your UMS.conf file.
 
 UserAgentAdditionalHeader = X-AV-Client-Info
-UserAgentAdditionalHeaderSearch = (FW|KD)-\\d{2}X[DE][7-9][0345]
-UpnpDetailsSearch = (FW|KD)-\\d{2}X[DE][7-9][0345]
+UserAgentAdditionalHeaderSearch = (FW|KD)-\\d{2}X[DEF][7-9][0345]
+UpnpDetailsSearch = (FW|KD)-\\d{2}X[DEF][7-9][0345]
 LoadingPriority = 2
 
 SeekByTime = true


### PR DESCRIPTION
I have a Sony Bravia 43XF8577 TV. It works flawlessly with the existing XD series configuration.

This PR extends the detection regexes to include these models out of the box.