### PR TITLE
tweaked audio track sorting heuristics

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -150,7 +150,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_CODE_THUMBS = "code_show_thumbs_no_code";
 	protected static final String KEY_CODE_TMO = "code_valid_timeout";
 	protected static final String KEY_CODE_USE = "code_enable";
-	public    static final String KEY_DISABLE_AUDIO_TRACK_SORTING = "disable_audio_track_sorting";
+	public    static final String KEY_SORT_AUDIO_TRACKS_BY_ALBUM_POSITION = "sort_audio_tracks_by_album_position";
 	protected static final String KEY_DISABLE_EXTERNAL_ENTITIES = "disable_external_entities";
 	protected static final String KEY_DISABLE_FAKESIZE = "disable_fakesize";
 	public    static final String KEY_DISABLE_SUBTITLES = "disable_subtitles";

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -4814,8 +4814,8 @@ public class PmsConfiguration extends RendererConfiguration {
 		return cs;
 	}
 
-	public boolean getDisableAudioTrackSorting() {
-		return getBoolean(KEY_DISABLE_AUDIO_TRACK_SORTING, false);
+	public boolean isSortAudioTracksByAlbumPosition() {
+		return getBoolean(KEY_SORT_AUDIO_TRACKS_BY_ALBUM_POSITION, true);
 	}
 
 	public boolean isDynamicPls() {

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -150,6 +150,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_CODE_THUMBS = "code_show_thumbs_no_code";
 	protected static final String KEY_CODE_TMO = "code_valid_timeout";
 	protected static final String KEY_CODE_USE = "code_enable";
+	public    static final String KEY_DISABLE_AUDIO_TRACK_SORTING = "disable_audio_track_sorting";
 	protected static final String KEY_DISABLE_EXTERNAL_ENTITIES = "disable_external_entities";
 	protected static final String KEY_DISABLE_FAKESIZE = "disable_fakesize";
 	public    static final String KEY_DISABLE_SUBTITLES = "disable_subtitles";
@@ -4811,6 +4812,10 @@ public class PmsConfiguration extends RendererConfiguration {
 		}
 
 		return cs;
+	}
+
+	public boolean getDisableAudioTrackSorting() {
+		return getBoolean(KEY_DISABLE_AUDIO_TRACK_SORTING, false);
 	}
 
 	public boolean isDynamicPls() {

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1163,9 +1163,13 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 * @param dlna Folder containing child objects of any kind
 	 *
 	 * @return
-	 * 	TRUE, if all audio child objects belong to the same album and the majority of files are audio.
+	 * 	TRUE, if AudioTrackSorting is not disabled, all audio child objects belong to the same album and the majority of files are audio. 
 	 */
 	private boolean shouldDoAudioTrackSorting(DLNAResource dlna) {
+		if (PMS.getConfiguration().getDisableAudioTrackSorting()) {
+			return false;
+		}
+
 		String album = null;
 		int numberOfAudioFiles = 0;
 		int numberOfOtherFiles = 0;

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1128,7 +1128,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 					ThreadPoolExecutor tpe = new ThreadPoolExecutor(Math.min(count, nParallelThreads), count, 20, TimeUnit.SECONDS, queue,
 						new BasicThreadFactory("DLNAResource resolver thread %d-%d"));
 
-					if (hasAudioFilesSameAlbum(dlna)) {
+					if (shouldDoAudioTrackSorting(dlna)) {
 						sortChildrenWithAudioElements(dlna);
 					}
 					for (int i = start; i < start + count && i < dlna.getChildren().size(); i++) {
@@ -1158,32 +1158,41 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 
 	/**
 	 * Check if all audio child elements belong to the same album. Here the Album string is matched. Another more strict alternative
-	 * implementaion could match the MBID record id (not implemented).
+	 * implementation could match the MBID record id (not implemented).
 	 *
 	 * @param dlna Folder containing child objects of any kind
 	 *
 	 * @return
-	 * 	TRUE, if all audio child objects belong to the same album.
+	 * 	TRUE, if all audio child objects belong to the same album and the majority of files are audio.
 	 */
-	private boolean hasAudioFilesSameAlbum(DLNAResource dlna) {
+	private boolean shouldDoAudioTrackSorting(DLNAResource dlna) {
 		String album = null;
+		int numberOfAudioFiles = 0;
+		int numberOfOtherFiles = 0;
+
 		boolean audioExists = false;
 		for (DLNAResource res : dlna.getChildren()) {
 			if (res.getFormat() != null && res.getFormat().isAudio()) {
+				numberOfAudioFiles++;
 				if (album == null) {
 					audioExists = true;
 					if (res.getMedia().getFirstAudioTrack() == null) {
 						return false;
 					}
 					album = res.getMedia().getFirstAudioTrack().getAlbum() != null ? res.getMedia().getFirstAudioTrack().getAlbum() : "";
+					if (StringUtils.isAllBlank(album)) {
+						return false;
+					}
 				} else {
 					if (!album.equals(res.getMedia().getFirstAudioTrack().getAlbum())) {
 						return false;
 					}
 				}
+			} else {
+				numberOfOtherFiles++;
 			}
 		}
-		return audioExists;
+		return audioExists && (numberOfAudioFiles > numberOfOtherFiles);
 	}
 
 	private void sortChildrenWithAudioElements(DLNAResource dlna) {

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1166,7 +1166,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 * 	TRUE, if AudioTrackSorting is not disabled, all audio child objects belong to the same album and the majority of files are audio.
 	 */
 	private boolean shouldDoAudioTrackSorting(DLNAResource dlna) {
-		if (PMS.getConfiguration().getDisableAudioTrackSorting()) {
+		if (!PMS.getConfiguration().isSortAudioTracksByAlbumPosition()) {
 			return false;
 		}
 

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1163,7 +1163,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 * @param dlna Folder containing child objects of any kind
 	 *
 	 * @return
-	 * 	TRUE, if AudioTrackSorting is not disabled, all audio child objects belong to the same album and the majority of files are audio. 
+	 * 	TRUE, if AudioTrackSorting is not disabled, all audio child objects belong to the same album and the majority of files are audio.
 	 */
 	private boolean shouldDoAudioTrackSorting(DLNAResource dlna) {
 		if (PMS.getConfiguration().getDisableAudioTrackSorting()) {


### PR DESCRIPTION
Tweaked #2689 

sort audio files by track/disc only if:

- audio files album tag is not blanc
- the majority of resources are audio files
- feature can be disabled by setting `disable_audio_track_sorting = true` in UMS.conf