### PR TITLE
Performance improvement

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
@@ -48,6 +48,7 @@ import com.sun.jna.Platform;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import net.pms.database.TableVideoMetadataActors;
 import net.pms.database.TableVideoMetadataAwards;
@@ -1411,6 +1412,7 @@ public class DLNAMediaDatabase implements Runnable {
 
 	public ArrayList<String> getStrings(String sql) {
 		ArrayList<String> list = new ArrayList<>();
+		HashSet<String> set = new HashSet<>();
 		try (Connection connection = getConnection()) {
 			TABLE_LOCK.readLock().lock();
 			try (
@@ -1420,11 +1422,9 @@ public class DLNAMediaDatabase implements Runnable {
 				while (rs.next()) {
 					String str = rs.getString(1);
 					if (isBlank(str)) {
-						if (!list.contains(NONAME)) {
-							list.add(NONAME);
-						}
-					} else if (!list.contains(str)) {
-						list.add(str);
+						set.add(NONAME);
+					} else {
+						set.add(str);
 					}
 				}
 			} finally {
@@ -1434,6 +1434,7 @@ public class DLNAMediaDatabase implements Runnable {
 			LOGGER.error(null, se);
 			return null;
 		}
+		list.addAll(set);
 		return list;
 	}
 


### PR DESCRIPTION
On large item sets (in my case browsing the media library to audio -> all audio files, 15.000 elements) the `DLNAMediaDatabase.getStrings()`method is not very performant. It took over 4 seconds to compute the data. With this PR it takes only 1 second (on my machine). 