### PR TITLE
Using TCK Tested JDK builds of OpenJDK 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
 
   windows-latest:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        java-version: [ 8 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java-version }}
@@ -56,6 +59,10 @@ jobs:
 
   linux-bionic:
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        java-version: [ 8 ]
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java-version }}
@@ -85,6 +92,10 @@ jobs:
 
   linux-focal:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java-version: [ 8 ]
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,13 +9,14 @@ jobs:
       matrix:
         # test against two different xcode version on MacOS
         xcode: [ 9.4.1, latest ]
+        java-version: [ 8 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
-          java-version: 8
+          distribution: 'zulu'
+          java-version: ${{ matrix.java-version }}
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4
         with:
@@ -34,11 +35,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
-          java-version: 8
+          distribution: 'zulu'
+          java-version: ${{ matrix.java-version }}
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4
         with:
@@ -57,11 +58,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
-          java-version: '8'
+          distribution: 'zulu'
+          java-version: ${{ matrix.java-version }}
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4
         with:
@@ -86,11 +87,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
-          java-version: '8'
+          distribution: 'zulu'
+          java-version: ${{ matrix.java-version }}
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4
         with:


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Please see more details at Foojay.io:
https://foojay.io/today/github-actions-with-java-part-2/