### PR TITLE
Audio items transcoding setting

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -252,7 +252,7 @@ CreateDLNATreeFaster =
 TranscodeVideo = 
 
 # Profile to use for transcoding audio files
-# Options: "LPCM", "MP3" or "WAV".
+# Options: "LPCM", "MP3" or "WAV" or "NO_TRANS". "NO_TRANS" disables audio file transcoding.
 # Default: LPCM
 TranscodeAudio = 
 

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -1346,14 +1346,14 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 					matchedMimeType = HTTPResource.MPEG_TYPEMIME;
 				}
 			} else if (HTTPResource.AUDIO_TRANSCODE.equals(mimeType)) {
-				if (isTranscodeToWAV()) {
-					matchedMimeType = HTTPResource.AUDIO_WAV_TYPEMIME;
+				if (isMediaTypeSupported(media.getMimeType())) {
+					matchedMimeType = media.getMimeType();
 				} else if (isTranscodeToMP3()) {
 					matchedMimeType = HTTPResource.AUDIO_MP3_TYPEMIME;
 				} else if (isTranscodeToLPCM()) {
 					matchedMimeType = defaultAudioTranscoding(media);
-				} else if (isMediaTypeSupported(media.getMimeType())) {
-					matchedMimeType = media.getMimeType();
+				} else if (isTranscodeToWAV()) {
+					matchedMimeType = HTTPResource.AUDIO_WAV_TYPEMIME;
 				} else {
 					matchedMimeType = defaultAudioTranscoding(media);
 				}
@@ -1823,7 +1823,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 * @return The codec name.
 	 */
 	public String getAudioTranscode() {
-		return getString(TRANSCODE_AUDIO, "");
+		return getString(TRANSCODE_AUDIO, LPCM);
 	}
 
 	/**

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -106,7 +106,6 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String MP3 = "MP3";
 	protected static final String WAV = "WAV";
 	protected static final String WMV = "WMV";
-	protected static final String NO_TRANS = "NO_TRANS";
 
 	// video transcoding options
 	protected static final String MPEGTSH264AAC = "MPEGTS-H264-AAC";
@@ -1202,10 +1201,6 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		return getAudioTranscode().equals(WAV);
 	}
 
-	public boolean isNoAudioTranscoding() { // check media renderer capabilities
-		return getAudioTranscode().equals(NO_TRANS);
-	}
-
 	public boolean isTranscodeAudioTo441() {
 		return getBoolean(TRANSCODE_AUDIO_441KHZ, false);
 	}
@@ -1357,7 +1352,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 					matchedMimeType = HTTPResource.AUDIO_MP3_TYPEMIME;
 				} else if (isTranscodeToLPCM()) {
 					matchedMimeType = defaultAudioTranscoding(media);
-				} else if (isNoAudioTranscoding() || isMediaTypeSupported(media.getMimeType())) {
+				} else if (isMediaTypeSupported(media.getMimeType())) {
 					matchedMimeType = media.getMimeType();
 				} else {
 					matchedMimeType = defaultAudioTranscoding(media);

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -106,6 +106,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	protected static final String MP3 = "MP3";
 	protected static final String WAV = "WAV";
 	protected static final String WMV = "WMV";
+	protected static final String NO_TRANS = "NO_TRANS";
 
 	// video transcoding options
 	protected static final String MPEGTSH264AAC = "MPEGTS-H264-AAC";
@@ -1201,6 +1202,10 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 		return getAudioTranscode().equals(WAV);
 	}
 
+	public boolean isNoAudioTranscoding() { // check media renderer capabilities
+		return getAudioTranscode().equals(NO_TRANS);
+	}
+
 	public boolean isTranscodeAudioTo441() {
 		return getBoolean(TRANSCODE_AUDIO_441KHZ, false);
 	}
@@ -1350,6 +1355,8 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 					matchedMimeType = HTTPResource.AUDIO_WAV_TYPEMIME;
 				} else if (isTranscodeToMP3()) {
 					matchedMimeType = HTTPResource.AUDIO_MP3_TYPEMIME;
+				} else if (isNoAudioTranscoding()) {
+					matchedMimeType = media.getMimeType();
 				} else {
 					// Default audio transcoding mime type
 					matchedMimeType = HTTPResource.AUDIO_LPCM_TYPEMIME;

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -1823,7 +1823,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 * @return The codec name.
 	 */
 	public String getAudioTranscode() {
-		return getString(TRANSCODE_AUDIO, LPCM);
+		return getString(TRANSCODE_AUDIO, "");
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2216,7 +2216,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 					addAttribute(sb, "pv:subtitleFileUri", getSubsURL(mediaSubtitle));
 				}
 
-				if (getFormat() != null && (getFormat().isVideo() || getFormat().isAudio()) && media != null && media.isMediaparsed()) {
+				if (getFormat() != null && (getFormat().isVideo()) && media != null && media.isMediaparsed()) {
 					long transcodedSize = mediaRenderer.getTranscodedSize();
 					if (player == null) {
 						addAttribute(sb, "size", media.getSize());

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -3153,7 +3153,11 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		}
 
 		InputStream is = null;
-		if (this instanceof RealFile && mediarenderer.isNoAudioTranscoding()) {
+		if (this instanceof RealFile && (mediarenderer.isNoAudioTranscoding() || mediarenderer.isMediaTypeSupported(media.getMimeType()))) {
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug(String.format("MediaType %s is supported by render device : %s",
+					media.getMimeType(), Boolean.toString(mediarenderer.isMediaTypeSupported(media.getMimeType()))));
+			}
 			is = new FileInputStream(((RealFile) this).getFile());
 		} else {
 			// (Re)start transcoding process if necessary

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2358,8 +2358,10 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 								addAttribute(sb, "size", media.getSize());
 							}
 						} else {
+							if (mediaRenderer.isMediaTypeSupported(media.getMimeType())) {
+								addAttribute(sb, "size", media.getSize());
 							// Calculate WAV size
-							if (
+							} else if (
 								firstAudioTrack != null &&
 								media.getDurationInSeconds() > 0.0 &&
 								transcodeFrequency > 0 &&

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2408,12 +2408,12 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 							transcodedExtension = "_transcoded_to.mpg";
 						}
 					} else if (media.isAudio()) {
-						if (mediaRenderer.isTranscodeToMP3()) {
+						if (mediaRenderer.isMediaTypeSupported(media.getMimeType())) {
+							transcodedExtension = "";
+						} else if (mediaRenderer.isTranscodeToMP3()) {
 							transcodedExtension = "_transcoded_to.mp3";
 						} else if (mediaRenderer.isTranscodeToWAV()) {
 							transcodedExtension = "_transcoded_to.wav";
-						} else if (mediaRenderer.isMediaTypeSupported(media.getMimeType())) {
-							transcodedExtension = "";
 						} else {
 							transcodedExtension = "_transcoded_to.pcm";
 						}


### PR DESCRIPTION
This PR adds the ability to natively serve audio files, without transcoding.

- If the renderer (Renderer Configuration file) supports native playback of the streamed audio file, the native file is being streamed instead of the transcoded file.
- If `TranscodeAudio` is set to `NO_TRANS` the native file is always being streamed.

Fixed issues, if native playback is used (not transcoded):
- MPD based UPnP renderer will show/update the played/duration time and progress bar.
- Some renderer extract cover art and other information from the metadata section of the streamed file instead of the UPnP resource information. Transcoded files however lose all metadata.
- Audiophile listeners don't like their files to get touched. The NO_TRANS flag leaves the audio file in any case untouched.