### PR TITLE
opt in sending date metadata for nextcp/2 renderer

### DIFF
--- a/src/main/external-resources/renderers/Nextcp2.conf
+++ b/src/main/external-resources/renderers/Nextcp2.conf
@@ -7,6 +7,8 @@ RendererName = NextCP2
 
 UserAgentSearch = nextcp
 
+SendDateMetadataYearForAudioTags = true
+
 # Supported audio formats:
 Supported = f:ac3                       m:audio/vnd.dolby.dd-raw
 Supported = f:acdpm                     m:audio/x-adpcm


### PR DESCRIPTION
Opt in sending `dc:date` metadata.

@SubJunk Maybe you can help me to find out UMS's strategy for implementing new features. I see the aspiration to disable features by default, only because there are renderer out there in the world that might not get along with (even spec conform) data structures or response objects. Wouldn't it be more understandable to enable new features by default, and identify the bogus devices and opt that feature out for the specific renderer?
