### PR TITLE
Added response for GetSearchCapabilities again. For compatibility pur…

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -329,6 +329,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final String KEY_UPNP_DEBUG = "upnp_debug";
 	protected static final String KEY_UPNP_ENABLED = "upnp_enable";
 	protected static final String KEY_UPNP_PORT = "upnp_port";
+	protected static final String KEY_UPNP_SEARCHCAPS_ENABLED = "upnp_search_caps_enabled";
 	protected static final String KEY_USE_CACHE = "use_cache";
 	protected static final String KEY_USE_EMBEDDED_SUBTITLES_STYLE = "use_embedded_subtitles_style";
 	protected static final String KEY_USE_IMDB_INFO = "use_imdb_info";
@@ -4163,6 +4164,10 @@ public class PmsConfiguration extends RendererConfiguration {
 
 	public int getUpnpPort() {
 		return getInt(KEY_UPNP_PORT, 1900);
+	}
+
+	public boolean getUpnpSearchCapsEnabled() {
+		return getBoolean(KEY_UPNP_SEARCHCAPS_ENABLED, true);
 	}
 
 	public String getUuid() {

--- a/src/main/java/net/pms/network/mediaserver/HTTPXMLHelper.java
+++ b/src/main/java/net/pms/network/mediaserver/HTTPXMLHelper.java
@@ -30,7 +30,8 @@ public class HTTPXMLHelper {
 	public static final String SEARCHRESPONSE_FOOTER = "</u:SearchResponse>";
 	public static final String SETBOOKMARK_RESPONSE = "<u:X_SetBookmarkResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"></u:X_SetBookmarkResponse>";
 	public static final String SORTCAPS_RESPONSE = "<u:GetSortCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SortCaps></SortCaps></u:GetSortCapabilitiesResponse>";
-	public static final String SEARCHCAPS_RESPONSE = "<u:GetSearchCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SearchCaps></SearchCaps></u:GetSearchCapabilitiesResponse>";
+	public static final String SEARCHCAPS_RESPONSE = "<u:GetSearchCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SearchCaps>upnp:class,dc:title,dc:creator,upnp:artist,upnp:album,upnp:genre</SearchCaps></u:GetSearchCapabilitiesResponse>";
+	public static final String SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED = "<u:GetSearchCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SearchCaps></SearchCaps></u:GetSearchCapabilitiesResponse>";
 	public static final String PROTOCOLINFO_RESPONSE =
 		"<u:GetProtocolInfoResponse xmlns:u=\"urn:schemas-upnp-org:service:ConnectionManager:1\"><Source>" +
 		"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN," +

--- a/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
@@ -1021,7 +1021,11 @@ public class RequestHandler implements HttpHandler {
 	}
 
 	private static String getSearchCapabilitiesHandler() {
-		return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+		if (PMS.getConfiguration().getUpnpSearchCapsEnabled()) {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+		} else {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED).toString();
+		}
 	}
 
 	private static String browseHandler(String requestBody, RendererConfiguration renderer) {

--- a/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
+++ b/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
@@ -886,7 +886,11 @@ public class RequestV2 extends HTTPResource {
 	}
 
 	private String getSearchCapabilitiesHandler() {
-		return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+		if (PMS.getConfiguration().getUpnpSearchCapsEnabled()) {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+		} else {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED).toString();
+		}
 	}
 
 	private String getProtocolInfoHandler() {

--- a/src/main/java/net/pms/network/mediaserver/socketchannelserver/Request.java
+++ b/src/main/java/net/pms/network/mediaserver/socketchannelserver/Request.java
@@ -733,7 +733,11 @@ public class Request extends HTTPResource {
 					response.append(CRLF);
 					response.append(HTTPXMLHelper.SOAP_ENCODING_HEADER);
 					response.append(CRLF);
-					response.append(HTTPXMLHelper.SEARCHCAPS_RESPONSE);
+					if (PMS.getConfiguration().getUpnpSearchCapsEnabled()) {
+						response.append(HTTPXMLHelper.SEARCHCAPS_RESPONSE);
+					} else {
+						response.append(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED);
+					}
 					response.append(CRLF);
 					response.append(HTTPXMLHelper.SOAP_ENCODING_FOOTER);
 					response.append(CRLF);


### PR DESCRIPTION
This is a follow up to #2624. Since that merge, BubbleUPnP doesn't do any server side searches on UMS, except server side search is forced in BubbleUPnP configuration. Since some might like this feature, I'd recommend to enable SearchCaps again making it configurable.

I think there were some renderer that had issues with active search caps. Therefore, for compatibility purposes responding to upnp `GetSearchCapabilities` requests can be reverted to the old logic by setting PMS configuration key `upnp_search_caps_enabled` to `false`. Default is `true`.