### PR TITLE
Bugfix: audio files get identified as video files -> Wrong 'protocolI…

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -1434,7 +1434,7 @@ public class DLNAMediaInfo implements Cloneable {
 		}
 
 		if (mimeType == null) {
-			if (codecV != null) {
+			if (codecV != null && !codecV.equals(DLNAMediaLang.UND)) {
 				if ("matroska".equals(container) || "mkv".equals(container)) {
 					mimeType = HTTPResource.MATROSKA_TYPEMIME;
 				} else if ("ogg".equals(container)) {
@@ -1462,7 +1462,7 @@ public class DLNAMediaInfo implements Cloneable {
 				} else if (codecV.contains("mpeg") || codecV.contains("mpg")) {
 					mimeType = HTTPResource.MPEG_TYPEMIME;
 				}
-			} else if (codecV == null && codecA != null) {
+			} else if ((codecV == null || codecV.equals(DLNAMediaLang.UND)) && codecA != null) {
 				if ("ogg".equals(container) || "oga".equals(container)) {
 					mimeType = HTTPResource.AUDIO_OGA_TYPEMIME;
 				} else if ("3gp".equals(container)) {

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -549,10 +549,6 @@ public class LibMediaInfoParser {
 				media.setContainer(DLNAMediaLang.UND);
 			}
 
-			if (media.getCodecV() == null) {
-				media.setCodecV(DLNAMediaLang.UND);
-			}
-
 			media.setMediaparsed(true);
 		}
 	}

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -549,6 +549,10 @@ public class LibMediaInfoParser {
 				media.setContainer(DLNAMediaLang.UND);
 			}
 
+			if (media.getCodecV() == null) {
+				media.setCodecV(DLNAMediaLang.UND);
+			}
+
 			media.setMediaparsed(true);
 		}
 	}


### PR DESCRIPTION
Audio files are being identified as video files at some points in the code, because the VideoCodec (VIDEOC attribute) is set to 'und' if no video is present, but UMS code checks against NULL later: 

DLNAMediaInfo line 1465 following 

```
} else if (codecV == null && codecA != null) {
	if ("ogg".equals(container) || "oga".equals(container)) {
		mimeType = HTTPResource.AUDIO_OGA_TYPEMIME;
	} else if ("3gp".equals(container)) {
		mimeType = HTTPResource.AUDIO_THREEGPPA_TYPEMIME;
	} else if ("3g2".equals(container)) {
		mimeType = HTTPResource.AUDIO_THREEGPP2A_TYPEMIME;
	} else if ("adts".equals(container)) {
[...]
```

For audio files the mime type will therefore not be checked delivering a wrong mime-type, leading to an incorrect protocol-info res-attribute (video/mpeg) instead of an audio/[...] in DIDL string. 

From my perspective NULL makes somehow more sense (changes in this PR). 
