### PR TITLE
Fixed failed database writes

### DIFF
--- a/src/main/java/net/pms/database/MediaTableCoverArtArchive.java
+++ b/src/main/java/net/pms/database/MediaTableCoverArtArchive.java
@@ -154,39 +154,37 @@ public final class MediaTableCoverArtArchive extends MediaTable {
 				LOGGER.trace("Searching for Cover Art Archive cover with \"{}\" before update", query);
 			}
 
-			try (Statement statement = connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE)) {
-				connection.setAutoCommit(false);
-				try (ResultSet result = statement.executeQuery(query)) {
-					if (result.next()) {
-						if (cover != null || result.getBlob("COVER") == null) {
-							if (trace) {
-								LOGGER.trace("Updating cover for MBID \"{}\"", mBID);
-							}
-							result.updateTimestamp("MODIFIED", new Timestamp(System.currentTimeMillis()));
-							if (cover != null) {
-								result.updateBytes("COVER", cover);
-							} else {
-								result.updateNull("COVER");
-							}
-							result.updateRow();
-						} else if (trace) {
-							LOGGER.trace("Leaving row {} alone since previous information seems better", result.getInt("ID"));
-						}
-					} else {
+			try (
+				Statement statement = connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
+				ResultSet result = statement.executeQuery(query)
+			) {
+				if (result.next()) {
+					if (cover != null || result.getBlob("COVER") == null) {
 						if (trace) {
-							LOGGER.trace("Inserting new cover for MBID \"{}\"", mBID);
+							LOGGER.trace("Updating cover for MBID \"{}\"", mBID);
 						}
-
-						result.moveToInsertRow();
 						result.updateTimestamp("MODIFIED", new Timestamp(System.currentTimeMillis()));
-						result.updateString("MBID", mBID);
 						if (cover != null) {
 							result.updateBytes("COVER", cover);
+						} else {
+							result.updateNull("COVER");
 						}
-						result.insertRow();
+						result.updateRow();
+					} else if (trace) {
+						LOGGER.trace("Leaving row {} alone since previous information seems better", result.getInt("ID"));
 					}
-				} finally {
-					connection.commit();
+				} else {
+					if (trace) {
+						LOGGER.trace("Inserting new cover for MBID \"{}\"", mBID);
+					}
+
+					result.moveToInsertRow();
+					result.updateTimestamp("MODIFIED", new Timestamp(System.currentTimeMillis()));
+					result.updateString("MBID", mBID);
+					if (cover != null) {
+						result.updateBytes("COVER", cover);
+					}
+					result.insertRow();
 				}
 			}
 		} catch (SQLException e) {

--- a/src/main/java/net/pms/database/MediaTableFailedLookups.java
+++ b/src/main/java/net/pms/database/MediaTableFailedLookups.java
@@ -216,22 +216,20 @@ public final class MediaTableFailedLookups extends MediaTable {
 				LOGGER.trace("Searching for file/series in " + TABLE_NAME + " with \"{}\" before update", query);
 			}
 
-			try (Statement statement = connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE)) {
-				connection.setAutoCommit(false);
-				try (ResultSet result = statement.executeQuery(query)) {
-					if (result.next()) {
-						result.updateString("FAILUREDETAILS", left(failureDetails, 20000));
-						result.updateString("VERSION", left(latestVersion, 1024));
-						result.updateRow();
-					} else {
-						result.moveToInsertRow();
-						result.updateString("FILENAME", left(fullPathToFile, 1024));
-						result.updateString("FAILUREDETAILS", left(failureDetails, 20000));
-						result.updateString("VERSION", left(latestVersion, 1024));
-						result.insertRow();
-					}
-				} finally {
-					connection.commit();
+			try (
+				Statement statement = connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
+				ResultSet result = statement.executeQuery(query)
+			) {
+				if (result.next()) {
+					result.updateString("FAILUREDETAILS", left(failureDetails, 20000));
+					result.updateString("VERSION", left(latestVersion, 1024));
+					result.updateRow();
+				} else {
+					result.moveToInsertRow();
+					result.updateString("FILENAME", left(fullPathToFile, 1024));
+					result.updateString("FAILUREDETAILS", left(failureDetails, 20000));
+					result.updateString("VERSION", left(latestVersion, 1024));
+					result.insertRow();
 				}
 			}
 		} catch (SQLException e) {

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -662,7 +662,6 @@ public class MediaTableFiles extends MediaTable {
 	 */
 	public static void insertOrUpdateData(final Connection connection, String name, long modified, int type, DLNAMediaInfo media) throws SQLException {
 		try {
-			connection.setAutoCommit(false);
 			long fileId = -1;
 			try (PreparedStatement ps = connection.prepareStatement(
 				"SELECT " +
@@ -866,8 +865,6 @@ public class MediaTableFiles extends MediaTable {
 				MediaTableAudiotracks.insertOrUpdateAudioTracks(connection, fileId, media);
 				MediaTableSubtracks.insertOrUpdateSubtitleTracks(connection, fileId, media);
 			}
-
-			connection.commit();
 		} catch (SQLException se) {
 			if (se.getErrorCode() == 23505) {
 				throw new SQLException(String.format(
@@ -925,17 +922,18 @@ public class MediaTableFiles extends MediaTable {
 			return;
 		}
 
-		connection.setAutoCommit(false);
-		try (PreparedStatement ps = connection.prepareStatement(
-			"SELECT " +
-				"ID, IMDBID, MEDIA_YEAR, MOVIEORSHOWNAME, MOVIEORSHOWNAMESIMPLE, TVSEASON, TVEPISODENUMBER, TVEPISODENAME, ISTVEPISODE, EXTRAINFORMATION, VERSION " +
-			"FROM " + TABLE_NAME + " " +
-			"WHERE " +
-				"FILENAME = ? AND MODIFIED = ? " +
-			"LIMIT 1",
-			ResultSet.TYPE_FORWARD_ONLY,
-			ResultSet.CONCUR_UPDATABLE
-		)) {
+		try (
+			PreparedStatement ps = connection.prepareStatement(
+				"SELECT " +
+					"ID, IMDBID, MEDIA_YEAR, MOVIEORSHOWNAME, MOVIEORSHOWNAMESIMPLE, TVSEASON, TVEPISODENUMBER, TVEPISODENAME, ISTVEPISODE, EXTRAINFORMATION, VERSION " +
+				"FROM " + TABLE_NAME + " " +
+				"WHERE " +
+					"FILENAME = ? AND MODIFIED = ? " +
+				"LIMIT 1",
+				ResultSet.TYPE_FORWARD_ONLY,
+				ResultSet.CONCUR_UPDATABLE
+			)
+		) {
 			ps.setString(1, path);
 			ps.setTimestamp(2, new Timestamp(modified));
 			try (ResultSet rs = ps.executeQuery()) {
@@ -956,7 +954,6 @@ public class MediaTableFiles extends MediaTable {
 					return;
 				}
 			}
-			connection.commit();
 		}
 	}
 

--- a/src/main/java/net/pms/database/MediaTableMetadata.java
+++ b/src/main/java/net/pms/database/MediaTableMetadata.java
@@ -141,26 +141,24 @@ public class MediaTableMetadata extends MediaTable {
 				LOGGER.trace("Searching for value in METADATA with \"{}\" before update", query);
 			}
 
-			try (Statement statement = connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE)) {
-				connection.setAutoCommit(false);
-				try (ResultSet result = statement.executeQuery(query)) {
-					boolean isCreatingNewRecord = false;
+			try (
+				Statement statement = connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
+				ResultSet result = statement.executeQuery(query)
+			) {
+				boolean isCreatingNewRecord = false;
 
-					if (!result.next()) {
-						isCreatingNewRecord = true;
-						result.moveToInsertRow();
-					}
+				if (!result.next()) {
+					isCreatingNewRecord = true;
+					result.moveToInsertRow();
+				}
 
-					result.updateString("M_KEY", key);
-					result.updateString("M_VALUE", value);
+				result.updateString("M_KEY", key);
+				result.updateString("M_VALUE", value);
 
-					if (isCreatingNewRecord) {
-						result.insertRow();
-					} else {
-						result.updateRow();
-					}
-				} finally {
-					connection.commit();
+				if (isCreatingNewRecord) {
+					result.insertRow();
+				} else {
+					result.updateRow();
 				}
 			}
 		} catch (SQLException se) {

--- a/src/main/java/net/pms/database/MediaTableMusicBrainzReleases.java
+++ b/src/main/java/net/pms/database/MediaTableMusicBrainzReleases.java
@@ -252,67 +252,65 @@ public final class MediaTableMusicBrainzReleases extends MediaTable {
 				LOGGER.trace("Searching for release MBID with \"{}\" before update", query);
 			}
 
-			try (Statement statement = connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE)) {
-				connection.setAutoCommit(false);
-				try (ResultSet result = statement.executeQuery(query)) {
-					if (result.next()) {
-						if (StringUtil.hasValue(mBID) || !StringUtil.hasValue(result.getString("MBID"))) {
-							if (trace) {
-								LOGGER.trace("Updating row {} to MBID \"{}\"", result.getInt("ID"), mBID);
-							}
-							result.updateTimestamp("MODIFIED", new Timestamp(System.currentTimeMillis()));
-							if (StringUtil.hasValue(mBID)) {
-								result.updateString("MBID", mBID);
-							} else {
-								result.updateNull("MBID");
-							}
-							result.updateRow();
-						} else if (trace) {
-							LOGGER.trace("Leaving row {} alone since previous information seems better", result.getInt("ID"));
-						}
-					} else {
+			try (
+				Statement statement = connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
+				ResultSet result = statement.executeQuery(query)
+			) {
+				if (result.next()) {
+					if (StringUtil.hasValue(mBID) || !StringUtil.hasValue(result.getString("MBID"))) {
 						if (trace) {
-							LOGGER.trace(
-								"Inserting new row for MBID \"{}\":\n" +
-								"     Artist    \"{}\"\n" +
-								"     Album     \"{}\"\n" +
-								"     Title     \"{}\"\n" +
-								"     Year      \"{}\"\n" +
-								"     Artist ID \"{}\"\n" +
-								"     Track ID  \"{}\"\n",
-								mBID, tagInfo.artist, tagInfo.album,
-								tagInfo.title, tagInfo.year,
-								tagInfo.artistId, tagInfo.trackId
-							);
+							LOGGER.trace("Updating row {} to MBID \"{}\"", result.getInt("ID"), mBID);
 						}
-
-						result.moveToInsertRow();
 						result.updateTimestamp("MODIFIED", new Timestamp(System.currentTimeMillis()));
 						if (StringUtil.hasValue(mBID)) {
 							result.updateString("MBID", mBID);
+						} else {
+							result.updateNull("MBID");
 						}
-						if (StringUtil.hasValue(tagInfo.album)) {
-							result.updateString("ALBUM", left(tagInfo.album, 1000));
-						}
-						if (StringUtil.hasValue(tagInfo.artist)) {
-							result.updateString("ARTIST", left(tagInfo.artist, 1000));
-						}
-						if (StringUtil.hasValue(tagInfo.title)) {
-							result.updateString("TITLE", left(tagInfo.title, 1000));
-						}
-						if (StringUtil.hasValue(tagInfo.year)) {
-							result.updateString("MEDIA_YEAR", left(tagInfo.year, 20));
-						}
-						if (StringUtil.hasValue(tagInfo.artistId)) {
-							result.updateString("ARTIST_ID", tagInfo.artistId);
-						}
-						if (StringUtil.hasValue(tagInfo.trackId)) {
-							result.updateString("TRACK_ID", tagInfo.trackId);
-						}
-						result.insertRow();
+						result.updateRow();
+					} else if (trace) {
+						LOGGER.trace("Leaving row {} alone since previous information seems better", result.getInt("ID"));
 					}
-				} finally {
-					connection.commit();
+				} else {
+					if (trace) {
+						LOGGER.trace(
+							"Inserting new row for MBID \"{}\":\n" +
+							"     Artist    \"{}\"\n" +
+							"     Album     \"{}\"\n" +
+							"     Title     \"{}\"\n" +
+							"     Year      \"{}\"\n" +
+							"     Artist ID \"{}\"\n" +
+							"     Track ID  \"{}\"\n",
+							mBID, tagInfo.artist, tagInfo.album,
+							tagInfo.title, tagInfo.year,
+							tagInfo.artistId, tagInfo.trackId
+						);
+					}
+
+					result.moveToInsertRow();
+					result.updateTimestamp("MODIFIED", new Timestamp(System.currentTimeMillis()));
+					if (StringUtil.hasValue(mBID)) {
+						result.updateString("MBID", mBID);
+					}
+					if (StringUtil.hasValue(tagInfo.album)) {
+						result.updateString("ALBUM", left(tagInfo.album, 1000));
+					}
+					if (StringUtil.hasValue(tagInfo.artist)) {
+						result.updateString("ARTIST", left(tagInfo.artist, 1000));
+					}
+					if (StringUtil.hasValue(tagInfo.title)) {
+						result.updateString("TITLE", left(tagInfo.title, 1000));
+					}
+					if (StringUtil.hasValue(tagInfo.year)) {
+						result.updateString("MEDIA_YEAR", left(tagInfo.year, 20));
+					}
+					if (StringUtil.hasValue(tagInfo.artistId)) {
+						result.updateString("ARTIST_ID", tagInfo.artistId);
+					}
+					if (StringUtil.hasValue(tagInfo.trackId)) {
+						result.updateString("TRACK_ID", tagInfo.trackId);
+					}
+					result.insertRow();
 				}
 			}
 		} catch (SQLException e) {

--- a/src/main/java/net/pms/database/MediaTableThumbnails.java
+++ b/src/main/java/net/pms/database/MediaTableThumbnails.java
@@ -202,6 +202,7 @@ public final class MediaTableThumbnails extends MediaTable {
 					}
 				} finally {
 					connection.commit();
+					connection.setAutoCommit(true);
 				}
 			}
 		} catch (SQLException e) {

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -3929,7 +3929,9 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 					try {
 						connection = MediaDatabase.getConnectionIfAvailable();
 						if (connection != null) {
+							connection.setAutoCommit(false);
 							MediaTableFiles.insertOrUpdateData(connection, file.getAbsolutePath(), file.lastModified(), getType(), media);
+							connection.commit();
 						}
 					} catch (SQLException e) {
 						LOGGER.error("Database error while trying to add parsed information for \"{}\" to the cache: {}", file,
@@ -5059,8 +5061,10 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			Connection connection = null;
 			try {
 				connection = MediaDatabase.getConnectionIfAvailable();
-				if (!MediaTableFiles.isDataExists(connection, file.getAbsolutePath(), file.lastModified())) {
+				if (connection != null && !MediaTableFiles.isDataExists(connection, file.getAbsolutePath(), file.lastModified())) {
+					connection.setAutoCommit(false);
 					MediaTableFiles.insertOrUpdateData(connection, file.getAbsolutePath(), file.lastModified(), formatType, null);
+					connection.commit();
 				}
 			} catch (SQLException e) {
 				LOGGER.error("Database error while trying to store \"{}\" in the cache: {}", file.getName(), e.getMessage());

--- a/src/main/java/net/pms/util/APIUtils.java
+++ b/src/main/java/net/pms/util/APIUtils.java
@@ -208,6 +208,9 @@ public class APIUtils {
 				if (connection == null) {
 					return;
 				}
+
+				connection.setAutoCommit(false);
+
 				if (MediaTableFiles.doesLatestApiMetadataExist(connection, file.getAbsolutePath(), file.lastModified())) {
 					LOGGER.trace("The latest metadata already exists for {}", file.getName());
 					return;
@@ -409,6 +412,7 @@ public class APIUtils {
 					}
 					MediaTableVideoMetadataReleased.set(connection, file.getAbsolutePath(), (String) metadataFromAPI.get("released"), -1);
 				}
+				connection.commit();
 			} catch (SQLException ex) {
 				LOGGER.trace("Error in API parsing:", ex);
 			} finally {


### PR DESCRIPTION
There were some cases of a method establishing a shared db `Connection`, then calling another method which altered that connection using `setAutoCommit`, which caused unexpected results.
In this commit I have tried to establish a pattern where the method that establishes the `Connection`, is also the one that alters it, which gives better visibility over the state of the `Connection`.
Along the way I did minor optimizations that shave milliseconds.

This is a high priority bugfix so can I please get a review soon @UniversalMediaServer/developers 

Closes #2856 