### PR TITLE
Show the folder name in the Status Line when the subtitles API

### DIFF
--- a/src/main/java/net/pms/util/OpenSubtitle.java
+++ b/src/main/java/net/pms/util/OpenSubtitle.java
@@ -5109,7 +5109,7 @@ public class OpenSubtitle {
 			} catch (SQLException ex) {
 				LOGGER.trace("Error in API parsing:", ex);
 			} finally {
-				frame.setStatusLine("");
+				frame.setStatusLine("Parsing Folder: " + file.getParent());
 			}
 		};
 		BACKGROUND_EXECUTOR.execute(r);


### PR DESCRIPTION
is searching for the files subs not the empty line which force the GUI to hide the Status Line and let the Shared folders to grow.