### PR TITLE
Update PlaylistFolder content

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -3613,7 +3613,6 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 * @since 1.71.0
 	 */
 	protected void setLastModified(long lastModified) {
-		// TODO rename lastmodified -> lastModified
 		this.lastModified = lastModified;
 	}
 

--- a/src/main/java/net/pms/dlna/PlaylistFolder.java
+++ b/src/main/java/net/pms/dlna/PlaylistFolder.java
@@ -130,6 +130,12 @@ public class PlaylistFolder extends DLNAResource {
 	}
 
 	@Override
+	public void resolve() {
+		getChildren().clear();
+		resolveOnce();
+	}
+
+	@Override
 	protected void resolveOnce() {
 		ArrayList<Entry> entries = new ArrayList<>();
 		boolean m3u = false;

--- a/src/main/java/net/pms/dlna/PlaylistFolder.java
+++ b/src/main/java/net/pms/dlna/PlaylistFolder.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PlaylistFolder extends DLNAResource {
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(PlaylistFolder.class);
 	private String name;
 	private String uri;
@@ -121,7 +122,8 @@ public class PlaylistFolder extends DLNAResource {
 				LOGGER.debug("PlaylistFolder albumart path : " + thumbnailImage.getAbsolutePath());
 				result = DLNAThumbnailInputStream.toThumbnailInputStream(new FileInputStream(thumbnailImage));
 			} catch (IOException e) {
-				LOGGER.debug("An error occurred while getting thumbnail for \"{}\", using generic thumbnail instead: {}", getName(), e.getMessage());
+				LOGGER.debug("An error occurred while getting thumbnail for \"{}\", using generic thumbnail instead: {}", getName(),
+					e.getMessage());
 				LOGGER.trace("", e);
 			}
 			return result != null ? result : super.getThumbnailInputStream();
@@ -132,6 +134,7 @@ public class PlaylistFolder extends DLNAResource {
 	@Override
 	public void resolve() {
 		getChildren().clear();
+		setLastModified(getPlaylistfile().lastModified());
 		resolveOnce();
 	}
 
@@ -235,16 +238,17 @@ public class PlaylistFolder extends DLNAResource {
 			} else {
 				String u = FileUtil.urlJoin(uri, entry.fileName);
 				if (type == Format.PLAYLIST && !entry.fileName.endsWith(ext)) {
-					// If the filename continues past the "extension" (i.e. has a query string) it's
-					// likely not a nested playlist but a media item, for instance Twitch TV media urls:
-					//    'http://video10.iad02.hls.twitch.tv/.../index-live.m3u8?token=id=235...'
+					// If the filename continues past the "extension" (i.e. has
+					// a query string) it's
+					// likely not a nested playlist but a media item, for
+					// instance Twitch TV media urls:
+					// 'http://video10.iad02.hls.twitch.tv/.../index-live.m3u8?token=id=235...'
 					type = defaultContent;
 				}
-				DLNAResource d =
-					type == Format.VIDEO ? new WebVideoStream(entry.title, u, null) :
+				DLNAResource d = type == Format.VIDEO ? new WebVideoStream(entry.title, u, null) :
 					type == Format.AUDIO ? new WebAudioStream(entry.title, u, null) :
-					type == Format.IMAGE ? new FeedItem(entry.title, u, null, null, Format.IMAGE) :
-					type == Format.PLAYLIST ? getPlaylist(entry.title, u, 0) : null;
+						type == Format.IMAGE ? new FeedItem(entry.title, u, null, null, Format.IMAGE) :
+							type == Format.PLAYLIST ? getPlaylist(entry.title, u, 0) : null;
 				if (d != null) {
 					addChild(d);
 					valid = true;
@@ -264,6 +268,7 @@ public class PlaylistFolder extends DLNAResource {
 	}
 
 	private static class Entry {
+
 		public String fileName;
 		public String title;
 
@@ -285,8 +290,8 @@ public class PlaylistFolder extends DLNAResource {
 					return FileUtil.isUrl(uri) ? null : new CueFolder(new File(uri));
 				case "ups":
 					return new Playlist(name, uri);
-			default:
-				break;
+				default:
+					break;
 			}
 		}
 		return null;

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -1185,7 +1185,10 @@ public class RequestV2 extends HTTPResource {
 
 		for (DLNAResource dlnaResource : files) {
 			if (dlnaResource instanceof PlaylistFolder) {
-				((PlaylistFolder) dlnaResource).resolve();
+				File f = new File(dlnaResource.getFileName());
+				if (dlnaResource.getLastModified() < f.lastModified()) {
+					((PlaylistFolder) dlnaResource).resolve();
+				}
 			}
 		}
 

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -56,6 +56,7 @@ import net.pms.dlna.DLNAMediaSubtitle;
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.DLNAThumbnailInputStream;
 import net.pms.dlna.MediaType;
+import net.pms.dlna.PlaylistFolder;
 import net.pms.dlna.Range;
 import net.pms.dlna.RealFile;
 import net.pms.dlna.virtual.MediaLibraryFolder;
@@ -1181,6 +1182,12 @@ public class RequestV2 extends HTTPResource {
 			mediaRenderer,
 			searchCriteria
 		);
+
+		for (DLNAResource dlnaResource : files) {
+			if (dlnaResource instanceof PlaylistFolder) {
+				((PlaylistFolder) dlnaResource).resolve();
+			}
+		}
 
 		if (searchCriteria != null && files != null) {
 			UMSUtils.filterResourcesByName(files, searchCriteria, false, false);

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -1183,15 +1183,6 @@ public class RequestV2 extends HTTPResource {
 			searchCriteria
 		);
 
-		for (DLNAResource dlnaResource : files) {
-			if (dlnaResource instanceof PlaylistFolder) {
-				File f = new File(dlnaResource.getFileName());
-				if (dlnaResource.getLastModified() < f.lastModified()) {
-					((PlaylistFolder) dlnaResource).resolve();
-				}
-			}
-		}
-
 		if (searchCriteria != null && files != null) {
 			UMSUtils.filterResourcesByName(files, searchCriteria, false, false);
 			if (xbox360 && files.size() > 0) {
@@ -1203,6 +1194,13 @@ public class RequestV2 extends HTTPResource {
 		StringBuilder filesData = new StringBuilder();
 		if (files != null) {
 			for (DLNAResource uf : files) {
+				if (uf instanceof PlaylistFolder) {
+					File f = new File(uf.getFileName());
+					if (uf.getLastModified() < f.lastModified()) {
+						((PlaylistFolder) uf).resolve();
+					}
+				}
+
 				if (xbox360 && containerID != null) {
 					uf.setFakeParentId(containerID);
 				}


### PR DESCRIPTION
At the moment changes (adding / removing elements) made in playlists-files (.m3u8 , m3u, etc.) are not visible in UMS, until UMS is restarted. 

This PR updates the playlist content each time the playlist is accessed. User's will see changes in playlists without restarting UMS.