### PR TITLE
Playlist API extension: new call getServerPlaylists

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/handlers/api/playlist/PlaylistIdentVO.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/api/playlist/PlaylistIdentVO.java
@@ -1,0 +1,21 @@
+package net.pms.network.mediaserver.handlers.api.playlist;
+
+
+/**
+ * Represents a server playlist entry
+ */
+public class PlaylistIdentVO {
+
+	public String playlistName = "";
+	public Integer playlistId = null;
+
+	public PlaylistIdentVO() {
+	}
+
+
+	public PlaylistIdentVO(String playlistName, Integer playlistId) {
+		super();
+		this.playlistName = playlistName;
+		this.playlistId = playlistId;
+	}
+}

--- a/src/main/java/net/pms/network/mediaserver/handlers/api/playlist/PlaylistService.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/api/playlist/PlaylistService.java
@@ -32,6 +32,11 @@ public class PlaylistService implements ApiResponseHandler {
 					String playlists = om.writeValueAsString(pm.getAvailablePlaylistNames());
 					output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json; charset=UTF-8");
 					return playlists;
+				case "getserverplaylists":
+					LOGGER.trace("getserverplaylists");
+					String serverPlaylists = om.writeValueAsString(pm.getServerAccessiblePlaylists());
+					output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json; charset=UTF-8");
+					return serverPlaylists;
 				case "addsongtoplaylist":
 					LOGGER.trace("addsongtoplaylist");
 					AudioPlaylistVO add = getParamsFromContent(content);


### PR DESCRIPTION
Added API call for obtaining managed playlists with UMS-IDs known to UMS (cache enabled). Managed playlist folder must be reachable by Library Scanner. Playlist can then be browsed (UPnP browse request) directly by deep link to objectID `$DBID$PLAYLIST$` + `ID`, where ID is referencing to the column ID from the FILES table.