### PR TITLE
fixes startup issue on MacOS if operation MacOS system version has no PATCH number set

### DIFF
--- a/src/main/java/net/pms/util/jna/macos/iokit/IOKitUtils.java
+++ b/src/main/java/net/pms/util/jna/macos/iokit/IOKitUtils.java
@@ -47,7 +47,7 @@ public class IOKitUtils {
 	private static IOKit ioKit = IOKit.INSTANCE;
 	private static CoreFoundation cf = CoreFoundation.INSTANCE;
 
-	protected static final Semver MAC_OS_VERSION = new Semver(System.getProperty("os.version"));;
+	protected static final Semver MAC_OS_VERSION;
 
 	private IOKitUtils() {
 	}
@@ -219,5 +219,19 @@ public class IOKitUtils {
 		}
 		LOGGER.warn("Unable to reset sleep timer; not supported by maxOS version {}", System.getProperty("os.version"));
 		return -1;
+	}
+
+	static {
+		int dotCount = 0;
+		String ver = System.getProperty("os.version");
+		for (int i = 0; i < ver.length(); i++) {
+			if (ver.charAt(i) == '.') {
+				dotCount++;
+			}
+		}
+		if (dotCount == 1) {
+			ver += ".0";
+		}
+		MAC_OS_VERSION = new Semver(ver);
 	}
 }


### PR DESCRIPTION
If OS release has no patch level set (like 12.4) UMS will not start because this format doesn't follow the "semantic versioning" specification for class `Semver`.

This fix added a patch version, if not present.