### PR TITLE
fixed cover art extraction with mediainfolib (> 18.03)

### DIFF
--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -62,16 +62,18 @@ public class LibMediaInfoParser {
 				VERSION = null;
 			}
 
-			if (VERSION != null && VERSION.isGreaterThan(new Version("18.03"))) {
-				mI.Option("Language", "raw");
-				mI.Option("Cover_Data", "base64");
-			}
+			if (VERSION != null)  {
+				if (VERSION.isGreaterThan(new Version("18.03"))) {
+					mI.Option("Language", "raw");
+					mI.Option("Cover_Data", "base64");
+				}
 
-			if (VERSION != null && VERSION.isGreaterThan(new Version("18.5"))) {
-				mI.Option("LegacyStreamDisplay", "1");
-				mI.Option("File_HighestFormat", "0");
-				mI.Option("File_ChannelLayout", "1");
-				mI.Option("Legacy", "1");
+				if (VERSION.isGreaterThan(new Version("18.5"))) {
+					mI.Option("LegacyStreamDisplay", "1");
+					mI.Option("File_HighestFormat", "0");
+					mI.Option("File_ChannelLayout", "1");
+					mI.Option("Legacy", "1");
+				}
 			}
 
 //			LOGGER.debug(MI.Option("Info_Parameters_CSV")); // It can be used to export all current MediaInfo parameters

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -62,6 +62,11 @@ public class LibMediaInfoParser {
 				VERSION = null;
 			}
 
+			if (VERSION != null && VERSION.isGreaterThan(new Version("18.03"))) {
+				mI.Option("Language", "raw");
+				mI.Option("Cover_Data", "base64");
+			}
+
 			if (VERSION != null && VERSION.isGreaterThan(new Version("18.5"))) {
 				mI.Option("LegacyStreamDisplay", "1");
 				mI.Option("File_HighestFormat", "0");


### PR DESCRIPTION
Reproduce:
- install current mediaInfolib (> 18.03)
- delete database
- add library folder with audio files that include cover art
- start UMS
- stop UMS
- inspect database table `thumbnails` -> EMPTY (at least for audio files)

With this PR, `thumbnails` table should be filled as expected.