### PR TITLE
Set MediaInfo defaults

### DIFF
--- a/src/main/external-resources/renderers/Amazon-FireTVStick-VimuPlayer.conf
+++ b/src/main/external-resources/renderers/Amazon-FireTVStick-VimuPlayer.conf
@@ -23,7 +23,6 @@ LoadingPriority = 2
 
 TranscodeAudio = LPCM
 H264Level41Limited = false
-MediaInfo = true
 TranscodeFastStart = true
 
 # Supported video formats:

--- a/src/main/external-resources/renderers/AnyCast.conf
+++ b/src/main/external-resources/renderers/AnyCast.conf
@@ -17,7 +17,6 @@ UserAgentSearch =
 UpnpDetailsSearch = AnyCast
 
 HalveBitrate = true
-MediaInfo = true
 DLNALocalizationRequired = true
 DefaultVBVBufSize = true
 SeekByTime = true

--- a/src/main/external-resources/renderers/Apple-TV-4K-VLC.conf
+++ b/src/main/external-resources/renderers/Apple-TV-4K-VLC.conf
@@ -22,7 +22,6 @@ DefaultVBVBufSize = true
 SendFolderThumbnails = false
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi      v:mp4          a:mp2|mp3                                        m:video/avi

--- a/src/main/external-resources/renderers/Apple-TV-VLC.conf
+++ b/src/main/external-resources/renderers/Apple-TV-VLC.conf
@@ -20,7 +20,6 @@ TranscodeVideo = MPEGTS-H264-AAC
 TranscodeAudio = WAV
 DefaultVBVBufSize = true
 SendFolderThumbnails = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             v:mp4          a:mp2|mp3                                        m:video/avi

--- a/src/main/external-resources/renderers/Apple-iDevice-VLC.conf
+++ b/src/main/external-resources/renderers/Apple-iDevice-VLC.conf
@@ -23,7 +23,6 @@ SupportedVideoBitDepths = 8,10,12
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
 H264Level41Limited = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             m:video/avi

--- a/src/main/external-resources/renderers/Apple-iDevice-VLC32bit.conf
+++ b/src/main/external-resources/renderers/Apple-iDevice-VLC32bit.conf
@@ -20,7 +20,6 @@ TranscodeVideo = MPEGTS-H264-AAC
 TranscodeAudio = WAV
 DefaultVBVBufSize = true
 SendFolderThumbnails = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             v:mp4                a:mp2|mp3                                    m:video/avi

--- a/src/main/external-resources/renderers/BlackBerry-PlayBook-KalemSoftMP.conf
+++ b/src/main/external-resources/renderers/BlackBerry-PlayBook-KalemSoftMP.conf
@@ -25,7 +25,6 @@ H264Level41Limited = false
 TranscodeFastStart = true
 CBRVideoBitrate = 15000
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegps|mpegts|mpg   m:video/mpeg

--- a/src/main/external-resources/renderers/Bush-FreeviewHighDefinitionDigitalSetTopBox.conf
+++ b/src/main/external-resources/renderers/Bush-FreeviewHighDefinitionDigitalSetTopBox.conf
@@ -24,6 +24,8 @@ UpnpDetailsSearch = Cabot Aurora Media Renderer , T7655_10ab
 
 TranscodeVideo = MPEGTS-H264-AC3
 
+MediaInfo = false
+
 # Taken from the user manual for HD DVR player Bush 2489502_R_D001 bought from Argos
 # Supported video formats:
 Supported = f:avi|divx   v:mp4|divx|mjpeg                                           a:mp3|lpcm|mpa|ac3                                          m:video/x-divx                    gmc:0

--- a/src/main/external-resources/renderers/Bush-FreeviewHighDefinitionDigitalSetTopBox.conf
+++ b/src/main/external-resources/renderers/Bush-FreeviewHighDefinitionDigitalSetTopBox.conf
@@ -24,7 +24,6 @@ UpnpDetailsSearch = Cabot Aurora Media Renderer , T7655_10ab
 
 TranscodeVideo = MPEGTS-H264-AC3
 
-MediaInfo = false
 
 # Taken from the user manual for HD DVR player Bush 2489502_R_D001 bought from Argos
 # Supported video formats:

--- a/src/main/external-resources/renderers/CambridgeAudio-AzurBD.conf
+++ b/src/main/external-resources/renderers/CambridgeAudio-AzurBD.conf
@@ -14,4 +14,3 @@ H264Level41Limited = false
 MuxLPCMToMpeg = false
 TranscodeExtensions = vob
 StreamExtensions = aac,ape,asf,avc,avi,dat,dff,divx,dsd,flv,flac,m2t,m2ts,mts,m4a,m4v,mp1,mp2,mp3,mp4,mpeg,mpg,mka,mkv,mov,pcm,QT,ts,vcd,vob,wav,wma,wmv,xvid
-MediaInfo = true

--- a/src/main/external-resources/renderers/DLink-DSM510.conf
+++ b/src/main/external-resources/renderers/DLink-DSM510.conf
@@ -18,4 +18,3 @@ ShowDVDTitleDuration = true
 CBRVideoBitrate = 15000
 WrapDTSIntoPCM = true
 HalveBitrate = true
-MediaInfo = true

--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -217,7 +217,7 @@ MaxVolume =
 # accurate information, speed up browsing and prevent potential playback errors.
 # It also enables the use of "Supported" to more accurately define the supported
 # formats for the renderer.
-# Default: false
+# Default: true
 MediaInfo = 
 
 # Use a faster method to create the DLNA tree using the MediaInfo library. It is

--- a/src/main/external-resources/renderers/Denon-4311CI.conf
+++ b/src/main/external-resources/renderers/Denon-4311CI.conf
@@ -54,11 +54,6 @@ TranscodeFastStart = true
 TranscodeAudio = LPCM
 
 #-----------------------------------------------------------------------------
-# MEDIAINFO
-
-MediaInfo = true
-
-#-----------------------------------------------------------------------------
 # Other useful hidden params and their default values if not defined:
 
 atz_limit = 2000

--- a/src/main/external-resources/renderers/Denon-X4200W.conf
+++ b/src/main/external-resources/renderers/Denon-X4200W.conf
@@ -54,11 +54,6 @@ TranscodeFastStart = true
 TranscodeAudio = LPCM
 
 #-----------------------------------------------------------------------------
-# MEDIAINFO
-
-MediaInfo = true
-
-#-----------------------------------------------------------------------------
 # Other useful hidden params and their default values if not defined:
 
 atz_limit = 2000

--- a/src/main/external-resources/renderers/DirecTV.conf
+++ b/src/main/external-resources/renderers/DirecTV.conf
@@ -21,4 +21,3 @@ CustomFFmpegOptions = -ac 2 -c:a mp2 -ab 192k
 CustomMencoderOptions = -channels 2 -lavcopts acodec=mp2:abitrate=192
 KeepAspectRatio = true
 HalveBitrate = true
-MediaInfo = true

--- a/src/main/external-resources/renderers/DirecTV.conf
+++ b/src/main/external-resources/renderers/DirecTV.conf
@@ -21,3 +21,4 @@ CustomFFmpegOptions = -ac 2 -c:a mp2 -ab 192k
 CustomMencoderOptions = -channels 2 -lavcopts acodec=mp2:abitrate=192
 KeepAspectRatio = true
 HalveBitrate = true
+MediaInfo = true

--- a/src/main/external-resources/renderers/FetchTV.conf
+++ b/src/main/external-resources/renderers/FetchTV.conf
@@ -19,7 +19,6 @@ UserAgentSearch = FetchTV
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3
 TranscodeFastStart = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi       v:xvid                                       a:mp3                                         m:video/avi

--- a/src/main/external-resources/renderers/Free-Freebox.conf
+++ b/src/main/external-resources/renderers/Free-Freebox.conf
@@ -18,3 +18,4 @@ TranscodeAudioTo441kHz = true
 TranscodeExtensions = wmv,asf
 StreamExtensions = mkv
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Free-Freebox.conf
+++ b/src/main/external-resources/renderers/Free-Freebox.conf
@@ -18,4 +18,3 @@ TranscodeAudioTo441kHz = true
 TranscodeExtensions = wmv,asf
 StreamExtensions = mkv
 HalveBitrate = true
-MediaInfo = false

--- a/src/main/external-resources/renderers/Freecom-MusicPal.conf
+++ b/src/main/external-resources/renderers/Freecom-MusicPal.conf
@@ -13,3 +13,4 @@ Image = false
 TranscodeAudio = WAV
 TranscodedVideoFileSize = -1
 MimeTypesChanges = video/avi=video/x-divx
+MediaInfo = false

--- a/src/main/external-resources/renderers/Freecom-MusicPal.conf
+++ b/src/main/external-resources/renderers/Freecom-MusicPal.conf
@@ -13,4 +13,3 @@ Image = false
 TranscodeAudio = WAV
 TranscodedVideoFileSize = -1
 MimeTypesChanges = video/avi=video/x-divx
-MediaInfo = false

--- a/src/main/external-resources/renderers/Google-Android-BubbleUPnP-MXPlayer.conf
+++ b/src/main/external-resources/renderers/Google-Android-BubbleUPnP-MXPlayer.conf
@@ -98,7 +98,6 @@ LoadingPriority = 2
 
 H264Level41Limited = false
 MaxVolume = 13
-MediaInfo = true
 TranscodeFastStart = true
 
 # Supported video formats:

--- a/src/main/external-resources/renderers/Google-Android-Chromecast.conf
+++ b/src/main/external-resources/renderers/Google-Android-Chromecast.conf
@@ -37,7 +37,6 @@ TranscodeAudio = MP3
 MaxVideoBitrateMbps = 20
 MimeTypesChanges = video/mpeg=video/mp4
 CustomFFmpegOptions = -async 1 -fflags +genpts -c:a libmp3lame -ac 2 -b:v 35000k -bufsize 35000k -f matroska
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mp4    v:mp4|h264    a:aac-lc|he-aac|mp3                 n:2       m:video/mp4

--- a/src/main/external-resources/renderers/Google-Android.conf
+++ b/src/main/external-resources/renderers/Google-Android.conf
@@ -14,5 +14,4 @@ MuxDTSToMpeg = true
 H264Level41Limited = false
 StreamExtensions = mkv,hdmov,hdm,flac,fla,dts,ogg,asf,asx,m2v,mp4,mpg,mpeg,avi,mov,wmv
 ChunkedTransfer = true
-HalveBitrate = true
-MediaInfo = false
+HalveBitrate = True

--- a/src/main/external-resources/renderers/Google-Android.conf
+++ b/src/main/external-resources/renderers/Google-Android.conf
@@ -15,3 +15,4 @@ H264Level41Limited = false
 StreamExtensions = mkv,hdmov,hdm,flac,fla,dts,ogg,asf,asx,m2v,mp4,mpg,mpeg,avi,mov,wmv
 ChunkedTransfer = true
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Google-Android.conf
+++ b/src/main/external-resources/renderers/Google-Android.conf
@@ -14,4 +14,4 @@ MuxDTSToMpeg = true
 H264Level41Limited = false
 StreamExtensions = mkv,hdmov,hdm,flac,fla,dts,ogg,asf,asx,m2v,mp4,mpg,mpeg,avi,mov,wmv
 ChunkedTransfer = true
-HalveBitrate = True
+HalveBitrate = true

--- a/src/main/external-resources/renderers/Google-ChromecastUltra.conf
+++ b/src/main/external-resources/renderers/Google-ChromecastUltra.conf
@@ -27,7 +27,6 @@ H264Level41Limited = false
 MaxVideoBitrateMbps = 40
 MimeTypesChanges = video/mpeg=video/mp4
 CustomFFmpegOptions = -async 1 -fflags +genpts -c:a libmp3lame -ac 2 -b:v 35000k -bufsize 35000k -f matroska
-MediaInfo = true
 
 # Supported video formats:
 # ChromecastUltra seems to be fine with mkv, and plays h265 unlike the classic

--- a/src/main/external-resources/renderers/Hama-IR320.conf
+++ b/src/main/external-resources/renderers/Hama-IR320.conf
@@ -21,7 +21,6 @@ UpnpDetailsSearch = IR320
 Video = false
 Image = false
 TranscodeAudio = WAV
-MediaInfo = true
 
 # Supported audio formats:
 Supported = f:m4a   m:audio/x-m4a

--- a/src/main/external-resources/renderers/Hisense-K680.conf
+++ b/src/main/external-resources/renderers/Hisense-K680.conf
@@ -22,7 +22,6 @@ LoadingPriority = 1
 
 MaxVideoBitrateMbps = 80
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             v:divx    a:ac3|mpa|mp3        w:1280   h:720   b:8000000    m:video/avi

--- a/src/main/external-resources/renderers/Kodi.conf
+++ b/src/main/external-resources/renderers/Kodi.conf
@@ -16,7 +16,6 @@ RendererIcon =
 
 UserAgentSearch = Kodi
 UpnpDetailsSearch = Kodi
-MediaInfo = true
 
 H264Level41Limited = false
 MaxVideoWidth = 3840

--- a/src/main/external-resources/renderers/LG-BP.conf
+++ b/src/main/external-resources/renderers/LG-BP.conf
@@ -17,7 +17,6 @@ UpnpDetailsSearch = LG-BP
 
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeFastStart = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2    v:h264|mp4|mpeg1|mpeg2|vc1   a:aac-lc|ac3|dts|mpa|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/LG-BP550.conf
+++ b/src/main/external-resources/renderers/LG-BP550.conf
@@ -18,7 +18,6 @@ LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeFastStart = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2    v:h264|mp4|mpeg1|mpeg2|vc1   a:aac-lc|ac3|dts|mpa|mp3|wma          m:video/3gpp

--- a/src/main/external-resources/renderers/LG-EG910V.conf
+++ b/src/main/external-resources/renderers/LG-EG910V.conf
@@ -17,7 +17,6 @@ H264Level41Limited = false
 DefaultVBVBufSize = true
 SeekByTime = true
 ChunkedTransfer = true
-MediaInfo = true
 
 # Supported video formats (might be off, but works for my media):
 Supported = f:avi|divx   v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv         a:aac-lc|he-aac|ac3|dts|eac3|lpcm|mp3|wma     m:video/avi

--- a/src/main/external-resources/renderers/LG-LA6200.conf
+++ b/src/main/external-resources/renderers/LG-LA6200.conf
@@ -14,7 +14,6 @@ UpnpDetailsSearch = LG Electronics , LG TV
 # Set loading priority to 1 to prefer this configuration over the others
 LoadingPriority = 0
 
-MediaInfo = true
 TranscodeAudio = MP3
 MaxVideoBitrateMbps = 50
 TranscodedVideoFileSize = -1

--- a/src/main/external-resources/renderers/LG-LA644V.conf
+++ b/src/main/external-resources/renderers/LG-LA644V.conf
@@ -21,4 +21,3 @@ MuxDTSToMpeg = true
 MaxVideoBitrateMbps = 50
 TranscodedVideoFileSize = -1
 StreamExtensions = asf,wmv,avi,divx,mp4,m4v,mov,3gp,3g2,mkv,ts,trp,tp,mts,m2ts,vob,mpg,mpeg,mp3,jpg,jpeg,jpe,jps,mpo
-MediaInfo = false

--- a/src/main/external-resources/renderers/LG-LA644V.conf
+++ b/src/main/external-resources/renderers/LG-LA644V.conf
@@ -21,3 +21,4 @@ MuxDTSToMpeg = true
 MaxVideoBitrateMbps = 50
 TranscodedVideoFileSize = -1
 StreamExtensions = asf,wmv,avi,divx,mp4,m4v,mov,3gp,3g2,mkv,ts,trp,tp,mts,m2ts,vob,mpg,mpeg,mp3,jpg,jpeg,jpe,jps,mpo
+MediaInfo = false

--- a/src/main/external-resources/renderers/LG-LB.conf
+++ b/src/main/external-resources/renderers/LG-LB.conf
@@ -20,7 +20,6 @@ LoadingPriority = 1
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3
 TranscodedVideoFileSize = -1
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2    v:h264|mp4              a:aac-lc                      m:video/3gpp

--- a/src/main/external-resources/renderers/LG-LM620.conf
+++ b/src/main/external-resources/renderers/LG-LM620.conf
@@ -25,7 +25,6 @@ TranscodeAudioTo441kHz = true
 TranscodeFastStart = true
 MimeTypesChanges = video/avi=video/x-divx
 WrapDTSIntoPCM = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpeg|mpegps|mpegts|mkv   v:mpeg1|mpeg2|mp4|h264   a:lpcm|mpa|wav|aac-lc|ac3       m:video/mpeg

--- a/src/main/external-resources/renderers/LG-LM660.conf
+++ b/src/main/external-resources/renderers/LG-LM660.conf
@@ -20,7 +20,6 @@ UpnpDetailsSearch = \d{2}LM660
 LoadingPriority = 1
 
 SeekByTime = true
-MediaInfo = true
 
 TranscodeVideo = MPEGTS-H264-AAC
 TranscodeFastStart = true

--- a/src/main/external-resources/renderers/LG-LS5700.conf
+++ b/src/main/external-resources/renderers/LG-LS5700.conf
@@ -17,7 +17,6 @@ UpnpDetailsSearch = \d{2}LS5700
 LoadingPriority = 1
 
 SeekByTime = true
-MediaInfo = true
 
 TranscodeVideo = MPEGTS-H264-AAC
 TranscodeFastStart = true

--- a/src/main/external-resources/renderers/LG-OLED.conf
+++ b/src/main/external-resources/renderers/LG-OLED.conf
@@ -54,7 +54,6 @@ MaxVideoHeight = 2160
 DefaultVBVBufSize = true
 SeekByTime = true
 ChunkedTransfer = true
-MediaInfo = true
 SupportedVideoBitDepths = 8,10,12
 
 # Supported video formats:

--- a/src/main/external-resources/renderers/LG-ST600.conf
+++ b/src/main/external-resources/renderers/LG-ST600.conf
@@ -18,7 +18,6 @@ TranscodedVideoFileSize = -1
 MimeTypesChanges = video/avi=video/x-divx
 StreamExtensions = avi
 WrapDTSIntoPCM = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegps|mpegts|mkv   v:mpeg1|mpeg2|mp4|h264   a:ac3|lpcm|aac-lc|mpa m:video/mpeg

--- a/src/main/external-resources/renderers/LG-UB820V.conf
+++ b/src/main/external-resources/renderers/LG-UB820V.conf
@@ -20,7 +20,6 @@ LoadingPriority = 1
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3
 TranscodedVideoFileSize = -1
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2    v:h264|mp4              a:aac-lc                    m:video/3gpp

--- a/src/main/external-resources/renderers/LG-UH770.conf
+++ b/src/main/external-resources/renderers/LG-UH770.conf
@@ -25,7 +25,6 @@ MaxVideoHeight = 2160
 DefaultVBVBufSize = true
 SeekByTime = true
 ChunkedTransfer = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi         v:h264|mjpeg|mp4|xvid             a:aac-lc|he-aac|ac3|dts|mp3|mpa            m:video/avi

--- a/src/main/external-resources/renderers/LG-WebOS.conf
+++ b/src/main/external-resources/renderers/LG-WebOS.conf
@@ -35,7 +35,6 @@ H264Level41Limited = false
 DefaultVBVBufSize = true
 SeekByTime = true
 ChunkedTransfer = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi         v:h264|mjpeg|mp4|xvid             a:aac-lc|he-aac|ac3|dts|mp3|mpa            m:video/avi

--- a/src/main/external-resources/renderers/Logitech-Squeezebox.conf
+++ b/src/main/external-resources/renderers/Logitech-Squeezebox.conf
@@ -21,7 +21,6 @@ UpnpDetailsSearch = Squeezebox
 Video = false
 Image = false
 TranscodeAudio = WAV
-MediaInfo = true
 
 # Supported audio formats:
 Supported = f:m4a    m:audio/x-m4a a:aac-lc|he-aac|alac

--- a/src/main/external-resources/renderers/Mediaplayer.conf
+++ b/src/main/external-resources/renderers/Mediaplayer.conf
@@ -9,8 +9,6 @@ UpnpDetailsSearch = Made in Manchester , Open Home Java Renderer: v0.0.9.8
 
 UserAgentSearch: Music Player Daemon
 
-MediaInfo=true
-
 # Supported audio formats:
 Supported = f:ac3                       m:audio/vnd.dolby.dd-raw
 Supported = f:acdpm                     m:audio/x-adpcm

--- a/src/main/external-resources/renderers/Microsoft-WindowsMediaPlayer.conf
+++ b/src/main/external-resources/renderers/Microsoft-WindowsMediaPlayer.conf
@@ -70,7 +70,6 @@ UpnpDetailsSearch = Windows Media Player
 TranscodeVideo = MPEGTS-MPEG2-AC3
 TranscodeAudio = WAV
 SeekByTime = exclusive
-MediaInfo = true
 TranscodeFastStart = true
 
 # Supported notes:

--- a/src/main/external-resources/renderers/Microsoft-Xbox360.conf
+++ b/src/main/external-resources/renderers/Microsoft-Xbox360.conf
@@ -26,7 +26,6 @@ TranscodeAudioTo441kHz = true
 TranscodedVideoAudioSampleRate = 44100
 CreateDLNATreeFaster = true
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi   v:divx|mp4   a:ac3|mp3         m:video/avi

--- a/src/main/external-resources/renderers/Microsoft-XboxOne.conf
+++ b/src/main/external-resources/renderers/Microsoft-XboxOne.conf
@@ -25,7 +25,6 @@ LoadingPriority = 1
 SeekByTime = exclusive
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudioTo441kHz = true
-MediaInfo = true
 HalveBitrate = true
 
 # Supported video formats:

--- a/src/main/external-resources/renderers/Miracast-M806.conf
+++ b/src/main/external-resources/renderers/Miracast-M806.conf
@@ -13,7 +13,7 @@ RendererIcon = miracast.png
 # {friendlyName=LOLLIPOP-1C3A18-DMR, manufacturer=Rockchip, modelName=Rockchip Media Renderer, modelNumber=1.0, modelDescription=Rockchip Media Renderer, DLNA(DMR), manufacturerURL=http://www.rock-chips.com, modelURL=http://www.rock-chips.com}
 # ============================================================================
 
-#MediaInfo = true
+MediaInfo = false
 UserAgentSearch =  stagefright/1.1
 UpnpDetailsSearch = Rockchip Media Renderer
 TranscodeAudio = MP3

--- a/src/main/external-resources/renderers/Miracast-M806.conf
+++ b/src/main/external-resources/renderers/Miracast-M806.conf
@@ -13,7 +13,6 @@ RendererIcon = miracast.png
 # {friendlyName=LOLLIPOP-1C3A18-DMR, manufacturer=Rockchip, modelName=Rockchip Media Renderer, modelNumber=1.0, modelDescription=Rockchip Media Renderer, DLNA(DMR), manufacturerURL=http://www.rock-chips.com, modelURL=http://www.rock-chips.com}
 # ============================================================================
 
-MediaInfo = false
 UserAgentSearch =  stagefright/1.1
 UpnpDetailsSearch = Rockchip Media Renderer
 TranscodeAudio = MP3

--- a/src/main/external-resources/renderers/Mirascreen.conf
+++ b/src/main/external-resources/renderers/Mirascreen.conf
@@ -17,7 +17,6 @@ UserAgentSearch =
 UpnpDetailsSearch = Mirascreen BFCFA04F
 
 LoadingPriority = 3
-MediaInfo = true
 SeekByTime = true
 TranscodeVideo = MPEGTS-MPEG2-AC3
 TranscodeAudio = MP3

--- a/src/main/external-resources/renderers/Movian.conf
+++ b/src/main/external-resources/renderers/Movian.conf
@@ -16,7 +16,6 @@ UserAgentSearch = Movian
 
 TranscodeVideo = MPEGTS-H264-AC3
 
-MediaInfo = true
 SeekByTime = true
 HalveBitrate = true
 ChunkedTransfer = false

--- a/src/main/external-resources/renderers/Naim-Mu-So.conf
+++ b/src/main/external-resources/renderers/Naim-Mu-So.conf
@@ -18,7 +18,6 @@ RendererIcon = Naim-Mu-So.png
 
 Video = false
 Image = false
-MediaInfo = true
 
 UserAgentSearch = Naim UPNP Controller|NaimUPnP
 LoadingPriority = 2

--- a/src/main/external-resources/renderers/Netgear-NeoTV.conf
+++ b/src/main/external-resources/renderers/Netgear-NeoTV.conf
@@ -23,4 +23,3 @@ TranscodeFastStart = true
 TranscodedVideoFileSize = 100000000000
 StreamExtensions = avi,xvid,divx,avc,mpg,mpeg,mp4,m4v,dat,vob,mkv,264,ts,tp,m2t,m2ts,asf,wmv,mp3,m4a,mka,wav,pcm,lpcm,wma,aac,flac,mka,aif,aiff,ogg,dts
 HalveBitrate = true
-MediaInfo = true

--- a/src/main/external-resources/renderers/Netgem-N7700.conf
+++ b/src/main/external-resources/renderers/Netgem-N7700.conf
@@ -19,7 +19,6 @@ UpnpDetailsSearch = 7700_201
 
 TranscodeVideo = MPEGTS-H264-AC3
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegts   v:h264   a:aac-lc|ac3   m:video/mpeg

--- a/src/main/external-resources/renderers/Nextcp2.conf
+++ b/src/main/external-resources/renderers/Nextcp2.conf
@@ -7,8 +7,6 @@ RendererName = NextCP2
 
 UserAgentSearch = nextcp
 
-MediaInfo=true
-
 # Supported audio formats:
 Supported = f:ac3                       m:audio/vnd.dolby.dd-raw
 Supported = f:acdpm                     m:audio/x-adpcm

--- a/src/main/external-resources/renderers/Nokia-N900.conf
+++ b/src/main/external-resources/renderers/Nokia-N900.conf
@@ -19,6 +19,7 @@ TranscodeAudioTo441kHz = true
 MuxH264ToMpegTS = false
 MuxLPCMToMpeg = false
 TranscodeExtensions = mp4
+MediaInfo = false
 
 # Video limitations from http://maemo.nokia.com/n900/tips/video-files/
 # The highest quality supported:

--- a/src/main/external-resources/renderers/Nokia-N900.conf
+++ b/src/main/external-resources/renderers/Nokia-N900.conf
@@ -19,7 +19,6 @@ TranscodeAudioTo441kHz = true
 MuxH264ToMpegTS = false
 MuxLPCMToMpeg = false
 TranscodeExtensions = mp4
-MediaInfo = false
 
 # Video limitations from http://maemo.nokia.com/n900/tips/video-files/
 # The highest quality supported:

--- a/src/main/external-resources/renderers/OPPO-BDP.conf
+++ b/src/main/external-resources/renderers/OPPO-BDP.conf
@@ -11,4 +11,3 @@ DefaultVBVBufSize = true
 TranscodeExtensions = iso,vob
 StreamExtensions = aac,flac,m4a,mp3,pcm,wav,wma,avi,mkv,mp4,m2ts,ts,wmv
 HalveBitrate = true
-MediaInfo = true

--- a/src/main/external-resources/renderers/OPPO-BDP83.conf
+++ b/src/main/external-resources/renderers/OPPO-BDP83.conf
@@ -11,4 +11,3 @@ DefaultVBVBufSize = true
 TranscodeExtensions = hdmov,hdm,flac,fla,dts,ogg,asf,asx,m2v,m4a,mov,mp4,iso,avi
 StreamExtensions = mkv,jpg,mp3,mpg,pcm,png,vob
 HalveBitrate = true
-MediaInfo = true

--- a/src/main/external-resources/renderers/Onkyo-TXNR7xx.conf
+++ b/src/main/external-resources/renderers/Onkyo-TXNR7xx.conf
@@ -14,3 +14,4 @@ SeekByTime = true
 WrapDTSIntoPCM = true
 StreamExtensions = mp3,wma,wav,aac,flac,oga,ogg,m4a,mp4,dsf,mlp
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Onkyo-TXNR7xx.conf
+++ b/src/main/external-resources/renderers/Onkyo-TXNR7xx.conf
@@ -14,4 +14,3 @@ SeekByTime = true
 WrapDTSIntoPCM = true
 StreamExtensions = mp3,wma,wav,aac,flac,oga,ogg,m4a,mp4,dsf,mlp
 HalveBitrate = true
-MediaInfo = false

--- a/src/main/external-resources/renderers/Onkyo-TXNR8xx.conf
+++ b/src/main/external-resources/renderers/Onkyo-TXNR8xx.conf
@@ -28,7 +28,6 @@ Image = false
 TranscodeFastStart = true
 atz_limit = 2000
 SeekByTime = exclusive
-MediaInfo = true
 
 # Supported audio formats:
 Supported = f:3g2a|3ga     n:2     a:aac-lc|he-aac                     s:96000     b:320000     m:audio/3gpp

--- a/src/main/external-resources/renderers/Panasonic-DMPBDT.conf
+++ b/src/main/external-resources/renderers/Panasonic-DMPBDT.conf
@@ -27,7 +27,6 @@ TranscodedVideoFileSize = 1000000
 KeepAspectRatio = true
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mkv      v:h264         a:aac-lc|ac3 m:video/x-matroska

--- a/src/main/external-resources/renderers/Panasonic-DMPBDT220.conf
+++ b/src/main/external-resources/renderers/Panasonic-DMPBDT220.conf
@@ -28,7 +28,6 @@ TranscodedVideoFileSize = 1000000
 KeepAspectRatio = true
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mkv      v:h264         a:aac-lc|ac3 m:video/x-matroska

--- a/src/main/external-resources/renderers/Panasonic-DMPBDT360.conf
+++ b/src/main/external-resources/renderers/Panasonic-DMPBDT360.conf
@@ -32,7 +32,6 @@ TranscodedVideoFileSize = 1000000
 KeepAspectRatio = true
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mkv       v:h264         a:aac-lc|dts|flac|vorbis   m:video/x-matroska

--- a/src/main/external-resources/renderers/Panasonic-DMR.conf
+++ b/src/main/external-resources/renderers/Panasonic-DMR.conf
@@ -33,7 +33,6 @@ TranscodeFastStart = true
 TranscodedVideoFileSize = 1000000
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats: DTS/DTS-HD/TRUEHD/EAC3/MPA/HE-AAC ?
 Supported = f:avi       v:h264|xvid     a:ac3|mp3                              m:video/avi

--- a/src/main/external-resources/renderers/Panasonic-HZ1500.conf
+++ b/src/main/external-resources/renderers/Panasonic-HZ1500.conf
@@ -24,7 +24,6 @@ SendDateMetadata = false
 MuxNonMod4Resolution = true
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                        a:aac-lc|he-aac                                   m:video/3gpp

--- a/src/main/external-resources/renderers/Panasonic-SCBTT.conf
+++ b/src/main/external-resources/renderers/Panasonic-SCBTT.conf
@@ -32,7 +32,6 @@ TranscodedVideoFileSize = 1000000
 KeepAspectRatio = true
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|divx                                           m:video/divx

--- a/src/main/external-resources/renderers/Panasonic-Viera.conf
+++ b/src/main/external-resources/renderers/Panasonic-Viera.conf
@@ -49,7 +49,6 @@ KeepAspectRatioTranscoding = true
 RescaleByRenderer = false
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Panasonic TVs support the following formats according to a manual:
 #    Containers: avchd, divx, mpeg2

--- a/src/main/external-resources/renderers/Panasonic-VieraAS600E.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraAS600E.conf
@@ -31,7 +31,6 @@ KeepAspectRatioTranscoding = true
 RescaleByRenderer = false
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|divx   v:divx|h264|mjpeg|mp4    a:ac3|lpcm|mp3|mpa                           m:video/avi          qpel:yes|no   gmc:0

--- a/src/main/external-resources/renderers/Panasonic-VieraAS650.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraAS650.conf
@@ -30,7 +30,6 @@ KeepAspectRatioTranscoding = true
 RescaleByRenderer = false
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp      v:h264               a:aac-lc|he-aac                               m:video/3gpp

--- a/src/main/external-resources/renderers/Panasonic-VieraCX680.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraCX680.conf
@@ -25,7 +25,6 @@ MuxNonMod4Resolution = true
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                       a:aac-lc|he-aac                                   m:video/3gpp

--- a/src/main/external-resources/renderers/Panasonic-VieraCX700.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraCX700.conf
@@ -26,7 +26,6 @@ MuxNonMod4Resolution = true
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                       a:aac-lc|he-aac                                   m:video/3gpp

--- a/src/main/external-resources/renderers/Panasonic-VieraDX.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraDX.conf
@@ -37,7 +37,6 @@ MuxNonMod4Resolution = true
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                       a:aac-lc|he-aac                                   m:video/3gpp

--- a/src/main/external-resources/renderers/Panasonic-VieraE6.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraE6.conf
@@ -32,7 +32,6 @@ KeepAspectRatioTranscoding = true
 H264Level41Limited = false
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # ============================================================================
 #

--- a/src/main/external-resources/renderers/Panasonic-VieraET60.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraET60.conf
@@ -24,7 +24,6 @@ TranscodeFastStart = true
 KeepAspectRatioTranscoding = true
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264               a:aac-lc|he-aac                        m:video/3gpp

--- a/src/main/external-resources/renderers/Panasonic-VieraGT50.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraGT50.conf
@@ -30,7 +30,6 @@ KeepAspectRatioTranscoding = true
 SendDateMetadata = false
 MuxNonMod4Resolution = true
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegts     v:h264|mpeg1|mpeg2                  a:aac-lc|he-aac|ac3|eac3|mpa                          m:video/mpeg

--- a/src/main/external-resources/renderers/Panasonic-VieraGX800B.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraGX800B.conf
@@ -29,7 +29,6 @@ KeepAspectRatioTranscoding = true
 RescaleByRenderer = false
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|divx   v:divx|mjpeg|mp4         a:ac3|lpcm|mp3|mpa    m:video/x-msvideo       qpel:yes|no   gmc:0

--- a/src/main/external-resources/renderers/Panasonic-VieraS60.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraS60.conf
@@ -26,7 +26,6 @@ TranscodeFastStart = true
 KeepAspectRatioTranscoding = true
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264               a:aac-lc|he-aac                        m:video/3gpp

--- a/src/main/external-resources/renderers/Panasonic-VieraST60.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraST60.conf
@@ -35,7 +35,6 @@ SendDateMetadata = false
 MuxNonMod4Resolution = true
 CustomFFmpegOptions = -preset superfast
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264                    a:aac-lc                              m:video/3gpp

--- a/src/main/external-resources/renderers/Panasonic-VieraTHPU30Z.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraTHPU30Z.conf
@@ -26,7 +26,6 @@ KeepAspectRatioTranscoding = true
 RescaleByRenderer = false
 SendDateMetadata = false
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mov       v:h264|mjpeg         a:aac-lc|ac3|lpcm|mp3   m:video/quicktime

--- a/src/main/external-resources/renderers/Panasonic-VieraTXL32V10E.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraTXL32V10E.conf
@@ -28,7 +28,6 @@ ShowSubMetadata = false
 WrapDTSIntoPCM = true
 Output3DFormat = ml
 PushMetadata = false
-MediaInfo = true
 
 
 # Supported video formats:

--- a/src/main/external-resources/renderers/Panasonic-VieraVT60.conf
+++ b/src/main/external-resources/renderers/Panasonic-VieraVT60.conf
@@ -32,7 +32,6 @@ MuxNonMod4Resolution = true
 CustomFFmpegOptions = -preset superfast
 PushMetadata = false
 H264Level41Limited = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264                       a:aac-lc                                          m:video/3gpp

--- a/src/main/external-resources/renderers/Philips-AndroidTV.conf
+++ b/src/main/external-resources/renderers/Philips-AndroidTV.conf
@@ -146,7 +146,6 @@ H264Level41Limited = false
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
 MaxVideoBitrateMbps = 60
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3g2|3gp   v:divx|h264|h265|mpeg1|mpeg2|mp4|vp9   a:aac-lc|ac3|eac3|he-aac|mp3|truehd|wav|wma   vbd:8|10   m:video/3gpp

--- a/src/main/external-resources/renderers/Philips-AureaAndNetTV.conf
+++ b/src/main/external-resources/renderers/Philips-AureaAndNetTV.conf
@@ -21,6 +21,7 @@ MuxDTSToMpeg = true
 TranscodeFastStart = true
 TranscodedVideoFileSize = 100000000000
 HalveBitrate = true
+MediaInfo = false
 
 # Needed for Philips Aurea that can only handle mpg, mp3
 # Not needed for Philips NetTV that can handle many formats natively

--- a/src/main/external-resources/renderers/Philips-PFL.conf
+++ b/src/main/external-resources/renderers/Philips-PFL.conf
@@ -153,7 +153,6 @@ CreateDLNATreeFaster = true
 TranscodeFastStart = true
 KeepAspectRatio = true
 HalveBitrate = true
-MediaInfo = true
 
 # Our Philips PFL-specific notes:
 # DTS is not supported.

--- a/src/main/external-resources/renderers/Philips-PUS-6500Series.conf
+++ b/src/main/external-resources/renderers/Philips-PUS-6500Series.conf
@@ -28,7 +28,6 @@ MaxVideoBitrateMbps = 30
 UseClosedCaption = true
 SubtitleHttpHeader = CaptionInfo.sec
 TranscodedVideoFileSize = 100000000000
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi      v:h264|h265|mpeg2|mp4   a:ac3|mp3|mpa                 m:video/x-msvideo

--- a/src/main/external-resources/renderers/Philips-PUS.conf
+++ b/src/main/external-resources/renderers/Philips-PUS.conf
@@ -27,7 +27,6 @@ MaxVideoBitrateMbps = 30
 UseClosedCaption = true
 SubtitleHttpHeader = CaptionInfo.sec
 TranscodedVideoFileSize = 100000000000
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi      v:h264|h265|mpeg2|mp4   a:ac3|mp3|mpa                 m:video/x-msvideo

--- a/src/main/external-resources/renderers/Philips-Streamium.conf
+++ b/src/main/external-resources/renderers/Philips-Streamium.conf
@@ -14,3 +14,4 @@ TranscodeAudio = WAV
 MimeTypesChanges = video/avi=video/x-divx
 StreamExtensions = m4a,wma,mp3,mp4,flac
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Pioneer-BDP.conf
+++ b/src/main/external-resources/renderers/Pioneer-BDP.conf
@@ -27,7 +27,6 @@ DLNALocalizationRequired = true
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3
 DefaultVBVBufSize = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2      v:mp4                     a:aac-lc|he-aac                                             m:video/3gpp

--- a/src/main/external-resources/renderers/Pioneer-Kuro.conf
+++ b/src/main/external-resources/renderers/Pioneer-Kuro.conf
@@ -15,3 +15,4 @@ MuxLPCMToMpeg = false
 MimeTypesChanges = audio/wav=audio/L16|video/mp4=video/mpeg
 TranscodeExtensions = dvr-ms,dvr,mkv,dv,ty,mov,ogm,hdmov,hdm,rmv,rmvb,rm,asf,evo,asx,flv,m2v,mpe,mod,tivo,ty,tmf,ts,tp,m2p,mp4,m4v,avi,wmv,wm,divx,div,flac,mlp,fla,wma,m4a,aac,dts,mka,ape,ogg,shn,mpc,ra,mp2,wv,oma,aa3,gif,png,arw,cr2,crw,dng,raf,mrw,nef,pef,tif,tiff
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/PopcornHour.conf
+++ b/src/main/external-resources/renderers/PopcornHour.conf
@@ -12,3 +12,4 @@ MuxDTSToMpeg = true
 H264Level41Limited = false
 StreamExtensions = mkv,hdmov,hdm,flac,fla,dts,ogg,asf,asx,m2v
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Realtek.conf
+++ b/src/main/external-resources/renderers/Realtek.conf
@@ -27,3 +27,4 @@ TranscodedVideoFileSize = -1
 MimeTypesChanges = video/avi=video/x-divx
 StreamExtensions = vob,iso,mkv,wmv,avi,xvid,divx,rvb,real,mp4,mp3,flac,fla,dts,ogg,asf,asx,m2v
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Roku-4640x.conf
+++ b/src/main/external-resources/renderers/Roku-4640x.conf
@@ -26,7 +26,6 @@ MaxVideoBitrateMbps = 32
 CustomFFmpegOptions = -x264opts cabac=1 -ac 2
 CustomMencoderOptions = -channels 2
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegts   v:h264   a:aac-lc|lpcm|mp2|mp3   n:2   m:video/vnd.dlna.mpeg-tts

--- a/src/main/external-resources/renderers/Roku-Roku3-3.conf
+++ b/src/main/external-resources/renderers/Roku-Roku3-3.conf
@@ -21,7 +21,6 @@ MaxVideoBitrateMbps = 16
 CustomFFmpegOptions = -vsync 0 -x264opts cabac=1 -async 1 -ac 2
 CustomMencoderOptions = -channels 2
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mkv      v:h264|mp4   a:aac-lc|mp2|mp3   n:2   m:video/x-matroska

--- a/src/main/external-resources/renderers/Roku-Roku3-5.conf
+++ b/src/main/external-resources/renderers/Roku-Roku3-5.conf
@@ -22,7 +22,6 @@ MaxVideoBitrateMbps = 24
 CustomFFmpegOptions = -x264opts cabac=1 -ac 2
 CustomMencoderOptions = -channels 2
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mkv      v:h264|mp4   a:aac-lc|flac|lpcm|mp2|mp3   n:2   m:video/x-matroska

--- a/src/main/external-resources/renderers/Roku-Roku3-6-7.conf
+++ b/src/main/external-resources/renderers/Roku-Roku3-6-7.conf
@@ -22,7 +22,6 @@ MaxVideoBitrateMbps = 32
 CustomFFmpegOptions = -x264opts cabac=1 -ac 2
 CustomMencoderOptions = -channels 2
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegts   v:h264   a:aac-lc|lpcm|mp2|mp3   n:2   m:video/vnd.dlna.mpeg-tts

--- a/src/main/external-resources/renderers/Roku-TV8.conf
+++ b/src/main/external-resources/renderers/Roku-TV8.conf
@@ -23,7 +23,6 @@ MaxVideoBitrateMbps = 32
 CustomFFmpegOptions = -x264opts cabac=1 -ac 2
 CustomMencoderOptions = -channels 2
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi       v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vp6|wmv   a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|wma   m:video/avi

--- a/src/main/external-resources/renderers/Roku-Ultra.conf
+++ b/src/main/external-resources/renderers/Roku-Ultra.conf
@@ -15,7 +15,6 @@ UserAgentSearch = Roku/4[68][60]0
 
 TranscodeVideo = MPEGTS-H264-AAC
 TranscodeAudio = MP3
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:asf                                     a:wma                                                         m:video/x-ms-asf

--- a/src/main/external-resources/renderers/Samsung-8series.conf
+++ b/src/main/external-resources/renderers/Samsung-8series.conf
@@ -33,7 +33,6 @@ SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                                           a:aac-lc|he-aac                                       m:video/3gpp                w:1920   h:1080

--- a/src/main/external-resources/renderers/Samsung-9series.conf
+++ b/src/main/external-resources/renderers/Samsung-9series.conf
@@ -41,7 +41,6 @@ SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2  v:h264                        a:aac-lc|he-aac                                     m:video/3gpp                 b:60000000     w:3840     h:2160

--- a/src/main/external-resources/renderers/Samsung-BDC6800.conf
+++ b/src/main/external-resources/renderers/Samsung-BDC6800.conf
@@ -32,4 +32,3 @@ Supported = f:wmv      v:vc1|wmv            a:wma                    m:video/x-m
 # Supported audio formats:
 Supported = f:mp3   m:audio/mpeg
 Supported = f:wma   m:audio/x-ms-wma
-MediaInfo = false

--- a/src/main/external-resources/renderers/Samsung-BDC6800.conf
+++ b/src/main/external-resources/renderers/Samsung-BDC6800.conf
@@ -32,3 +32,4 @@ Supported = f:wmv      v:vc1|wmv            a:wma                    m:video/x-m
 # Supported audio formats:
 Supported = f:mp3   m:audio/mpeg
 Supported = f:wma   m:audio/x-ms-wma
+MediaInfo = false

--- a/src/main/external-resources/renderers/Samsung-BDH6500.conf
+++ b/src/main/external-resources/renderers/Samsung-BDH6500.conf
@@ -26,7 +26,6 @@ ChunkedTransfer = true
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp             v:h264|mjpeg|mp4|mpeg1|mpeg2|sor|vc1|wmv   a:adpcm|aac-lc|he-aac|ac3|dts|eac3|lpcm|mp3|wma           m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-C6600.conf
+++ b/src/main/external-resources/renderers/Samsung-C6600.conf
@@ -28,7 +28,6 @@ ChunkedTransfer = true
 TranscodedVideoFileSize = 1000000
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp      v:h264|mp4              a:aac-lc|he-aac              m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-CD.conf
+++ b/src/main/external-resources/renderers/Samsung-CD.conf
@@ -43,7 +43,6 @@ MaxVideoBitrateMbps = 25
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|mkv             m:video/avi

--- a/src/main/external-resources/renderers/Samsung-D6400.conf
+++ b/src/main/external-resources/renderers/Samsung-D6400.conf
@@ -23,7 +23,6 @@ MuxDTSToMpeg = true
 MaxVideoBitrateMbps = 25
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp                 v:h264|mp4   a:aac-lc|he-aac|adpcm m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-D7000.conf
+++ b/src/main/external-resources/renderers/Samsung-D7000.conf
@@ -23,7 +23,6 @@ MuxDTSToMpeg = true
 MaxVideoBitrateMbps = 25
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|mkv             m:video/avi

--- a/src/main/external-resources/renderers/Samsung-EH5300.conf
+++ b/src/main/external-resources/renderers/Samsung-EH5300.conf
@@ -27,8 +27,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
-
 # Supported video formats:
 Supported = f:3gp             v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vp6|vp8|wmv   a:aac-lc|he-aac|ac3|adpcm|dts|eac3|lpcm|mp3|wma           m:video/3gpp
 Supported = f:avi             v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vp6|vp8|wmv   a:aac-lc|he-aac|ac3|adpcm|dts|eac3|lpcm|mp3|wma   gmc:0   m:video/avi

--- a/src/main/external-resources/renderers/Samsung-EH6070.conf
+++ b/src/main/external-resources/renderers/Samsung-EH6070.conf
@@ -26,7 +26,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp             v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|wmv   a:aac-lc|he-aac|ac3|dts|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-ES6100.conf
+++ b/src/main/external-resources/renderers/Samsung-ES6100.conf
@@ -22,7 +22,6 @@ MaxVideoBitrateMbps = 60
 ChunkedTransfer = true
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp             v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vp6|wmv   a:aac-lc|he-aac|ac3|adpcm|dts|eac3|lpcm|mp3|wma                 m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-ES6575.conf
+++ b/src/main/external-resources/renderers/Samsung-ES6575.conf
@@ -21,7 +21,6 @@ MaxVideoBitrateMbps = 60
 ChunkedTransfer = true
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             m:video/avi

--- a/src/main/external-resources/renderers/Samsung-ES8000.conf
+++ b/src/main/external-resources/renderers/Samsung-ES8000.conf
@@ -29,7 +29,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp             v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|wmv   a:aac-lc|he-aac|ac3|dts|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-ES8005.conf
+++ b/src/main/external-resources/renderers/Samsung-ES8005.conf
@@ -27,7 +27,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp             v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vp6|wmv   a:aac-lc|he-aac|ac3|dts|eac3|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-F5100.conf
+++ b/src/main/external-resources/renderers/Samsung-F5100.conf
@@ -24,7 +24,6 @@ SeekByTime = true
 ChunkedTransfer = true
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             v:h264|mp4           a:ac3|dts|lpcm|mp3|wma   m:video/avi

--- a/src/main/external-resources/renderers/Samsung-F5505.conf
+++ b/src/main/external-resources/renderers/Samsung-F5505.conf
@@ -27,7 +27,6 @@ ChunkedTransfer = true
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2         v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vp6|wmv   a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-F5900.conf
+++ b/src/main/external-resources/renderers/Samsung-F5900.conf
@@ -25,7 +25,6 @@ ChunkedTransfer = true
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2         v:h264|mjpeg|mp4|mpeg1|mpeg2|wmv   a:aac-lc|he-aac|ac3|dts|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-GalaxyNoteTab.conf
+++ b/src/main/external-resources/renderers/Samsung-GalaxyNoteTab.conf
@@ -28,7 +28,6 @@ DisableMencoderNoskip = true
 TranscodedVideoFileSize = -1
 TranscodeFastStart = true
 CustomFFmpegOptions = -async 1 -fflags +genpts -c:a libmp3lame -ac 2 -b:v 35000k -bufsize 35000k -f matroska
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3g2|3gp   v:h264|mp4             a:aac        m:video/3gpp          n:2

--- a/src/main/external-resources/renderers/Samsung-GalaxyS5.conf
+++ b/src/main/external-resources/renderers/Samsung-GalaxyS5.conf
@@ -23,7 +23,6 @@ DisableMencoderNoskip = true
 TranscodedVideoFileSize = -1
 TranscodeFastStart = true
 CustomFFmpegOptions = -async 1 -fflags +genpts -c:a libmp3lame -ac 2 -b:v 35000k -bufsize 35000k -f matroska
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|divx   v:divx|mp4   a:mp3          m:video/x-divx     gmc:0   n:2

--- a/src/main/external-resources/renderers/Samsung-GalaxyS7.conf
+++ b/src/main/external-resources/renderers/Samsung-GalaxyS7.conf
@@ -20,7 +20,6 @@ DisableMencoderNoskip = true
 TranscodedVideoFileSize = -1
 TranscodeFastStart = true
 CustomFFmpegOptions = -async 1 -fflags +genpts -c:a libmp3lame -ac 2 -b:v 35000k -bufsize 35000k -f matroska
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|divx   v:divx|mp4   a:mp3          m:video/x-divx     gmc:0   n:2

--- a/src/main/external-resources/renderers/Samsung-H4500.conf
+++ b/src/main/external-resources/renderers/Samsung-H4500.conf
@@ -18,7 +18,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac-lc|he-aac|ac3|dts|eac3|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-H6203.conf
+++ b/src/main/external-resources/renderers/Samsung-H6203.conf
@@ -19,7 +19,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv        a:aac-lc|he-aac|ac3|adpcm|dts|eac3|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-H6400.conf
+++ b/src/main/external-resources/renderers/Samsung-H6400.conf
@@ -20,7 +20,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|sor|vc1|vp6|wmv        a:aac-lc|he-aac|ac3|adpcm|dts|eac3|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-HTE3.conf
+++ b/src/main/external-resources/renderers/Samsung-HTE3.conf
@@ -22,7 +22,6 @@ TranscodeFastStart = true
 MaxVideoBitrateMbps = 25
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi      v:h264|mp4           a:ac3|dts|lpcm|mp3|wma   m:video/avi

--- a/src/main/external-resources/renderers/Samsung-HTF4.conf
+++ b/src/main/external-resources/renderers/Samsung-HTF4.conf
@@ -25,7 +25,6 @@ SeekByTime = true
 ChunkedTransfer = true
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             v:divx|h264|mp4      a:ac3|dts|lpcm|mp3|wma   m:video/avi

--- a/src/main/external-resources/renderers/Samsung-HU7000.conf
+++ b/src/main/external-resources/renderers/Samsung-HU7000.conf
@@ -18,7 +18,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac-lc|he-aac|ac3|dts|eac3|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-HU9000.conf
+++ b/src/main/external-resources/renderers/Samsung-HU9000.conf
@@ -18,7 +18,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac-lc|he-aac|ac3|dts|eac3|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-J55xx.conf
+++ b/src/main/external-resources/renderers/Samsung-J55xx.conf
@@ -26,7 +26,6 @@ PrependTrackNumbers = true
 UseClosedCaption = true
 SubtitleHttpHeader = CaptionInfo.sec
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|mkv             m:video/x-matroska

--- a/src/main/external-resources/renderers/Samsung-J6200.conf
+++ b/src/main/external-resources/renderers/Samsung-J6200.conf
@@ -27,7 +27,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp        v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|sor|vc1|vp6|wmv        a:aac-lc|he-aac|ac3|adpcm|dts|eac3|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-JU6400.conf
+++ b/src/main/external-resources/renderers/Samsung-JU6400.conf
@@ -27,7 +27,6 @@ SeekByTime = true
 ChunkedTransfer = true
 UseClosedCaption = true
 SubtitleHttpHeader = CaptionInfo.sec
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|mkv             m:video/x-matroska

--- a/src/main/external-resources/renderers/Samsung-Mobile.conf
+++ b/src/main/external-resources/renderers/Samsung-Mobile.conf
@@ -32,3 +32,4 @@ CustomMencoderQualitySettings = keyint=0:vqscale=5:vqmin=2
 CustomMencoderOptions = -channels 2 -lavcopts vcodec=mpeg4:acodec=mp2:abitrate=192
 DisableMencoderNoskip = true
 KeepAspectRatio = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Samsung-NotCD.conf
+++ b/src/main/external-resources/renderers/Samsung-NotCD.conf
@@ -37,7 +37,6 @@ ChunkedTransfer = true
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|mkv             m:video/avi

--- a/src/main/external-resources/renderers/Samsung-PL51E490.conf
+++ b/src/main/external-resources/renderers/Samsung-PL51E490.conf
@@ -27,7 +27,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp             v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|wmv   a:aac-lc|he-aac|ac3|adpcm|dts|eac3|lpcm|mp3|wma   m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-Q6.conf
+++ b/src/main/external-resources/renderers/Samsung-Q6.conf
@@ -34,7 +34,6 @@ SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                                           a:aac-lc|he-aac                                       m:video/3gpp                w:1920   h:1080

--- a/src/main/external-resources/renderers/Samsung-Q70.conf
+++ b/src/main/external-resources/renderers/Samsung-Q70.conf
@@ -34,7 +34,6 @@ TranscodedVideoFileSize = 1000000
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                                           a:aac-lc|he-aac                                       m:video/3gpp                w:1920   h:1080

--- a/src/main/external-resources/renderers/Samsung-Q9.conf
+++ b/src/main/external-resources/renderers/Samsung-Q9.conf
@@ -29,7 +29,6 @@ SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
 PushMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp        v:h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv   a:aac-lc|he-aac|ac3|dts|eac3|lpcm|mp3|wma    w:1920 h:1080 b:20000000   se:ASS|MICRODVD|SAMI|SUBRIP si:ASS|SUBRIP|VOBSUB  m:video/3gpp

--- a/src/main/external-resources/renderers/Samsung-SMTG7400.conf
+++ b/src/main/external-resources/renderers/Samsung-SMTG7400.conf
@@ -20,7 +20,6 @@ TranscodeFastStart = true
 TranscodedVideoFileSize = -1
 StreamExtensions = m4v
 SubtitleHttpHeader = CaptionInfo.sec
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mov	m:video/quicktime

--- a/src/main/external-resources/renderers/Samsung-Soundbar-MS750.conf
+++ b/src/main/external-resources/renderers/Samsung-Soundbar-MS750.conf
@@ -24,7 +24,6 @@ Video = false
 Image = false
 TranscodeAudio = WAV
 PushMetadata = false
-MediaInfo = true
 
 # Supported audio formats:
 Supported = f:m4a   m:audio/x-m4a

--- a/src/main/external-resources/renderers/Samsung-UHD-2019-8K.conf
+++ b/src/main/external-resources/renderers/Samsung-UHD-2019-8K.conf
@@ -31,7 +31,6 @@ TranscodeFastStart = true
 SeekByTime = true
 UseClosedCaption = true
 SubtitleHttpHeader = CaptionInfo.sec
-MediaInfo = true
 
 MaxVideoWidth = 7680
 MaxVideoHeight = 4320

--- a/src/main/external-resources/renderers/Samsung-UHD-2019.conf
+++ b/src/main/external-resources/renderers/Samsung-UHD-2019.conf
@@ -36,7 +36,6 @@ TranscodeFastStart = true
 SeekByTime = true
 UseClosedCaption = true
 SubtitleHttpHeader = CaptionInfo.sec
-MediaInfo = true
 
 MaxVideoWidth = 4096
 MaxVideoHeight = 2160

--- a/src/main/external-resources/renderers/Samsung-UHD.conf
+++ b/src/main/external-resources/renderers/Samsung-UHD.conf
@@ -35,7 +35,6 @@ TranscodeFastStart = true
 SeekByTime = true
 UseClosedCaption = true
 SubtitleHttpHeader = CaptionInfo.sec
-MediaInfo = true
 
 MaxVideoWidth = 4096
 MaxVideoHeight = 2160

--- a/src/main/external-resources/renderers/Samsung-WiseLink.conf
+++ b/src/main/external-resources/renderers/Samsung-WiseLink.conf
@@ -11,7 +11,6 @@ TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = WAV
 DefaultVBVBufSize = true
 MuxDTSToMpeg = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi|divx        v:mp4|divx|mjpeg         a:mp3|lpcm|mpa|ac3      m:video/x-divx

--- a/src/main/external-resources/renderers/Sharp-Aquos.conf
+++ b/src/main/external-resources/renderers/Sharp-Aquos.conf
@@ -17,7 +17,6 @@ UserAgentSearch = SHARP-AQUOS-DMP
 CreateDLNATreeFaster = true
 WrapDTSIntoPCM = true
 HalveBitrate = true
-MediaInfo = true
 
 # The following information was obtained from page 47 of the manual from:
 # http://files.sharpusa.com/Downloads/ForHome/HomeEntertainment/LCDTVs/Manuals/tel_man_LC40_46_52_60LE830U.pdf

--- a/src/main/external-resources/renderers/Showtime3.conf
+++ b/src/main/external-resources/renderers/Showtime3.conf
@@ -13,7 +13,6 @@ TranscodedVideoFileSize = -1
 MimeTypesChanges = video/avi=video/x-divx
 WrapDTSIntoPCM = true
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegps|mpegts|mkv   v:mpeg1|mpeg2|mp4|h264   a:ac3|lpcm|aac-lc|mpa   m:video/mpeg

--- a/src/main/external-resources/renderers/Showtime4.conf
+++ b/src/main/external-resources/renderers/Showtime4.conf
@@ -13,7 +13,6 @@ TranscodedVideoFileSize = -1
 MimeTypesChanges = video/avi=video/x-divx
 WrapDTSIntoPCM = true
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegps|mpegts   v:mpeg1|mpeg2|mp4|h264   a:ac3|lpcm|aac-lc|mpa   m:video/mpeg

--- a/src/main/external-resources/renderers/Sony-Bluray-BDP-S3700.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray-BDP-S3700.conf
@@ -32,7 +32,6 @@ DefaultVBVBufSize = true
 ChunkedTransfer = true
 TextWrap = width:52 indent:10 height:3 whitespace:9
 SendDateMetadata = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             v:mp4           a:ac3|lpcm|mp3|mpa                          m:video/mp4

--- a/src/main/external-resources/renderers/Sony-Bluray-UBP-X800M2.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray-UBP-X800M2.conf
@@ -22,7 +22,6 @@ LoadingPriority = 2
 UserAgentAdditionalHeader = X-AV-Client-Info
 UserAgentAdditionalHeaderSearch = (cn="Sony Corporation"; mn="UBP-X800M2")
 DLNALocalizationRequired = true
-MediaInfo = true
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = LPCM
 DefaultVBVBufSize = true

--- a/src/main/external-resources/renderers/Sony-Bluray.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray.conf
@@ -31,7 +31,6 @@ ChunkedTransfer = true
 TextWrap = width:52 indent:10 height:3 whitespace:9
 SendDateMetadata = false
 HalveBitrate = true
-MediaInfo = true
 
 # Specs below taken from http://www.sony.co.uk/product/blu-ray-disc-player/bdp-s370#pageType=TechnicalSpecs
 # then fine-tuned by lengthy trial and error since so much of that advertised spec is inaccurate.

--- a/src/main/external-resources/renderers/Sony-Bluray2013.conf
+++ b/src/main/external-resources/renderers/Sony-Bluray2013.conf
@@ -23,7 +23,6 @@ ChunkedTransfer = true
 TextWrap = width:52 indent:10 height:3 whitespace:9
 SendDateMetadata = false
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             v:mp4           a:ac3|lpcm|mp3|mpa                          m:video/mp4

--- a/src/main/external-resources/renderers/Sony-Bravia4500.conf
+++ b/src/main/external-resources/renderers/Sony-Bravia4500.conf
@@ -18,3 +18,4 @@ MuxNonMod4Resolution = true
 TranscodeExtensions = dvr-ms,dvr,mkv,dv,ty,mov,ogm,hdmov,hdm,rmv,rmvb,rm,asf,evo,asx,flv,m2v,mpe,mod,tivo,ty,tmf,ts,tp,m2p,mp4,m4v,avi,wmv,wm,divx,div,flac,mlp,fla,wma,m4a,aac,dts,mka,ape,ogg,shn,mpc,ra,mp2,wv,oma,aa3,gif,png,arw,cr2,crw,dng,raf,mrw,nef,pef,tif,tiff
 AccurateDLNAOrgPN = true
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Sony-Bravia5500.conf
+++ b/src/main/external-resources/renderers/Sony-Bravia5500.conf
@@ -18,8 +18,6 @@ CreateDLNATreeFaster = true
 KeepAspectRatio = true
 KeepAspectRatioTranscoding = true 
 HalveBitrate = true
-MediaInfo = true
-
 # Supported video formats:
 Supported = f:mpegps   v:mpeg2|h264   a:aac-lc|ac3|mpa   m:video/mpeg
 Supported = f:mpegts   v:mpeg2|h264   a:aac-lc|ac3|mpa   m:video/vnd.dlna.mpeg-tts

--- a/src/main/external-resources/renderers/Sony-BraviaAG.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaAG.conf
@@ -27,8 +27,6 @@ TranscodeVideo = MPEGTS-H264-AC3
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
 
-MediaInfo = true
-
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                a:aac-lc|he-aac|ac3|eac3|mpa
 Supported = f:avi       v:divx|mp4|mjpeg          a:ac3|eac3|mp3|mpa

--- a/src/main/external-resources/renderers/Sony-BraviaBX305.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaBX305.conf
@@ -16,3 +16,4 @@ MimeTypesChanges = audio/wav=audio/L16
 TranscodeExtensions = avi,mov,mp4
 StreamExtensions = mpg,mpeg
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Sony-BraviaEX.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaEX.conf
@@ -27,7 +27,6 @@ CustomMencoderOptions = -vf softskip,expand=::::1:16/9:2,scale=1283:720 -lavcopt
 AccurateDLNAOrgPN = true
 MuxNonMod4Resolution = true
 HalveBitrate = true
-MediaInfo = true
 
 # Our Bravia EX-specific notes:
 # DTS is not supported.

--- a/src/main/external-resources/renderers/Sony-BraviaEX620.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaEX620.conf
@@ -20,3 +20,4 @@ TranscodeExtensions = mkv,avi,divx,ogv,3gp,3g2,rm,rmvb,mov,flv,mvc
 StreamExtensions = mpg,mpe,mpeg,m2t,m2ts,mts,mp4,asf,wmv
 AccurateDLNAOrgPN = true
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Sony-BraviaEX725.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaEX725.conf
@@ -25,7 +25,6 @@ CreateDLNATreeFaster = true
 AccurateDLNAOrgPN = true
 MuxNonMod4Resolution = true
 HalveBitrate = true
-MediaInfo = true
 
 # Our Bravia EX-specific notes:
 # DTS is not supported.

--- a/src/main/external-resources/renderers/Sony-BraviaHX.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaHX.conf
@@ -24,7 +24,6 @@ DefaultVBVBufSize = true
 AccurateDLNAOrgPN = true
 MuxNonMod4Resolution = true
 HalveBitrate = true
-MediaInfo = true
 
 # Our Bravia HX-specific notes:
 # DTS is not supported.

--- a/src/main/external-resources/renderers/Sony-BraviaHX75.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaHX75.conf
@@ -24,7 +24,6 @@ DefaultVBVBufSize = true
 AccurateDLNAOrgPN = true
 MuxNonMod4Resolution = true
 HalveBitrate = true
-MediaInfo = true
 
 # Our Bravia HX-specific notes:
 # DTS is not supported.

--- a/src/main/external-resources/renderers/Sony-BraviaNX70x.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaNX70x.conf
@@ -28,7 +28,6 @@ CreateDLNATreeFaster = true
 AccurateDLNAOrgPN = true
 MuxNonMod4Resolution = true
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegps|mpegts   v:mpeg1|mpeg2|mp4|h264   a:ac3|lpcm|mpa   m:video/mpeg

--- a/src/main/external-resources/renderers/Sony-BraviaNX800.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaNX800.conf
@@ -27,7 +27,6 @@ TranscodeVideo = MPEGTS-MPEG2-AC3
 TranscodeAudio = LPCM
 DLNALocalizationRequired = true
 DefaultVBVBufSize = true
-MediaInfo = true
 MuxNonMod4Resolution = true
 AccurateDLNAOrgPN = true
 TranscodeFastStart = true

--- a/src/main/external-resources/renderers/Sony-BraviaW.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaW.conf
@@ -29,7 +29,6 @@ MediaParserV2_ThumbnailGeneration = true
 AccurateDLNAOrgPN = true
 SendFolderThumbnails = false
 HalveBitrate = true
-MediaInfo = true
 
 # Our Bravia W-specific notes:
 # DTS is not supported.

--- a/src/main/external-resources/renderers/Sony-BraviaX.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaX.conf
@@ -23,8 +23,6 @@ UserAgentAdditionalHeader = X-AV-Client-Info
 UserAgentAdditionalHeaderSearch = (KD|FW)-[0-9][0-9](S|X|Z)[0-9]{1,4}D
 UpnpDetailsSearch = Sony , (KD|FW)-[0-9][0-9](S|X|Z)[0-9]{1,4}D
 
-MediaInfo = true
-
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4           a:aac-lc|he-aac|ac3|eac3|mpa              m:video/3gpp
 Supported = f:avi       v:divx|mp4|mjpeg     a:ac3|eac3|mp3|mpa                        m:video/avi

--- a/src/main/external-resources/renderers/Sony-BraviaXBR-OLED.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaXBR-OLED.conf
@@ -21,7 +21,6 @@ LoadingPriority = 2
 SeekByTime = true
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = WAV
-MediaInfo = true
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
 SupportedVideoBitDepths = 8,10,12

--- a/src/main/external-resources/renderers/Sony-BraviaXBR.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaXBR.conf
@@ -30,7 +30,6 @@ MediaParserV2_ThumbnailGeneration = true
 AccurateDLNAOrgPN = true
 WrapDTSIntoPCM = true
 HalveBitrate = true
-MediaInfo = true
 
 # The supported formats below were taken from the following link:
 # http://docs.esupport.sony.com/imanual/NA/2013/XBR55-65X900A/uc_uen/codeclist.html#4

--- a/src/main/external-resources/renderers/Sony-BraviaXD.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaXD.conf
@@ -45,7 +45,6 @@ CreateDLNATreeFaster = true
 AccurateDLNAOrgPN = true
 MaxVideoBitrateMbps = 90
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2    v:h264|mp4                         a:aac-lc|he-aac|ac3|eac3|mpa              m:video/3gpp

--- a/src/main/external-resources/renderers/Sony-BraviaXH.conf
+++ b/src/main/external-resources/renderers/Sony-BraviaXH.conf
@@ -30,7 +30,6 @@ ThumbnailAsResource = true
 CreateDLNATreeFaster = true
 MaxVideoBitrateMbps = 90
 SendDLNAOrgFlags = false
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|3g2    v:h264|mp4                         a:aac-lc|he-aac|ac3|eac3|mpa              m:video/3gpp

--- a/src/main/external-resources/renderers/Sony-HomeTheatreSystem.conf
+++ b/src/main/external-resources/renderers/Sony-HomeTheatreSystem.conf
@@ -27,7 +27,6 @@ TranscodeFastStart = true
 TranscodedVideoFileSize = -1
 WrapDTSIntoPCM = true
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegps|mpegts   m:video/mpeg

--- a/src/main/external-resources/renderers/Sony-PlayStation3.conf
+++ b/src/main/external-resources/renderers/Sony-PlayStation3.conf
@@ -28,7 +28,6 @@ TranscodedVideoFileSize = -1
 MimeTypesChanges = video/avi=video/x-divx
 WrapDTSIntoPCM = true
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegps     v:mpeg1|mpeg2|mp4|h264   a:ac3|lpcm           m:video/mpeg

--- a/src/main/external-resources/renderers/Sony-PlayStation4.conf
+++ b/src/main/external-resources/renderers/Sony-PlayStation4.conf
@@ -21,7 +21,6 @@ TranscodedVideoFileSize = -1
 RemoveTagsFromSRTSubtitles = false
 H264Level41Limited = false
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi      v:mp4|h264     a:aac-lc|ac3|mp3                           m:video/avi

--- a/src/main/external-resources/renderers/Sony-PlayStationVita.conf
+++ b/src/main/external-resources/renderers/Sony-PlayStationVita.conf
@@ -25,7 +25,6 @@ H264Level41Limited = true
 TranscodeFastStart = true
 TranscodedVideoFileSize = -1
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mp4      v:h264|mp4   a:aac-lc   m:video/mp4

--- a/src/main/external-resources/renderers/Sony-SMPN100.conf
+++ b/src/main/external-resources/renderers/Sony-SMPN100.conf
@@ -29,7 +29,6 @@ TranscodeVideo = MPEGTS-MPEG2-AC3
 DefaultVBVBufSize = true
 ChunkedTransfer = true
 HalveBitrate = true
-MediaInfo = true
 
 # Specs below taken from http://www.sony.co.uk/product/blu-ray-disc-player/bdp-s370#pageType=TechnicalSpecs
 # then fine-tuned by lengthy trial and error since so much of that advertised spec is inaccurate.

--- a/src/main/external-resources/renderers/Sony-STR-DN1080.conf
+++ b/src/main/external-resources/renderers/Sony-STR-DN1080.conf
@@ -23,7 +23,6 @@ Video = false
 Image = false
 SeekByTime = true
 TranscodeAudio = MP3
-MediaInfo = true
 
 # Supported audio formats:
 Supported = f:aac	m:audio/mp4

--- a/src/main/external-resources/renderers/Sony-STR5800ES.conf
+++ b/src/main/external-resources/renderers/Sony-STR5800ES.conf
@@ -27,7 +27,6 @@ TranscodeVideo = MPEGTS-MPEG2-AC3
 DefaultVBVBufSize = true
 ChunkedTransfer = true
 HalveBitrate = true
-MediaInfo = true
 
 # Specs below taken from http://www.sony.co.uk/product/blu-ray-disc-player/bdp-s370#pageType=TechnicalSpecs
 # then fine-tuned by lengthy trial and error since so much of that advertised spec is inaccurate.

--- a/src/main/external-resources/renderers/Sony-Xperia.conf
+++ b/src/main/external-resources/renderers/Sony-Xperia.conf
@@ -18,7 +18,6 @@ MuxNonMod4Resolution = true
 CreateDLNATreeFaster = true
 AccurateDLNAOrgPN = true
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp|mov|mp4|mpegts   v:mp4|h264   a:aac-lc|mp3   b:320   m:video/mp4

--- a/src/main/external-resources/renderers/Sony-XperiaZ3.conf
+++ b/src/main/external-resources/renderers/Sony-XperiaZ3.conf
@@ -27,7 +27,6 @@ MuxNonMod4Resolution = true
 CreateDLNATreeFaster = true
 AccurateDLNAOrgPN = true
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp             v:h263|h264|mp4        m:video/3gpp

--- a/src/main/external-resources/renderers/Technisat-S1Plus.conf
+++ b/src/main/external-resources/renderers/Technisat-S1Plus.conf
@@ -22,7 +22,6 @@ TranscodeAudio = MP3
 CustomFFmpegOptions = -target pal-dvd
 CustomMencoderOptions = -mpegopts format=dvd:film2pal
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mp4             v:h264|mp4     a:aac-lc|ac3     m:video/mp4

--- a/src/main/external-resources/renderers/Telefunken-TV.conf
+++ b/src/main/external-resources/renderers/Telefunken-TV.conf
@@ -21,7 +21,6 @@ UpnpDetailsSearch = TELEFUNKENTV
 
 MaxVideoBitrateMbps = 80
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:3gp      v:h264|mp4               a:ac3|eac3|adpcm|lpcm   m:video/3gpp

--- a/src/main/external-resources/renderers/Telstra-Tbox.conf
+++ b/src/main/external-resources/renderers/Telstra-Tbox.conf
@@ -15,3 +15,4 @@ TranscodeExtensions = wmv,asf
 StreamExtensions = mkv,avi,mp4,mov,mpg,mpeg,mpegts,mpegps,mov
 WrapDTSIntoPCM = true
 HalveBitrate = true
+MediaInfo = false

--- a/src/main/external-resources/renderers/Thomson-U3.conf
+++ b/src/main/external-resources/renderers/Thomson-U3.conf
@@ -20,7 +20,6 @@ SeekByTime = exclusive
 TranscodeVideo = MPEGTS-H264-AC3
 WrapDTSIntoPCM = false
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             m:video/avi

--- a/src/main/external-resources/renderers/VLC-for-desktop.conf
+++ b/src/main/external-resources/renderers/VLC-for-desktop.conf
@@ -26,7 +26,6 @@ TranscodeAudio = WAV
 DefaultVBVBufSize = true
 SendFolderThumbnails = false
 SupportedVideoBitDepths = 8,10
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:avi             m:video/avi

--- a/src/main/external-resources/renderers/VideoWeb-VideoWebTV.conf
+++ b/src/main/external-resources/renderers/VideoWeb-VideoWebTV.conf
@@ -25,3 +25,4 @@ TranscodeExtensions = flv
 StreamExtensions = avi,xvid,divx,avc,mpg,mpeg,mkv,264,ts,tp,m2t,m2ts,wmv,mp3,wav,pcm,lpcm,wma,aac,flac,mka,aif,aiff,ogg,dts
 ShowDVDTitleDuration = true
 CBRVideoBitrate = 15000
+MediaInfo = false

--- a/src/main/external-resources/renderers/Vizio-SmartTV.conf
+++ b/src/main/external-resources/renderers/Vizio-SmartTV.conf
@@ -25,7 +25,6 @@ WrapDTSIntoPCM = true
 TranscodeFastStart = true
 KeepAspectRatio = true
 HalveBitrate = true
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegps|mpegts   v:mpeg1|mpeg2|mp4|h264   a:ac3|lpcm|aac-lc|mpa   m:video/mpeg

--- a/src/main/external-resources/renderers/WesternDigital-WDTVLive.conf
+++ b/src/main/external-resources/renderers/WesternDigital-WDTVLive.conf
@@ -18,7 +18,6 @@ UpnpDetailsSearch = Western Digital , WD TV
 
 ShowDVDTitleDuration = true
 CBRVideoBitrate = 15000
-MediaInfo = true
 
 # Supported video formats:
 Supported = f:mpegps|mpegts   m:video/mpeg

--- a/src/main/external-resources/renderers/XBMC.conf
+++ b/src/main/external-resources/renderers/XBMC.conf
@@ -27,3 +27,4 @@ HalveBitrate = true
 # Supported subtitles formats:
 SupportedExternalSubtitlesFormats = SUBRIP
 SupportedInternalSubtitlesFormats = SUBRIP
+MediaInfo = false

--- a/src/main/external-resources/renderers/Yamaha-AV.conf
+++ b/src/main/external-resources/renderers/Yamaha-AV.conf
@@ -26,7 +26,6 @@ Video = false
 Image = false
 SeekByTime = true
 TranscodeAudio = WAV
-MediaInfo = true
 
 # Supported audio formats:
 Supported = f:m4a              m:audio/x-m4a              a:(?!alac).+

--- a/src/main/external-resources/renderers/Yamaha-RN303.conf
+++ b/src/main/external-resources/renderers/Yamaha-RN303.conf
@@ -20,7 +20,6 @@ Image = false
 SeekByTime = true
 TranscodeAudio = WAV
 StreamExtensions = dff,dsf,l16,lpcm
-MediaInfo = true
 
 # Supported audio formats:
 Supported = f:aiff   m:audio/L16

--- a/src/main/external-resources/renderers/Yamaha-RN500.conf
+++ b/src/main/external-resources/renderers/Yamaha-RN500.conf
@@ -12,7 +12,6 @@ LoadingPriority = 1
 Video = false
 Image = false
 TranscodeAudio = WAV
-MediaInfo = true
 
 # Supported audio formats:
 Supported = f:mp3   m:audio/mpeg

--- a/src/main/external-resources/renderers/Yamaha-RXA1010.conf
+++ b/src/main/external-resources/renderers/Yamaha-RXA1010.conf
@@ -15,3 +15,4 @@ Video = false
 Image = false
 SeekByTime = true
 StreamExtensions = wav,flac,mp3,wma,aac
+MediaInfo = false

--- a/src/main/external-resources/renderers/Yamaha-RXA2050.conf
+++ b/src/main/external-resources/renderers/Yamaha-RXA2050.conf
@@ -28,7 +28,6 @@ Image = false
 SeekByTime = true
 TranscodeAudio = WAV
 StreamExtensions = dff,dsf,l16,lpcm
-MediaInfo = true
 
 # Supported audio formats:
 Supported = f:m4a              m:audio/x-m4a              a:(?!alac).+

--- a/src/main/external-resources/renderers/Yamaha-RXV3900.conf
+++ b/src/main/external-resources/renderers/Yamaha-RXV3900.conf
@@ -15,3 +15,4 @@ Image = false
 SeekByTime = true
 TranscodeAudio = MP3
 StreamExtensions = wav, flac, mp3, wma, aac
+MediaInfo = false

--- a/src/main/external-resources/renderers/Yamaha-RXV500D.conf
+++ b/src/main/external-resources/renderers/Yamaha-RXV500D.conf
@@ -30,3 +30,4 @@ Image = false
 SeekByTime = true
 TranscodeAudio = MP3
 StreamExtensions = lpcm,wav,flac,mp3,wma,aac
+MediaInfo = false

--- a/src/main/external-resources/renderers/Yamaha-RXV671.conf
+++ b/src/main/external-resources/renderers/Yamaha-RXV671.conf
@@ -15,3 +15,4 @@ Image = false
 SeekByTime = true
 TranscodeAudio = MP3
 StreamExtensions = wav, flac, mp3, wma, aac
+MediaInfo = false

--- a/src/main/external-resources/renderers/foobar2000-mobile.conf
+++ b/src/main/external-resources/renderers/foobar2000-mobile.conf
@@ -14,8 +14,6 @@ RendererIcon = foobar2000-mobile.png
 
 UserAgentSearch = foobar2000-mobile
 
-MediaInfo = true
-
 Video = false
 Image = false
 

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -2119,7 +2119,7 @@ public class RendererConfiguration extends UPNPHelper.Renderer {
 	 * @return whether to use MediaInfo
 	 */
 	public boolean isUseMediaInfo() {
-		return getBoolean(MEDIAPARSERV2, false) && LibMediaInfoParser.isValid();
+		return getBoolean(MEDIAPARSERV2, true) && LibMediaInfoParser.isValid();
 	}
 
 	public boolean isMediaInfoThumbnailGeneration() {


### PR DESCRIPTION
- Any file that had explicitly set false was left as false as well as any file that did not have MediaInfo set was explicitly set to false.
- Changed Default Behaviour in `RendererConfiguration.java`

Closes #2598 