### PR TITLE
Fix bump skin to work with jquery 3.5.1

### DIFF
--- a/src/main/external-resources/web/bump/bump.html
+++ b/src/main/external-resources/web/bump/bump.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<title>bump</title>
-		<link rel="stylesheet" href="/files/web.css" type="text/css"> 
+		<link rel="stylesheet" href="/files/web.css" type="text/css">
 		<link rel="stylesheet" href="/files/web-narrow.css" type="text/css">
 		<link rel="stylesheet" href="/files/web-wide.css" type="text/css">
 		<script>
@@ -67,7 +67,7 @@
 
 							   var addr='http://127.0.0.1:9001';
 							   if(typeof bump !== 'undefined' && bump.enabled()){return;}
-							   loadjs('https://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js',function(){
+							   loadjs('https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js',function(){
 							   loadjs(addr+'/bump/bump.js',function(){
 							   bump.start(addr);
 							   });

--- a/src/main/external-resources/web/bump/skin/skin.js
+++ b/src/main/external-resources/web/bump/skin/skin.js
@@ -32,13 +32,13 @@ var img = bump.setImages({
 $('body').append([
 	'<div class="bumpcontainer"><table class="bumppanel"><tr>',
 	'<td id="bumpsettings">',
-		'<select id="bplaylist"/>',
-		'<span id="bplaylistctrl"/>',
-		'<select id="brenderers"/>',
+		'<select id="bplaylist"></select>',
+		'<span id="bplaylistctrl"></span>',
+		'<select id="brenderers"></select>',
 	'</td>',
 	'<td><input id="bumpvol"/></td>',
-	'<td id="bumpmute"/>',
-	'<td id="bumpctrl"/>',
+	'<td id="bumpmute"></td>',
+	'<td id="bumpctrl"></td>',
 	'<td id="bumppos" title="Show/hide playlist">0:00</td>',
 	'<td><div id="bexit"><img id="bclose"/></div></td>',
 	'</tr></table></div>'
@@ -58,7 +58,7 @@ bump.addButton('add', '#bplaylistctrl', 'Add to playlist');
 bump.addButton('remove', '#bplaylistctrl', 'Remove from playlist');
 bump.addButton('clear', '#bplaylistctrl', 'Clear playlist');
 
-// css: go crazy. Modify/add/remove blocks as appropriate using jquery selector syntax 
+// css: go crazy. Modify/add/remove blocks as appropriate using jquery selector syntax
 
 $('.bumpcontainer').css({
 	position:'fixed',    /* Do not scroll out of view on this or other websites */
@@ -128,4 +128,3 @@ $('head').append(['<style>',
 	'.bumpcontainer .bselected {font-style:italic;color:blue;}',
 	'</style>',
 ].join(''));
-


### PR DESCRIPTION
**Problem:**
In the web view renderers can no longer be selected. `bump`s media control buttons appear, but not the renderer selection. (tested with UMS 10.6.0 and Vivaldi Browser 4.0, but problem already exists longer, since transition to jquery 3.5.1)

**Solution:**
Use proper end tags in the `bump` skin file.

**Context:**
In HTML5 self-closing tags are only allowed for the defined void elements (and foreign elements).
https://html.spec.whatwg.org/multipage/syntax.html#start-tags

It seems jquery changed the way it recovers from self-closing non-void elements.
In jquery 3.5.1 the `bplaylistctrl` and `brenderers` are removed in the process, breaking `bump`'s renderer selection.