### PR TITLE
Bump FFmpeg to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<project.binaries>${project.basedir}/target/bin</project.binaries>
 
 		<project.binaries-base>https://www.universalmediaserver.com/svn/binaries</project.binaries-base>
-		<binary-revision>143</binary-revision>
+		<binary-revision>144</binary-revision>
 
 		<exec-maven-plugin-version>3.0.0</exec-maven-plugin-version>
 		<maven-antrun-plugin-version>3.0.0</maven-antrun-plugin-version>
@@ -2492,10 +2492,10 @@
 
 										<!-- Download binaries -->
 										<get src="${project.binaries-base}/osx/dcraw?p=${binary-revision}" dest="${project.binaries}/osx/dcraw" usetimestamp="true" />
-										<get src="${project.binaries-base}/osx/ffmpeg?p=${binary-revision}" dest="${project.binaries}/osx/ffmpeg" usetimestamp="true" />
 										<get src="${project.binaries-base}/osx/libmediainfo.dylib?p=${binary-revision}" dest="${project.binaries}/libmediainfo.dylib" usetimestamp="true" />
 										<get src="${project.binaries-base}/osx/youtube-dl?p=${binary-revision}" dest="${project.binaries}/osx/youtube-dl" usetimestamp="true" />
 										<get src="${project.binaries-base}/MediaInfo-License.html?p=${binary-revision}" dest="${project.binaries}/MediaInfo-License.html" usetimestamp="true" />
+										<get src="${project.binaries-base}/osx/10.15/ffmpeg?p=${binary-revision}" dest="${project.binaries}/osx/10.15/ffmpeg" usetimestamp="true" />
 										<get src="${project.binaries-base}/osx/10.15/flac?p=${binary-revision}" dest="${project.binaries}/osx/10.15/flac" usetimestamp="true" />
 										<get src="${project.binaries-base}/osx/10.15/mencoder?p=${binary-revision}" dest="${project.binaries}/osx/10.15/mencoder" usetimestamp="true" />
 										<get src="${project.binaries-base}/osx/10.15/mplayer?p=${binary-revision}" dest="${project.binaries}/osx/10.15/mplayer" usetimestamp="true" />

--- a/src/main/assembly/assembly-macos.xml
+++ b/src/main/assembly/assembly-macos.xml
@@ -25,6 +25,7 @@
 			<fileMode>0755</fileMode>
 			<includes>
 				<include>builds.txt</include>
+				<include>ffmpeg</include>
 				<include>flac</include>
 				<include>mencoder</include>
 				<include>mplayer</include>
@@ -41,7 +42,6 @@
 			<fileMode>0755</fileMode>
 			<includes>
 				<include>dcraw</include>
-				<include>ffmpeg</include>
 				<include>libmediainfo.dylib</include>
 				<include>youtube-dl</include>
 			</includes>


### PR DESCRIPTION
This was necessary for the HLS work I'm doing - our current version has some bugs with it