### PR TITLE
Added bitsPerSample to DIDL result

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2314,6 +2314,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 									addAttribute(sb, "nrAudioChannels", transcodeNumberOfChannels);
 								}
 							}
+							addAttribute(sb, "bitsPerSample", firstAudioTrack.getBitsperSample());
 						}
 
 						if (player == null) {


### PR DESCRIPTION
Browse requests do not populate `bitsPerSample` attribute in the DIDL result string (at leaset for audio items). This fixes it.