### PR TITLE
servlet the webserver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,21 @@
 			<version>3.10.6.Final</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>9.4.44.v20210927</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlet</artifactId>
+			<version>9.4.44.v20210927</version>
+		</dependency>
 
 		<!-- maven replacement for nsisant-1.2.jar -->
 		<dependency>

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -23,7 +23,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import com.sun.jna.Platform;
-import com.sun.net.httpserver.HttpServer;
 import java.awt.*;
 import java.io.*;
 import java.net.BindException;
@@ -74,11 +73,11 @@ import net.pms.network.UPNPHelper;
 import net.pms.newgui.*;
 import net.pms.newgui.StatusTab.ConnectionState;
 import net.pms.newgui.components.WindowProperties.WindowPropertiesConfiguration;
-import net.pms.remote.RemoteWeb;
 import net.pms.service.Services;
 import net.pms.update.AutoUpdater;
 import net.pms.util.*;
 import net.pms.util.jna.macos.iokit.IOKitUtils;
+import net.pms.webserver.WebServer;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.apache.commons.configuration.event.ConfigurationListener;
@@ -573,7 +572,7 @@ public class PMS {
 		// Web stuff
 		if (configuration.useWebInterface()) {
 			try {
-				web = new RemoteWeb(configuration.getWebPort());
+				web = WebServer.createServer(configuration.getWebPort());
 			} catch (BindException b) {
 				LOGGER.error("FATAL ERROR: Unable to bind web interface on port: " + configuration.getWebPort() + ", because: " + b.getMessage());
 				LOGGER.info("Maybe another process is running or the hostname is wrong.");
@@ -1137,7 +1136,7 @@ public class PMS {
 		return server;
 	}
 
-	public HttpServer getWebServer() {
+	public Object getWebServer() {
 		return web == null ? null : web.getServer();
 	}
 
@@ -1521,10 +1520,10 @@ public class PMS {
 		setLocale(language, "", "");
 	}
 
-	private RemoteWeb web;
+	private WebServer web;
 
 	@Nullable
-	public RemoteWeb getWebInterface() {
+	public WebServer getWebInterface() {
 		return web;
 	}
 

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -346,6 +346,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_WEB_CONT_VIDEO = "web_continue_video";
 	protected static final String KEY_WEB_CONTROL = "web_control";
 	protected static final String KEY_WEB_ENABLE = "web_enable";
+	protected static final String KEY_WEB_TYPE = "web_type";
 	protected static final String KEY_WEB_FLASH = "web_flash";
 	protected static final String KEY_WEB_HEIGHT = "web_height";
 	protected static final String KEY_WEB_IMAGE_SLIDE = "web_image_show_delay";
@@ -4691,6 +4692,10 @@ public class PmsConfiguration extends RendererConfiguration {
 
 	public boolean useWebInterface() {
 		return getBoolean(KEY_WEB_ENABLE, true);
+	}
+
+	public String getWebType(String fallback) {
+		return getString(KEY_WEB_TYPE, fallback);
 	}
 
 	public boolean isAutomaticMaximumBitrate() {

--- a/src/main/java/net/pms/configuration/WebRender.java
+++ b/src/main/java/net/pms/configuration/WebRender.java
@@ -46,7 +46,7 @@ import net.pms.formats.image.PNG;
 import net.pms.image.ImageFormat;
 import net.pms.io.OutputParams;
 import net.pms.network.HTTPResource;
-import net.pms.remote.RemoteUtil;
+import net.pms.webserver.RemoteUtil;
 import net.pms.util.BasicPlayer;
 import net.pms.util.StringUtil;
 import org.apache.commons.configuration.ConfigurationException;

--- a/src/main/java/net/pms/network/UPNPHelper.java
+++ b/src/main/java/net/pms/network/UPNPHelper.java
@@ -95,7 +95,7 @@ public class UPNPHelper extends UPNPControl {
 	private static final PmsConfiguration CONFIGURATION = PMS.getConfiguration();
 
 	private static final UPNPHelper INSTANCE = new UPNPHelper();
-	private static PlayerControlHandler httpControlHandler;
+	private static boolean httpControlHandled;
 	private static final String UUID = "uuid:";
 
 	private static MulticastSocket multicastSocket;
@@ -121,16 +121,16 @@ public class UPNPHelper extends UPNPControl {
 		getHttpControlHandler();
 	}
 
-	public static PlayerControlHandler getHttpControlHandler() {
+	public static void getHttpControlHandler() {
 		if (
-			httpControlHandler == null &&
-			PMS.get().getWebServer() != null &&
+			!httpControlHandled &&
+			PMS.get().getWebInterface() != null &&
 			!"false".equals(CONFIGURATION.getBumpAddress().toLowerCase())
 		) {
-			httpControlHandler = new PlayerControlHandler(PMS.get().getWebInterface());
+			httpControlHandled = true;
+			PMS.get().getWebInterface().setPlayerControlService();
 			LOGGER.debug("Attached http player control handler to web server");
 		}
-		return httpControlHandler;
 	}
 
 	private static String lastSearch = null;

--- a/src/main/java/net/pms/webserver/HttpServletHelper.java
+++ b/src/main/java/net/pms/webserver/HttpServletHelper.java
@@ -1,0 +1,55 @@
+/*
+ * Universal Media Server, for streaming any media to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+public class HttpServletHelper {
+
+	public static List<Map.Entry<String, String>> getHttpHeaders(HttpServletRequest request) {
+		List<Map.Entry<String, String>> headers = new ArrayList<>();
+		for (Enumeration<String> names = request.getHeaderNames(); names.hasMoreElements();) {
+			String name = (String) names.nextElement();
+			for (Enumeration<String> values = request.getHeaders(name); values.hasMoreElements();) {
+				headers.add(new AbstractMap.SimpleEntry<>(name, (String) values.nextElement()));
+			}
+		}
+		return headers;
+	}
+
+	public static String getCookie(String name, HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					return cookie.getValue();
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/net/pms/webserver/RemoteUtil.java
+++ b/src/main/java/net/pms/webserver/RemoteUtil.java
@@ -337,13 +337,13 @@ public class RemoteUtil {
 		return p.getName();
 	}
 
-	public static String getQueryVars(String query, String var) {
+	public static String getQueryVars(String query, String str) {
 		if (StringUtils.isEmpty(query)) {
 			return null;
 		}
 		for (String p : query.split("&")) {
 			String[] pair = p.split("=");
-			if (pair[0].equalsIgnoreCase(var)) {
+			if (pair[0].equalsIgnoreCase(str)) {
 				if (pair.length > 1 && StringUtils.isNotEmpty(pair[1])) {
 					return pair[1];
 				}

--- a/src/main/java/net/pms/webserver/WebServer.java
+++ b/src/main/java/net/pms/webserver/WebServer.java
@@ -1,0 +1,97 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver;
+
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Map;
+import net.pms.PMS;
+import net.pms.configuration.PmsConfiguration;
+import net.pms.dlna.RootFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class WebServer implements WebServerInterface {
+	private static final Logger LOGGER = LoggerFactory.getLogger(WebServerJetty.class);
+	protected static final PmsConfiguration CONFIGURATION = PMS.getConfiguration();
+	protected static final int DEFAULT_PORT = CONFIGURATION.getWebPort();
+	private WebServerInterface webServer;
+	protected final Map<String, RootFolder> roots;
+	protected final RemoteUtil.ResourceManager resources;
+
+	public WebServer() throws IOException {
+		roots = new HashMap<>();
+		// Add "classpaths" for resolving web resources
+		resources = AccessController.doPrivileged((PrivilegedAction<RemoteUtil.ResourceManager>) () -> new RemoteUtil.ResourceManager(
+				"file:" + CONFIGURATION.getProfileDirectory() + "/web/",
+				"jar:file:" + CONFIGURATION.getProfileDirectory() + "/web.zip!/",
+				"file:" + CONFIGURATION.getWebPath() + "/"
+		));
+	}
+
+	public String getTag(String user) {
+		String tag = PMS.getCredTag("web", user);
+		if (tag == null) {
+			return user;
+		}
+		return tag;
+	}
+
+	public RemoteUtil.ResourceManager getResources() {
+		return resources;
+	}
+
+	@Override
+	public Object getServer() {
+		return webServer.getServer();
+	}
+
+	@Override
+	public int getPort() {
+		return webServer.getPort();
+	}
+
+	@Override
+	public String getAddress() {
+		return webServer.getAddress();
+	}
+
+	@Override
+	public String getUrl() {
+		return webServer.getUrl();
+	}
+
+	@Override
+	public boolean isSecure() {
+		return webServer.isSecure();
+	}
+
+	public static WebServer createServer(int port) throws IOException {
+		if ("jetty".equals(CONFIGURATION.getWebType(""))) {
+			LOGGER.debug("Using jetty as web server");
+			return new WebServerJetty(port);
+		} else {
+			LOGGER.debug("Using httpserver as web server");
+			return new WebServerSun(port);
+		}
+	}
+}

--- a/src/main/java/net/pms/webserver/WebServerInterface.java
+++ b/src/main/java/net/pms/webserver/WebServerInterface.java
@@ -1,0 +1,29 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver;
+
+public interface WebServerInterface {
+	Object getServer();
+	int getPort();
+	String getAddress();
+	String getUrl();
+	boolean isSecure();
+	boolean setPlayerControlService();
+}

--- a/src/main/java/net/pms/webserver/WebServerJetty.java
+++ b/src/main/java/net/pms/webserver/WebServerJetty.java
@@ -1,0 +1,147 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver;
+
+import net.pms.webserver.servlets.*;
+import java.io.File;
+import java.io.IOException;
+import net.pms.PMS;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.StdErrLog;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebServerJetty extends WebServerServlets implements WebServerInterface {
+	private static final Logger LOGGER = LoggerFactory.getLogger(WebServerJetty.class);
+	private Server server;
+	private boolean isSecure;
+
+	public WebServerJetty(int port) throws IOException {
+		if (port <= 0) {
+			port = DEFAULT_PORT;
+		}
+
+		Log.setLog(new StdErrLog());
+		int maxThreads = CONFIGURATION.getWebThreads();
+		QueuedThreadPool threadPool = new QueuedThreadPool(maxThreads);
+		server = new Server(threadPool);
+
+		// Initialize the HTTP(S) server
+		if (CONFIGURATION.getWebHttps()) {
+			HttpConfiguration httpsConfiguration = new HttpConfiguration();
+			httpsConfiguration.addCustomizer(new SecureRequestCustomizer());
+			File keystoreFile = new File("UMS.jks");
+			SslContextFactory sslContextFactory = new SslContextFactory();
+			sslContextFactory.setKeyStorePath(keystoreFile.getAbsolutePath());
+			sslContextFactory.setKeyStorePassword("umsums");
+			sslContextFactory.setKeyManagerPassword("umsums");
+			ServerConnector sslConnector = new ServerConnector(server,
+				new SslConnectionFactory(sslContextFactory, "http/1.1"),
+				new HttpConnectionFactory(httpsConfiguration));
+			sslConnector.setPort(port);
+			server.setConnectors(new Connector[] {sslConnector});
+			isSecure = true;
+		} else {
+			ServerConnector connector = new ServerConnector(server);
+			connector.setPort(port);
+			server.setConnectors(new Connector[] {connector});
+			isSecure = false;
+		}
+
+		ServletHandler servletHandler = new ServletHandler();
+		server.setHandler(servletHandler);
+
+		servletHandler.addServletWithMapping(new ServletHolder("base", new WebServerServlet(this)), "/*");
+		servletHandler.addServletWithMapping(new ServletHolder("browse", new BrowseServlet(this)), "/browse/*");
+		servletHandler.addServletWithMapping(new ServletHolder("doc", new DocServlet(this)), "/doc/*");
+		servletHandler.addServletWithMapping(new ServletHolder("files", new RemoteFileServlet(this)), "/files/*");
+		servletHandler.addServletWithMapping(new ServletHolder("fmedia", new MediaServlet(this, true)), "/fmedia/*");
+		servletHandler.addServletWithMapping(new ServletHolder("m3u8", new M3u8Servlet(this)), "/m3u8/*");
+		servletHandler.addServletWithMapping(new ServletHolder("media", new MediaServlet(this)), "/media/*");
+		servletHandler.addServletWithMapping(new ServletHolder("play", new PlayServlet(this)), "/play/*");
+		servletHandler.addServletWithMapping(new ServletHolder("playerstatus", new PlayersStatusServlet(this)), "/playerstatus/*");
+		servletHandler.addServletWithMapping(new ServletHolder("playlist", new PlayListServlet(this)), "/playlist/*");
+		servletHandler.addServletWithMapping(new ServletHolder("poll", new PoolServlet(this)), "/poll/*");
+		servletHandler.addServletWithMapping(new ServletHolder("raw", new RawServlet(this)), "/raw/*");
+		servletHandler.addServletWithMapping(new ServletHolder("thumb", new ThumbServlet(this)), "/thumb/*");
+
+		if (server != null) {
+			try {
+				LOGGER.info("Starting jetty web server {}", Server.getVersion());
+				server.start();
+				LOGGER.info("Web server started");
+				//server.join();
+			} catch (Exception ex) {
+			}
+		}
+	}
+
+	@Override
+	public boolean isSecure() {
+		return isSecure;
+	}
+
+	@Override
+	public Server getServer() {
+		return server;
+	}
+
+	@Override
+	public int getPort() {
+		return server.getURI().getPort();
+	}
+
+	@Override
+	public String getAddress() {
+		return PMS.get().getServer().getHost() + ":" + getPort();
+	}
+
+	@Override
+	public String getUrl() {
+		if (server != null) {
+			return (isSecure ? "https://" : "http://") + getAddress();
+		}
+		return null;
+	}
+
+	@Override
+	public boolean setPlayerControlService() {
+		if (server != null) {
+			Handler handler = server.getHandler();
+			if (handler instanceof ServletHandler) {
+				((ServletHandler) handler).addServletWithMapping(new ServletHolder("bump", new PlayerControlServlet(this)), "/bump/*");
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/net/pms/webserver/WebServerServlets.java
+++ b/src/main/java/net/pms/webserver/WebServerServlets.java
@@ -1,0 +1,108 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.UUID;
+import java.net.UnknownHostException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.PMS;
+import net.pms.configuration.RendererConfiguration;
+import net.pms.configuration.WebRender;
+import net.pms.dlna.RootFolder;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class WebServerServlets extends WebServer {
+	private static final Logger LOGGER = LoggerFactory.getLogger(WebServerServlets.class);
+
+	public WebServerServlets() throws IOException {
+	}
+
+	public RootFolder getRoot(HttpServletRequest request, HttpServletResponse response) throws InterruptedException {
+		String user = RemoteUtil.userName(request);
+		return getRoot(user, false, request, response);
+	}
+
+	public RootFolder getRoot(String user, HttpServletRequest request, HttpServletResponse response) throws InterruptedException {
+		return getRoot(user, false, request, response);
+	}
+
+	public RootFolder getRoot(String user, boolean create, HttpServletRequest request, HttpServletResponse response) throws InterruptedException {
+		String cookie = HttpServletHelper.getCookie("UMS", request);
+		RootFolder root;
+		synchronized (roots) {
+			root = roots.get(cookie);
+			if (root == null) {
+				// Double-check for cookie errors
+				WebRender valid = RemoteUtil.matchRenderer(user, request);
+				if (valid != null) {
+					// A browser of the same type and user is already connected
+					// at
+					// this ip but for some reason we didn't get a cookie match.
+					RootFolder validRoot = valid.getRootFolder();
+					// Do a reverse lookup to see if it's been registered
+					for (Map.Entry<String, RootFolder> entry : roots.entrySet()) {
+						if (entry.getValue() == validRoot) {
+							// Found
+							root = validRoot;
+							cookie = entry.getKey();
+							LOGGER.debug("Allowing browser connection without cookie match: {}: {}", valid.getRendererName(),
+								request.getRemoteAddr());
+							break;
+						}
+					}
+				}
+			}
+
+			if (!create || (root != null)) {
+				response.addHeader("Set-Cookie", "UMS=" + cookie + ";Path=/;SameSite=Strict");
+				return root;
+			}
+
+			root = new RootFolder();
+			try {
+				WebRender render = new WebRender(user);
+				root.setDefaultRenderer(render);
+				render.setRootFolder(root);
+				render.associateIP(InetAddress.getByName(request.getRemoteAddr()));
+				render.associatePort(request.getRemotePort());
+				if (CONFIGURATION.useWebSubLang()) {
+					render.setSubLang(StringUtils.join(RemoteUtil.getLangs(request), ","));
+				}
+				render.setBrowserInfo(HttpServletHelper.getCookie("UMSINFO", request), request.getHeader("User-agent"));
+				PMS.get().setRendererFound(render);
+			} catch (ConfigurationException | UnknownHostException e) {
+				root.setDefaultRenderer(RendererConfiguration.getDefaultConf());
+			}
+
+			root.discoverChildren();
+			cookie = UUID.randomUUID().toString();
+			response.addHeader("Set-Cookie", "UMS=" + cookie + ";Path=/;SameSite=Strict");
+			roots.put(cookie, root);
+		}
+		return root;
+	}
+}

--- a/src/main/java/net/pms/webserver/handlers/RemoteBrowseHandler.java
+++ b/src/main/java/net/pms/webserver/handlers/RemoteBrowseHandler.java
@@ -1,0 +1,550 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.handlers;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import net.pms.Messages;
+import net.pms.PMS;
+import net.pms.configuration.PmsConfiguration;
+import net.pms.configuration.RendererConfiguration;
+import net.pms.dlna.CodeEnter;
+import net.pms.dlna.DLNAResource;
+import net.pms.dlna.Playlist;
+import net.pms.dlna.RootFolder;
+import net.pms.dlna.virtual.MediaLibraryFolder;
+import net.pms.dlna.virtual.VirtualVideoAction;
+import net.pms.util.PropertiesUtil;
+import net.pms.util.UMSUtils;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerSun;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("restriction")
+public class RemoteBrowseHandler implements HttpHandler {
+	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteBrowseHandler.class);
+	private final WebServerSun parent;
+	private final static PmsConfiguration CONFIGURATION = PMS.getConfiguration();
+
+	public RemoteBrowseHandler(WebServerSun parent) {
+		this.parent = parent;
+	}
+
+	private final HashMap<String, Object> mustacheVars = new HashMap<>();
+
+	/**
+	 * @param resource
+	 * @param idForWeb
+	 * @param name
+	 * @param thumb
+	 * @param t
+	 * @param isFolder
+	 * @return a set of HTML strings to display a clickable thumbnail
+	 */
+	private HashMap<String, String> getMediaHTML(DLNAResource resource, String idForWeb, String name, String thumb, HttpExchange t) {
+		boolean upnpAllowed = RemoteUtil.bumpAllowed(t);
+		boolean upnpControl = RendererConfiguration.hasConnectedControlPlayers();
+		String pageTypeUri = "/play/";
+		if (resource.isFolder()) {
+			pageTypeUri = "/browse/";
+		}
+
+		StringBuilder bumpHTML = new StringBuilder();
+		HashMap<String, String> item = new HashMap<>();
+		if (!resource.isFolder() && upnpAllowed) {
+			if (upnpControl) {
+				bumpHTML.append("<a class=\"bumpIcon\" href=\"javascript:bump.start('//")
+					.append(parent.getAddress()).append("','/play/").append(idForWeb).append("','")
+					.append(name.replace("'", "\\'")).append("')\" title=\"")
+					.append(RemoteUtil.getMsgString("Web.1", t)).append("\"></a>");
+			} else {
+				bumpHTML.append("<a class=\"bumpIcon icondisabled\" href=\"javascript:notify('warn','")
+					.append(RemoteUtil.getMsgString("Web.2", t))
+					.append("')\" title=\"").append(RemoteUtil.getMsgString("Web.3", t)).append("\"></a>");
+			}
+
+			if (resource.getParent() instanceof Playlist) {
+				bumpHTML.append("\n<a class=\"playlist_del\" href=\"#\" onclick=\"umsAjax('/playlist/del/")
+					.append(idForWeb).append("', true);return false;\" title=\"")
+					.append(RemoteUtil.getMsgString("Web.4", t)).append("\"></a>");
+			} else {
+				bumpHTML.append("\n<a class=\"playlist_add\" href=\"#\" onclick=\"umsAjax('/playlist/add/")
+					.append(idForWeb).append("', false);return false;\" title=\"")
+					.append(RemoteUtil.getMsgString("Web.5", t)).append("\"></a>");
+			}
+		} else {
+			// ensure that we got a string
+			bumpHTML.append("");
+		}
+
+		bumpHTML.append("\n<a class=\"download\" href=\"/m3u8/").append(idForWeb).append(".m3u8\" title=\"")
+			.append(RemoteUtil.getMsgString("Web.DownloadAsPlaylist", t)).append("\"></a>");
+
+		item.put("actions", bumpHTML.toString());
+
+		if (
+			resource.isFolder() ||
+			resource.isResume() ||
+			resource instanceof VirtualVideoAction ||
+			(
+				resource.getFormat() != null &&
+				(
+					resource.getFormat().isVideo() ||
+					resource.getFormat().isAudio() ||
+					resource.getFormat().isImage()
+				)
+			)
+		) {
+			StringBuilder thumbHTML = new StringBuilder();
+			thumbHTML.append("<a href=\"").append(pageTypeUri).append(idForWeb)
+				.append("\" title=\"").append(name).append("\">")
+				.append("<img class=\"thumb\" loading=\"lazy\" src=\"").append(thumb).append("\" alt=\"").append(name).append("\">")
+				.append("</a>");
+			item.put("thumb", thumbHTML.toString());
+
+			StringBuilder captionHTML = new StringBuilder();
+			captionHTML.append("<a href=\"").append(pageTypeUri).append(idForWeb)
+				.append("\" title=\"").append(name).append("\">")
+				.append("<span class=\"caption\">").append(name).append("</span>")
+				.append("</a>");
+			item.put("caption", captionHTML.toString());
+		}
+
+		return item;
+	}
+
+	private String mkBrowsePage(String id, HttpExchange t) throws IOException, InterruptedException {
+		LOGGER.debug("Make browse page " + id);
+		String user = RemoteUtil.userName(t);
+		RootFolder root = parent.getRoot(user, true, t);
+		DLNAResource rootResource = id.equals("0") ? null : root.getDLNAResource(id, null);
+		String search = RemoteUtil.getQueryVars(t.getRequestURI().getQuery(), "str");
+		String language = RemoteUtil.getFirstSupportedLanguage(t);
+
+		String enterSearchStringText = RemoteUtil.getMsgString("Web.8", language);
+
+		List<DLNAResource> resources = root.getDLNAResources(id, true, 0, 0, root.getDefaultRenderer(), search);
+		if (
+			!resources.isEmpty() &&
+			resources.get(0).getParent() != null &&
+			(resources.get(0).getParent() instanceof CodeEnter)
+		) {
+			// this is a code folder the search string is  entered code
+			CodeEnter ce = (CodeEnter) resources.get(0).getParent();
+			ce.setEnteredCode(search);
+			if (!ce.validCode(ce)) {
+				// invalid code throw error
+				throw new IOException("Auth error");
+			}
+			DLNAResource real = ce.getResource();
+			if (!real.isFolder()) {
+				// no folder   -> redirect
+				Headers hdr = t.getResponseHeaders();
+				hdr.add("Location", "/play/" + real.getId());
+				RemoteUtil.respond(t, "", 302, "text/html");
+				// return null here to avoid multiple responses
+				return null;
+			}
+			// redirect to ourself
+			Headers hdr = t.getResponseHeaders();
+			hdr.add("Location", "/browse/" + real.getResourceId());
+			RemoteUtil.respond(t, "", 302, "text/html");
+			return null;
+		}
+		if (StringUtils.isNotEmpty(search) && !(resources instanceof CodeEnter)) {
+			UMSUtils.filterResourcesByName(resources, search, false, false);
+		}
+
+		boolean hasFile = false;
+
+		ArrayList<String> breadcrumbs = new ArrayList<>();
+		ArrayList<String> folders = new ArrayList<>();
+
+		// Will contain the direct child of Media Library, for shortcuts
+		ArrayList<String> mediaLibraryFolders = new ArrayList<>();
+
+		ArrayList<HashMap<String, String>> media = new ArrayList<>();
+		StringBuilder backLinkHTML = new StringBuilder();
+		Boolean isShowBreadcrumbs = false;
+
+		if (
+			!resources.isEmpty() &&
+			resources.get(0).getParent() != null &&
+			resources.get(0).getParent().isFolder()
+		) {
+			DLNAResource thisResourceFromResources = resources.get(0).getParent();
+			String thisName = thisResourceFromResources.getDisplayName();
+			if (thisName.equals(Messages.getString("PMS.MediaLibrary"))) {
+				for (DLNAResource resource : resources) {
+					String newId = resource.getResourceId();
+					String idForWeb = URLEncoder.encode(newId, "UTF-8");
+					StringBuilder thumbHTML = new StringBuilder();
+					String name = StringEscapeUtils.escapeHtml4(resource.resumeName());
+					HashMap<String, String> item = new HashMap<>();
+					String faIcon;
+					switch (name) {
+						case "Video":
+							faIcon = "fa-video";
+							break;
+						case "Audio":
+							faIcon = "fa-music";
+							break;
+						case "Photo":
+							faIcon = "fa-images";
+							break;
+						default:
+							faIcon = "fa-folder";
+						}
+					thumbHTML.append("<a href=\"/browse/").append(idForWeb);
+					thumbHTML.append("\" title=\"").append(name).append("\">");
+					thumbHTML.append("<i class=\"fas ").append(faIcon).append(" fa-5x\"></i>");
+					thumbHTML.append("</a>");
+					item.put("thumb", thumbHTML.toString());
+
+					StringBuilder captionHTML = new StringBuilder();
+					captionHTML.append("<a href=\"/browse/").append(idForWeb);
+					captionHTML.append("\" title=\"").append(name).append("\">");
+					captionHTML.append("<span class=\"caption\">").append(name).append("</span>");
+					captionHTML.append("</a>");
+
+					item.put("caption", captionHTML.toString());
+					item.put("actions", "<span class=\"floatRight\"></span>");
+					media.add(item);
+					hasFile = true;
+				}
+			}
+			breadcrumbs.add("<li class=\"active\">" + thisName + "</li>");
+			while (thisResourceFromResources.getParent() != null && thisResourceFromResources.getParent().isFolder()) {
+				thisResourceFromResources = thisResourceFromResources.getParent();
+				String ancestorName = thisResourceFromResources.getDisplayName().equals("root") ? Messages.getString("Web.Home") : thisResourceFromResources.getDisplayName();
+				String ancestorID = thisResourceFromResources.getResourceId();
+				String ancestorIDForWeb = URLEncoder.encode(ancestorID, "UTF-8");
+				String ancestorUri = "/browse/" + ancestorIDForWeb;
+				breadcrumbs.add(0, "<li><a href=\"" + ancestorUri + "\">" + ancestorName + "</a></li>");
+				isShowBreadcrumbs = true;
+			}
+
+			if (resources.get(0).getParent().getParent() != null) {
+				DLNAResource parentFromResources = resources.get(0).getParent().getParent();
+				String parentID = parentFromResources.getResourceId();
+				String parentIDForWeb = URLEncoder.encode(parentID, "UTF-8");
+				String backUri = "/browse/" + parentIDForWeb;
+				backLinkHTML.append("<a href=\"").append(backUri).append("\" title=\"").append(RemoteUtil.getMsgString("Web.10", t)).append("\">");
+				backLinkHTML.append("<span><i class=\"fa fa-angle-left\"></i> ").append(RemoteUtil.getMsgString("Web.10", t)).append("</span>");
+				backLinkHTML.append("</a>");
+				folders.add(backLinkHTML.toString());
+			} else {
+				folders.add("");
+			}
+		}
+		mustacheVars.put("isShowBreadcrumbs", isShowBreadcrumbs);
+		mustacheVars.put("breadcrumbs", breadcrumbs);
+		mustacheVars.put("javascriptVarsScript", "");
+		mustacheVars.put("recentlyPlayed", "");
+		mustacheVars.put("recentlyPlayedLink", "");
+		mustacheVars.put("hasRecentlyPlayed", false);
+		mustacheVars.put("inProgress", "");
+		mustacheVars.put("inProgressLink", "");
+		mustacheVars.put("isTVSeriesWithAPIData", false);
+		mustacheVars.put("hasInProgress", false);
+		mustacheVars.put("recentlyAdded", "");
+		mustacheVars.put("recentlyAddedLink", "");
+		mustacheVars.put("hasRecentlyAdded", false);
+		mustacheVars.put("mostPlayed", "");
+		mustacheVars.put("mostPlayedLink", "");
+		mustacheVars.put("hasMostPlayed", false);
+		mustacheVars.put("mediaLibraryFolders", "");
+		mustacheVars.put("isFrontPage", false);
+
+		// Generate innerHtml snippets for folders and media items
+		for (DLNAResource resource : resources) {
+			String newId = resource.getResourceId();
+			String idForWeb = URLEncoder.encode(newId, "UTF-8");
+			String thumbnailUri = "/thumb/" + idForWeb;
+			String name = StringEscapeUtils.escapeHtml4(resource.resumeName());
+
+			if (resource instanceof VirtualVideoAction) {
+				// Let's take the VVA real early
+				StringBuilder thumbHTML = new StringBuilder();
+				HashMap<String, String> item = new HashMap<>();
+				thumbHTML.append("<a href=\"#\" onclick=\"umsAjax('/play/").append(idForWeb)
+						.append("', true);return false;\" title=\"").append(name).append("\">")
+						.append("<img class=\"thumb\" loading=\"lazy\" src=\"").append(thumbnailUri).append("\" alt=\"").append(name).append("\">")
+						.append("</a>");
+				item.put("thumb", thumbHTML.toString());
+
+				StringBuilder captionHTML = new StringBuilder();
+				captionHTML.append("<a href=\"#\" onclick=\"umsAjax('/play/").append(idForWeb)
+						.append("', true);return false;\" title=\"").append(name).append("\">")
+						.append("<span class=\"caption\">").append(name).append("</span>")
+						.append("</a>");
+				item.put("caption", captionHTML.toString());
+				item.put("actions", "<span class=\"floatRight\"></span>");
+				media.add(item);
+				hasFile = true;
+				continue;
+			}
+
+			if (resource.isFolder()) {
+				Boolean isDisplayFoldersAsThumbnails = false;
+				/*
+				 * Display folders as thumbnails instead of down the left side if:
+				 * - The parent is TV Shows, or
+				 * - This is a filtered metadata folder within TV shows, or
+				 * - This is Recommendations
+				 */
+				if (
+					resource.getParent().getDisplayName().equals(Messages.getString("VirtualFolder.4")) ||
+					resource.getParent().getDisplayName().equals(Messages.getString("MediaLibrary.Recommendations")) ||
+					(
+						resource.getParent().getParent() != null &&
+						resource.getParent().getParent().getDisplayName().equals(Messages.getString("VirtualFolder.FilterByProgress"))
+					) ||
+					(
+						resource.getParent().getParent() != null &&
+						resource.getParent().getParent().getParent() != null &&
+						resource.getParent().getParent().getParent().getDisplayName().equals(Messages.getString("VirtualFolder.FilterByInformation"))
+					)
+				) {
+					isDisplayFoldersAsThumbnails = true;
+				}
+
+				if (!isDisplayFoldersAsThumbnails || !(isDisplayFoldersAsThumbnails && (resource instanceof MediaLibraryFolder))) {
+					boolean addFolderToFoldersListOnLeft = true;
+
+					// Populate the front page
+					if (id.equals("0") && resource.getName().equals(Messages.getString("PMS.MediaLibrary"))) {
+						mustacheVars.put("isFrontPage", true);
+
+						List<DLNAResource> videoSearchResults = root.getDLNAResources(resource.getId(), true, 0, 0, root.getDefaultRenderer(), Messages.getString("PMS.34"));
+						UMSUtils.filterResourcesByName(videoSearchResults, Messages.getString("PMS.34"), true, true);
+						DLNAResource videoFolder = videoSearchResults.get(0);
+
+						List<DLNAResource> audioSearchResults = root.getDLNAResources(resource.getId(), true, 0, 0, root.getDefaultRenderer(), Messages.getString("PMS.1"));
+						UMSUtils.filterResourcesByName(audioSearchResults, Messages.getString("PMS.1"), true, true);
+						DLNAResource audioFolder = audioSearchResults.get(0);
+
+						List<DLNAResource> imageSearchResults = root.getDLNAResources(resource.getId(), true, 0, 0, root.getDefaultRenderer(), Messages.getString("PMS.31"));
+						UMSUtils.filterResourcesByName(imageSearchResults, Messages.getString("PMS.31"), true, true);
+						DLNAResource imagesFolder = imageSearchResults.get(0);
+
+						mediaLibraryFolders.add(addMediaLibraryChildToMustacheVars(videoFolder, enterSearchStringText));
+						mediaLibraryFolders.add(addMediaLibraryChildToMustacheVars(audioFolder, enterSearchStringText));
+						mediaLibraryFolders.add(addMediaLibraryChildToMustacheVars(imagesFolder, enterSearchStringText));
+
+						addMediaLibraryFolderToFrontPage(videoFolder, root, "MediaLibrary.RecentlyAdded", "Web.RecentlyAddedVideos", "hasRecentlyAdded", "recentlyAdded", t);
+						addMediaLibraryFolderToFrontPage(videoFolder, root, "VirtualFolder.1", "Web.RecentlyPlayedVideos", "hasRecentlyPlayed", "recentlyPlayed", t);
+						addMediaLibraryFolderToFrontPage(videoFolder, root, "MediaLibrary.InProgress", "Web.InProgressVideos", "hasInProgress", "inProgress", t);
+						addMediaLibraryFolderToFrontPage(videoFolder, root, "MediaLibrary.MostPlayed", "Web.MostPlayedVideos", "hasMostPlayed", "mostPlayed", t);
+
+						addFolderToFoldersListOnLeft = false;
+					}
+
+					if (addFolderToFoldersListOnLeft) {
+						StringBuilder folderHTML = new StringBuilder();
+						// The resource is a folder
+						String resourceUri = "/browse/" + idForWeb;
+						boolean code = (resource instanceof CodeEnter);
+						if (code) {
+							enterSearchStringText = RemoteUtil.getMsgString("Web.9", t);
+						}
+						if (resource.getClass().getName().contains("SearchFolder") || code) {
+							// search folder add a prompt
+							// NOTE!!!
+							// Yes doing getClass.getname is REALLY BAD, but this
+							// is to make legacy plugins utilize this function as well
+							folderHTML.append("<a href=\"javascript:void(0);\" onclick=\"searchFun('").append(resourceUri).append("','")
+							.append(enterSearchStringText).append("');\" title=\"").append(name).append("\">");
+						} else {
+							folderHTML.append("<a href=\"").append(resourceUri).append("\" oncontextmenu=\"searchFun('").append(resourceUri)
+							.append("','").append(enterSearchStringText).append("');\" title=\"").append(name).append("\">");
+						}
+						folderHTML.append("<div class=\"folder-thumbnail\" style=\"background-image:url(").append(thumbnailUri).append(")\"></div>");
+						folderHTML.append("<span>").append(name).append("</span>");
+						folderHTML.append("</a>");
+						folders.add(folderHTML.toString());
+					}
+				}
+			} else {
+				// The resource is a media file
+				media.add(getMediaHTML(resource, idForWeb, name, thumbnailUri, t));
+				hasFile = true;
+			}
+		}
+
+		if (rootResource != null && rootResource instanceof MediaLibraryFolder) {
+			MediaLibraryFolder folder = (MediaLibraryFolder) rootResource;
+			if (
+				folder.isTVSeries() &&
+				CONFIGURATION.getUseCache()
+			) {
+				String apiMetadataAsJavaScriptVars = RemoteUtil.getAPIMetadataAsJavaScriptVars(rootResource, language, true, root);
+				if (apiMetadataAsJavaScriptVars != null) {
+					mustacheVars.put("isTVSeriesWithAPIData", true);
+					mustacheVars.put("javascriptVarsScript", apiMetadataAsJavaScriptVars);
+				}
+			}
+
+			// Check whether this resource is expected to contain folders that display as big thumbnails
+			if (
+				folder.getDisplayName().equals(Messages.getString("VirtualFolder.4")) ||
+				folder.getDisplayName().equals(Messages.getString("MediaLibrary.Recommendations")) ||
+				(
+					folder.getParent() != null &&
+					folder.getParent().getDisplayName().equals(Messages.getString("VirtualFolder.FilterByProgress"))
+				) ||
+				(
+					folder.getParent() != null &&
+					folder.getParent().getParent() != null &&
+					folder.getParent().getParent().getDisplayName().equals(Messages.getString("VirtualFolder.FilterByInformation"))
+				)
+			) {
+				for (DLNAResource resource : resources) {
+					if (resource instanceof MediaLibraryFolder) {
+						String newId = resource.getResourceId();
+						String idForWeb = URLEncoder.encode(newId, "UTF-8");
+						String thumb = "/thumb/" + idForWeb;
+						String name = StringEscapeUtils.escapeHtml4(resource.resumeName());
+
+						media.add(getMediaHTML(resource, idForWeb, name, thumb, t));
+						hasFile = true;
+					}
+				}
+			}
+		}
+
+		if (CONFIGURATION.useWebControl()) {
+			mustacheVars.put("push", true);
+		}
+		if (hasFile) {
+			mustacheVars.put("folderId", id);
+			mustacheVars.put("downloadFolderTooltip", RemoteUtil.getMsgString("Web.DownloadFolderAsPlaylist", t));
+		}
+
+		mustacheVars.put("name", id.equals("0") ? CONFIGURATION.getServerDisplayName() : StringEscapeUtils.escapeHtml4(root.getDLNAResource(id, null).getDisplayName()));
+		mustacheVars.put("hasFile", hasFile);
+		mustacheVars.put("folders", folders);
+		mustacheVars.put("mediaLibraryFolders", mediaLibraryFolders);
+		mustacheVars.put("media", media);
+		mustacheVars.put("umsversion", PropertiesUtil.getProjectProperties().get("project.version"));
+
+		return parent.getResources().getTemplate("browse.html").execute(mustacheVars);
+	}
+
+	@Override
+	public void handle(HttpExchange t) throws IOException {
+		try {
+			if (RemoteUtil.deny(t)) {
+				throw new IOException("Access denied");
+			}
+			String id = RemoteUtil.getId("browse/", t);
+			LOGGER.debug("Got a browse request found id " + id);
+			String response = mkBrowsePage(id, t);
+			LOGGER.trace("Browse page:\n{}", response);
+			RemoteUtil.respond(t, response, 200, "text/html");
+		} catch (IOException e) {
+			throw e;
+		} catch (Exception e) {
+			// Nothing should get here, this is just to avoid crashing the thread
+			LOGGER.error("Unexpected error in RemoteBrowseHandler.handle(): {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+
+	private void addMediaLibraryFolderToFrontPage(
+		DLNAResource videoFolder,
+		RootFolder root,
+		String folderNameKey,
+		String headingKey,
+		String hasFolderVarName,
+		String childrenVarName,
+		HttpExchange t
+	) throws IOException {
+		int i = 0;
+		List<DLNAResource> videoFolderChildren = videoFolder.getDLNAResources(videoFolder.getId(), true, 0, 0, root.getDefaultRenderer(), Messages.getString(folderNameKey));
+		UMSUtils.filterResourcesByName(videoFolderChildren, Messages.getString(folderNameKey), true, true);
+		if (videoFolderChildren.isEmpty()) {
+			LOGGER.trace("The videoFolderChildren folder was empty after filtering for " + Messages.getString(folderNameKey));
+			return;
+		}
+		DLNAResource recentlyPlayedFolder = videoFolderChildren.get(0);
+
+		ArrayList<HashMap<String, String>> recentlyPlayedVideosHTML = new ArrayList<>();
+		List<DLNAResource> recentlyPlayedVideos = root.getDLNAResources(recentlyPlayedFolder.getId(), true, 0, 6, root.getDefaultRenderer());
+
+		for (DLNAResource recentlyPlayedResource : recentlyPlayedVideos) {
+			String recentlyPlayedId = recentlyPlayedResource.getResourceId();
+			String recentlyPlayedIdForWeb = URLEncoder.encode(recentlyPlayedId, "UTF-8");
+			String recentlyPlayedThumb = "/thumb/" + recentlyPlayedIdForWeb;
+			String recentlyPlayedName = StringEscapeUtils.escapeHtml4(recentlyPlayedResource.resumeName());
+
+			// Skip the #--TRANSCODE--# entry
+			if (recentlyPlayedName.equals(Messages.getString("TranscodeVirtualFolder.0"))) {
+				continue;
+			}
+
+			recentlyPlayedVideosHTML.add(getMediaHTML(recentlyPlayedResource, recentlyPlayedIdForWeb, recentlyPlayedName, recentlyPlayedThumb, t));
+			i++;
+
+			if (i == 1) {
+				mustacheVars.put(hasFolderVarName, true);
+				StringBuilder recentlyPlayedLink = new StringBuilder();
+				String recentlyPlayedFolderId = recentlyPlayedFolder.getResourceId();
+				String recentlyPlayedFolderidForWeb = URLEncoder.encode(recentlyPlayedFolderId, "UTF-8");
+				recentlyPlayedLink.append("<a href=\"/browse/").append(recentlyPlayedFolderidForWeb).append("\">");
+				recentlyPlayedLink.append(Messages.getString(headingKey)).append(":");
+				recentlyPlayedLink.append("</a>");
+
+				String linkVarName = childrenVarName + "Link";
+				mustacheVars.put(linkVarName, recentlyPlayedLink.toString());
+			}
+		}
+		mustacheVars.put(childrenVarName, recentlyPlayedVideosHTML);
+	}
+
+	private String addMediaLibraryChildToMustacheVars(
+		DLNAResource childFolder,
+		String enterSearchStringText
+	) throws UnsupportedEncodingException {
+		String mediaLibraryChildId = childFolder.getResourceId();
+		String mediaLibraryChildIdForWeb = URLEncoder.encode(mediaLibraryChildId, "UTF-8");
+		String mediaLibraryChildUri = "/browse/" + mediaLibraryChildIdForWeb;
+		String mediaLibraryChildThumbUri = "/thumb/" + mediaLibraryChildIdForWeb;
+		String mediaLibraryChildname = StringEscapeUtils.escapeHtml4(childFolder.resumeName());
+		StringBuilder mediaLibraryFolderHTML = new StringBuilder();
+		mediaLibraryFolderHTML
+				.append("<a href=\"").append(mediaLibraryChildUri).append("\" oncontextmenu=\"searchFun('").append(mediaLibraryChildUri)
+				.append("','").append(enterSearchStringText).append("');\">")
+					.append("<div class=\"folder-thumbnail\" style=\"background-image:url(").append(mediaLibraryChildThumbUri).append(")\"></div>")
+					.append("<span>").append(mediaLibraryChildname).append("</span>")
+				.append("</a>");
+		return mediaLibraryFolderHTML.toString();
+	}
+}

--- a/src/main/java/net/pms/webserver/handlers/RemoteMediaHandler.java
+++ b/src/main/java/net/pms/webserver/handlers/RemoteMediaHandler.java
@@ -1,4 +1,23 @@
-package net.pms.remote;
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.handlers;
 
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
@@ -15,27 +34,29 @@ import net.pms.encoders.FFmpegWebVideo;
 import net.pms.encoders.PlayerFactory;
 import net.pms.encoders.StandardPlayerId;
 import net.pms.util.FileUtil;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerSun;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("restriction")
 public class RemoteMediaHandler implements HttpHandler {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteMediaHandler.class);
-	private RemoteWeb parent;
+	private WebServerSun parent;
 	private String path;
 	private RendererConfiguration renderer;
 	private boolean flash;
 
-	public RemoteMediaHandler(RemoteWeb parent) {
+	public RemoteMediaHandler(WebServerSun parent) {
 		this(parent, "media/", null);
 	}
 
-	public RemoteMediaHandler(RemoteWeb parent, boolean flash) {
+	public RemoteMediaHandler(WebServerSun parent, boolean flash) {
 		this(parent, "fmedia/", null);
 		this.flash = flash;
 	}
 
-	public RemoteMediaHandler(RemoteWeb parent, String path, RendererConfiguration renderer) {
+	public RemoteMediaHandler(WebServerSun parent, String path, RendererConfiguration renderer) {
 		this.flash = false;
 		this.parent = parent;
 		this.path = path;

--- a/src/main/java/net/pms/webserver/handlers/RemotePlayHandler.java
+++ b/src/main/java/net/pms/webserver/handlers/RemotePlayHandler.java
@@ -1,0 +1,421 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.handlers;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import java.io.File;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import net.pms.Messages;
+import net.pms.PMS;
+import net.pms.configuration.FormatConfiguration;
+import net.pms.configuration.PmsConfiguration;
+import net.pms.configuration.RendererConfiguration;
+import net.pms.configuration.WebRender;
+import net.pms.dlna.DLNAResource;
+import net.pms.dlna.FileTranscodeVirtualFolder;
+import net.pms.dlna.Playlist;
+import net.pms.dlna.RootFolder;
+import net.pms.dlna.virtual.VirtualVideoAction;
+import net.pms.encoders.Player;
+import net.pms.external.ExternalFactory;
+import net.pms.external.URLResolver.URLResult;
+import net.pms.formats.Format;
+import net.pms.formats.v2.SubtitleType;
+import net.pms.io.OutputParams;
+import net.pms.network.HTTPResource;
+import net.pms.util.FileUtil;
+import net.pms.util.SubtitleUtils;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerSun;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("restriction")
+public class RemotePlayHandler implements HttpHandler {
+	private static final Logger LOGGER = LoggerFactory.getLogger(RemotePlayHandler.class);
+	private WebServerSun parent;
+	private static final PmsConfiguration CONFIGURATION = PMS.getConfiguration();
+
+	public RemotePlayHandler(WebServerSun parent) {
+		this.parent = parent;
+	}
+
+	private static String returnPage() {
+		// special page to return
+		return "<html><head><script>window.refresh=true;history.back()</script></head></html>";
+	}
+
+	private static void addNextByType(DLNAResource d, HashMap<String, Object> vars) {
+		List<DLNAResource> children = d.getParent().getChildren();
+		boolean looping = CONFIGURATION.getWebAutoLoop(d.getFormat());
+		int type = d.getType();
+		int size = children.size();
+		int mod = looping ? size : 9999;
+		int self = children.indexOf(d);
+		for (int step = -1; step < 2; step += 2) {
+			int i = self;
+			int offset = (step < 0 && looping) ? size : 0;
+			DLNAResource next = null;
+			while (true) {
+				i = (offset + i + step) % mod;
+				if (i >= size || i < 0 || i == self) {
+					break; // Not found
+				}
+				next = children.get(i);
+				if (next.getType() == type && !next.isFolder()) {
+					break; // Found
+				}
+				next = null;
+			}
+			String pos = step > 0 ? "next" : "prev";
+			vars.put(pos + "Id", next != null ? next.getResourceId() : null);
+			vars.put(pos + "Attr", next != null ? (" title=\"" + StringEscapeUtils.escapeHtml(next.resumeName()) + "\"") : " disabled");
+		}
+	}
+
+	private String mkPage(String id, HttpExchange t) throws IOException, InterruptedException {
+		HashMap<String, Object> mustacheVars = new HashMap<>();
+		mustacheVars.put("serverName", CONFIGURATION.getServerDisplayName());
+
+		LOGGER.debug("Make play page " + id);
+		String language = RemoteUtil.getFirstSupportedLanguage(t);
+		RootFolder root = parent.getRoot(RemoteUtil.userName(t), t);
+		if (root == null) {
+			LOGGER.debug("root not found");
+			throw new IOException("Unknown root");
+		}
+		WebRender renderer = (WebRender) root.getDefaultRenderer();
+		renderer.setBrowserInfo(RemoteUtil.getCookie("UMSINFO", t), t.getRequestHeaders().getFirst("User-agent"));
+		//List<DLNAResource> res = root.getDLNAResources(id, false, 0, 0, renderer);
+		DLNAResource rootResource = root.getDLNAResource(id, renderer);
+		if (rootResource == null) {
+			LOGGER.debug("Bad web play id: " + id);
+			throw new IOException("Bad Id");
+		}
+		if (!rootResource.isCodeValid(rootResource)) {
+			LOGGER.debug("coded object with invalid code");
+			throw new IOException("Bad code");
+		}
+		if (rootResource instanceof VirtualVideoAction) {
+			// for VVA we just call the enable fun directly
+			// waste of resource to play dummy video
+			if (((VirtualVideoAction) rootResource).enable()) {
+				renderer.notify(renderer.INFO, rootResource.getName() + " enabled");
+			} else {
+				renderer.notify(renderer.INFO, rootResource.getName() + " disabled");
+			}
+			return returnPage();
+		}
+
+		String name = StringEscapeUtils.escapeHtml(rootResource.resumeName());
+		String id1 = URLEncoder.encode(id, "UTF-8");
+		mustacheVars.put("poster", "/thumb/" + id1);
+		ArrayList<String> folders = new ArrayList<>();
+		ArrayList<String> breadcrumbs = new ArrayList<>();
+		StringBuilder backLinkHTML = new StringBuilder();
+		Boolean isShowBreadcrumbs = false;
+
+		if (
+			rootResource.getParent() != null &&
+			rootResource.getParent().isFolder()
+		) {
+			DLNAResource thisResourceFromResources = rootResource;
+
+			breadcrumbs.add("<li class=\"active\">" + name + "</li>");
+			while (thisResourceFromResources.getParent() != null && thisResourceFromResources.getParent().isFolder()) {
+				thisResourceFromResources = thisResourceFromResources.getParent();
+				String ancestorName = thisResourceFromResources.getDisplayName().equals("root") ? Messages.getString("Web.Home") : thisResourceFromResources.getDisplayName();
+				ancestorName = StringEscapeUtils.escapeHtml(ancestorName);
+				String ancestorID = thisResourceFromResources.getResourceId();
+				String ancestorIDForWeb = URLEncoder.encode(ancestorID, "UTF-8");
+				String ancestorUri = "/browse/" + ancestorIDForWeb;
+				breadcrumbs.add(0, "<li><a href=\"" + ancestorUri + "\">" + ancestorName + "</a></li>");
+				isShowBreadcrumbs = true;
+			}
+
+			DLNAResource parentFromResources = rootResource.getParent();
+			String parentID = parentFromResources.getResourceId();
+			String parentIDForWeb = URLEncoder.encode(parentID, "UTF-8");
+			String backUri = "/browse/" + parentIDForWeb;
+			backLinkHTML.append("<a href=\"").append(backUri).append("\" title=\"").append(RemoteUtil.getMsgString("Web.10", t)).append("\">");
+			backLinkHTML.append("<span><i class=\"fa fa-angle-left\"></i> ").append(RemoteUtil.getMsgString("Web.10", t)).append("</span>");
+			backLinkHTML.append("</a>");
+			folders.add(backLinkHTML.toString());
+		}
+		mustacheVars.put("isShowBreadcrumbs", isShowBreadcrumbs);
+		mustacheVars.put("breadcrumbs", breadcrumbs);
+		mustacheVars.put("folders", folders);
+
+		Format format = rootResource.getFormat();
+		boolean isImage = format.isImage();
+		boolean isVideo = format.isVideo();
+		boolean isAudio = format.isAudio();
+		String query = t.getRequestURI().getQuery();
+		boolean forceFlash = StringUtils.isNotEmpty(RemoteUtil.getQueryVars(query, "flash"));
+		boolean forcehtml5 = StringUtils.isNotEmpty(RemoteUtil.getQueryVars(query, "html5"));
+		boolean flowplayer = isVideo && (forceFlash || (!forcehtml5 && CONFIGURATION.getWebFlash()));
+
+		// hack here to ensure we got a root folder to use for recently played etc.
+		root.getDefaultRenderer().setRootFolder(root);
+		String mime = root.getDefaultRenderer().getMimeType(rootResource);
+		String mediaType = isVideo ? "video" : isAudio ? "audio" : isImage ? "image" : "";
+		String auto = "autoplay";
+		@SuppressWarnings("unused")
+		String coverImage = "";
+
+		mustacheVars.put("isVideoWithAPIData", false);
+		mustacheVars.put("javascriptVarsScript", "");
+		if (isVideo) {
+			if (CONFIGURATION.getUseCache()) {
+				String apiMetadataAsJavaScriptVars = RemoteUtil.getAPIMetadataAsJavaScriptVars(rootResource, language, false, root);
+				if (apiMetadataAsJavaScriptVars != null) {
+					mustacheVars.put("javascriptVarsScript", apiMetadataAsJavaScriptVars);
+					mustacheVars.put("isVideoWithAPIData", true);
+				}
+			}
+
+			if (mime.equals(FormatConfiguration.MIMETYPE_AUTO)) {
+				if (rootResource.getMedia() != null && rootResource.getMedia().getMimeType() != null) {
+					mime = rootResource.getMedia().getMimeType();
+				}
+			}
+			if (!flowplayer) {
+				if (!RemoteUtil.directmime(mime) || RemoteUtil.transMp4(mime, rootResource.getMedia()) || rootResource.isResume()) {
+					WebRender render = (WebRender) rootResource.getDefaultRenderer();
+					mime = render != null ? render.getVideoMimeType() : RemoteUtil.transMime();
+				}
+			}
+		}
+		mustacheVars.put("isVideo", isVideo);
+
+		// Controls whether to use the browser's native audio player
+		mustacheVars.put("isNativeAudio", false);
+		if (
+			isAudio &&
+			// Audio types that are natively supported by all major browsers:
+			mime.equals(HTTPResource.AUDIO_MP3_TYPEMIME)
+		) {
+			mustacheVars.put("isNativeAudio", true);
+		}
+
+		mustacheVars.put("name", name);
+		mustacheVars.put("id1", id1);
+		mustacheVars.put("autoContinue", CONFIGURATION.getWebAutoCont(format));
+		if (CONFIGURATION.isDynamicPls()) {
+			if (rootResource.getParent() instanceof Playlist) {
+				mustacheVars.put("plsOp", "del");
+				mustacheVars.put("plsSign", "-");
+				mustacheVars.put("plsAttr", RemoteUtil.getMsgString("Web.4", t));
+			} else {
+				mustacheVars.put("plsOp", "add");
+				mustacheVars.put("plsSign", "+");
+				mustacheVars.put("plsAttr", RemoteUtil.getMsgString("Web.5", t));
+			}
+		}
+		addNextByType(rootResource, mustacheVars);
+		if (isImage) {
+			// do this like this to simplify the code
+			// skip all player crap since img tag works well
+			int delay = CONFIGURATION.getWebImgSlideDelay() * 1000;
+			if (delay > 0 && CONFIGURATION.getWebAutoCont(format)) {
+				mustacheVars.put("delay", delay);
+			}
+		} else {
+			mustacheVars.put("mediaType", mediaType);
+			mustacheVars.put("auto", auto);
+			mustacheVars.put("mime", mime);
+			if (flowplayer) {
+				if (
+					RemoteUtil.directmime(mime) &&
+					!RemoteUtil.transMp4(mime, rootResource.getMedia()) &&
+					!rootResource.isResume() &&
+					!forceFlash
+				) {
+					mustacheVars.put("src", true);
+				}
+			} else {
+				mustacheVars.put("width", renderer.getVideoWidth());
+				mustacheVars.put("height", renderer.getVideoHeight());
+			}
+		}
+		if (CONFIGURATION.useWebControl()) {
+			mustacheVars.put("push", true);
+		}
+
+		if (isVideo && CONFIGURATION.getWebSubs()) {
+			// only if subs are requested as <track> tags
+			// otherwise we'll transcode them in
+			boolean isFFmpegFontConfig = CONFIGURATION.isFFmpegFontConfig();
+			if (isFFmpegFontConfig) { // do not apply fontconfig to flowplayer subs
+				CONFIGURATION.setFFmpegFontConfig(false);
+			}
+			OutputParams p = new OutputParams(CONFIGURATION);
+			p.setSid(rootResource.getMediaSubtitle());
+			Player.setAudioAndSubs(rootResource, p);
+			if (p.getSid() != null && p.getSid().getType().isText()) {
+				try {
+					File subFile = SubtitleUtils.getSubtitles(rootResource, rootResource.getMedia(), p, CONFIGURATION, SubtitleType.WEBVTT);
+					LOGGER.debug("subFile " + subFile);
+					if (subFile != null) {
+						mustacheVars.put("sub", parent.getResources().add(subFile));
+					}
+				} catch (Exception e) {
+					LOGGER.debug("error when doing sub file " + e);
+				}
+			}
+
+			CONFIGURATION.setFFmpegFontConfig(isFFmpegFontConfig); // return back original fontconfig value
+		}
+
+		return parent.getResources().getTemplate(isImage ? "image.html" : flowplayer ? "flow.html" : "play.html").execute(mustacheVars);
+	}
+
+	private String mkM3u8(DLNAResource dlna) {
+		if (dlna != null) {
+			return makeM3u8(dlna.isFolder() ? dlna.getChildren() : Arrays.asList(new DLNAResource[]{dlna}));
+		}
+		return null;
+	}
+
+	private String makeM3u8(List<DLNAResource> resources) {
+		ArrayList<Map<String, Object>> items = new ArrayList<>();
+		double targetDuration = 1;
+		for (DLNAResource dlna : resources) {
+			if (dlna != null && !dlna.isFolder() && !dlna.isResume() && !(dlna instanceof VirtualVideoAction)) {
+				double duration = dlna.getMedia() != null ? dlna.getMedia().getDurationInSeconds() : -1;
+				if (duration > targetDuration) {
+					targetDuration = duration + 1;
+				}
+				String url = null;
+
+				if (!FileUtil.isUrl(dlna.getSystemName())) {
+					// Get the resource url
+					boolean isTranscodeFolderItem = dlna.isNoName() && (dlna.getParent() instanceof FileTranscodeVirtualFolder);
+					// If the resource is not a transcode folder item, tag its url for forced streaming
+					url = dlna.getURL(isTranscodeFolderItem  ? "" : RendererConfiguration.NOTRANSCODE, true, false);
+
+				} else {
+					// It's a WEB.conf item or plugin-provided url, make sure it's resolved
+					url = dlna.getSystemName();
+					if (!dlna.isURLResolved()) {
+						URLResult r = ExternalFactory.resolveURL(url);
+						if (r != null && StringUtils.isNotEmpty(r.url)) {
+							url = r.url;
+						}
+					}
+				}
+
+				Map<String, Object> item = new HashMap<>();
+				item.put("duration", duration != 0 ? duration : -1);
+				item.put("title", dlna.resumeName());
+				item.put("url", url);
+				items.add(item);
+			}
+		}
+
+		if (!items.isEmpty()) {
+			HashMap<String, Object> vars = new HashMap<>();
+			vars.put("targetDuration", targetDuration != 0 ? targetDuration : -1);
+			vars.put("items", items);
+			return parent.getResources().getTemplate("play.m3u8").execute(vars);
+		}
+		return null;
+	}
+
+	@Override
+	public void handle(HttpExchange t) throws IOException {
+		try {
+			if (RemoteUtil.deny(t)) {
+				throw new IOException("Access denied");
+			}
+			String p = t.getRequestURI().getPath();
+			if (p.contains("/play/")) {
+				LOGGER.debug("got a play request " + t.getRequestURI());
+				String id = RemoteUtil.getId("play/", t);
+				String response = mkPage(id, t);
+				//LOGGER.trace("play page " + response);
+				RemoteUtil.respond(t, response, 200, "text/html");
+			} else if (p.contains("/playerstatus/")) {
+				String json = IOUtils.toString(t.getRequestBody(), StandardCharsets.UTF_8);
+				LOGGER.trace("got player status: " + json);
+				RemoteUtil.respond(t, "", 200, "text/html");
+
+				RootFolder root = parent.getRoot(RemoteUtil.userName(t), t);
+				if (root == null) {
+					LOGGER.debug("root not found");
+					throw new IOException("Unknown root");
+				}
+				WebRender renderer = (WebRender) root.getDefaultRenderer();
+				((WebRender.WebPlayer) renderer.getPlayer()).setData(json);
+			} else if (p.contains("/playlist/")) {
+				String[] tmp = p.split("/");
+				// sanity
+				if (tmp.length < 3) {
+					throw new IOException("Bad request");
+				}
+				String op = tmp[tmp.length - 2];
+				String id = tmp[tmp.length - 1];
+				DLNAResource r = PMS.getGlobalRepo().get(id);
+				if (r != null) {
+					RootFolder root = parent.getRoot(RemoteUtil.userName(t), t);
+					if (root == null) {
+						LOGGER.debug("root not found");
+						throw new IOException("Unknown root");
+					}
+					WebRender renderer = (WebRender) root.getDefaultRenderer();
+					if (op.equals("add")) {
+						PMS.get().getDynamicPls().add(r);
+						renderer.notify(RendererConfiguration.OK, "Added '" + r.getDisplayName() + "' to dynamic playlist");
+					} else if (op.equals("del") && (r.getParent() instanceof Playlist)) {
+						((Playlist) r.getParent()).remove(r);
+						renderer.notify(RendererConfiguration.INFO, "Removed '" + r.getDisplayName() + "' from playlist");
+					}
+				}
+				RemoteUtil.respond(t, returnPage(), 200, "text/html");
+			}  else if (p.contains("/m3u8/")) {
+				String id = StringUtils.substringBefore(StringUtils.substringAfter(p, "/m3u8/"), ".m3u8");
+				String response = mkM3u8(PMS.getGlobalRepo().get(id));
+				if (response != null) {
+					LOGGER.debug("sending m3u8:\n" + response);
+					RemoteUtil.respond(t, response, 200, "application/x-mpegURL");
+				} else {
+					RemoteUtil.respond(t, "<html><body>404 - File Not Found: " + p + "</body></html>", 404, "text/html");
+				}
+			}
+		} catch (IOException e) {
+			throw e;
+		} catch (Exception e) {
+			// Nothing should get here, this is just to avoid crashing the thread
+			LOGGER.error("Unexpected error in RemotePlayHandler.handle(): {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+}

--- a/src/main/java/net/pms/webserver/handlers/RemoteRawHandler.java
+++ b/src/main/java/net/pms/webserver/handlers/RemoteRawHandler.java
@@ -1,0 +1,149 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.handlers;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import net.pms.PMS;
+import net.pms.configuration.WebRender;
+import net.pms.dlna.DLNAResource;
+import net.pms.dlna.Range;
+import net.pms.dlna.RootFolder;
+import net.pms.encoders.ImagePlayer;
+import net.pms.image.Image;
+import net.pms.image.ImageFormat;
+import net.pms.image.ImageInfo;
+import net.pms.image.ImagesUtil.ScaleType;
+import net.pms.io.OutputParams;
+import net.pms.io.ProcessWrapper;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerSun;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RemoteRawHandler implements HttpHandler {
+	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteRawHandler.class);
+	private final WebServerSun parent;
+
+	public RemoteRawHandler(WebServerSun parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	public void handle(HttpExchange t) throws IOException {
+		try {
+			LOGGER.debug("got a raw request " + t.getRequestURI());
+			if (RemoteUtil.deny(t)) {
+				throw new IOException("Access denied");
+			}
+
+			RootFolder root = parent.getRoot(RemoteUtil.userName(t), t);
+			if (root == null) {
+				throw new IOException("Unknown root");
+			}
+			String id;
+			id = RemoteUtil.strip(RemoteUtil.getId("raw/", t));
+			LOGGER.debug("raw id " + id);
+			List<DLNAResource> res = root.getDLNAResources(id, false, 0, 0, root.getDefaultRenderer());
+			if (res.size() != 1) {
+				// another error
+				LOGGER.debug("media unkonwn");
+				throw new IOException("Bad id");
+			}
+			DLNAResource dlna = res.get(0);
+			long len;
+			String mime = null;
+			InputStream in;
+			Range.Byte range;
+			if (dlna.getMedia() != null && dlna.getMedia().isImage() && dlna.getMedia().getImageInfo() != null) {
+				boolean supported = false;
+				ImageInfo imageInfo = dlna.getMedia().getImageInfo();
+				if (root.getDefaultRenderer() instanceof WebRender) {
+					WebRender renderer = (WebRender) root.getDefaultRenderer();
+					supported = renderer.isImageFormatSupported(imageInfo.getFormat());
+				}
+				mime = dlna.getFormat() != null ?
+					dlna.getFormat().mimeType() :
+					root.getDefaultRenderer().getMimeType(dlna);
+
+				len = supported && imageInfo.getSize() != ImageInfo.SIZE_UNKNOWN ? imageInfo.getSize() : dlna.length();
+				range = new Range.Byte(0L, len);
+				if (supported) {
+					in = dlna.getInputStream();
+				} else {
+					InputStream imageInputStream;
+					if (dlna.getPlayer() instanceof ImagePlayer) {
+						ProcessWrapper transcodeProcess = dlna.getPlayer().launchTranscode(
+							dlna,
+							dlna.getMedia(),
+							new OutputParams(PMS.getConfiguration())
+						);
+						imageInputStream = transcodeProcess != null ? transcodeProcess.getInputStream(0) : null;
+					} else {
+						imageInputStream = dlna.getInputStream();
+					}
+					Image image = Image.toImage(imageInputStream, 3840, 2400, ScaleType.MAX, ImageFormat.JPEG, false);
+					len = image == null ? 0 : image.getBytes(false).length;
+					in = image == null ? null : new ByteArrayInputStream(image.getBytes(false));
+				}
+			} else {
+				len = dlna.length();
+				dlna.setPlayer(null);
+				range = RemoteUtil.parseRange(t.getRequestHeaders(), len);
+				in = dlna.getInputStream(range, root.getDefaultRenderer());
+				if (len == 0) {
+					// For web resources actual length may be unknown until we open the stream
+					len = dlna.length();
+				}
+				mime = root.getDefaultRenderer().getMimeType(dlna);
+			}
+
+			Headers hdr = t.getResponseHeaders();
+			LOGGER.debug("Sending media \"{}\" with mime type \"{}\"", dlna, mime);
+			hdr.add("Content-Type", mime);
+			hdr.add("Accept-Ranges", "bytes");
+			hdr.add("Server", PMS.get().getServerName());
+			hdr.add("Connection", "keep-alive");
+			hdr.add("Transfer-Encoding", "chunked");
+			if (in != null && in.available() != len) {
+				hdr.add("Content-Range", "bytes " + range.getStart() + "-" + in.available() + "/" + len);
+				t.sendResponseHeaders(206, in.available());
+			} else {
+				t.sendResponseHeaders(200, 0);
+			}
+			OutputStream os = new BufferedOutputStream(t.getResponseBody(), 512 * 1024);
+			LOGGER.debug("start raw dump");
+			RemoteUtil.dump(in, os);
+		} catch (IOException e) {
+			throw e;
+		} catch (Exception e) {
+			// Nothing should get here, this is just to avoid crashing the thread
+			LOGGER.error("Unexpected error in RemoteRawHandler.handle(): {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+}

--- a/src/main/java/net/pms/webserver/servlets/DocServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/DocServlet.java
@@ -1,0 +1,99 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import com.samskivert.mustache.MustacheException;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.PMS;
+import net.pms.newgui.DbgPacker;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DocServlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(DocServlet.class);
+
+	public DocServlet(WebServerServlets parent) {
+		super(parent);
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		try {
+			InetAddress inetAddress = InetAddress.getByName(request.getRemoteAddr());
+			URI uri = URI.create(request.getRequestURI());
+			LOGGER.debug("root req " + uri);
+			if (RemoteUtil.deny(inetAddress)) {
+				throw new IOException("Access denied");
+			}
+			if (uri.getPath().contains("favicon")) {
+				RemoteUtil.sendLogo(response);
+				return;
+			}
+
+			HashMap<String, Object> vars = new HashMap<>();
+			vars.put("logs", getLogs(true));
+			if (CONFIGURATION.getUseCache()) {
+				vars.put("cache",
+					"http://" + PMS.get().getServer().getHost() + ":" + PMS.get().getServer().getPort() + "/console/home");
+			}
+
+			String responseString = parent.getResources().getTemplate("doc.html").execute(vars);
+			RemoteUtil.respondHtml(response, responseString);
+		} catch (IOException e) {
+			throw e;
+		} catch (MustacheException e) {
+			// Nothing should get here, this is just to avoid crashing the thread
+			LOGGER.error("Unexpected error in DocServlet.doGet(): {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+
+	private ArrayList<HashMap<String, String>> getLogs(boolean asList) {
+		Set<File> files = new DbgPacker().getItems();
+		if (!asList) {
+			return null;
+		}
+		ArrayList<HashMap<String, String>> logs = new ArrayList<>();
+		for (File f : files) {
+			if (f.exists()) {
+				String id = String.valueOf(parent.getResources().add(f));
+				if (asList) {
+					HashMap<String, String> item = new HashMap<>();
+					item.put("filename", f.getName());
+					item.put("id", id);
+					logs.add(item);
+				}
+			}
+		}
+		return logs;
+	}
+
+}

--- a/src/main/java/net/pms/webserver/servlets/M3u8Servlet.java
+++ b/src/main/java/net/pms/webserver/servlets/M3u8Servlet.java
@@ -1,0 +1,122 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.PMS;
+import net.pms.configuration.RendererConfiguration;
+import net.pms.dlna.DLNAResource;
+import net.pms.dlna.FileTranscodeVirtualFolder;
+import net.pms.dlna.virtual.VirtualVideoAction;
+import net.pms.external.ExternalFactory;
+import net.pms.external.URLResolver.URLResult;
+import net.pms.util.FileUtil;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class M3u8Servlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(M3u8Servlet.class);
+
+	public M3u8Servlet(WebServerServlets parent) {
+		super(parent);
+	}
+
+	private String makeM3u8(DLNAResource dlna) {
+		if (dlna != null) {
+			return makeM3u8(dlna.isFolder() ? dlna.getChildren() : Arrays.asList(new DLNAResource[]{dlna}));
+		}
+		return null;
+	}
+
+	private String makeM3u8(List<DLNAResource> resources) {
+		ArrayList<Map<String, Object>> items = new ArrayList<>();
+		double targetDuration = 1;
+		for (DLNAResource dlna : resources) {
+			if (dlna != null && !dlna.isFolder() && !dlna.isResume() && !(dlna instanceof VirtualVideoAction)) {
+				double duration = dlna.getMedia() != null ? dlna.getMedia().getDurationInSeconds() : -1;
+				if (duration > targetDuration) {
+					targetDuration = duration + 1;
+				}
+				String url;
+
+				if (!FileUtil.isUrl(dlna.getSystemName())) {
+					// Get the resource url
+					boolean isTranscodeFolderItem = dlna.isNoName() && (dlna.getParent() instanceof FileTranscodeVirtualFolder);
+					// If the resource is not a transcode folder item, tag its url for forced streaming
+					url = dlna.getURL(isTranscodeFolderItem  ? "" : RendererConfiguration.NOTRANSCODE, true, false);
+
+				} else {
+					// It's a WEB.conf item or plugin-provided url, make sure it's resolved
+					url = dlna.getSystemName();
+					if (!dlna.isURLResolved()) {
+						URLResult r = ExternalFactory.resolveURL(url);
+						if (r != null && StringUtils.isNotEmpty(r.url)) {
+							url = r.url;
+						}
+					}
+				}
+
+				Map<String, Object> item = new HashMap<>();
+				item.put("duration", duration != 0 ? duration : -1);
+				item.put("title", dlna.resumeName());
+				item.put("url", url);
+				items.add(item);
+			}
+		}
+
+		if (!items.isEmpty()) {
+			HashMap<String, Object> vars = new HashMap<>();
+			vars.put("targetDuration", targetDuration != 0 ? targetDuration : -1);
+			vars.put("items", items);
+			return parent.getResources().getTemplate("play.m3u8").execute(vars);
+		}
+		return null;
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		try {
+			URI uri = URI.create(request.getRequestURI());
+			String p = uri.getPath();
+			String id = StringUtils.substringBefore(StringUtils.substringAfter(p, "/m3u8/"), ".m3u8");
+			String responseString = makeM3u8(PMS.getGlobalRepo().get(id));
+			if (responseString != null) {
+				LOGGER.debug("sending m3u8:\n" + responseString);
+				RemoteUtil.respond(response, responseString, "application/x-mpegURL");
+			} else {
+				response.sendError(404, "<html><body>404 - File Not Found: " + p + "</body></html>");
+			}
+		} catch (IOException e) {
+			throw e;
+		}
+	}
+}

--- a/src/main/java/net/pms/webserver/servlets/MediaServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/MediaServlet.java
@@ -1,0 +1,186 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.PMS;
+import net.pms.configuration.FormatConfiguration;
+import net.pms.configuration.RendererConfiguration;
+import net.pms.configuration.WebRender;
+import net.pms.dlna.*;
+import net.pms.encoders.FFmpegWebVideo;
+import net.pms.encoders.PlayerFactory;
+import net.pms.encoders.StandardPlayerId;
+import net.pms.util.FileUtil;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MediaServlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(MediaServlet.class);
+	private final boolean flash;
+	private final String path;
+	private final RendererConfiguration renderer;
+
+	public MediaServlet(WebServerServlets parent) {
+		this(parent, "media/", null, false);
+	}
+
+	public MediaServlet(WebServerServlets parent, boolean flash) {
+		this(parent, flash ? "fmedia/" : "media/", null, flash);
+	}
+
+	public MediaServlet(WebServerServlets parent, String path, RendererConfiguration renderer) {
+		this(parent, path, renderer, false);
+	}
+
+	public MediaServlet(WebServerServlets parent, String path, RendererConfiguration renderer, boolean flash) {
+		super(parent);
+		this.flash = flash;
+		this.path = path;
+		this.renderer = renderer;
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		try {
+			RootFolder root = parent.getRoot(request, response);
+			if (root == null) {
+				LOGGER.debug("root not found");
+				response.sendError(401, "Unknown root");
+				return;
+			}
+			/*
+			Headers h = httpExchange.getRequestHeaders();
+			for (String h1 : h.keySet()) {
+				LOGGER.debug("key " + h1 + "=" + h.get(h1));
+			}
+			*/
+			URI uri = URI.create(request.getRequestURI());
+			String id = RemoteUtil.getId(path, uri);
+			id = RemoteUtil.strip(id);
+			RendererConfiguration defaultRenderer = renderer;
+			if (renderer == null) {
+				defaultRenderer = root.getDefaultRenderer();
+			}
+			DLNAResource resource = root.getDLNAResource(id, defaultRenderer);
+			if (resource == null) {
+				// another error
+				LOGGER.debug("media unkonwn");
+				response.sendError(400, "Bad id");
+				return;
+			}
+			if (!resource.isCodeValid(resource)) {
+				LOGGER.debug("coded object with invalid code");
+				response.sendError(400, "Bad code");
+				return;
+			}
+			DLNAMediaSubtitle sid = null;
+			String mimeType = root.getDefaultRenderer().getMimeType(resource);
+			//DLNAResource dlna = res.get(0);
+			WebRender render = (WebRender) defaultRenderer;
+			DLNAMediaInfo media = resource.getMedia();
+			if (media == null) {
+				media = new DLNAMediaInfo();
+				resource.setMedia(media);
+			}
+			if (mimeType.equals(FormatConfiguration.MIMETYPE_AUTO) && media.getMimeType() != null) {
+				mimeType = media.getMimeType();
+			}
+			int code = 200;
+			resource.setDefaultRenderer(defaultRenderer);
+			if (resource.getFormat().isVideo()) {
+				if (flash) {
+					mimeType = "video/flash";
+				} else if (!RemoteUtil.directmime(mimeType) || RemoteUtil.transMp4(mimeType, media)) {
+					mimeType = render != null ? render.getVideoMimeType() : RemoteUtil.transMime();
+					// TODO: Use normal engine priorities instead of the following hacks
+					if (FileUtil.isUrl(resource.getSystemName())) {
+						if (FFmpegWebVideo.isYouTubeURL(resource.getSystemName())) {
+							resource.setPlayer(PlayerFactory.getPlayer(StandardPlayerId.YOUTUBE_DL, false, false));
+						} else {
+							resource.setPlayer(PlayerFactory.getPlayer(StandardPlayerId.FFMPEG_WEB_VIDEO, false, false));
+						}
+					} else if (!(resource instanceof DVDISOTitle)) {
+						resource.setPlayer(PlayerFactory.getPlayer(StandardPlayerId.FFMPEG_VIDEO, false, false));
+					}
+					//code = 206;
+				}
+				if (
+					PMS.getConfiguration().getWebSubs() &&
+					resource.getMediaSubtitle() != null &&
+					resource.getMediaSubtitle().isExternal()
+				) {
+					// fetched on the side
+					sid = resource.getMediaSubtitle();
+					resource.setMediaSubtitle(null);
+				}
+			}
+
+			if (!RemoteUtil.directmime(mimeType) && resource.getFormat().isAudio()) {
+				resource.setPlayer(PlayerFactory.getPlayer(StandardPlayerId.FFMPEG_AUDIO, false, false));
+				code = 206;
+			}
+
+			media.setMimeType(mimeType);
+			Range.Byte range = RemoteUtil.parseRange(request.getHeader("Range"), resource.length());
+			LOGGER.debug("Sending {} with mime type {} to {}", resource, mimeType, renderer);
+			InputStream in = resource.getInputStream(range, root.getDefaultRenderer());
+			if (range.getEnd() == 0) {
+				// For web resources actual length may be unknown until we open the stream
+				range.setEnd(resource.length());
+			}
+			response.addHeader("Content-Type", mimeType);
+			response.addHeader("Accept-Ranges", "bytes");
+			long end = range.getEnd();
+			long start = range.getStart();
+			String rStr = start + "-" + end + "/*";
+			response.addHeader("Content-Range", "bytes " + rStr);
+			if (start != 0) {
+				code = 206;
+			}
+
+			response.addHeader("Server", PMS.get().getServerName());
+			response.addHeader("Connection", "keep-alive");
+			response.setStatus(code);
+			OutputStream os = response.getOutputStream();
+			if (render != null) {
+				render.start(resource);
+			}
+			if (sid != null) {
+				resource.setMediaSubtitle(sid);
+			}
+			RemoteUtil.dumpDirect(in, os);
+		} catch (IOException e) {
+			throw e;
+		} catch (InterruptedException e) {
+			// Nothing should get here, this is just to avoid crashing the thread
+			LOGGER.error("Unexpected error in MediaServlet.doGet(): {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+}

--- a/src/main/java/net/pms/webserver/servlets/PlayListServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PlayListServlet.java
@@ -1,0 +1,84 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import java.io.IOException;
+import java.net.URI;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.PMS;
+import net.pms.configuration.RendererConfiguration;
+import net.pms.configuration.WebRender;
+import net.pms.dlna.DLNAResource;
+import net.pms.dlna.Playlist;
+import net.pms.dlna.RootFolder;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PlayListServlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(PlayListServlet.class);
+	private static final String RETURN_PAGE = "<html><head><script>window.refresh=true;history.back()</script></head></html>";
+
+	public PlayListServlet(WebServerServlets parent) {
+		super(parent);
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		try {
+			URI uri = URI.create(request.getRequestURI());
+			String p = uri.getPath();
+			String[] tmp = p.split("/");
+			if (tmp.length < 3) {
+				response.sendError(400, "Bad request");
+				return;
+			}
+			String op = tmp[tmp.length - 2];
+			String id = tmp[tmp.length - 1];
+			DLNAResource r = PMS.getGlobalRepo().get(id);
+			if (r != null) {
+				RootFolder root = parent.getRoot(request, response);
+				if (root == null) {
+					LOGGER.debug("root not found");
+					response.sendError(401, "Unknown root");
+					return;
+				}
+				WebRender renderer = (WebRender) root.getDefaultRenderer();
+				if (op.equals("add")) {
+					PMS.get().getDynamicPls().add(r);
+					renderer.notify(RendererConfiguration.OK, "Added '" + r.getDisplayName() + "' to dynamic playlist");
+				} else if (op.equals("del") && (r.getParent() instanceof Playlist)) {
+					((Playlist) r.getParent()).remove(r);
+					renderer.notify(RendererConfiguration.INFO, "Removed '" + r.getDisplayName() + "' from playlist");
+				}
+			}
+			RemoteUtil.respondHtml(response, RETURN_PAGE);
+		} catch (IOException e) {
+			throw e;
+		} catch (InterruptedException e) {
+			// Nothing should get here, this is just to avoid crashing the thread
+			LOGGER.error("Unexpected error in PlayListServlet.doGet(): {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+}

--- a/src/main/java/net/pms/webserver/servlets/PlayListServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PlayListServlet.java
@@ -66,10 +66,14 @@ public class PlayListServlet extends WebServerServlet {
 				WebRender renderer = (WebRender) root.getDefaultRenderer();
 				if (op.equals("add")) {
 					PMS.get().getDynamicPls().add(r);
-					renderer.notify(RendererConfiguration.OK, "Added '" + r.getDisplayName() + "' to dynamic playlist");
+					synchronized(renderer) {
+						renderer.notify(RendererConfiguration.OK, "Added '" + r.getDisplayName() + "' to dynamic playlist");
+					}
 				} else if (op.equals("del") && (r.getParent() instanceof Playlist)) {
 					((Playlist) r.getParent()).remove(r);
-					renderer.notify(RendererConfiguration.INFO, "Removed '" + r.getDisplayName() + "' from playlist");
+					synchronized(renderer) {
+						renderer.notify(RendererConfiguration.INFO, "Removed '" + r.getDisplayName() + "' from playlist");
+					}
 				}
 			}
 			RemoteUtil.respondHtml(response, RETURN_PAGE);

--- a/src/main/java/net/pms/webserver/servlets/PlayListServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PlayListServlet.java
@@ -66,12 +66,12 @@ public class PlayListServlet extends WebServerServlet {
 				WebRender renderer = (WebRender) root.getDefaultRenderer();
 				if (op.equals("add")) {
 					PMS.get().getDynamicPls().add(r);
-					synchronized(renderer) {
+					synchronized (renderer) {
 						renderer.notify(RendererConfiguration.OK, "Added '" + r.getDisplayName() + "' to dynamic playlist");
 					}
 				} else if (op.equals("del") && (r.getParent() instanceof Playlist)) {
 					((Playlist) r.getParent()).remove(r);
-					synchronized(renderer) {
+					synchronized (renderer) {
 						renderer.notify(RendererConfiguration.INFO, "Removed '" + r.getDisplayName() + "' from playlist");
 					}
 				}

--- a/src/main/java/net/pms/webserver/servlets/PlayServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PlayServlet.java
@@ -117,7 +117,7 @@ public class PlayServlet extends WebServerServlet {
 		if (rootResource instanceof VirtualVideoAction) {
 			// for VVA we just call the enable fun directly
 			// waste of resource to play dummy video
-			synchronized(renderer) {
+			synchronized (renderer) {
 				if (((VirtualVideoAction) rootResource).enable()) {
 					renderer.notify(RendererConfiguration.INFO, rootResource.getName() + " enabled");
 				} else {

--- a/src/main/java/net/pms/webserver/servlets/PlayServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PlayServlet.java
@@ -117,10 +117,12 @@ public class PlayServlet extends WebServerServlet {
 		if (rootResource instanceof VirtualVideoAction) {
 			// for VVA we just call the enable fun directly
 			// waste of resource to play dummy video
-			if (((VirtualVideoAction) rootResource).enable()) {
-				renderer.notify(RendererConfiguration.INFO, rootResource.getName() + " enabled");
-			} else {
-				renderer.notify(RendererConfiguration.INFO, rootResource.getName() + " disabled");
+			synchronized(renderer) {
+				if (((VirtualVideoAction) rootResource).enable()) {
+					renderer.notify(RendererConfiguration.INFO, rootResource.getName() + " enabled");
+				} else {
+					renderer.notify(RendererConfiguration.INFO, rootResource.getName() + " disabled");
+				}
 			}
 			return RETURN_PAGE;
 		}

--- a/src/main/java/net/pms/webserver/servlets/PlayerControlServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PlayerControlServlet.java
@@ -197,7 +197,7 @@ public class PlayerControlServlet extends WebServerServlet {
 		return "";
 	}
 
-	public RendererConfiguration getDefaultRenderer() {
+	public synchronized RendererConfiguration getDefaultRenderer() {
 		if (defaultRenderer == null && bumpAddress != null) {
 			try {
 				InetAddress ia = InetAddress.getByName(bumpAddress);
@@ -208,7 +208,7 @@ public class PlayerControlServlet extends WebServerServlet {
 		return (defaultRenderer != null && !defaultRenderer.isOffline()) ? defaultRenderer : null;
 	}
 
-	public String getRenderers(InetAddress client) {
+	public synchronized String getRenderers(InetAddress client) {
 		Logical player = selectedPlayers.get(client);
 		RendererConfiguration selected = player != null ? player.renderer : getDefaultRenderer();
 		ArrayList<String> json = new ArrayList<>();

--- a/src/main/java/net/pms/webserver/servlets/PlayerControlServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PlayerControlServlet.java
@@ -1,0 +1,253 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.UnknownHostException;
+import java.util.*;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.PMS;
+import net.pms.configuration.RendererConfiguration;
+import net.pms.configuration.WebRender;
+import net.pms.network.UPNPHelper;
+import net.pms.util.BasicPlayer.Logical;
+import net.pms.util.StringUtil;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PlayerControlServlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(PlayerControlServlet.class);
+	private static final String JSON_STATE = "\"state\":{\"playback\":%d,\"mute\":\"%s\",\"volume\":%d,\"position\":\"%s\",\"duration\":\"%s\",\"uri\":\"%s\"}";
+
+	protected final HashMap<String, Logical> players;
+	protected final HashMap<InetAddress, Logical> selectedPlayers;
+	protected final String bumpAddress;
+	protected RendererConfiguration defaultRenderer;
+	@SuppressWarnings(value = "unused")
+	protected final File bumpjs;
+	protected final File skindir;
+
+	public PlayerControlServlet(WebServerServlets parent) {
+		super(parent);
+		players = new HashMap<>();
+		selectedPlayers = new HashMap<>();
+		String basepath = CONFIGURATION.getWebPath().getPath();
+		bumpjs = new File(FilenameUtils.concat(basepath, CONFIGURATION.getBumpJS("bump/bump.js")));
+		skindir = new File(FilenameUtils.concat(basepath, CONFIGURATION.getBumpSkinDir("bump/skin")));
+		bumpAddress = CONFIGURATION.getBumpAddress();
+		defaultRenderer = null;
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		URI uri = URI.create(request.getRequestURI());
+		String[] p = uri.getPath().split("/");
+		Map<String, String> query = parseQuery(uri);
+
+		String responseString = "";
+		String mime = "text/html";
+		boolean log = true;
+		ArrayList<String> json = new ArrayList<>();
+
+		String uuid = p.length > 3 ? p[3] : null;
+		Logical player = uuid != null ? getPlayer(uuid) : null;
+		InetAddress inetAddress = InetAddress.getByName(request.getRemoteAddr());
+		if (player != null) {
+			switch (p[2]) {
+				case "status":
+					// limit status updates to one per second
+					UPNPHelper.sleep(1000);
+					log = false;
+					break;
+				case "play":
+					player.pressPlay(translate(query.get("uri")), query.get("title"));
+					break;
+				case "stop":
+					player.pressStop();
+					break;
+				case "prev":
+					player.prev();
+					break;
+				case "next":
+					player.next();
+					break;
+				case "fwd":
+					player.forward();
+					break;
+				case "rew":
+					player.rewind();
+					break;
+				case "mute":
+					player.mute();
+					break;
+				case "setvolume":
+					player.setVolume(Integer.parseInt(query.get("vol")));
+					break;
+				case "add":
+					player.add(-1, translate(query.get("uri")), query.get("title"), null, true);
+					break;
+				case "remove":
+					player.remove(translate(query.get("uri")));
+					break;
+				case "clear":
+					player.clear();
+					break;
+				case "seturi":
+					player.setURI(translate(query.get("uri")), query.get("title"));
+					break;
+			}
+			json.add(getPlayerState(player));
+			json.add(getPlaylist(player));
+			selectedPlayers.put(inetAddress, player);
+		} else if (p.length == 2) {
+			responseString = parent.getResources().read("bump/bump.html")
+				.replace("http://127.0.0.1:9001", parent.getUrl());
+		} else if (p[2].equals("bump.js")) {
+			responseString = getBumpJS();
+			mime = "text/javascript";
+		} else if (p[2].equals("renderers")) {
+			json.add(getRenderers(inetAddress));
+		} else if (p[2].startsWith("skin.")) {
+			RemoteUtil.dumpFile(new File(skindir, p[2].substring(5)), response);
+			return;
+		}
+
+		if (!json.isEmpty()) {
+			if (player != null) {
+				json.add("\"uuid\":\"" + uuid + "\"");
+			}
+			responseString = "{" + StringUtils.join(json, ",") + "}";
+		}
+
+		if (log) {
+			LOGGER.debug("Received http player control request from {}: {}", inetAddress, uri);
+		}
+
+		// w/o this client may receive response status 0 and no content
+		response.addHeader("Access-Control-Allow-Origin", "*");
+		RemoteUtil.respond(response, responseString, 200, mime);
+	}
+
+	public static Map<String, String> parseQuery(URI uri) {
+		Map<String, String> vars = new LinkedHashMap<>();
+		String raw = uri.getRawQuery();
+		if (!StringUtils.isBlank(raw)) {
+			try {
+				String[] q = raw.split("&|=");
+				for (int i = 0; i < q.length; i += 2) {
+					vars.put(URLDecoder.decode(q[i], "UTF-8"), UPNPHelper.unescape(URLDecoder.decode(q[i + 1], "UTF-8")));
+				}
+			} catch (UnsupportedEncodingException e) {
+				LOGGER.debug("Error parsing query string '" + uri.getQuery() + "' :" + e);
+			}
+		}
+		return vars;
+	}
+
+	public Logical getPlayer(String uuid) {
+		Logical player = players.get(uuid);
+		if (player == null) {
+			try {
+				RendererConfiguration renderer = RendererConfiguration.getRendererConfigurationByUUID(uuid);
+				if (renderer != null) {
+					player = (Logical) renderer.getPlayer();
+					players.put(uuid, player);
+				}
+			} catch (Exception e) {
+				LOGGER.debug("Error retrieving player {}: {}", uuid, e.getMessage());
+				LOGGER.trace("", e);
+			}
+		}
+		return player;
+	}
+
+	public String getPlayerState(Logical player) {
+		if (player != null) {
+			Logical.State state = player.getState();
+			return String.format(JSON_STATE, state.playback, state.mute, state.volume, StringUtil.shortTime(state.position, 4), StringUtil.shortTime(state.duration, 4), state.uri/*, state.metadata*/);
+		}
+		return "";
+	}
+
+	public RendererConfiguration getDefaultRenderer() {
+		if (defaultRenderer == null && bumpAddress != null) {
+			try {
+				InetAddress ia = InetAddress.getByName(bumpAddress);
+				defaultRenderer = RendererConfiguration.getRendererConfigurationBySocketAddress(ia);
+			} catch (UnknownHostException e) {
+			}
+		}
+		return (defaultRenderer != null && !defaultRenderer.isOffline()) ? defaultRenderer : null;
+	}
+
+	public String getRenderers(InetAddress client) {
+		Logical player = selectedPlayers.get(client);
+		RendererConfiguration selected = player != null ? player.renderer : getDefaultRenderer();
+		ArrayList<String> json = new ArrayList<>();
+		for (RendererConfiguration r : RendererConfiguration.getConnectedControlPlayers()) {
+			json.add(String.format("[\"%s\",%d,\"%s\"]", (r instanceof WebRender) ? r.uuid : r, r == selected ? 1 : 0, r.uuid));
+		}
+		return "\"renderers\":[" + StringUtils.join(json, ",") + "]";
+	}
+
+	public String getPlaylist(Logical player) {
+		ArrayList<String> json = new ArrayList<>();
+		Logical.Playlist playlist = player.playlist;
+		playlist.validate();
+		Logical.Playlist.Item selected = (Logical.Playlist.Item) playlist.getSelectedItem();
+		int i;
+		for (i = 0; i < playlist.getSize(); i++) {
+			Logical.Playlist.Item item = (Logical.Playlist.Item) playlist.getElementAt(i);
+			json.add(String.format("[\"%s\",%d,\"%s\"]",
+				item.toString().replace("\"", "\\\""), item == selected ? 1 : 0, "$i$" + i));
+		}
+		return "\"playlist\":[" + StringUtils.join(json, ",") + "]";
+	}
+
+	public String getBumpJS() {
+		RemoteUtil.ResourceManager resources = parent.getResources();
+		return resources.read("bump/bump.js") +
+			"\nvar bumpskin = function() {\n" +
+			resources.read("bump/skin/skin.js") +
+			"\n}";
+	}
+
+	public static String translate(String uri) {
+		return uri.startsWith("/play/") ?
+			(PMS.get().getServer().getURL() + "/get/" + uri.substring(6).replace("%24", "$")) : uri;
+	}
+
+	@SuppressWarnings("unused")
+	private static String getId(String uri) {
+		return uri.startsWith("/play/") ? uri.substring(6) : "";
+	}
+
+}

--- a/src/main/java/net/pms/webserver/servlets/PlayersStatusServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PlayersStatusServlet.java
@@ -1,0 +1,63 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.configuration.WebRender;
+import net.pms.dlna.RootFolder;
+import net.pms.webserver.WebServerServlets;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PlayersStatusServlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(PlayersStatusServlet.class);
+
+	public PlayersStatusServlet(WebServerServlets parent) {
+		super(parent);
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		try {
+			String json = IOUtils.toString(request.getReader());
+			LOGGER.trace("got player status: " + json);
+			RootFolder root = parent.getRoot(request, response);
+			if (root == null) {
+				LOGGER.debug("root not found");
+				response.sendError(401, "Unknown root");
+				return;
+			}
+			WebRender renderer = (WebRender) root.getDefaultRenderer();
+			((WebRender.WebPlayer) renderer.getPlayer()).setData(json);
+			response.setContentType("text/html");
+			response.setStatus(200);
+		} catch (IOException e) {
+			throw e;
+		} catch (InterruptedException e) {
+			// Nothing should get here, this is just to avoid crashing the thread
+			LOGGER.error("Unexpected error in PlayersStatusServlet.doGet(): {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+}

--- a/src/main/java/net/pms/webserver/servlets/PlayersStatusServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PlayersStatusServlet.java
@@ -38,7 +38,7 @@ public class PlayersStatusServlet extends WebServerServlet {
 	}
 
 	@Override
-	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		try {
 			String json = IOUtils.toString(request.getReader());
 			LOGGER.trace("got player status: " + json);
@@ -56,7 +56,7 @@ public class PlayersStatusServlet extends WebServerServlet {
 			throw e;
 		} catch (InterruptedException e) {
 			// Nothing should get here, this is just to avoid crashing the thread
-			LOGGER.error("Unexpected error in PlayersStatusServlet.doGet(): {}", e.getMessage());
+			LOGGER.error("Unexpected error in PlayersStatusServlet.doPost(): {}", e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}

--- a/src/main/java/net/pms/webserver/servlets/PoolServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/PoolServlet.java
@@ -1,0 +1,62 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.configuration.WebRender;
+import net.pms.dlna.RootFolder;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PoolServlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(PoolServlet.class);
+
+	public PoolServlet(WebServerServlets parent) {
+		super(parent);
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		try {
+			RootFolder root = parent.getRoot(request, response);
+			if (root == null) {
+				LOGGER.debug("root not found");
+				response.sendError(401, "Unknown root");
+				return;
+			}
+			WebRender renderer = (WebRender) root.getDefaultRenderer();
+			String json = renderer.getPushData();
+			RemoteUtil.respond(response, json, "application/json");
+		} catch (IOException e) {
+			throw e;
+		} catch (InterruptedException e) {
+			// This can happen if a browser is left open and our cookie changed, or something like that
+			// I'm just leaving this note here as a clue for the next person who encounters this
+			LOGGER.error("Unexpected error on web interface. Please try closing any tabs or windows that contain UMS and try again");
+			LOGGER.debug("", e);
+		}
+	}
+
+}

--- a/src/main/java/net/pms/webserver/servlets/RawServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/RawServlet.java
@@ -1,14 +1,34 @@
-package net.pms.remote;
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
 
-import com.sun.net.httpserver.Headers;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import net.pms.PMS;
 import net.pms.configuration.WebRender;
 import net.pms.dlna.DLNAResource;
@@ -21,41 +41,41 @@ import net.pms.image.ImageInfo;
 import net.pms.image.ImagesUtil.ScaleType;
 import net.pms.io.OutputParams;
 import net.pms.io.ProcessWrapper;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RemoteRawHandler implements HttpHandler {
-	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteRawHandler.class);
-	private RemoteWeb parent;
+public class RawServlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(RawServlet.class);
 
-	public RemoteRawHandler(RemoteWeb parent) {
-		this.parent = parent;
+	public RawServlet(WebServerServlets parent) {
+		super(parent);
 	}
 
 	@Override
-	public void handle(HttpExchange t) throws IOException {
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		try {
-			LOGGER.debug("got a raw request " + t.getRequestURI());
-			if (RemoteUtil.deny(t)) {
-				throw new IOException("Access denied");
-			}
-
-			RootFolder root = parent.getRoot(RemoteUtil.userName(t), t);
+			URI uri = URI.create(request.getRequestURI());
+			LOGGER.debug("got a raw request " + uri);
+			RootFolder root = parent.getRoot(request, response);
 			if (root == null) {
-				throw new IOException("Unknown root");
+				LOGGER.debug("root not found");
+				response.sendError(401, "Unknown root");
+				return;
 			}
-			String id;
-			id = RemoteUtil.strip(RemoteUtil.getId("raw/", t));
+			String id = RemoteUtil.strip(RemoteUtil.getId("raw/", uri));
 			LOGGER.debug("raw id " + id);
 			List<DLNAResource> res = root.getDLNAResources(id, false, 0, 0, root.getDefaultRenderer());
 			if (res.size() != 1) {
 				// another error
 				LOGGER.debug("media unkonwn");
-				throw new IOException("Bad id");
+				response.sendError(404, "Bad id");
+				return;
 			}
 			DLNAResource dlna = res.get(0);
 			long len;
-			String mime = null;
+			String mime;
 			InputStream in;
 			Range.Byte range;
 			if (dlna.getMedia() != null && dlna.getMedia().isImage() && dlna.getMedia().getImageInfo() != null) {
@@ -92,7 +112,7 @@ public class RemoteRawHandler implements HttpHandler {
 			} else {
 				len = dlna.length();
 				dlna.setPlayer(null);
-				range = RemoteUtil.parseRange(t.getRequestHeaders(), len);
+				range = RemoteUtil.parseRange(request.getHeader("Range"), len);
 				in = dlna.getInputStream(range, root.getDefaultRenderer());
 				if (len == 0) {
 					// For web resources actual length may be unknown until we open the stream
@@ -101,27 +121,28 @@ public class RemoteRawHandler implements HttpHandler {
 				mime = root.getDefaultRenderer().getMimeType(dlna);
 			}
 
-			Headers hdr = t.getResponseHeaders();
 			LOGGER.debug("Sending media \"{}\" with mime type \"{}\"", dlna, mime);
-			hdr.add("Content-Type", mime);
-			hdr.add("Accept-Ranges", "bytes");
-			hdr.add("Server", PMS.get().getServerName());
-			hdr.add("Connection", "keep-alive");
-			hdr.add("Transfer-Encoding", "chunked");
+			response.setContentType(mime);
+			response.addHeader("Accept-Ranges", "bytes");
+			response.addHeader("Server", PMS.get().getServerName());
+			response.addHeader("Connection", "keep-alive");
+			response.addHeader("Transfer-Encoding", "chunked");
 			if (in != null && in.available() != len) {
-				hdr.add("Content-Range", "bytes " + range.getStart() + "-" + in.available() + "/" + len);
-				t.sendResponseHeaders(206, in.available());
+				response.addHeader("Content-Range", "bytes " + range.getStart() + "-" + in.available() + "/" + len);
+				response.setContentLength(in.available());
+				response.setStatus(206);
 			} else {
-				t.sendResponseHeaders(200, 0);
+				response.setStatus(200);
 			}
-			OutputStream os = new BufferedOutputStream(t.getResponseBody(), 512 * 1024);
+
+			OutputStream os = new BufferedOutputStream(response.getOutputStream(), 512 * 1024);
 			LOGGER.debug("start raw dump");
-			RemoteUtil.dump(in, os);
+			RemoteUtil.dumpDirect(in, os);
 		} catch (IOException e) {
 			throw e;
-		} catch (Exception e) {
+		} catch (InterruptedException e) {
 			// Nothing should get here, this is just to avoid crashing the thread
-			LOGGER.error("Unexpected error in RemoteRawHandler.handle(): {}", e.getMessage());
+			LOGGER.error("Unexpected error in RawServlet.doGet(): {}", e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}

--- a/src/main/java/net/pms/webserver/servlets/RemoteFileServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/RemoteFileServlet.java
@@ -1,0 +1,183 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import com.samskivert.mustache.MustacheException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.CookieHandler;
+import java.net.CookieManager;
+import java.net.HttpCookie;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.PMS;
+import net.pms.network.HTTPResource;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RemoteFileServlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteFileServlet.class);
+
+	public RemoteFileServlet(WebServerServlets parent) {
+		super(parent);
+	}
+
+	@Override
+	protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		try {
+			URI uri = URI.create(request.getRequestURI());
+			LOGGER.debug("Handling web interface file request \"{}\"", uri);
+
+			String path = uri.getPath();
+			String responseString = null;
+			String mime = null;
+			int status = 200;
+
+			if (path.contains("crossdomain.xml")) {
+				responseString = "<?xml version=\"1.0\"?>" +
+					"<!-- http://www.bitsontherun.com/crossdomain.xml -->" +
+					"<cross-domain-policy>" +
+					"<allow-access-from domain=\"*\" />" +
+					"</cross-domain-policy>";
+				mime = "text/xml";
+
+			} else if (path.startsWith("/files/log/")) {
+				String filename = path.substring(11);
+				if (filename.equals("info")) {
+					String log = PMS.get().getFrame().getLog();
+					log = log.replaceAll("\n", "<br>");
+					String fullLink = "<br><a href=\"/files/log/full\">Full log</a><br><br>";
+					String x = fullLink + log;
+					if (StringUtils.isNotEmpty(log)) {
+						x = x + fullLink;
+					}
+					responseString = "<html><title>UMS LOG</title><body>" + x + "</body></html>";
+				} else {
+					File file = parent.getResources().getFile(filename);
+					if (file != null) {
+						filename = file.getName();
+						HashMap<String, Object> vars = new HashMap<>();
+						vars.put("title", filename);
+						vars.put("brush", filename.endsWith("debug.log") ? "debug_log" : filename.endsWith(".log") ? "log" : "conf");
+						vars.put("log", RemoteUtil.read(file).replace("<", "&lt;"));
+						responseString = parent.getResources().getTemplate("util/log.html").execute(vars);
+					} else {
+						status = 404;
+					}
+				}
+				mime = "text/html";
+			} else if (path.startsWith("/files/proxy")) {
+				String url = uri.getQuery();
+				if (url != null) {
+					url = url.substring(2);
+				}
+
+				InputStream in;
+				CookieManager cookieManager = (CookieManager) CookieHandler.getDefault();
+				if (cookieManager == null) {
+					cookieManager = new CookieManager();
+					CookieHandler.setDefault(cookieManager);
+				}
+
+				switch (request.getMethod()) {
+					case "POST":
+						byte[] buf = new byte[4096];
+						int n;
+						String str = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
+						URLConnection conn = new URL(url).openConnection();
+						((HttpURLConnection) conn).setRequestMethod("POST");
+						conn.setRequestProperty("Content-type", request.getHeader("Content-type"));
+						conn.setRequestProperty("Content-Length", String.valueOf(str.length()));
+						conn.setDoOutput(true);
+						OutputStreamWriter writer = new OutputStreamWriter(conn.getOutputStream());
+						writer.write(str);
+						writer.flush();
+						in = conn.getInputStream();
+						ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+						while ((n = in.read(buf)) > -1) {
+							bytes.write(buf, 0, n);
+						}
+						in = new ByteArrayInputStream(bytes.toByteArray());
+						if (LOGGER.isDebugEnabled()) {
+							List<HttpCookie> cookies = cookieManager.getCookieStore().getCookies();
+							for (HttpCookie cookie : cookies) {
+								LOGGER.debug("Domain: {}, Cookie: {}", cookie.getDomain(), cookie);
+							}
+						}
+						break;
+					case "OPTIONS":
+						in = new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
+						break;
+					default:
+						in = HTTPResource.downloadAndSend(url, false);
+						if (LOGGER.isDebugEnabled()) {
+							List<HttpCookie> cookies = cookieManager.getCookieStore().getCookies();
+							for (HttpCookie cookie : cookies) {
+								LOGGER.debug("Domain: {}, Cookie: {}", cookie.getDomain(), cookie);
+							}
+						}
+						break;
+				}
+				response.setContentType("text/plain");
+				response.addHeader("Access-Control-Allow-Origin", "*");
+				response.addHeader("Access-Control-Allow-Headers", "User-Agent");
+				response.addHeader("Access-Control-Allow-Headers", "Content-Type");
+				RemoteUtil.dumpDirect(in, response);
+				return;
+			} else if (parent.getResources().write(path.substring(7), response)) {
+				// The resource manager found and sent the file, all done.
+				return;
+
+			} else {
+				status = 404;
+			}
+
+			if (status == 404 && responseString == null) {
+				responseString = "<html><body>404 - File Not Found: " + path + "</body></html>";
+				mime = "text/html";
+			}
+			RemoteUtil.respond(response, responseString, status, mime);
+		} catch (IOException e) {
+			throw e;
+		} catch (MustacheException e) {
+			// Nothing should get here, this is just to avoid crashing the
+			// thread
+			LOGGER.error("Unexpected error in RemoteFileHandler.handle(): {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+
+}

--- a/src/main/java/net/pms/webserver/servlets/RemoteFileServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/RemoteFileServlet.java
@@ -78,7 +78,7 @@ public class RemoteFileServlet extends WebServerServlet {
 				String filename = path.substring(11);
 				if (filename.equals("info")) {
 					String log = PMS.get().getFrame().getLog();
-					log = log.replaceAll("\n", "<br>");
+					log = log.replace("\n", "<br>");
 					String fullLink = "<br><a href=\"/files/log/full\">Full log</a><br><br>";
 					String x = fullLink + log;
 					if (StringUtils.isNotEmpty(log)) {

--- a/src/main/java/net/pms/webserver/servlets/ThumbServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/ThumbServlet.java
@@ -1,0 +1,122 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.dlna.DLNAResource;
+import net.pms.dlna.DLNAThumbnailInputStream;
+import net.pms.dlna.RealFile;
+import net.pms.dlna.RootFolder;
+import net.pms.dlna.virtual.MediaLibraryFolder;
+import net.pms.image.BufferedImageFilterChain;
+import net.pms.image.ImageFormat;
+import net.pms.network.HTTPResource;
+import net.pms.util.FullyPlayed;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ThumbServlet extends WebServerServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ThumbServlet.class);
+
+	public ThumbServlet(WebServerServlets parent) {
+		super(parent);
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		try {
+			URI uri = URI.create(request.getRequestURI());
+			String id = RemoteUtil.getId("thumb/", uri);
+			LOGGER.trace("web thumb req " + id);
+			if (id.contains("logo")) {
+				RemoteUtil.sendLogo(response);
+				return;
+			}
+			RootFolder root = parent.getRoot(request, response);
+			if (root == null) {
+				LOGGER.debug("root not found");
+				response.sendError(401, "Unknown root");
+				return;
+			}
+
+			final DLNAResource r = root.getDLNAResource(id, root.getDefaultRenderer());
+			if (r == null) {
+				// another error
+				LOGGER.debug("media unkonwn");
+				response.sendError(400, "Bad id");
+				return;
+			}
+
+			DLNAThumbnailInputStream in;
+			if (!CONFIGURATION.isShowCodeThumbs() && !r.isCodeValid(r)) {
+				// we shouldn't show the thumbs for coded objects
+				// unless the code is entered
+				in = r.getGenericThumbnailInputStream(null);
+			} else {
+				r.checkThumbnail();
+				in = r.fetchThumbnailInputStream();
+				if (in == null) {
+					// if r is null for some reason, default to generic thumb
+					in = r.getGenericThumbnailInputStream(null);
+				}
+			}
+
+			BufferedImageFilterChain filterChain = null;
+			if (
+				(
+					r instanceof RealFile &&
+					FullyPlayed.isFullyPlayedFileMark(((RealFile) r).getFile())
+				) ||
+				(
+					r instanceof MediaLibraryFolder &&
+					((MediaLibraryFolder) r).isTVSeries() &&
+					FullyPlayed.isFullyPlayedTVSeriesMark(((MediaLibraryFolder) r).getName())
+				)
+			) {
+				filterChain = new BufferedImageFilterChain(FullyPlayed.getOverlayFilter());
+			}
+			filterChain = r.addFlagFilters(filterChain);
+			if (filterChain != null) {
+				in = in.transcode(in.getDLNAImageProfile(), false, filterChain);
+			}
+			response.setContentType(ImageFormat.PNG.equals(in.getFormat()) ? HTTPResource.PNG_TYPEMIME : HTTPResource.JPEG_TYPEMIME);
+			response.addHeader("Accept-Ranges", "bytes");
+			response.addHeader("Connection", "keep-alive");
+			response.setContentLengthLong(in.getSize());
+
+			OutputStream os = response.getOutputStream();
+			LOGGER.trace("Web thumbnail: Input is {} output is {}", in, os);
+			RemoteUtil.dumpDirect(in, os);
+		} catch (IOException e) {
+			throw e;
+		} catch (InterruptedException e) {
+			// Nothing should get here, this is just to avoid crashing the thread
+			LOGGER.error("Unexpected error in ThumbServlet.doGet(): {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+}

--- a/src/main/java/net/pms/webserver/servlets/WebServerServlet.java
+++ b/src/main/java/net/pms/webserver/servlets/WebServerServlet.java
@@ -1,0 +1,91 @@
+/*
+ * Universal Media Server, for streaming any medias to DLNA
+ * compatible renderers based on the http://www.ps3mediaserver.org.
+ * Copyright (C) 2012 UMS developers.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.webserver.servlets;
+
+import com.samskivert.mustache.MustacheException;
+import com.samskivert.mustache.Template;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.HashMap;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import net.pms.PMS;
+import net.pms.configuration.PmsConfiguration;
+import net.pms.webserver.RemoteUtil;
+import net.pms.webserver.WebServerServlets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebServerServlet extends HttpServlet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(WebServerServlet.class);
+	protected static final PmsConfiguration CONFIGURATION = PMS.getConfiguration();
+	protected final WebServerServlets parent;
+
+	public WebServerServlet(final WebServerServlets parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+		URI uri = URI.create(request.getRequestURI());
+		if (uri.getPath().contains("favicon")) {
+			RemoteUtil.sendLogo(response);
+			return;
+		}
+		HashMap<String, Object> vars = new HashMap<>();
+		vars.put("serverName", CONFIGURATION.getServerDisplayName());
+		try {
+			Template template = parent.getResources().getTemplate("start.html");
+			if (template != null) {
+				String responseString = template.execute(vars);
+				RemoteUtil.respond(response, responseString, 200, "text/html");
+			} else {
+				response.sendError(404, "Web template \"start.html\" not found");
+			}
+		} catch (MustacheException e) {
+			LOGGER.error("An error occurred while generating a HTTP response: {}", e.getMessage());
+			LOGGER.trace("", e);
+		}
+	}
+
+	@Override
+	protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		try {
+			InetAddress inetAddress = InetAddress.getByName(request.getRemoteAddr());
+			if (RemoteUtil.deny(inetAddress)) {
+				LOGGER.debug("Web Server: Access denied to {}", inetAddress);
+				response.sendError(403, "Access denied");
+				return;
+			}
+			super.service(request, response);
+		} catch (IOException e) {
+			throw e;
+		}
+	}
+
+	@Override
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+		//by default same as doGet
+		doGet(request, response);
+	}
+}


### PR DESCRIPTION
Servlet the webserver part.

- Rename the `remote` directory to `webserver` to reflect what is under.
- Moved the handlers classes to `webserver.handlers` package (sun httpserver handlers).
- Moved the `net.pms.network.PlayerControlHandler` to the `webserver` package as it is served under it.
- Added all servlets classes in the `webserver.servlets` package.
- Server is still using the old way (sun `httpserver`) to be sure we can test everything before setting `jetty` by default.
- Added a config key to allow testing jetty (`web_type =jetty`).

This is a first shoot, it may need some improvements.
The good thing is that the default is to run like before (sun httpserver way).

Servlets can be served by many web container (jetty, tomcat, etc).

On this pull, Jetty is on version 9.4 (due to Java 8) and need `javax.servlet` version 3.1.