### PR TITLE
LG OLED UpnpDetailsSearch regex fix

### DIFF
--- a/src/main/external-resources/renderers/LG-OLED.conf
+++ b/src/main/external-resources/renderers/LG-OLED.conf
@@ -33,11 +33,17 @@ RendererIcon = lg-lb6500.png
 #
 # Manual link:
 # https://www.lg.com/us/support/manuals-documents?customerModelCode=OLED65C9PUA&csSalesCode=OLED65C9PUA.AUS&category=CT10000018&subcategory=CT30017665
+#
+# The following block is all sent from OLED55B9SLA
+# friendlyName=[LG] webOS TV OLED55B9SLA
+# modelNumber=OLED55B9SLA
+#
+# Page describing LG OLED model numbers: https://en.tab-tv.com/?page_id=7111
 # ============================================================================
 #
 
-UserAgentSearch = OLED\d{2}[BCE]\d{1}[AP]U[AB]
-UpnpDetailsSearch = OLED\d{2}C9PUA
+UserAgentSearch = OLED\d{2}[ABCEGW][0-9X]
+UpnpDetailsSearch = OLED\d{2}[ABCEGW][0-9X]
 LoadingPriority = 2
 
 TranscodeVideo = MPEGTS-H264-AC3


### PR DESCRIPTION
Extending LG OLED UpnpDetailsSearch regex so it should match all LG OLED 2016-2021.