### PR TITLE
UPnP search disable configuration item moved to MediaRenderer Configuration

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -113,7 +113,6 @@ UpnpDetailsSearch =
 # UPnP search capabilities. In case a renderer has issues browsing or searching
 # content, set this property to false.
 # Default: true
-
 UpnpSearchCapsEnabled = 
 
 # Optional additional HTTP header for better detection. When defined, UMS also

--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -109,6 +109,13 @@ UserAgentSearch =
 # Default: ""
 UpnpDetailsSearch = 
 
+# If UpnpSearchCapsEnabled is set to true, UMS will notify Media Renderer of available
+# UPnP search capabilities. In case a renderer has issues browsing or searching
+# content, set this property to false.
+# Default: true
+
+UpnpSearchCapsEnabled = 
+
 # Optional additional HTTP header for better detection. When defined, UMS also
 # considers this header when trying to find a match.
 #

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -218,7 +218,7 @@ public class RendererConfiguration extends Renderer {
 	protected static final String WRAP_DTS_INTO_PCM = "WrapDTSIntoPCM";
 	protected static final String WRAP_ENCODED_AUDIO_INTO_PCM = "WrapEncodedAudioIntoPCM";
 	protected static final String DISABLE_UMS_RESUME = "DisableUmsResume";
-	protected static final String DISABLE_SEARCHCAPS = "upnp_search_caps_disabled";
+	protected static final String UPNP_ENABLE_SEARCHCAPS = "upnp_search_caps_enabled = true";
 
 	private static int maximumBitrateTotal = 0;
 	public static final String UNKNOWN_ICON = "unknown.png";
@@ -332,8 +332,8 @@ public class RendererConfiguration extends Renderer {
 		return configurationReader.getInt(key, def);
 	}
 
-	public boolean isUpnpSearchCapsDisabled() {
-		return getBoolean(DISABLE_SEARCHCAPS, false);
+	public boolean isUpnpSearchCapsEnabled() {
+		return getBoolean(UPNP_ENABLE_SEARCHCAPS, true);
 	}
 
 	public long getLong(String key, long def) {

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -218,7 +218,7 @@ public class RendererConfiguration extends Renderer {
 	protected static final String WRAP_DTS_INTO_PCM = "WrapDTSIntoPCM";
 	protected static final String WRAP_ENCODED_AUDIO_INTO_PCM = "WrapEncodedAudioIntoPCM";
 	protected static final String DISABLE_UMS_RESUME = "DisableUmsResume";
-	protected static final String UPNP_ENABLE_SEARCHCAPS = "UpnpSearchCapsEnabled = true";
+	protected static final String UPNP_ENABLE_SEARCHCAPS = "UpnpSearchCapsEnabled";
 
 	private static int maximumBitrateTotal = 0;
 	public static final String UNKNOWN_ICON = "unknown.png";

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -218,7 +218,7 @@ public class RendererConfiguration extends Renderer {
 	protected static final String WRAP_DTS_INTO_PCM = "WrapDTSIntoPCM";
 	protected static final String WRAP_ENCODED_AUDIO_INTO_PCM = "WrapEncodedAudioIntoPCM";
 	protected static final String DISABLE_UMS_RESUME = "DisableUmsResume";
-	protected static final String UPNP_ENABLE_SEARCHCAPS = "upnp_search_caps_enabled = true";
+	protected static final String UPNP_ENABLE_SEARCHCAPS = "UpnpSearchCapsEnabled = true";
 
 	private static int maximumBitrateTotal = 0;
 	public static final String UNKNOWN_ICON = "unknown.png";

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -218,6 +218,7 @@ public class RendererConfiguration extends Renderer {
 	protected static final String WRAP_DTS_INTO_PCM = "WrapDTSIntoPCM";
 	protected static final String WRAP_ENCODED_AUDIO_INTO_PCM = "WrapEncodedAudioIntoPCM";
 	protected static final String DISABLE_UMS_RESUME = "DisableUmsResume";
+	protected static final String DISABLE_SEARCHCAPS = "upnp_search_caps_disabled";
 
 	private static int maximumBitrateTotal = 0;
 	public static final String UNKNOWN_ICON = "unknown.png";
@@ -329,6 +330,10 @@ public class RendererConfiguration extends Renderer {
 
 	public int getInt(String key, int def) {
 		return configurationReader.getInt(key, def);
+	}
+
+	public boolean isUpnpSearchCapsDisabled() {
+		return getBoolean(DISABLE_SEARCHCAPS, false);
 	}
 
 	public long getLong(String key, long def) {

--- a/src/main/java/net/pms/network/mediaserver/HTTPXMLHelper.java
+++ b/src/main/java/net/pms/network/mediaserver/HTTPXMLHelper.java
@@ -30,7 +30,8 @@ public class HTTPXMLHelper {
 	public static final String SEARCHRESPONSE_FOOTER = "</u:SearchResponse>";
 	public static final String SETBOOKMARK_RESPONSE = "<u:X_SetBookmarkResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"></u:X_SetBookmarkResponse>";
 	public static final String SORTCAPS_RESPONSE = "<u:GetSortCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SortCaps></SortCaps></u:GetSortCapabilitiesResponse>";
-	public static final String SEARCHCAPS_RESPONSE = "<u:GetSearchCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SearchCaps></SearchCaps></u:GetSearchCapabilitiesResponse>";
+	public static final String SEARCHCAPS_RESPONSE = "<u:GetSearchCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SearchCaps>upnp:class,dc:title,dc:creator,upnp:artist,upnp:album,upnp:genre</SearchCaps></u:GetSearchCapabilitiesResponse>";
+	public static final String SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED = "<u:GetSearchCapabilitiesResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\"><SearchCaps></SearchCaps></u:GetSearchCapabilitiesResponse>";
 	public static final String PROTOCOLINFO_RESPONSE =
 		"<u:GetProtocolInfoResponse xmlns:u=\"urn:schemas-upnp-org:service:ConnectionManager:1\"><Source>" +
 		"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN," +

--- a/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
@@ -1021,10 +1021,10 @@ public class RequestHandler implements HttpHandler {
 	}
 
 	private static String getSearchCapabilitiesHandler(RendererConfiguration mediaRenderer) {
-		if (mediaRenderer.isUpnpSearchCapsDisabled()) {
-			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED).toString();
-		} else {
+		if (mediaRenderer.isUpnpSearchCapsEnabled()) {
 			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+		} else {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED).toString();
 		}
 	}
 

--- a/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
@@ -239,7 +239,7 @@ public class RequestHandler implements HttpHandler {
 				} else if (soapaction != null && soapaction.contains("ContentDirectory:1#GetSortCapabilities")) {
 					sendResponse(exchange, renderer, 200, getSortCapabilitiesHandler(), CONTENT_TYPE_XML_UTF8);
 				} else if (soapaction != null && soapaction.contains("ContentDirectory:1#GetSearchCapabilities")) {
-					sendResponse(exchange, renderer, 200, getSearchCapabilitiesHandler(), CONTENT_TYPE_XML_UTF8);
+					sendResponse(exchange, renderer, 200, getSearchCapabilitiesHandler(renderer), CONTENT_TYPE_XML_UTF8);
 				} else if (soapaction != null && soapaction.contains("ContentDirectory:1#Browse")) {
 					sendResponse(exchange, renderer, 200, browseHandler(requestBody, renderer), CONTENT_TYPE_XML_UTF8);
 				} else if (soapaction != null && soapaction.contains("ContentDirectory:1#Search")) {
@@ -1020,8 +1020,12 @@ public class RequestHandler implements HttpHandler {
 		return createResponse(HTTPXMLHelper.SORTCAPS_RESPONSE).toString();
 	}
 
-	private static String getSearchCapabilitiesHandler() {
-		return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+	private static String getSearchCapabilitiesHandler(RendererConfiguration mediaRenderer) {
+		if (mediaRenderer.isUpnpSearchCapsDisabled()) {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED).toString();
+		} else {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+		}
 	}
 
 	private static String browseHandler(String requestBody, RendererConfiguration renderer) {

--- a/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
+++ b/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
@@ -758,7 +758,7 @@ public class RequestV2 extends HTTPResource {
 				} else if (soapaction != null && soapaction.contains("ContentDirectory:1#GetSortCapabilities")) {
 					response.append(getSortCapabilitiesHandler());
 				} else if (soapaction != null && soapaction.contains("ContentDirectory:1#GetSearchCapabilities")) {
-					response.append(getSearchCapabilitiesHandler());
+					response.append(getSearchCapabilitiesHandler(mediaRenderer));
 				} else if (soapaction != null && soapaction.contains("ContentDirectory:1#Browse")) {
 					response.append(browseHandler());
 				} else if (soapaction != null && soapaction.contains("ContentDirectory:1#Search")) {
@@ -885,8 +885,12 @@ public class RequestV2 extends HTTPResource {
 		return createResponse(HTTPXMLHelper.SORTCAPS_RESPONSE).toString();
 	}
 
-	private String getSearchCapabilitiesHandler() {
-		return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+	private String getSearchCapabilitiesHandler(RendererConfiguration mediaRenderer) {
+		if (mediaRenderer.isUpnpSearchCapsDisabled()) {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED).toString();
+		} else {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+		}
 	}
 
 	private String getProtocolInfoHandler() {

--- a/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
+++ b/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
@@ -886,10 +886,10 @@ public class RequestV2 extends HTTPResource {
 	}
 
 	private String getSearchCapabilitiesHandler(RendererConfiguration mediaRenderer) {
-		if (mediaRenderer.isUpnpSearchCapsDisabled()) {
-			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED).toString();
-		} else {
+		if (mediaRenderer.isUpnpSearchCapsEnabled()) {
 			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE).toString();
+		} else {
+			return createResponse(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED).toString();
 		}
 	}
 

--- a/src/main/java/net/pms/network/mediaserver/socketchannelserver/Request.java
+++ b/src/main/java/net/pms/network/mediaserver/socketchannelserver/Request.java
@@ -733,10 +733,10 @@ public class Request extends HTTPResource {
 					response.append(CRLF);
 					response.append(HTTPXMLHelper.SOAP_ENCODING_HEADER);
 					response.append(CRLF);
-					if (mediaRenderer.isUpnpSearchCapsDisabled()) {
-						response.append(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED);
-					} else {
+					if (mediaRenderer.isUpnpSearchCapsEnabled()) {
 						response.append(HTTPXMLHelper.SEARCHCAPS_RESPONSE);
+					} else {
+						response.append(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED);
 					}
 					response.append(CRLF);
 					response.append(HTTPXMLHelper.SOAP_ENCODING_FOOTER);

--- a/src/main/java/net/pms/network/mediaserver/socketchannelserver/Request.java
+++ b/src/main/java/net/pms/network/mediaserver/socketchannelserver/Request.java
@@ -733,7 +733,11 @@ public class Request extends HTTPResource {
 					response.append(CRLF);
 					response.append(HTTPXMLHelper.SOAP_ENCODING_HEADER);
 					response.append(CRLF);
-					response.append(HTTPXMLHelper.SEARCHCAPS_RESPONSE);
+					if (mediaRenderer.isUpnpSearchCapsDisabled()) {
+						response.append(HTTPXMLHelper.SEARCHCAPS_RESPONSE_SEARCH_DEACTIVATED);
+					} else {
+						response.append(HTTPXMLHelper.SEARCHCAPS_RESPONSE);
+					}
 					response.append(CRLF);
 					response.append(HTTPXMLHelper.SOAP_ENCODING_FOOTER);
 					response.append(CRLF);


### PR DESCRIPTION
After the discussion in #3106 I think the configuration option for disabling UPnP search should be placed in MediaRenderer configuration, because it probably effects only a few devices.

UPnP search can be disabled for a specific renderer device by setting 
`upnp_search_caps_disabled = true`
default `false`.