### PR TITLE
Fix non utf8 processWrapper

### DIFF
--- a/src/main/java/net/pms/io/OutputTextConsumer.java
+++ b/src/main/java/net/pms/io/OutputTextConsumer.java
@@ -47,7 +47,7 @@ public class OutputTextConsumer extends OutputConsumer {
 			if (Platform.isWindows() && WinUtils.getOEMCharset() != null) {
 				charset = WinUtils.getOEMCharset();
 			} else {
-				charset = StandardCharsets.UTF_16;
+				charset = StandardCharsets.UTF_8;
 			}
 		}
 	}

--- a/src/main/java/net/pms/io/OutputTextConsumer.java
+++ b/src/main/java/net/pms/io/OutputTextConsumer.java
@@ -18,8 +18,11 @@
  */
 package net.pms.io;
 
+import com.sun.jna.Platform;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,19 +36,26 @@ import org.slf4j.LoggerFactory;
  */
 public class OutputTextConsumer extends OutputConsumer {
 	private static final Logger LOGGER = LoggerFactory.getLogger(OutputTextConsumer.class);
-	private List<String> lines = new ArrayList<>();
-	private Object linesLock = new Object();
-	private boolean log;
+	private static Charset charset = null;
+	private final List<String> lines = new ArrayList<>();
+	private final Object linesLock = new Object();
+	private final boolean log;
 
 	public OutputTextConsumer(InputStream inputStream, boolean log) {
 		super(inputStream);
-		linesLock = new Object();
 		this.log = log;
+		if (charset == null) {
+			if (Platform.isWindows() && WinUtils.getOEMCharset() != null) {
+				charset = WinUtils.getOEMCharset();
+			} else {
+				charset = StandardCharsets.UTF_16;
+			}
+		}
 	}
 
 	@Override
 	public void run() {
-		try (LineIterator it = IOUtils.lineIterator(inputStream, StandardCharsets.UTF_8)) {
+		try (LineIterator it = IOUtils.lineIterator(new InputStreamReader(inputStream, charset))) {
 			while (it.hasNext()) {
 				String line = it.nextLine();
 

--- a/src/main/java/net/pms/io/OutputTextConsumer.java
+++ b/src/main/java/net/pms/io/OutputTextConsumer.java
@@ -21,7 +21,6 @@ package net.pms.io;
 import com.sun.jna.Platform;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -55,7 +54,7 @@ public class OutputTextConsumer extends OutputConsumer {
 
 	@Override
 	public void run() {
-		try (LineIterator it = IOUtils.lineIterator(new InputStreamReader(inputStream, charset))) {
+		try (LineIterator it = IOUtils.lineIterator(inputStream, charset)) {
 			while (it.hasNext()) {
 				String line = it.nextLine();
 


### PR DESCRIPTION
**Fact :** logged line from processWrapper on windows show strange characters on the logfile on systems using non ascii char like accent, non latin, etc.
Windows process inputstream connected to the normal output use the windows encoding.
When reading debug files from others, I've seen a lot of them with that issue (on ping output, ffmpeg output, etc).

This fix fill once the static (to avoid checking each time the class is use) charset used by the system on the OutputTextConsumer Class.
On the same time, I also set some variable final for code optimization.

