### PR TITLE
Rollback h2database to 197

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,8 +194,8 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<!-- Versions above 1.4.199 should only be used when https://github.com/UniversalMediaServer/UniversalMediaServer/issues/2030 is done -->
-			<version>1.4.199</version>
+			<!-- Versions above 1.4.197 should only be used when https://github.com/UniversalMediaServer/UniversalMediaServer/issues/2030 is done -->
+			<version>1.4.197</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
This still needs more testing. I have tested it on my existing database and it seems to work though.

I have been investigating why UMS doesn't always shut down cleanly, and h2database 198 is partly responsible for it, though we can workaround it by disabling multithreading like I did here https://github.com/UniversalMediaServer/UniversalMediaServer/pull/2589/files#diff-25449232e5cc977f814fb9fd3fc79a6710ed9b5f5a3792128fa64a4e41b1d338R174

There is also another bug that has been preventing them from doing a release for the last 2 years https://github.com/h2database/h2database/issues/2491#issuecomment-662318859

When we updated to version 200, we had to rollback because it was incompatible with previous versions for some users, s

Basically it seems that 197 is the most stable version for us until certain things are fixed, on their end and on ours, like us implementing https://github.com/UniversalMediaServer/UniversalMediaServer/issues/2030