### PR TITLE
web settings DirectoryChooser fixes

### DIFF
--- a/configuration-client/src/components/DirectoryChooser/DirectoryChooser.tsx
+++ b/configuration-client/src/components/DirectoryChooser/DirectoryChooser.tsx
@@ -2,7 +2,7 @@ import { Button, Box, Stack, Modal, Group, TextInput, Breadcrumbs, Paper } from 
 import { showNotification } from '@mantine/notifications';
 import React, { useState } from 'react';
 import axios from 'axios';
-import { Folder, Folders } from 'tabler-icons-react';
+import { Devices2, Folder, Folders } from 'tabler-icons-react';
 
 export default function DirectoryChooser(props: {
   path: string,
@@ -14,8 +14,9 @@ export default function DirectoryChooser(props: {
   const [opened, setOpened] = useState(false);
 
   const [directories, setDirectories] = useState([] as { value: string, label: string }[]);
-  const [children, setChildren] = useState([] as { value: string, label: string }[]);
+  const [parents, setParents] = useState([] as { value: string, label: string }[]);
   const [selectedDirectory, setSelectedDirectory] = useState('');
+  const [separator, setSeparator] = useState('/');
 
   const openGitHubNewIssue = () => {
     window.location.href = 'https://github.com/UniversalMediaServer/UniversalMediaServer/issues/new';
@@ -35,15 +36,12 @@ export default function DirectoryChooser(props: {
   };
 
   const getSubdirectories = (path: string) => {
-    let apiUri = '/configuration-api/directories';
-    if (path) {
-      apiUri += '?path=' + path;
-    }
-    axios.get(apiUri)
+    axios.post('/configuration-api/directories', {path:(path)?path:''})
       .then(function (response: any) {
         const directoriesResponse = response.data;
-        setDirectories(directoriesResponse.parents);
-        setChildren(directoriesResponse.children.reverse());
+        setSeparator(directoriesResponse.separator);
+        setDirectories(directoriesResponse.childrens);
+        setParents(directoriesResponse.parents.reverse());
       })
       .catch(function (error: Error) {
         console.log(error);
@@ -76,19 +74,29 @@ export default function DirectoryChooser(props: {
       >
         <Box sx={{ maxWidth: 700 }} mx="auto">
           <Paper shadow="md" p="xs" withBorder>
-            <Breadcrumbs>
-              {children.map(child => (
-                <Button
-                  loading={isLoading}
-                  onClick={() => getSubdirectories(child.value)}
-                  key={"breadcrumb" + child.label}
-                  variant="default"
-                  compact
-                >
-                  {child.label}
-                </Button>
-              ))}
-            </Breadcrumbs>
+            <Group>
+              <Button
+                loading={isLoading}
+                onClick={() => getSubdirectories('roots')}
+                variant="default"
+                compact
+              >
+                <Devices2 />
+              </Button>
+              <Breadcrumbs separator={separator}>
+                {parents.map(parent => (
+                  <Button
+                    loading={isLoading}
+                    onClick={() => getSubdirectories(parent.value)}
+                    key={"breadcrumb" + parent.label}
+                    variant="default"
+                    compact
+                  >
+                    {parent.label}
+                  </Button>
+                ))}
+              </Breadcrumbs>
+            </Group>
           </Paper>
           <Stack spacing="xs" align="flex-start" justify="flex-start" mt="xl">
             {directories.map(directory => (

--- a/configuration-client/src/services/accounts-service.ts
+++ b/configuration-client/src/services/accounts-service.ts
@@ -27,7 +27,7 @@ export const getUserGroup = (user: UmsUser, accounts: UmsAccounts) => {
 };
 
 export const getUserGroupsSelection = (accounts: UmsAccounts) => {
-  let result = [];
+  const result = [];
   result.push({ value: '0', label: 'None' });
   accounts.groups.forEach((group) => {
     if (group.id > 0) {


### PR DESCRIPTION
> enforce security to /directories

Do not allow non logged users to browse your disk.

> moved parseQueryString to WebInterfaceServerUtil

Function may be use by all handlers.

> set getDirectoryResponse as static.

> getSubdirectories fix URISyntaxException thrown on windows

Get request with unescaped URI throw URISyntaxException.

> getSubdirectories use post instead of get.

Easier to create/handle the request.

> refactor parents to childrens, and parent to childrens to reflect the reality.

directory parents are directory container, not children.

> fix file separator for breadcrumbs on windows.

Use the correct file separator for all systems.

> added roots to enable select/browsing roots.

Added button at start to show the roots.
Before we cannot select a root folder (like "/" or "c:") and cannot browse other roots (like "e:")