### PR TITLE
Checking for non set variables with better syntax

### DIFF
--- a/contrib/build-pms-binaries.sh
+++ b/contrib/build-pms-binaries.sh
@@ -152,7 +152,7 @@ check_binary() {
     BINARY=$1
     BINARY_PATH=`command -v $BINARY`
     
-    if [ "$BINARY_PATH" == "" ]; then
+    if [ -z "$BINARY_PATH" ]; then
         case "$BINARY" in
         ant)
             if is_osx; then

--- a/contrib/download-pms-binaries-source.sh
+++ b/contrib/download-pms-binaries-source.sh
@@ -56,7 +56,7 @@ check_binary() {
     BINARY=$1
     BINARY_PATH=`command -v $BINARY`
 
-    if [ "$BINARY_PATH" == "" ]; then
+    if [ -z "$BINARY_PATH" ]; then
         case "$BINARY" in
         git)
             if is_osx; then

--- a/src/main/external-resources/UMS.sh
+++ b/src/main/external-resources/UMS.sh
@@ -20,7 +20,7 @@ if $cygwin ; then
 fi
 
 # Setup PMS_HOME
-if [ "x$PMS_HOME" = "x" ]; then
+if [ -z "$PMS_HOME" ]; then
     PMS_HOME="$DIRNAME"
 fi
 
@@ -29,11 +29,11 @@ export PMS_HOME
 cd "$PMS_HOME"
 
 # Setup the JVM
-if [ "x$JAVA" = "x" ]; then
-    if [ "x$JAVA_HOME" != "x" ]; then
-        JAVA="$JAVA_HOME/bin/java"
-    else
+if [ -z "$JAVA" ]; then
+    if [ -z "$JAVA_HOME" ]; then
         JAVA="java"
+    else
+        JAVA="$JAVA_HOME/bin/java"
     fi
 fi
 
@@ -52,19 +52,19 @@ if $cygwin; then
     PMS_HOME=`cygpath --path --windows "$PMS_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
 fi
- 
+
 # Configure fontconfig (used by our build of FFmpeg)
-if [ "x$FONTCONFIG_PATH" = "x" ]; then
+if [ -z "$FONTCONFIG_PATH" ]; then
     FONTCONFIG_PATH=/etc/fonts
     export FONTCONFIG_PATH
 fi
-if [ "x$FONTCONFIG_FILE" = "x" ]; then
+if [ -z "$FONTCONFIG_FILE" ]; then
     FONTCONFIG_FILE=/etc/fonts/fonts.conf
     export FONTCONFIG_FILE
 fi
 
 # Provide a means of setting max memory using an environment variable
-if [ "x$UMS_MAX_MEMORY" = "x" ]; then
+if [ -z "$UMS_MAX_MEMORY" ]; then
     UMS_MAX_MEMORY=1280M
 fi
 


### PR DESCRIPTION
The -z option is widely understood wheras the idea of having a prefix, evaluating the string and then look, if it is just the prefix is a bit harder to understand.