### PR TITLE
Windows Service

### DIFF
--- a/src/main/external-resources/nsis/setup.nsi
+++ b/src/main/external-resources/nsis/setup.nsi
@@ -241,6 +241,8 @@ Section "Program Files"
 
 	SetOutPath "$INSTDIR\win32"
 	${If} ${RunningX64}
+		Delete /REBOOTOK "${PROJECT_BASEDIR}\target\bin\win32\service\wrapper.exe"
+		Delete /REBOOTOK "${PROJECT_BASEDIR}\target\bin\win32\service\wrapper.dll"
 		File /r /x "wrapper.exe" /x "wrapper.dll" "${PROJECT_BASEDIR}\target\bin\win32\service"
 		Rename "service\wrapper-x64.exe" "service\wrapper.exe"
 		Rename "service\wrapper-x64.dll" "service\wrapper.dll"


### PR DESCRIPTION
fix #3199

Now delete the x86 files if they exist because renaming fails if they do.