### PR TITLE
web settings fix select

### DIFF
--- a/configuration-client/src/components/Accounts/Accounts.tsx
+++ b/configuration-client/src/components/Accounts/Accounts.tsx
@@ -33,7 +33,7 @@ const Accounts = () => {
   };
 
   function NewUserForm(accounts: UmsAccounts) {
-    const newUserForm = useForm({ initialValues: {username:null,password:null,groupid:0,displayname:null} });
+    const newUserForm = useForm({ initialValues: {username:null,password:null,groupid:"0",displayname:null} });
     const handleNewUserSubmit = (values: typeof newUserForm.values) => {
       const data = {operation:'createuser', username:values.username, password:values.password, groupid:values.groupid, displayname:values.displayname};
       postAccountAction(data, 'User creation', 'New user was created successfully', 'New user was not created.');
@@ -49,9 +49,9 @@ const Accounts = () => {
         />
         <PasswordInput
           required
-          label='Password'
+          label="Password"
           name="username"
-          type='password'
+          type="password"
           {...newUserForm.getInputProps('password')}
         />
         <TextInput
@@ -62,10 +62,10 @@ const Accounts = () => {
         />
         <Select
           required
-          label='Group'
+          label="Group"
           name="groupId"
           data={groupDatas2}
-          value='0'
+          {...newUserForm.getInputProps('groupid')}
         />
         <Group position="right" mt="md">
           <Button type="submit">
@@ -93,9 +93,9 @@ const Accounts = () => {
         />
         <PasswordInput
           required
-          label='Password'
+          label="Password"
           name="username"
-          type='password'
+          type="password"
           {...userIdentityForm.getInputProps('password')}
         />
         <Group position="right" mt="md">
@@ -131,7 +131,7 @@ const Accounts = () => {
   };
 
   function UserGroupForm(user: UmsUser, accounts: UmsAccounts) {
-    const userGroupForm = useForm({ initialValues: {id:user.id,groupId:user.groupId} });
+    const userGroupForm = useForm({ initialValues: {id:user.id,groupId:user.groupId.toString()} });
     const handleUserGroupSubmit = (values: typeof userGroupForm.values) => {
       const data = {operation:'modifyuser', userid:user.id, groupid:values.groupId};
       postAccountAction(data, 'User group change', 'User group was changed successfully', 'User group was not changed.');
@@ -141,11 +141,11 @@ const Accounts = () => {
       <form onSubmit={userGroupForm.onSubmit(handleUserGroupSubmit)}>
         <Divider my="sm" label="Group" />
         <Select
-          label='Group'
+          label="Group"
           name="groupId"
           disabled={!accounts.groupsManage}
           data={groupDatas}
-          value={user.groupId.toString()}
+          {...userGroupForm.getInputProps('groupId')}
         />
         {accounts.groupsManage && (
           <Group position="right" mt="md">

--- a/configuration-client/src/components/Settings/Settings.tsx
+++ b/configuration-client/src/components/Settings/Settings.tsx
@@ -25,6 +25,7 @@ export default function Settings() {
   const enabledRendererNamesSettingsRef = useRef([]);
   const audioCoverSuppliersSettingsRef = useRef([]);
   const sortMethodsSettingsRef = useRef([]);
+  const numberOfCpuCoresSettingsRef = useRef(1);
 
   const i18n = useContext(I18nContext);
   const session = useContext(SessionContext);
@@ -58,7 +59,7 @@ export default function Settings() {
     minimized: false,
     mpeg2_main_settings: 'Automatic (Wired)',
     network_interface: '',
-    number_of_cpu_cores: 4,
+    number_of_cpu_cores: numberOfCpuCoresSettingsRef.current,
     port: '',
     renderer_default: '',
     renderer_force_default: false,
@@ -101,6 +102,10 @@ export default function Settings() {
         enabledRendererNamesSettingsRef.current = settingsResponse.enabledRendererNames;
         audioCoverSuppliersSettingsRef.current = settingsResponse.audioCoverSuppliers;
         sortMethodsSettingsRef.current = settingsResponse.sortMethods;
+        numberOfCpuCoresSettingsRef.current = settingsResponse.numberOfCpuCores;
+
+        //update default settings
+        defaultSettings.number_of_cpu_cores = settingsResponse.numberOfCpuCores;
 
         // merge defaults with what we receive, which might only be non-default values
         const userConfig = _.merge(defaultSettings, settingsResponse.userSettings);
@@ -272,7 +277,7 @@ export default function Settings() {
                     disabled={!canModify}
                     label={i18n['NetworkTab.MediaServerEngine']}
                     data={serverEnginesSettingsRef.current}
-                    value={String(form.getInputProps('server_engine').value)}
+                    {...form.getInputProps('server_engine')}
                   />
                 </Tooltip>
 
@@ -334,7 +339,7 @@ export default function Settings() {
               mt="xs"
               label={i18n['FoldTab.26']}
               data={audioCoverSuppliersSettingsRef.current}
-              value={String(form.getInputProps('audio_thumbnails_method').value)}
+              {...form.getInputProps('audio_thumbnails_method')}
             />
             <DirectoryChooser
               path={form.getInputProps('alternate_thumb_folder').value}
@@ -348,7 +353,7 @@ export default function Settings() {
                   mt="xs"
                   label={i18n['FoldTab.26']}
                   data={sortMethodsSettingsRef.current}
-                  value={String(form.getInputProps('sort_method').value)}
+                  {...form.getInputProps('sort_method')}
                 />
               </Accordion.Item>
             </Accordion>
@@ -429,10 +434,10 @@ export default function Settings() {
                   {...form.getInputProps('maximum_video_buffer_size')}
                 />
                 <NumberInput
-                  label={i18n['TrTab2.24']?.replace('%d', defaultSettings.number_of_cpu_cores)}
+                  label={i18n['TrTab2.24']?.replace('%d', numberOfCpuCoresSettingsRef.current.toString())}
                   size="xs"
-                  max={64}
-                  min={0}
+                  max={numberOfCpuCoresSettingsRef.current}
+                  min={1}
                   disabled={false}
                   {...form.getInputProps('number_of_cpu_cores')}
                 />

--- a/src/main/java/net/pms/network/webinterfaceserver/configuration/handlers/ConfigurationApiHandler.java
+++ b/src/main/java/net/pms/network/webinterfaceserver/configuration/handlers/ConfigurationApiHandler.java
@@ -177,7 +177,7 @@ public class ConfigurationApiHandler implements HttpHandler {
 					}
 				}
 				//select need string, not number
-				String[] needConvertToString = {"server_engine", "number_of_cpu_cores", "audio_thumbnails_method", "sort_method"};
+				String[] needConvertToString = {"server_engine", "audio_thumbnails_method", "sort_method"};
 				for (String key : needConvertToString) {
 					if (configurationAsJson.has(key) && configurationAsJson.get(key).isJsonPrimitive()) {
 						String value = configurationAsJson.get(key).getAsString();

--- a/src/main/java/net/pms/network/webinterfaceserver/configuration/handlers/ConfigurationApiHandler.java
+++ b/src/main/java/net/pms/network/webinterfaceserver/configuration/handlers/ConfigurationApiHandler.java
@@ -22,6 +22,7 @@ package net.pms.network.webinterfaceserver.configuration.handlers;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.*;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -36,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import net.pms.Messages;
 import net.pms.PMS;
@@ -103,6 +105,15 @@ public class ConfigurationApiHandler implements HttpHandler {
 		"x264_constant_rate_factor"
 	};
 
+	public static final String[] VALID_EMPTY_KEYS = {
+		"alternate_thumb_folder",
+		"hostname",
+		"ip_filter",
+		"network_interface",
+		"port",
+		"renderer_default"
+	};
+
 	public static final String BASE_PATH = "/configuration-api";
 
 	private final Gson gson = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
@@ -141,8 +152,6 @@ public class ConfigurationApiHandler implements HttpHandler {
 					WebInterfaceServerUtil.respond(exchange, "{\"error\": \"Forbidden\"}", 403, "application/json");
 					return;
 				}
-				String configurationAsJsonString = pmsConfiguration.getConfigurationAsJsonString();
-
 				JsonObject jsonResponse = new JsonObject();
 
 				jsonResponse.add("languages", Languages.getLanguagesAsJsonArray());
@@ -152,8 +161,29 @@ public class ConfigurationApiHandler implements HttpHandler {
 				jsonResponse.add("enabledRendererNames", RendererConfiguration.getEnabledRendererNamesAsJsonArray());
 				jsonResponse.add("audioCoverSuppliers", PmsConfiguration.getAudioCoverSuppliersAsJsonArray());
 				jsonResponse.add("sortMethods", PmsConfiguration.getSortMethodsAsJsonArray());
+				int numberOfCpuCores = Runtime.getRuntime().availableProcessors();
+				if (numberOfCpuCores < 1) {
+					numberOfCpuCores = 1;
+				}
+				jsonResponse.add("numberOfCpuCores", new JsonPrimitive(numberOfCpuCores));
 
+				String configurationAsJsonString = pmsConfiguration.getConfigurationAsJsonString();
 				JsonObject configurationAsJson = JsonParser.parseString(configurationAsJsonString).getAsJsonObject();
+				//back to default value if empty
+				List<String> validEmptyKeys = Arrays.asList(VALID_EMPTY_KEYS);
+				for (String key : VALID_KEYS) {
+					if (!validEmptyKeys.contains(key) && configurationAsJson.has(key) && configurationAsJson.get(key).isJsonPrimitive() && "".equals(configurationAsJson.get(key).getAsString())) {
+						configurationAsJson.remove(key);
+					}
+				}
+				//select need string, not number
+				String[] needConvertToString = {"server_engine", "number_of_cpu_cores", "audio_thumbnails_method", "sort_method"};
+				for (String key : needConvertToString) {
+					if (configurationAsJson.has(key) && configurationAsJson.get(key).isJsonPrimitive()) {
+						String value = configurationAsJson.get(key).getAsString();
+						configurationAsJson.add(key, new JsonPrimitive(value));
+					}
+				}
 				jsonResponse.add("userSettings", configurationAsJson);
 
 				WebInterfaceServerUtil.respond(exchange, jsonResponse.toString(), 200, "application/json");


### PR DESCRIPTION
> fix select need string, not number

`Select` Mantine does not handle correctly the value.
Workaround by sending stringed numbers.

> back to default value if empty

If react receive empty string for setting, it will not back to default value as UMS does.

> real numberOfCpuCores handle

This was hard coded, and permit 0 value (UMS doesn't).