### PR TITLE
Maven slf4j and oshi-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -583,7 +583,7 @@
 			<!-- Check the org.slf4j:slf4j-api version of the other libraries before upgrading -->
 			<!-- Check the net.java.dev.jna:jna version of the other libraries before upgrading -->
 			<!-- Check the net.java.dev.jna:jna-platform version of the other libraries before upgrading -->
-			<version>6.1.1</version>
+			<version>6.1.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,17 +79,29 @@
 
 		<!--
 			org.slf4j:slf4j-api is shared with
+				- net.pms:ums
+				- com.rometools:rome
+				- ch.qos.logback:logback-classic
+				- com.github.junrar:junrar
+				- org.digitalmediaserver:cuelib-core
 				- su.litvak.chromecast:api-v2
 				- fm.last:coverartarchive-api
 				- com.github.oshi:oshi-core
 
-			Check the org.slf4j:slf4j-api version of the other libraries before upgrading
+			Check the org.slf4j:slf4j-api version of the other library before upgrading
+		-->
+		<slf4j-api-version>1.7.36</slf4j-api-version>
+
+		<!--
+			ch.qos.logback:logback-classic and logback-core is shared with
+				- net.pms:ums
 		-->
 		<logback-version>1.2.10</logback-version>
 		<surefire-version>3.0.0-M5</surefire-version>
 
 		<!--
 			net.java.dev.jna:jna-platform is shared with
+				- net.pms:ums
 				- com.github.oshi:oshi-core
 
 			Check the net.java.dev.jna:jna-platform version of the other library before upgrading
@@ -125,6 +137,12 @@
 		</repository>
 	</repositories>
 	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<!-- Check the org.slf4j:slf4j-api version of the other libraries before upgrading -->
+			<version>${slf4j-api-version}</version>
+		</dependency>
 		<!-- TODO this can be removed when MEncoder is removed -->
 		<dependency>
 			<groupId>org.beanshell</groupId>
@@ -161,9 +179,18 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
+			<!--
+				org.apache.httpcomponents:httpclient is shared with
+					- net.pms:ums
+					- org.apache.httpcomponents:httpasyncclient
+					- fm.last:coverartarchive-api
+
+				Check the org.apache.httpcomponents:httpclient version of the other library before upgrading
+			-->
 			<version>4.5.13</version>
 			<exclusions>
 				<exclusion>
+					<!-- org.apache.httpcomponents:httpcore updated from httpasyncclient -->
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpcore</artifactId>
 				</exclusion>
@@ -204,7 +231,14 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+			<!-- Check the org.slf4j:slf4j-api version of the other libraries before upgrading -->
 			<version>${logback-version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
@@ -232,15 +266,7 @@
 		<dependency>
 			<groupId>com.rometools</groupId>
 			<artifactId>rome</artifactId>
-			<!--
-				org.slf4j:slf4j-api is shared with
-					- ch.qos.logback:logback-classic
-					- su.litvak.chromecast
-					- fm.last:coverartarchive-api
-					- com.github.oshi:oshi-core
-
-				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
-			-->
+			<!-- Check the org.slf4j:slf4j-api version of the other libraries before upgrading -->
 			<version>1.18.0</version>
 			<exclusions>
 				<exclusion>
@@ -357,6 +383,7 @@
 		<dependency>
 			<groupId>com.github.junrar</groupId>
 			<artifactId>junrar</artifactId>
+			<!-- Check the org.slf4j:slf4j-api version of the other libraries before upgrading -->
 			<version>7.4.1</version>
 			<exclusions>
 				<exclusion>
@@ -368,6 +395,7 @@
 		<dependency>
 			<groupId>org.digitalmediaserver</groupId>
 			<artifactId>cuelib-core</artifactId>
+			<!-- Check the org.slf4j:slf4j-api version of the other libraries before upgrading -->
 			<version>2.0.0</version>
 			<exclusions>
 				<exclusion>
@@ -482,14 +510,7 @@
 		<dependency>
 			<groupId>su.litvak.chromecast</groupId>
 			<artifactId>api-v2</artifactId>
-			<!--
-				org.slf4j:slf4j-api is shared with
-					- ch.qos.logback:logback-classic
-					- fm.last:coverartarchive-api
-					- com.github.oshi:oshi-core
-
-				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
-			-->
+			<!-- Check the org.slf4j:slf4j-api version of the other libraries before upgrading -->
 			<version>0.11.3</version>
 			<exclusions>
 				<exclusion>
@@ -511,14 +532,8 @@
 		<dependency>
 			<groupId>fm.last</groupId>
 			<artifactId>coverartarchive-api</artifactId>
+			<!-- Check the org.slf4j:slf4j-api version of the other libraries before upgrading -->
 			<!--
-				org.slf4j:slf4j-api is shared with
-					- ch.qos.logback:logback-classic
-					- su.litvak.chromecast
-					- com.github.oshi:oshi-core
-
-				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
-
 				commons-logging:commons-logging is shared with
 					- commons-configuration:commons-configuration
 
@@ -565,24 +580,22 @@
 		<dependency>
 			<groupId>com.github.oshi</groupId>
 			<artifactId>oshi-core</artifactId>
-			<!--
-				org.slf4j:slf4j-api is shared with
-					- ch.qos.logback:logback-classic
-					- su.litvak.chromecast
-					- fm.last:coverartarchive-api
-
-				Check the org.slf4j:slf4j-api version of the other libraries before upgrading
-
-				net.java.dev.jna:jna-platform is shared with
-					- net.pms:ums
-
-				Check the net.java.dev.jna:jna-platform version before upgrading
-			-->
-			<version>5.8.6</version>
+			<!-- Check the org.slf4j:slf4j-api version of the other libraries before upgrading -->
+			<!-- Check the net.java.dev.jna:jna version of the other libraries before upgrading -->
+			<!-- Check the net.java.dev.jna:jna-platform version of the other libraries before upgrading -->
+			<version>6.1.1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>net.java.dev.jna</groupId>
+					<artifactId>jna</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>net.java.dev.jna</groupId>
+					<artifactId>jna-platform</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 				- fm.last:coverartarchive-api
 				- com.github.oshi:oshi-core
 
-			Check the org.slf4j:slf4j-api version of the other library before upgrading
+			Check the org.slf4j:slf4j-api version of the other libraries before upgrading
 		-->
 		<slf4j-api-version>1.7.36</slf4j-api-version>
 
@@ -104,7 +104,7 @@
 				- net.pms:ums
 				- com.github.oshi:oshi-core
 
-			Check the net.java.dev.jna:jna-platform version of the other library before upgrading
+			Check the net.java.dev.jna:jna-platform version of the other libraries before upgrading
 		-->
 		<jna-version>5.10.0</jna-version>
 
@@ -185,7 +185,7 @@
 					- org.apache.httpcomponents:httpasyncclient
 					- fm.last:coverartarchive-api
 
-				Check the org.apache.httpcomponents:httpclient version of the other library before upgrading
+				Check the org.apache.httpcomponents:httpclient version of the other libraries before upgrading
 			-->
 			<version>4.5.13</version>
 			<exclusions>
@@ -203,7 +203,7 @@
 				commons-io:commons-io is shared with
 					- fm.last:coverartarchive-api
 
-				Check the commons-io:commons-io version of the library before upgrading
+				Check the commons-io:commons-io version of the libraries before upgrading
 			-->
 			<version>2.11.0</version>
 		</dependency>


### PR DESCRIPTION
- maven direct slf4j dependency as UMS use it directly.
- bump oshi-core from 5.8.6 to 6.1.2