### PR TITLE
Remove video.js second toolbar

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -1420,7 +1420,7 @@ web_threads =
 
 # Web flash
 # ---------
-# Use flash player by default.
+# Use flash player on the web interface.
 # Default: false
 web_flash =
 

--- a/src/main/external-resources/web/play.html
+++ b/src/main/external-resources/web/play.html
@@ -48,9 +48,6 @@
 	{{#nextId}}
 				function next() {window.location.replace('/play/{{nextId}}?html5=1');}
 	{{/nextId}}
-	{{#isVideo}}
-				function flash() {window.location.replace('/play/{{id1}}?flash=1');}
-	{{/isVideo}}
 			</script>
 			<div id="Container" class="noHzScroll">
 				<div id="FoldersContainer">
@@ -94,28 +91,22 @@
 								<p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
 							</{{mediaType}}>
 							{{^isVideo}}
-							<div class="well {{^isVideo}}full-card{{/isVideo}}">
-								<h2>{{name}}</h2>
-								{{#isNativeAudio}}
-									<img id="poster" src="/thumb/{{id1}}" style="max-width:100%;" />
-								{{/isNativeAudio}}
-							</div>
+								<div class="well {{^isVideo}}full-card{{/isVideo}}">
+									<h2>{{name}}</h2>
+									{{#isNativeAudio}}
+										<img id="poster" src="/thumb/{{id1}}" style="max-width:100%;" />
+									{{/isNativeAudio}}
+								</div>
 							{{/isVideo}}
 							{{^isNativeAudio}}
-							<div id="toolbar" class=" {{^isVideo}}full-card{{/isVideo}}">
-								<button id="prev" onclick="prev()"{{prevAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-prev"></span></button>
-								<button id="play" onclick="play()" type="button" class="btn btn-sm btn-playbar"><span class="icon-player-play"></span></button>
-								<button id="pause" onclick="pause()" type="button" class="btn btn-sm btn-playbar"><span class="icon-player-pause"></span></button>
-								<button id="next" onclick="next()"{{nextAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-next"></span></button>
-								{{#plsSign}}
-								<button id="playlist" title="{{plsAttr}}" onclick="umsAjax('/playlist/{{plsOp}}/{{id1}}', false);return false;" type="button" class="btn btn-sm btn-playbar">{{plsSign}}</button>
-								{{/plsSign}}
-								{{#isVideo}}
-								<button id="flash" onclick="flash()" title="Switch to flash player" type="button" class="btn btn-sm btn-playbar"><span>Flash</span></button>
-								{{/isVideo}}
-								<a href="/raw/{{id1}}" target="_blank" download="{{name}}" id="DownloadLink" title="Download this {{mediaType}}" class="btn btn-sm btn-playbar"><span class="fa fa-download"></span></a>
-								<button id="fullscreen" onclick="GoInFullscreen(videojs('player'));" title="Fullscreen Mode" class="btn btn-sm btn-playbar"><span class="icon-player-size-fullscreen"></span></button>
-							</div>
+								<div id="toolbar" class=" {{^isVideo}}full-card{{/isVideo}}">
+									<button id="prev" onclick="prev()"{{prevAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-prev"></span></button>
+									<button id="next" onclick="next()"{{nextAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-next"></span></button>
+									{{#plsSign}}
+									<button id="playlist" title="{{plsAttr}}" onclick="umsAjax('/playlist/{{plsOp}}/{{id1}}', false);return false;" type="button" class="btn btn-sm btn-playbar">{{plsSign}}</button>
+									{{/plsSign}}
+									<a href="/raw/{{id1}}" target="_blank" download="{{name}}" id="DownloadLink" title="Download this {{mediaType}}" class="btn btn-sm btn-playbar"><span class="fa fa-download"></span></a>
+								</div>
 							{{/isNativeAudio}}
 						</div>
 					{{/isVideoWithAPIData}}
@@ -158,17 +149,11 @@
 								{{/isVideo}}
 								<div id="toolbar" class=" {{^isVideo}}full-card{{/isVideo}}">
 									<button id="prev" onclick="prev()"{{prevAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-prev"></span></button>
-									<button id="play" onclick="play()" type="button" class="btn btn-sm btn-playbar"><span class="icon-player-play"></span></button>
-									<button id="pause" onclick="pause()" type="button" class="btn btn-sm btn-playbar"><span class="icon-player-pause"></span></button>
 									<button id="next" onclick="next()"{{nextAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-next"></span></button>
 									{{#plsSign}}
 										<button id="playlist" title="{{plsAttr}}" onclick="umsAjax('/playlist/{{plsOp}}/{{id1}}', false);return false;" type="button" class="btn btn-sm btn-playbar">{{plsSign}}</button>
 									{{/plsSign}}
-									{{#isVideo}}
-										<button id="flash" onclick="flash()" title="Switch to flash player" type="button" class="btn btn-sm btn-playbar"><span>Flash</span></button>
-									{{/isVideo}}
 									<a href="/raw/{{id1}}" target="_blank" download="{{name}}" id="DownloadLink" title="Download this {{mediaType}}" class="btn btn-sm btn-playbar"><span class="fa fa-download"></span></a>
-									<button id="fullscreen" onclick="GoInFullscreen(videojs('player'));" title="Fullscreen Mode" class="btn btn-sm btn-playbar"><span class="icon-player-size-fullscreen"></span></button>
 								</div>
 							</div>
 							<div class="mediaInfoText">

--- a/src/main/external-resources/web/play.html
+++ b/src/main/external-resources/web/play.html
@@ -41,14 +41,6 @@
 					</div>
 				</div>
 			</nav>
-			<script>
-	{{#prevId}}
-				function prev() {window.location.replace('/play/{{prevId}}?html5=1');}
-	{{/prevId}}
-	{{#nextId}}
-				function next() {window.location.replace('/play/{{nextId}}?html5=1');}
-	{{/nextId}}
-			</script>
 			<div id="Container" class="noHzScroll">
 				<div id="FoldersContainer">
 					<ul id="Folders" class="nav nav-sidebar">
@@ -99,14 +91,11 @@
 								</div>
 							{{/isVideo}}
 							{{^isNativeAudio}}
-								<div id="toolbar" class=" {{^isVideo}}full-card{{/isVideo}}">
-									<button id="prev" onclick="prev()"{{prevAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-prev"></span></button>
-									<button id="next" onclick="next()"{{nextAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-next"></span></button>
-									{{#plsSign}}
-									<button id="playlist" title="{{plsAttr}}" onclick="umsAjax('/playlist/{{plsOp}}/{{id1}}', false);return false;" type="button" class="btn btn-sm btn-playbar">{{plsSign}}</button>
-									{{/plsSign}}
-									<a href="/raw/{{id1}}" target="_blank" download="{{name}}" id="DownloadLink" title="Download this {{mediaType}}" class="btn btn-sm btn-playbar"><span class="fa fa-download"></span></a>
-								</div>
+								{{#plsSign}}
+									<div id="toolbar" class="{{^isVideo}}full-card{{/isVideo}}">
+										<button id="playlist" title="{{plsAttr}}" onclick="umsAjax('/playlist/{{plsOp}}/{{id1}}', false);return false;" type="button" class="btn btn-sm btn-playbar">{{plsSign}}</button>
+									</div>
+								{{/plsSign}}
 							{{/isNativeAudio}}
 						</div>
 					{{/isVideoWithAPIData}}
@@ -147,14 +136,11 @@
 										<h2>{{name}}</h2>
 									</div>
 								{{/isVideo}}
-								<div id="toolbar" class=" {{^isVideo}}full-card{{/isVideo}}">
-									<button id="prev" onclick="prev()"{{prevAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-prev"></span></button>
-									<button id="next" onclick="next()"{{nextAttr}} type="button" class="btn btn-sm btn-playbar"><span class="icon-player-next"></span></button>
-									{{#plsSign}}
+								{{#plsSign}}
+									<div id="toolbar" class="{{^isVideo}}full-card{{/isVideo}}">
 										<button id="playlist" title="{{plsAttr}}" onclick="umsAjax('/playlist/{{plsOp}}/{{id1}}', false);return false;" type="button" class="btn btn-sm btn-playbar">{{plsSign}}</button>
-									{{/plsSign}}
-									<a href="/raw/{{id1}}" target="_blank" download="{{name}}" id="DownloadLink" title="Download this {{mediaType}}" class="btn btn-sm btn-playbar"><span class="fa fa-download"></span></a>
-								</div>
+									</div>
+								{{/plsSign}}
 							</div>
 							<div class="mediaInfoText">
 								<h1>{{name}}</h1>
@@ -201,6 +187,39 @@
 						status('volume', (player.volume * 100).toFixed(0));
 					}
 
+					var Button = videojs.getComponent('Button');
+					{{#prevId}}
+						var prevButton = new Button(videojs('player'), {
+							className: 'icon-player-prev',
+							controlText: '{{prevName}}',
+							clickHandler: function(event) {
+								window.location.replace('/play/{{prevId}}?html5=1');
+								videojs.log('prev clicked');
+							}
+						});
+						var prevButtonAddedResponse = videojs('player').controlBar.addChild(prevButton);
+					{{/prevId}}
+					{{#nextId}}
+						var nextButton = new Button(videojs('player'), {
+							className: 'icon-player-next',
+							controlText: '{{nextName}}',
+							clickHandler: function(event) {
+								window.location.replace('/play/{{nextId}}?html5=1');
+								videojs.log('next clicked');
+							}
+						});
+						var nextButtonAddedResponse = videojs('player').controlBar.addChild(nextButton);
+					{{/nextId}}
+					var downloadButton = new Button(videojs('player'), {
+						className: 'fa fa-download',
+						controlText: 'Download this {{mediaType}}',
+						clickHandler: function(event) {
+							window.location.replace('/raw/{{id1}}');
+							videojs.log('download clicked');
+						},
+					});
+					var downloadButtonAddedResponse = videojs('player').controlBar.addChild(downloadButton);
+
 					player.addEventListener('playing', function(){status('playback', 'PLAYING');});
 					player.addEventListener('play', function(){status('playback', 'PLAYING');});
 
@@ -242,11 +261,10 @@
 									break;
 							}
 						}
-					{{/push}}			
+					{{/push}}
 				</script>
 			{{/isNativeAudio}}
 			<input type="hidden" class="jQKeyboard" name="dummy">
-			<script src="/files/util/fontawesome/js/all.min.js"></script>
 		</div>
 	</body>
 </html>

--- a/src/main/java/net/pms/network/webinterfaceserver/handlers/PlayHandler.java
+++ b/src/main/java/net/pms/network/webinterfaceserver/handlers/PlayHandler.java
@@ -169,7 +169,7 @@ public class PlayHandler implements HttpHandler {
 			}
 			String pos = step > 0 ? "next" : "prev";
 			vars.put(pos + "Id", next != null ? next.getResourceId() : null);
-			vars.put(pos + "Attr", next != null ? (" title=\"" + StringEscapeUtils.escapeHtml(next.resumeName()) + "\"") : " disabled");
+			vars.put(pos + "Name", next != null ? (StringEscapeUtils.escapeHtml(next.resumeName())) : null);
 		}
 	}
 


### PR DESCRIPTION
This also removes the ability to switch to the Flash player in the GUI, but I have left in the code for legacy users to use it via UMS.conf

Closes https://github.com/UniversalMediaServer/UniversalMediaServer/issues/2819