### PR TITLE
split around "," and whitespace char

### DIFF
--- a/src/main/java/net/pms/formats/Format.java
+++ b/src/main/java/net/pms/formats/Format.java
@@ -318,7 +318,7 @@ public abstract class Format implements Cloneable {
 				return true;
 			}
 
-			String[] extensionsArray = extensionsString.split(",");
+			String[] extensionsArray = extensionsString.split(", ");
 			for (String extension : extensionsArray) {
 				if (StringUtil.hasValue(extension) && extension.equalsIgnoreCase(matchedExtension)) {
 					return true;

--- a/src/main/java/net/pms/formats/Format.java
+++ b/src/main/java/net/pms/formats/Format.java
@@ -318,9 +318,9 @@ public abstract class Format implements Cloneable {
 				return true;
 			}
 
-			String[] extensionsArray = extensionsString.split(", ");
+			String[] extensionsArray = extensionsString.split(",");
 			for (String extension : extensionsArray) {
-				if (StringUtil.hasValue(extension) && extension.equalsIgnoreCase(matchedExtension)) {
+				if (StringUtil.hasValue(extension) && extension.trim().equalsIgnoreCase(matchedExtension)) {
 					return true;
 				}
 			}


### PR DESCRIPTION
The code for identifying StreamingExtensions are split around ",". This means the extensions have to be configured like this:
`StreamExtensions = wav,flac,mp3,wma,aac`

Widely used is however :
`StreamExtensions = wav, flac, mp3, wma, aac`

This PR allows both options.