### PR TITLE
Speed up playback on Kodi

### DIFF
--- a/src/main/external-resources/renderers/Kodi.conf
+++ b/src/main/external-resources/renderers/Kodi.conf
@@ -21,6 +21,7 @@ H264Level41Limited = false
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160
 SupportedVideoBitDepths = 8,10,12
+TranscodeFastStart = true
 
 Supported = f:3gp             v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac-lc|he-aac|ac3|eac3|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma        m:video/3gpp
 Supported = f:avi             v:cvid|divx|h263|h264|h265|mjpeg|mp4|mpeg1|mpeg2|vc1|wmv   a:aac-lc|he-aac|ac3|eac3|dts|dtshd|lpcm|mp2|mp3|mpa|truehd|wma        m:video/avi


### PR DESCRIPTION
Playback on Kodi takes lot of time. This helps to start playback about half time faster.