### PR TITLE
Fix NPE for possibly slow remote urls in DLNAResource.

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -2505,7 +2505,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 
 			// DESC Metadata support: add ability for control point to identify
 			// song by MusicBrainz TrackID
-			if (media.isAudio() && media.getFirstAudioTrack() != null && media.getFirstAudioTrack().getMbidRecord() != null) {
+			if (media != null && media.isAudio() && media.getFirstAudioTrack() != null && media.getFirstAudioTrack().getMbidRecord() != null) {
 				openTag(sb, "desc");
 				addAttribute(sb, "id", "2");
 				// TODO add real namespace


### PR DESCRIPTION
For me this NPE was manifesting when using Web content or `m3u` playlists with urls to my `tvheadned`. 
Randomly some tv channels were not showing up in the `dlna` clients giving only empty folders. While it was working ok over the web. After this change it seems to be stable so far.