### PR TITLE
Revert "Bump logback-version from 1.2.3 to 1.2.4"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 
 			Check the org.slf4j:slf4j-api version of the other libraries before upgrading
 		-->
-		<logback-version>1.2.4</logback-version>
+		<logback-version>1.2.3</logback-version>
 		<surefire-version>3.0.0-M5</surefire-version>
 
 		<!--


### PR DESCRIPTION
Reverts UniversalMediaServer/UniversalMediaServer#2568

It broke building because of the shared slf4j dependency