### PR TITLE
Set maximum bitrate for MPEG-2

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -573,7 +573,7 @@ public class FFMpegVideo extends Player {
 			if (!bitrateLevel41Limited) {
 				// Set maximum bitrate for MPEG-2 which should be 10.08 Mbit/s
 				// for audio + video bitrate. See the https://en.wikipedia.org/wiki/MPEG-2
-				if (params.getMediaRenderer().isTranscodeToMPEG2() && defaultMaxBitrates[0] > 10 && !dtsRemux) {
+				if (!dtsRemux && params.getMediaRenderer().isTranscodeToMPEG2() && defaultMaxBitrates[0] > 10) {
 					defaultMaxBitrates[0] = 10;
 				}
 

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -571,6 +571,12 @@ public class FFMpegVideo extends Player {
 			}
 
 			if (!bitrateLevel41Limited) {
+				// Set maximum bitrate for MPEG-2 which should be 10.08 Mbit/s
+				// for audio + video bitrate. See the https://en.wikipedia.org/wiki/MPEG-2
+				if (params.getMediaRenderer().isTranscodeToMPEG2() && defaultMaxBitrates[0] > 10 && !dtsRemux) {
+					defaultMaxBitrates[0] = 10;
+				}
+
 				// Make room for audio
 				if (dtsRemux) {
 					defaultMaxBitrates[0] -= 1510;

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -573,8 +573,8 @@ public class FFMpegVideo extends Player {
 			if (!bitrateLevel41Limited) {
 				// Set maximum bitrate for MPEG-2 which should be 10.08 Mbit/s
 				// for audio + video bitrate. See the https://en.wikipedia.org/wiki/MPEG-2
-				if (!dtsRemux && params.getMediaRenderer().isTranscodeToMPEG2() && defaultMaxBitrates[0] > 10) {
-					defaultMaxBitrates[0] = 10;
+				if (!dtsRemux && params.getMediaRenderer().isTranscodeToMPEG2() && defaultMaxBitrates[0] > 10000) {
+					defaultMaxBitrates[0] = 10000;
 				}
 
 				// Make room for audio


### PR DESCRIPTION
This could fix problems when users set the maximal net throughput higher than the MPEG-2 is capable to do. This could fix the problem reported in http://www.universalmediaserver.com/forum/viewtopic.php?f=9&p=43217#p43217 where the FFmpeg is producing the transcoded video with the maxbitrate 19 Mbit/sec.