### PR TITLE
First run fixes

### DIFF
--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -513,11 +513,17 @@ public class PMS {
 				configuration.setEnginePriorityBelow(YoutubeDl.ID, FFmpegWebVideo.ID);
 			}
 
-			// Set default local shared content
-			configuration.setSharedFoldersToDefault();
+			// Set default local shared content if the wizard has not set it
+			if (configuration.isSharedFoldersEmpty()) {
+				configuration.setSharedFoldersToDefault();
+			}
 
 			// Set default remote shared content
-			configuration.writeWebConfigurationFile();
+			String webConfPath = configuration.getWebConfPath();
+			File webConf = new File(webConfPath);
+			if (!webConf.exists()) {
+				configuration.writeWebConfigurationFile();
+			}
 
 			// Ensure this only happens once
 			configuration.setHasRunOnce();

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -3316,11 +3316,14 @@ public class PmsConfiguration extends RendererConfiguration {
 	public void setOnlySharedDirectory(String directoryPath) {
 		synchronized (sharedFoldersLock) {
 			configuration.setProperty(KEY_FOLDERS, directoryPath);
+			configuration.setProperty(KEY_FOLDERS_MONITORED, directoryPath);
 			ArrayList<Path> tmpSharedfolders = new ArrayList<>();
 			Path folder = Paths.get(directoryPath);
 			tmpSharedfolders.add(folder);
 			sharedFolders = tmpSharedfolders;
+			monitoredFolders = tmpSharedfolders;
 			sharedFoldersRead = true;
+			monitoredFoldersRead = true;
 		}
 	}
 


### PR DESCRIPTION
Fixes bugs that can be encountered by first time users or people manually setting up configs

- Fixed overwriting the shared folder from the wizard with defaults
- Fixed overwriting WEB.conf with defaults if UMS.conf is missing
- Fixed initial shared folder not being monitored