### PR TITLE
read AudioFile tag only if coverart archive table is being updated.

### DIFF
--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -451,14 +451,14 @@ public class RealFile extends MapFile {
 			String mbReleaseId = getMedia().getAudioTracksList().get(0).getMbidRecord();
 			if (!StringUtils.isAllBlank(mbReleaseId)) {
 				try {
-					AudioFile af;
-					if ("mp2".equals(FileUtil.getExtension(getFile()).toLowerCase(Locale.ROOT))) {
-						af = AudioFileIO.readAs(getFile(), "mp3");
-					} else {
-						af = AudioFileIO.read(getFile());
-					}
-					Tag t = af.getTag();
 					if (!MediaTableCoverArtArchive.hasCover(mbReleaseId)) {
+						AudioFile af;
+						if ("mp2".equals(FileUtil.getExtension(getFile()).toLowerCase(Locale.ROOT))) {
+							af = AudioFileIO.readAs(getFile(), "mp3");
+						} else {
+							af = AudioFileIO.read(getFile());
+						}
+						Tag t = af.getTag();
 						LOGGER.trace("no artwork in MediaTableCoverArtArchive table");
 						if (t.getFirstArtwork() != null) {
 							byte[] artBytes = t.getFirstArtwork().getBinaryData();


### PR DESCRIPTION
AudioFile tag is read even if it is not used any more later on. This should speed access to container with many audio playlists.