### PR TITLE
h2database from 1.4.197 to 2.0.202 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,8 +193,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<!-- Versions above 1.4.197 should only be used when https://github.com/UniversalMediaServer/UniversalMediaServer/issues/2030 is done -->
-			<version>1.4.197</version>
+			<version>2.0.202</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>

--- a/src/main/java/net/pms/database/TableAudiotracks.java
+++ b/src/main/java/net/pms/database/TableAudiotracks.java
@@ -134,7 +134,7 @@ public class TableAudiotracks extends Tables {
 			sb.append(", ALBUMARTIST       VARCHAR2(").append(SIZE_MAX).append(')');
 			sb.append(", SONGNAME          VARCHAR2(").append(SIZE_MAX).append(')');
 			sb.append(", GENRE             VARCHAR2(").append(SIZE_GENRE).append(')');
-			sb.append(", YEAR              INT");
+			sb.append(", `YEAR`              INT");
 			sb.append(", TRACK             INT");
 			sb.append(", DISC              INT");
 			sb.append(", DELAY             INT");
@@ -161,7 +161,7 @@ public class TableAudiotracks extends Tables {
 			executeUpdate(connection, "CREATE INDEX IDXGENRE on AUDIOTRACKS (GENRE asc);");
 
 			LOGGER.trace("Creating index IDXYEAR");
-			executeUpdate(connection, "CREATE INDEX IDXYEAR on AUDIOTRACKS (YEAR asc);");
+			executeUpdate(connection, "CREATE INDEX IDXYEAR on AUDIOTRACKS (`YEAR` asc);");
 		}
 	}
 

--- a/src/main/java/net/pms/database/TableMusicBrainzReleases.java
+++ b/src/main/java/net/pms/database/TableMusicBrainzReleases.java
@@ -149,7 +149,7 @@ public final class TableMusicBrainzReleases extends Tables {
 			if (added) {
 				where.append(and);
 			}
-			where.append("YEAR").append(sqlNullIfBlank(tagInfo.year, true, false));
+			where.append("`YEAR`").append(sqlNullIfBlank(tagInfo.year, true, false));
 		}
 
 		return where.toString();
@@ -356,7 +356,7 @@ public final class TableMusicBrainzReleases extends Tables {
 							"ALTER TABLE " + TABLE_NAME + " ALTER COLUMN TITLE VARCHAR(1000)"
 						);
 						statement.executeUpdate(
-							"ALTER TABLE " + TABLE_NAME + " ALTER COLUMN YEAR VARCHAR(20)"
+							"ALTER TABLE " + TABLE_NAME + " ALTER COLUMN `YEAR` VARCHAR(20)"
 						);
 						break;
 					default:
@@ -386,7 +386,7 @@ public final class TableMusicBrainzReleases extends Tables {
 					"ARTIST VARCHAR(1000), " +
 					"ALBUM VARCHAR(1000), " +
 					"TITLE VARCHAR(1000), " +
-					"YEAR VARCHAR(20), " +
+					"`YEAR` VARCHAR(20), " +
 					"ARTIST_ID VARCHAR(36), " +
 					"TRACK_ID VARCHAR(36)" +
 				")");

--- a/src/main/java/net/pms/database/TableTVSeries.java
+++ b/src/main/java/net/pms/database/TableTVSeries.java
@@ -112,7 +112,7 @@ public final class TableTVSeries extends Tables {
 							insertQuery = "INSERT INTO " + TABLE_NAME + " (SIMPLIFIEDTITLE, TITLE) VALUES (?, ?)";
 						} else {
 							insertQuery = "INSERT INTO " + TABLE_NAME + " (" +
-								"ENDYEAR, IMDBID, PLOT, SIMPLIFIEDTITLE, STARTYEAR, TITLE, TOTALSEASONS, VOTES, YEAR, VERSION" +
+								"ENDYEAR, IMDBID, PLOT, SIMPLIFIEDTITLE, STARTYEAR, TITLE, TOTALSEASONS, VOTES, `YEAR`, VERSION" +
 							") VALUES (" +
 								"?, ?, ?, ?, ?, ?, ?, ?, ?, ?" +
 							")";
@@ -597,7 +597,7 @@ public final class TableTVSeries extends Tables {
 					"TOTALSEASONS    DOUBLE, " +
 					"VERSION    VARCHAR2(1024), " +
 					"VOTES    VARCHAR2(1024), " +
-					"YEAR    VARCHAR2(1024) " +
+					"`YEAR`    VARCHAR2(1024) " +
 				")"
 			);
 			statement.execute("CREATE INDEX IMDBID_IDX ON " + TABLE_NAME + "(IMDBID)");

--- a/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaDatabase.java
@@ -92,7 +92,7 @@ public class DLNAMediaDatabase implements Runnable {
 	private Thread scanner;
 	private final JdbcConnectionPool cp;
 	private int dbCount;
-	
+
 	public static final String TABLE_NAME = "FILES";
 
 	/**
@@ -526,14 +526,14 @@ public class DLNAMediaDatabase implements Runnable {
 
 	/**
 	 * Migrate the h2 database from version 1.4.197 to version 2.
-	 * 
+	 *
 	 */
 	private void migrateDatabaseVersion2() {
-		String h2_version = org.h2.engine.Constants.VERSION;
-		LOGGER.info("Migrating database to v{}", h2_version);
+		String h2Version = org.h2.engine.Constants.VERSION;
+		LOGGER.info("Migrating database to v{}", h2Version);
 		if (!net.pms.PMS.isHeadless()) {
 			try {
-				PMS.get().getFrame().setStatusLine("Migrating database to v" + h2_version);
+				PMS.get().getFrame().setStatusLine("Migrating database to v" + h2Version);
 			} catch (NullPointerException e) {
 				LOGGER.debug("Failed to set status, probably because GUI is not initialized yet. Error was {}", e);
 			}
@@ -544,7 +544,7 @@ public class DLNAMediaDatabase implements Runnable {
 		prprts.setProperty("password", DB_PASSWORD);
 		try {
 			Upgrade.upgrade(oldUrl, prprts, 197);
-			LOGGER.info("The database successfully migrated to version {}", h2_version);
+			LOGGER.info("The database successfully migrated to version {}", h2Version);
 		} catch (Exception e) {
 			LOGGER.error(
 				"Database migration failed: {}",


### PR DESCRIPTION
Fixes #2715
- Update h2database dependency from 1.4.197 to 2.0.202.
- Migrate database from h2 format 1 to format 2 on needed.
- set DB_USER / DB_PASSWORD as private static.
- Escape words KEY, VALUE and YEAR in SQL queries. (These are reserved SQL words and will result in query fail with new h2 version.)