### PR TITLE
Cling enable the streamserver by default

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/cling/UmsUpnpServiceConfiguration.java
+++ b/src/main/java/net/pms/network/mediaserver/cling/UmsUpnpServiceConfiguration.java
@@ -22,7 +22,6 @@ package net.pms.network.mediaserver.cling;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.network.mediaserver.cling.transport.impl.JdkHttpURLConnectionStreamClient;
-import net.pms.network.mediaserver.cling.transport.impl.EmptyStreamServer;
 import net.pms.network.mediaserver.cling.transport.impl.JdkHttpURLConnectionStreamClientConfiguration;
 import net.pms.network.mediaserver.cling.transport.impl.UmsNetworkAddressFactory;
 import org.fourthline.cling.DefaultUpnpServiceConfiguration;
@@ -31,6 +30,7 @@ import org.fourthline.cling.model.message.UpnpHeaders;
 import org.fourthline.cling.model.message.header.UpnpHeader;
 import org.fourthline.cling.model.meta.RemoteDeviceIdentity;
 import org.fourthline.cling.transport.impl.StreamServerConfigurationImpl;
+import org.fourthline.cling.transport.impl.StreamServerImpl;
 import org.fourthline.cling.transport.spi.NetworkAddressFactory;
 import org.fourthline.cling.transport.spi.StreamClient;
 import org.fourthline.cling.transport.spi.StreamServer;
@@ -68,10 +68,8 @@ public class UmsUpnpServiceConfiguration extends DefaultUpnpServiceConfiguration
 
 	@Override
 	public StreamServer createStreamServer(NetworkAddressFactory networkAddressFactory) {
-		return new EmptyStreamServer(
-				new StreamServerConfigurationImpl(
-						networkAddressFactory.getStreamListenPort()
-				)
+		return new StreamServerImpl(
+				new StreamServerConfigurationImpl(0)
 		);
 	}
 


### PR DESCRIPTION
fix @valib founded bug 👍
Cling use it's own http server to receive events from subscribed upnp devices.