### PR TITLE
update jaudiotagger from version 2.2.6 to version 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,11 +123,6 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- jaudiotagger repository made by goxr3plus -->
-		<repository>
-			<id>jitpack.io</id>
-			<url>https://jitpack.io</url>
-		</repository>
 	</repositories>
 	<dependencies>
 		<!-- TODO this can be removed when MEncoder is removed -->
@@ -345,9 +340,9 @@
 			<version>2.16.0</version>
 		</dependency>
 		<dependency>
-			<groupId>com.github.goxr3plus</groupId>
+			<groupId>net.jthink</groupId>
 			<artifactId>jaudiotagger</artifactId>
-			<version>2.2.7</version>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.jgoodies</groupId>


### PR DESCRIPTION
We use goxr3plus [Fake Repository](https://github.com/goxr3plus/jaudiotagger) in order to use `JAudioTagger` 2.2.6 with Gradle and Maven.
That add a repository dependency on `jitpack.io`.
As said on the [Fake Repository](https://github.com/goxr3plus/jaudiotagger) webpage, it's just a fork from [ijabz/jaudiotagger](https://bitbucket.org/ijabz/jaudiotagger)

[ijabz/jaudiotagger](https://bitbucket.org/ijabz/jaudiotagger) webpage advise that it is available from Maven central repository.
So use it... and update to the latest version 3.0.1.
Remove the repository dependency on `jitpack.io`.