### PR TITLE
Database optimizations

### DIFF
--- a/src/main/external-resources/web/util/jquery.ums.js
+++ b/src/main/external-resources/web/util/jquery.ums.js
@@ -482,7 +482,7 @@ function useApiImages(apiImages) {
 				setBackgroundAndColorScheme('backgroundPreload');
 			}
 			setTimeout(function() {
-				backgroundImagePreCreation.src = imageBaseURL + 'original' + randomBackground.file_path;
+				backgroundImagePreCreation.src = apiMetadata.imageBaseURL + 'original' + randomBackground.file_path;
 				$('.backgroundPreloadContainer').html(backgroundImagePreCreation);
 			});
 
@@ -501,7 +501,7 @@ function useApiImages(apiImages) {
 			logoImagePreCreation.id = 'logo';
 			logoImagePreCreation.style.maxHeight = '150px';
 			logoImagePreCreation.style.maxWidth = 'calc(100% - 61px)'; // width minus the IMDb icon
-			logoImagePreCreation.src = imageBaseURL + 'w500' + logo.file_path;
+			logoImagePreCreation.src = apiMetadata.imageBaseURL + 'w500' + logo.file_path;
 			$('h1').html(logoImagePreCreation);
 			$('h1').css('margin','10px 0 30px 0');
 			return false;
@@ -510,47 +510,50 @@ function useApiImages(apiImages) {
 }
 
 function populateMetadataDisplayFromGlobalVars() {
+	if (!apiMetadata) {
+		return;
+	}
 	var isDark = $('body').hasClass('dark');
 	var badgeClass = isDark ? 'badge-light' : 'badge-dark';
-	if (!_.isEmpty(actors)) {
+	if (!_.isEmpty(apiMetadata.actors)) {
 		var actorLinks = [];
-		for (var i = 0; i < actors.length; i++) {
-			var actor = actors[i];
+		for (var i = 0; i < apiMetadata.actors.length; i++) {
+			var actor = apiMetadata.actors[i];
 			actorLinks.push('<a href="/browse/' + actor.id + '" class="badge ' + badgeClass + '">' + actor.name + '</a>');
 		}
-		$('.actors').html('<strong>' + actorsTranslation + ':</strong> ' + actorLinks.join(''));
+		$('.actors').html('<strong>' + apiMetadata.actorsTranslation + ':</strong> ' + actorLinks.join(''));
 	}
-	if (awards) {
-		$('.awards').html('<strong>' + awardsTranslation + ':</strong> ' + awards);
+	if (apiMetadata.awards) {
+		$('.awards').html('<strong>' + apiMetadata.awardsTranslation + ':</strong> ' + apiMetadata.awards);
 	}
-	if (country && country.id) {
-		$('.country').html('<strong>' + countryTranslation + ':</strong> <a href="/browse/' + country.id + '" class="badge ' + badgeClass + '">' + country.name + '</a>');
+	if (apiMetadata.countries && apiMetadata.countries[0] && apiMetadata.countries[0].id) {
+		$('.country').html('<strong>' + apiMetadata.countryTranslation + ':</strong> <a href="/browse/' + apiMetadata.countries[0].id + '" class="badge ' + badgeClass + '">' + apiMetadata.countries[0].name + '</a>');
 	}
-	if (director && director.id) {
-		$('.director').html('<strong>' + directorTranslation + ':</strong> <a href="/browse/' + director.id + '" class="badge ' + badgeClass + '">' + director.name + '</a>');
+	if (apiMetadata.directors && apiMetadata.directors[0] && apiMetadata.directors[0].id) {
+		$('.director').html('<strong>' + apiMetadata.directorTranslation + ':</strong> <a href="/browse/' + apiMetadata.directors[0].id + '" class="badge ' + badgeClass + '">' + apiMetadata.directors[0].name + '</a>');
 	}
-	if (imageBaseURL) {
-		if (seriesImages && seriesImages[0]) {
-			useApiImages(seriesImages);
-		} else if (images && images[0]) {
-			useApiImages(images);
+	if (apiMetadata.imageBaseURL) {
+		if (apiMetadata.seriesImages && apiMetadata.seriesImages[0]) {
+			useApiImages(apiMetadata.seriesImages);
+		} else if (apiMetadata.images && apiMetadata.images[0]) {
+			useApiImages(apiMetadata.images);
 		}
 	}
-	if (imdbID) {
-		$('h1').append(' <a href="https://www.imdb.com/title/' + imdbID + '/" id="imdbLink"><i class=\"fab fa-imdb\"></i></a>');
+	if (apiMetadata.imdbID) {
+		$('h1').append(' <a href="https://www.imdb.com/title/' + apiMetadata.imdbID + '/" id="imdbLink"><i class=\"fab fa-imdb\"></i></a>');
 	}
-	if (genres && genres[0]) {
+	if (apiMetadata.genres && apiMetadata.genres[0]) {
 		var genreLinks = [];
-		for (var i = 0; i < genres.length; i++) {
-			var genre = genres[i];
+		for (var i = 0; i < apiMetadata.genres.length; i++) {
+			var genre = apiMetadata.genres[i];
 			genreLinks.push('<a href="/browse/' + genre.id + '" class="badge ' + badgeClass + '">' + genre.name + '</a>');
 		}
-		$('.genres').html('<strong>' + genresTranslation + ':</strong> ' + genreLinks.join(''));
+		$('.genres').html('<strong>' + apiMetadata.genresTranslation + ':</strong> ' + genreLinks.join(''));
 	}
-	if (plot) {
-		$('.plot').html('<strong>' + plotTranslation + ':</strong> ' + plot);
+	if (apiMetadata.plot) {
+		$('.plot').html('<strong>' + apiMetadata.plotTranslation + ':</strong> ' + apiMetadata.plot);
 	}
-	if (poster) {
+	if (apiMetadata.poster) {
 		var img = new Image();
 		if (!isBackgroundImage) {
 			// If there is no background image from the API, set the color from the poster
@@ -559,26 +562,26 @@ function populateMetadataDisplayFromGlobalVars() {
 		img.crossOrigin = '';
 		img.id = 'poster';
 		img.style.maxHeight = '500px';
-		img.src = poster;
+		img.src = apiMetadata.poster;
 		$('.posterContainer').html(img);
 	}
-	if (rated && rated.id) {
-		$('.rated').html('<strong>' + ratedTranslation + ':</strong> <a href="/browse/' + rated.id + '" class="badge ' + badgeClass + '">' + rated.name + '</a>');
+	if (apiMetadata.rated && apiMetadata.rated.id) {
+		$('.rated').html('<strong>' + apiMetadata.ratedTranslation + ':</strong> <a href="/browse/' + apiMetadata.rated.id + '" class="badge ' + badgeClass + '">' + apiMetadata.rated.name + '</a>');
 	}
-	if (ratings && ratings[0]) {
-		$('.ratings').html('<strong>' + ratingsTranslation + ':</strong>');
+	if (apiMetadata.ratings && apiMetadata.ratings[0]) {
+		$('.ratings').html('<strong>' + apiMetadata.ratingsTranslation + ':</strong>');
 		var ratingsList = "<ul>";
-		for (var i = 0; i < ratings.length; i++) {
-			ratingsList += '<li>' + ratings[i].source + ': ' + ratings[i].value + '</li>';
+		for (var i = 0; i < apiMetadata.ratings.length; i++) {
+			ratingsList += '<li>' + apiMetadata.ratings[i].source + ': ' + apiMetadata.ratings[i].value + '</li>';
 		}
 		ratingsList += "</ul>";
 		$('.ratings').append(ratingsList);
 	}
-	if (startYear) {
-		$('.startYear').html('<strong>' + yearStartedTranslation + ':</strong> ' + startYear);
+	if (apiMetadata.startYear) {
+		$('.startYear').html('<strong>' + apiMetadata.yearStartedTranslation + ':</strong> ' + apiMetadata.startYear);
 	}
-	if (totalSeasons) {
-		$('.totalSeasons').html('<strong>' + totalSeasonsTranslation + ':</strong> ' + totalSeasons);
+	if (apiMetadata.totalSeasons) {
+		$('.totalSeasons').html('<strong>' + apiMetadata.totalSeasonsTranslation + ':</strong> ' + apiMetadata.totalSeasons);
 	}
 
 }

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -757,6 +757,7 @@ public class PMS {
 				}
 
 				if (MediaDatabase.isInstantiated()) {
+					LOGGER.debug("Shutting down database");
 					MediaDatabase.shutdown();
 					MediaDatabase.createDatabaseReportIfNeeded();
 				}

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -669,10 +669,7 @@ public class PMS {
 		new Thread("Connection Checker") {
 			@Override
 			public void run() {
-				try {
-					Thread.sleep(7000);
-				} catch (InterruptedException e) {
-				}
+				UMSUtils.sleep(7000);
 
 				if (foundRenderers.isEmpty()) {
 					frame.setConnectionState(ConnectionState.DISCONNECTED);

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -37,6 +37,7 @@ import net.pms.util.FormattableColor;
 import net.pms.util.InvalidArgumentException;
 import net.pms.util.PropertiesUtil;
 import net.pms.util.StringUtil;
+import net.pms.util.UMSUtils;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -2840,10 +2841,7 @@ public class RendererConfiguration extends Renderer {
 						state.position = ("NOT_IMPLEMENTED" + (elapsed / 1000 % 2 == 0 ? "  " : "--"));
 					}
 					alert();
-					try {
-						Thread.sleep(1000);
-					} catch (InterruptedException e) {
-					}
+					UMSUtils.sleep(1000);
 				}
 				// Reset only if another item hasn't already begun playing
 				if (renderer.getPlayingRes() == null) {

--- a/src/main/java/net/pms/database/Database.java
+++ b/src/main/java/net/pms/database/Database.java
@@ -24,6 +24,7 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import net.pms.Messages;
 import net.pms.PMS;
+import net.pms.util.UMSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,7 +117,7 @@ public abstract class Database extends DatabaseHelper {
 				needRetry = DatabaseEmbedded.openFailed(dbName, se);
 			} else {
 				LOGGER.debug("Database connection error, retrying in 10 seconds");
-				sleep(10000);
+				UMSUtils.sleep(10000);
 				needRetry = true;
 			}
 			if (needRetry) {
@@ -197,19 +198,6 @@ public abstract class Database extends DatabaseHelper {
 			} catch (NullPointerException e1) {
 				LOGGER.debug("Failed to show database connection error message, probably because GUI is not initialized yet. Error was {}", e1);
 			}
-		}
-	}
-
-	/**
-	 * Utility method to call {@link Thread#sleep(long)} without having to catch
-	 * the InterruptedException.
-	 *
-	 * @param delay the delay
-	 */
-	public static void sleep(int delay) {
-		try {
-			Thread.sleep(delay);
-		} catch (InterruptedException e) {
 		}
 	}
 

--- a/src/main/java/net/pms/database/Database.java
+++ b/src/main/java/net/pms/database/Database.java
@@ -166,9 +166,8 @@ public abstract class Database extends DatabaseHelper {
 		}
 
 		if (embedded) {
-			Connection con = null;
 			try {
-				con = getConnection();
+				Connection con = getConnection();
 				DatabaseEmbedded.shutdown(con);
 			} catch (SQLException ex) {
 				LOGGER.error("shutdown DB ", ex);

--- a/src/main/java/net/pms/database/Database.java
+++ b/src/main/java/net/pms/database/Database.java
@@ -166,7 +166,9 @@ public abstract class Database extends DatabaseHelper {
 		}
 
 		if (embedded) {
-			try (Connection con = getConnection()) {
+			Connection con = null;
+			try {
+				con = getConnection();
 				DatabaseEmbedded.shutdown(con);
 			} catch (SQLException ex) {
 				LOGGER.error("shutdown DB ", ex);

--- a/src/main/java/net/pms/database/DatabaseEmbedded.java
+++ b/src/main/java/net/pms/database/DatabaseEmbedded.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -232,12 +233,15 @@ public class DatabaseEmbedded {
 			try (ResultSet rs = connection.getMetaData().getTables(null, "PUBLIC", "%", new String[] {"BASE TABLE"})) {
 				while (rs.next()) {
 					String tableName = rs.getString("TABLE_NAME");
-					try (Statement st = connection.createStatement(); ResultSet rs2 = st.executeQuery("SELECT STORAGE_TYPE FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='" + tableName + "'")) {
-						if (rs2.first()) {
-							String storageType = rs2.getString("STORAGE_TYPE");
-							if (!askedStorageType.equals(storageType)) {
-								upgradeTables = true;
-								break;
+					try (PreparedStatement statement = connection.prepareStatement("SELECT STORAGE_TYPE FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ? LIMIT 1")) {
+						statement.setString(1, tableName);
+						try (ResultSet rs2 = statement.executeQuery()) {
+							if (rs2.first()) {
+								String storageType = rs2.getString("STORAGE_TYPE");
+								if (!askedStorageType.equals(storageType)) {
+									upgradeTables = true;
+									break;
+								}
 							}
 						}
 					}

--- a/src/main/java/net/pms/database/DatabaseEmbedded.java
+++ b/src/main/java/net/pms/database/DatabaseEmbedded.java
@@ -28,6 +28,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
+import net.pms.util.UMSUtils;
 import org.apache.commons.io.FileUtils;
 import org.h2.engine.Constants;
 import org.h2.tools.ConvertTraceFile;
@@ -130,7 +131,7 @@ public class DatabaseEmbedded {
 			}
 		} else {
 			LOGGER.debug("Database connection error, retrying in 10 seconds");
-			Database.sleep(10000);
+			UMSUtils.sleep(10000);
 			return true;
 		}
 	}

--- a/src/main/java/net/pms/database/MediaDatabase.java
+++ b/src/main/java/net/pms/database/MediaDatabase.java
@@ -87,7 +87,7 @@ public class MediaDatabase extends Database {
 				// Files and metadata
 				MediaTableMetadata.checkTable(connection);
 				MediaTableFiles.checkTable(connection);
-				MediaTableVideoMetadatas.checkTable(connection);
+				MediaTableVideoMetadata.checkTable(connection);
 				MediaTableSubtracks.checkTable(connection);
 				MediaTableChapters.checkTable(connection);
 				MediaTableRegexpRules.checkTable(connection);

--- a/src/main/java/net/pms/database/MediaDatabase.java
+++ b/src/main/java/net/pms/database/MediaDatabase.java
@@ -87,6 +87,7 @@ public class MediaDatabase extends Database {
 				// Files and metadata
 				MediaTableMetadata.checkTable(connection);
 				MediaTableFiles.checkTable(connection);
+				MediaTableVideoMetadatas.checkTable(connection);
 				MediaTableSubtracks.checkTable(connection);
 				MediaTableChapters.checkTable(connection);
 				MediaTableRegexpRules.checkTable(connection);

--- a/src/main/java/net/pms/database/MediaTableAudiotracks.java
+++ b/src/main/java/net/pms/database/MediaTableAudiotracks.java
@@ -41,15 +41,26 @@ import net.pms.dlna.DLNAMediaInfo;
 public class MediaTableAudiotracks extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableAudiotracks.class);
 	public static final String TABLE_NAME = "AUDIOTRACKS";
+	/**
+	 * COLUMNS NAMES
+	 */
+	private static final String COL_MBID_RECORD = "MBID_RECORD";
+	private static final String COL_MBID_TRACK = "MBID_TRACK";
+	private static final String COL_LIKE_SONG = "LIKESONG";
+	private static final String COL_DISC = "DISC";
+	/**
+	 * COLUMNS with table name
+	 */
 	public static final String FILEID = TABLE_NAME + ".FILEID";
-	public static final String ARTIST = TABLE_NAME + ".ARTIST";
 	public static final String ALBUM = TABLE_NAME + ".ALBUM";
 	public static final String ALBUMARTIST = TABLE_NAME + ".ALBUMARTIST";
+	public static final String ARTIST = TABLE_NAME + ".ARTIST";
+	public static final String GENRE = TABLE_NAME + ".GENRE";
+	public static final String MBID_RECORD = TABLE_NAME + "." + COL_MBID_RECORD;
+	public static final String MBID_TRACK = TABLE_NAME + "." + COL_MBID_TRACK;
+	public static final String MEDIA_YEAR = TABLE_NAME + ".MEDIA_YEAR";
 	public static final String TRACK = TABLE_NAME + ".TRACK";
-	private static final String MBID_RECORD = "MBID_RECORD";
-	private static final String MBID_TRACK = "MBID_TRACK";
-	private static final String LIKE_SONG = "LIKESONG";
-	private static final String DISC = "DISC";
+
 	private static final int SIZE_LANG = 3;
 	private static final int SIZE_GENRE = 64;
 	private static final int SIZE_MUXINGMODE = 32;
@@ -93,16 +104,16 @@ public class MediaTableAudiotracks extends MediaTable {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
 				case 1:
-					if (!isColumnExist(connection, TABLE_NAME, MBID_RECORD)) {
-						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD " + MBID_RECORD + " UUID");
+					if (!isColumnExist(connection, TABLE_NAME, COL_MBID_RECORD)) {
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD " + COL_MBID_RECORD + " UUID");
 					}
-					if (!isColumnExist(connection, TABLE_NAME, MBID_TRACK)) {
-						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD " + MBID_TRACK + " UUID");
+					if (!isColumnExist(connection, TABLE_NAME, COL_MBID_TRACK)) {
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD " + COL_MBID_TRACK + " UUID");
 					}
 					break;
 				case 2:
-					if (!isColumnExist(connection, TABLE_NAME, DISC)) {
-						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD " + DISC + " INT");
+					if (!isColumnExist(connection, TABLE_NAME, COL_DISC)) {
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD " + COL_DISC + " INT");
 					}
 					break;
 				case 3:
@@ -116,11 +127,11 @@ public class MediaTableAudiotracks extends MediaTable {
 					}
 					break;
 				case 4:
-					if (!isColumnExist(connection, TABLE_NAME, LIKE_SONG)) {
-						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD " + LIKE_SONG + " BOOLEAN");
-						LOGGER.trace("Adding " + LIKE_SONG + " to table " + TABLE_NAME);
-						executeUpdate(connection, "CREATE INDEX IDX_LIKE_SONG ON " + TABLE_NAME + " (" + LIKE_SONG + ");");
-						LOGGER.trace("Indexing column " + LIKE_SONG + " on table " + TABLE_NAME);
+					if (!isColumnExist(connection, TABLE_NAME, COL_LIKE_SONG)) {
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD " + COL_LIKE_SONG + " BOOLEAN");
+						LOGGER.trace("Adding " + COL_LIKE_SONG + " to table " + TABLE_NAME);
+						executeUpdate(connection, "CREATE INDEX IDX_LIKE_SONG ON " + TABLE_NAME + " (" + COL_LIKE_SONG + ");");
+						LOGGER.trace("Indexing column " + COL_LIKE_SONG + " on table " + TABLE_NAME);
 					}
 					break;
 				case 5:

--- a/src/main/java/net/pms/database/MediaTableAudiotracks.java
+++ b/src/main/java/net/pms/database/MediaTableAudiotracks.java
@@ -41,6 +41,11 @@ import net.pms.dlna.DLNAMediaInfo;
 public class MediaTableAudiotracks extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableAudiotracks.class);
 	public static final String TABLE_NAME = "AUDIOTRACKS";
+	public static final String FILEID = TABLE_NAME + ".FILEID";
+	public static final String ARTIST = TABLE_NAME + ".ARTIST";
+	public static final String ALBUM = TABLE_NAME + ".ALBUM";
+	public static final String ALBUMARTIST = TABLE_NAME + ".ALBUMARTIST";
+	public static final String TRACK = TABLE_NAME + ".TRACK";
 	private static final String MBID_RECORD = "MBID_RECORD";
 	private static final String MBID_TRACK = "MBID_TRACK";
 	private static final String LIKE_SONG = "LIKESONG";

--- a/src/main/java/net/pms/database/MediaTableAudiotracks.java
+++ b/src/main/java/net/pms/database/MediaTableAudiotracks.java
@@ -51,15 +51,15 @@ public class MediaTableAudiotracks extends MediaTable {
 	/**
 	 * COLUMNS with table name
 	 */
-	public static final String FILEID = TABLE_NAME + ".FILEID";
-	public static final String ALBUM = TABLE_NAME + ".ALBUM";
-	public static final String ALBUMARTIST = TABLE_NAME + ".ALBUMARTIST";
-	public static final String ARTIST = TABLE_NAME + ".ARTIST";
-	public static final String GENRE = TABLE_NAME + ".GENRE";
-	public static final String MBID_RECORD = TABLE_NAME + "." + COL_MBID_RECORD;
-	public static final String MBID_TRACK = TABLE_NAME + "." + COL_MBID_TRACK;
-	public static final String MEDIA_YEAR = TABLE_NAME + ".MEDIA_YEAR";
-	public static final String TRACK = TABLE_NAME + ".TRACK";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + ".FILEID";
+	public static final String TABLE_COL_ALBUM = TABLE_NAME + ".ALBUM";
+	public static final String TABLE_COL_ALBUMARTIST = TABLE_NAME + ".ALBUMARTIST";
+	public static final String TABLE_COL_ARTIST = TABLE_NAME + ".ARTIST";
+	public static final String TABLE_COL_GENRE = TABLE_NAME + ".GENRE";
+	public static final String TABLE_COL_MBID_RECORD = TABLE_NAME + "." + COL_MBID_RECORD;
+	public static final String TABLE_COL_MBID_TRACK = TABLE_NAME + "." + COL_MBID_TRACK;
+	public static final String TABLE_COL_MEDIA_YEAR = TABLE_NAME + ".MEDIA_YEAR";
+	public static final String TABLE_COL_TRACK = TABLE_NAME + ".TRACK";
 
 	private static final int SIZE_LANG = 3;
 	private static final int SIZE_GENRE = 64;

--- a/src/main/java/net/pms/database/MediaTableChapters.java
+++ b/src/main/java/net/pms/database/MediaTableChapters.java
@@ -38,7 +38,7 @@ public class MediaTableChapters extends MediaTable {
 	private static final int SIZE_LANG = 3;
 
 	public static final String TABLE_NAME = "CHAPTERS";
-	public static final String FILEID = TABLE_NAME + ".FILEID";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + ".FILEID";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableChapters.java
+++ b/src/main/java/net/pms/database/MediaTableChapters.java
@@ -38,6 +38,7 @@ public class MediaTableChapters extends MediaTable {
 	private static final int SIZE_LANG = 3;
 
 	public static final String TABLE_NAME = "CHAPTERS";
+	public static final String FILEID = TABLE_NAME + ".FILEID";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableFailedLookups.java
+++ b/src/main/java/net/pms/database/MediaTableFailedLookups.java
@@ -32,6 +32,16 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableFailedLookups extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableFailedLookups.class);
 	public static final String TABLE_NAME = "FAILED_LOOKUPS";
+	private static final String COL_LASTATTEMPT = "LASTATTEMPT";
+	public static final String LASTATTEMPT = TABLE_NAME + "." + COL_LASTATTEMPT;
+	public static final String FAILUREDETAILS = TABLE_NAME + ".FAILUREDETAILS";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String VERSION = TABLE_NAME + ".VERSION";
+	private static final String SQL_GET_LASTATTEMPT = "SELECT " + LASTATTEMPT + " FROM " + TABLE_NAME + " WHERE " + FILENAME + " = ? LIMIT 1";
+	private static final String SQL_GET_LASTATTEMPT_VERSION = "SELECT " + LASTATTEMPT + " FROM " + TABLE_NAME + " WHERE " + FILENAME + " = ? AND " + VERSION + " = ? LIMIT 1";
+	private static final String SQL_GET_FILENAME = "SELECT " + FILENAME + ", " + FAILUREDETAILS + ", " + VERSION + " FROM " + TABLE_NAME + " WHERE " + FILENAME + " = ? LIMIT 1";
+	private static final String SQL_DELETE_FILENAME = "DELETE FROM  " + TABLE_NAME + " WHERE " + FILENAME + " = ?";
+	private static final String SQL_DELETE_FILENAME_LIKE = "DELETE FROM  " + TABLE_NAME + " WHERE " + FILENAME + " LIKE ?";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -137,39 +147,44 @@ public final class MediaTableFailedLookups extends MediaTable {
 	 */
 	public static boolean hasLookupFailedRecently(final Connection connection, final String fullPathToFile, final boolean isVideo) {
 		boolean removeAfter = false;
-		String latestVersion;
-		if (isVideo) {
-			latestVersion = APIUtils.getApiDataVideoVersion();
+		String latestVersion = null;
+		if (CONFIGURATION.getExternalNetwork()) {
+			if (isVideo) {
+				latestVersion = APIUtils.getApiDataVideoVersion();
+			} else {
+				latestVersion = APIUtils.getApiDataSeriesVersion();
+			}
+		}
+		String sql;
+		if (latestVersion != null) {
+			sql = SQL_GET_LASTATTEMPT_VERSION;
 		} else {
-			latestVersion = APIUtils.getApiDataSeriesVersion();
+			sql = SQL_GET_LASTATTEMPT;
 		}
-		StringBuilder sql = new StringBuilder();
-		sql.append("SELECT LASTATTEMPT FROM " + TABLE_NAME + " WHERE FILENAME = ").append(sqlQuote(fullPathToFile)).append(" ");
-		if (latestVersion != null && CONFIGURATION.getExternalNetwork()) {
-			sql.append(" AND VERSION = ").append(sqlQuote(latestVersion)).append(" ");
-		}
-		sql.append("LIMIT 1");
 
-		try (
-			PreparedStatement selectStatement = connection.prepareStatement(sql.toString());
-			ResultSet rs = selectStatement.executeQuery()
-		) {
-			if (rs.next()) {
-				LOGGER.trace("We have failed a lookup for {} so let's see if it was recent", fullPathToFile);
+		try (PreparedStatement selectStatement = connection.prepareStatement(sql)) {
+			selectStatement.setString(1, fullPathToFile);
+			if (latestVersion != null) {
+				selectStatement.setString(2, latestVersion);
+			}
+			try (ResultSet rs = selectStatement.executeQuery()) {
+				if (rs.next()) {
+					LOGGER.trace("We have failed a lookup for {} so let's see if it was recent", fullPathToFile);
 
-				OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-				OffsetDateTime lastAttempt = rs.getObject("LASTATTEMPT", OffsetDateTime.class);
-				if (lastAttempt.plusWeeks(1).isAfter(now)) {
-					// The last attempt happened in the last week
-					return true;
+					OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+					OffsetDateTime lastAttempt = rs.getObject(COL_LASTATTEMPT, OffsetDateTime.class);
+					if (lastAttempt.plusWeeks(1).isAfter(now)) {
+						// The last attempt happened in the last week
+						return true;
+					} else {
+						// The last attempt happened over a week ago, let's remove it so it can be tried again
+						removeAfter = true;
+						return false;
+					}
 				} else {
-					// The last attempt happened over a week ago, let's remove it so it can be tried again
-					removeAfter = true;
+					LOGGER.trace("We have no failed lookups stored for {}", fullPathToFile);
 					return false;
 				}
-			} else {
-				LOGGER.trace("We have no failed lookups stored for {}", fullPathToFile);
-				return false;
 			}
 		} catch (Exception e) {
 			LOGGER.error(
@@ -199,7 +214,6 @@ public final class MediaTableFailedLookups extends MediaTable {
 	 * @param isVideo
 	 */
 	public static void set(final Connection connection, final String fullPathToFile, final String failureDetails, final boolean isVideo) {
-		boolean trace = LOGGER.isTraceEnabled();
 		String latestVersion;
 		if (isVideo) {
 			latestVersion = APIUtils.getApiDataVideoVersion();
@@ -208,25 +222,20 @@ public final class MediaTableFailedLookups extends MediaTable {
 		}
 
 		try {
-			String query = "SELECT FILENAME, FAILUREDETAILS, VERSION FROM " + TABLE_NAME + " WHERE FILENAME = " + sqlQuote(fullPathToFile) + " LIMIT 1";
-			if (trace) {
-				LOGGER.trace("Searching for file/series in " + TABLE_NAME + " with \"{}\" before update", query);
-			}
-
-			try (
-				Statement statement = connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
-				ResultSet result = statement.executeQuery(query)
-			) {
-				if (result.next()) {
-					result.updateString("FAILUREDETAILS", left(failureDetails, 20000));
-					result.updateString("VERSION", left(latestVersion, 1024));
-					result.updateRow();
-				} else {
-					result.moveToInsertRow();
-					result.updateString("FILENAME", left(fullPathToFile, 1024));
-					result.updateString("FAILUREDETAILS", left(failureDetails, 20000));
-					result.updateString("VERSION", left(latestVersion, 1024));
-					result.insertRow();
+			try (PreparedStatement statement = connection.prepareStatement(SQL_GET_FILENAME, ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE)) {
+				statement.setString(1, fullPathToFile);
+				try (ResultSet result = statement.executeQuery()) {
+					if (result.next()) {
+						result.updateString("FAILUREDETAILS", left(failureDetails, 20000));
+						result.updateString("VERSION", left(latestVersion, 1024));
+						result.updateRow();
+					} else {
+						result.moveToInsertRow();
+						result.updateString("FILENAME", left(fullPathToFile, 1024));
+						result.updateString("FAILUREDETAILS", left(failureDetails, 20000));
+						result.updateString("VERSION", left(latestVersion, 1024));
+						result.insertRow();
+					}
 				}
 			}
 		} catch (SQLException e) {
@@ -250,11 +259,10 @@ public final class MediaTableFailedLookups extends MediaTable {
 	 */
 	public static void remove(final Connection connection, final String filename, boolean useLike) {
 		try {
-			String query =
-				"DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +
-				(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-			try (Statement statement = connection.createStatement()) {
-				int rows = statement.executeUpdate(query);
+			String sql = useLike ? SQL_DELETE_FILENAME_LIKE : SQL_DELETE_FILENAME;
+			try (PreparedStatement statement = connection.prepareStatement(sql)) {
+				statement.setString(1, filename);
+				int rows = statement.executeUpdate();
 				LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
 			}
 		} catch (SQLException e) {

--- a/src/main/java/net/pms/database/MediaTableFailedLookups.java
+++ b/src/main/java/net/pms/database/MediaTableFailedLookups.java
@@ -33,15 +33,15 @@ public final class MediaTableFailedLookups extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableFailedLookups.class);
 	public static final String TABLE_NAME = "FAILED_LOOKUPS";
 	private static final String COL_LASTATTEMPT = "LASTATTEMPT";
-	public static final String LASTATTEMPT = TABLE_NAME + "." + COL_LASTATTEMPT;
-	public static final String FAILUREDETAILS = TABLE_NAME + ".FAILUREDETAILS";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String VERSION = TABLE_NAME + ".VERSION";
-	private static final String SQL_GET_LASTATTEMPT = "SELECT " + LASTATTEMPT + " FROM " + TABLE_NAME + " WHERE " + FILENAME + " = ? LIMIT 1";
-	private static final String SQL_GET_LASTATTEMPT_VERSION = "SELECT " + LASTATTEMPT + " FROM " + TABLE_NAME + " WHERE " + FILENAME + " = ? AND " + VERSION + " = ? LIMIT 1";
-	private static final String SQL_GET_FILENAME = "SELECT " + FILENAME + ", " + FAILUREDETAILS + ", " + VERSION + " FROM " + TABLE_NAME + " WHERE " + FILENAME + " = ? LIMIT 1";
-	private static final String SQL_DELETE_FILENAME = "DELETE FROM  " + TABLE_NAME + " WHERE " + FILENAME + " = ?";
-	private static final String SQL_DELETE_FILENAME_LIKE = "DELETE FROM  " + TABLE_NAME + " WHERE " + FILENAME + " LIKE ?";
+	public static final String TABLE_COL_LASTATTEMPT = TABLE_NAME + "." + COL_LASTATTEMPT;
+	public static final String TABLE_COL_FAILUREDETAILS = TABLE_NAME + ".FAILUREDETAILS";
+	public static final String TABLE_COL_FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TABLE_COL_VERSION = TABLE_NAME + ".VERSION";
+	private static final String SQL_GET_LASTATTEMPT = "SELECT " + TABLE_COL_LASTATTEMPT + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ? LIMIT 1";
+	private static final String SQL_GET_LASTATTEMPT_VERSION = "SELECT " + TABLE_COL_LASTATTEMPT + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ? AND " + TABLE_COL_VERSION + " = ? LIMIT 1";
+	private static final String SQL_GET_FILENAME = "SELECT " + TABLE_COL_FILENAME + ", " + TABLE_COL_FAILUREDETAILS + ", " + TABLE_COL_VERSION + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ? LIMIT 1";
+	private static final String SQL_DELETE_FILENAME = "DELETE FROM  " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ?";
+	private static final String SQL_DELETE_FILENAME_LIKE = "DELETE FROM  " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " LIKE ?";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -224,6 +224,7 @@ public final class MediaTableFailedLookups extends MediaTable {
 		try {
 			try (PreparedStatement statement = connection.prepareStatement(SQL_GET_FILENAME, ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE)) {
 				statement.setString(1, fullPathToFile);
+				LOGGER.trace("Searching for file/series in " + TABLE_NAME + " with \"{}\" before update", statement);
 				try (ResultSet result = statement.executeQuery()) {
 					if (result.next()) {
 						result.updateString("FAILUREDETAILS", left(failureDetails, 20000));

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -304,6 +304,16 @@ public class MediaTableFiles extends MediaTable {
 							executeUpdate(connection, "DROP INDEX IF EXISTS " + index);
 						}
 
+						//set old json datas to be rescanned
+						if (isColumnExist(connection, TABLE_NAME, "VERSION")) {
+							String[] badJsonColumns = {"CREDITS", "EXTERNALIDS", "PRODUCTIONCOMPANIES", "PRODUCTIONCOUNTRIES"};
+							for (String badJsonColumn : badJsonColumns) {
+								if (isColumnExist(connection, TABLE_NAME, badJsonColumn)) {
+									executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET VERSION = '' WHERE RIGHT(" + badJsonColumn + ", 1) = ','");
+								}
+							}
+						}
+
 						//move datas
 						String[] columns = {"IMDBID", "MEDIA_YEAR", "MOVIEORSHOWNAME", "MOVIEORSHOWNAMESIMPLE", "TVSEASON", "TVEPISODENUMBER", "TVEPISODENAME", "ISTVEPISODE", "EXTRAINFORMATION", "VERSION",
 							"BUDGET", "CREDITS", "EXTERNALIDS", "HOMEPAGE", "IMAGES", "ORIGINALLANGUAGE", "ORIGINALTITLE", "PRODUCTIONCOMPANIES", "PRODUCTIONCOUNTRIES", "REVENUE"};

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -423,8 +423,8 @@ public class MediaTableFiles extends MediaTable {
 
 			LOGGER.trace("Creating index FORMAT_TYPE_MODIFIED");
 			statement.execute("CREATE INDEX FORMAT_TYPE_MODIFIED on " + TABLE_NAME + " (FORMAT_TYPE, MODIFIED)");
-	
-			LOGGER.trace("Creating index on "+ THUMBID);
+
+			LOGGER.trace("Creating index on " + THUMBID);
 			statement.execute("CREATE INDEX " + TABLE_NAME + "_" + COL_THUMBID + "_IDX ON " + TABLE_NAME + "(" + COL_THUMBID + ")");
 		}
 	}

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -37,7 +37,6 @@ import static org.apache.commons.lang3.StringUtils.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import net.pms.util.FileUtil;
@@ -1239,47 +1238,6 @@ public class MediaTableFiles extends MediaTable {
 			return null;
 		}
 		return list;
-	}
-
-	/**
-	 * @param connection the db connection
-	 * @param filename
-	 * @return all data across all tables for a video file, if it has an IMDb ID stored.
-	 */
-	public static List<HashMap<String, Object>> getAPIResultsByFilenameIncludingExternalTables(final Connection connection, final String filename) {
-		boolean trace = LOGGER.isTraceEnabled();
-
-		try {
-			String query = "SELECT * " +
-				"FROM " + TABLE_NAME + " " +
-				MediaTableVideoMetadatas.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataActors.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataAwards.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataCountries.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataDirectors.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataGenres.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataProduction.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataPosters.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataRated.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataRatings.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadataReleased.SQL_LEFT_JOIN_TABLE_FILES +
-				"WHERE " + FILENAME + " = ? AND " + MediaTableVideoMetadatas.IMDBID + " != ''";
-
-			try (PreparedStatement ps = connection.prepareStatement(query)) {
-				ps.setString(1, filename);
-				if (trace) {
-					LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", ps);
-				}
-				try (ResultSet resultSet = ps.executeQuery()) {
-					return convertResultSetToList(resultSet);
-				}
-			}
-		} catch (SQLException e) {
-			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", filename, e.getMessage());
-			LOGGER.trace("", e);
-		}
-
-		return null;
 	}
 
 	/**

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -590,24 +590,27 @@ public class MediaTableFiles extends MediaTable {
 						media.setPixelAspectRatio(rs.getString("PIXELASPECTRATIO"));
 						media.setScanType((DLNAMediaInfo.ScanType) rs.getObject("SCANTYPE"));
 						media.setScanOrder((DLNAMediaInfo.ScanOrder) rs.getObject("SCANORDER"));
-						media.setIMDbID(rs.getString("IMDBID"));
-						media.setYear(rs.getString("MEDIA_YEAR"));
-						media.setMovieOrShowName(rs.getString("MOVIEORSHOWNAME"));
-						media.setSimplifiedMovieOrShowName(rs.getString("MOVIEORSHOWNAMESIMPLE"));
-						media.setExtraInformation(rs.getString("EXTRAINFORMATION"));
+						if (!StringUtils.isEmpty(rs.getString("MOVIEORSHOWNAME"))) {
+							DLNAMediaVideoMetadata videoMetadata = new DLNAMediaVideoMetadata();
+							videoMetadata.setIMDbID(rs.getString("IMDBID"));
+							videoMetadata.setYear(rs.getString("MEDIA_YEAR"));
+							videoMetadata.setMovieOrShowName(rs.getString("MOVIEORSHOWNAME"));
+							videoMetadata.setSimplifiedMovieOrShowName(rs.getString("MOVIEORSHOWNAMESIMPLE"));
+							videoMetadata.setExtraInformation(rs.getString("EXTRAINFORMATION"));
 
-						if (rs.getBoolean("ISTVEPISODE")) {
-							media.setTVSeason(rs.getString("TVSEASON"));
-							media.setTVEpisodeNumber(rs.getString("TVEPISODENUMBER"));
-							media.setTVEpisodeName(rs.getString("TVEPISODENAME"));
-							media.setIsTVEpisode(true);
-						} else {
-							media.setIsTVEpisode(false);
+							if (rs.getBoolean("ISTVEPISODE")) {
+								videoMetadata.setTVSeason(rs.getString("TVSEASON"));
+								videoMetadata.setTVEpisodeNumber(rs.getString("TVEPISODENUMBER"));
+								videoMetadata.setTVEpisodeName(rs.getString("TVEPISODENAME"));
+								videoMetadata.setIsTVEpisode(true);
+							} else {
+								videoMetadata.setIsTVEpisode(false);
+							}
+
+							// Fields from TV Series table
+							videoMetadata.setTVSeriesStartYear(rs.getString("STARTYEAR"));
+							media.setVideoMetadata(videoMetadata);
 						}
-
-						// Fields from TV Series table
-						media.setTVSeriesStartYear(rs.getString("STARTYEAR"));
-
 						media.setMediaparsed(true);
 						audios.setInt(1, id);
 						try (ResultSet elements = audios.executeQuery()) {
@@ -771,19 +774,23 @@ public class MediaTableFiles extends MediaTable {
 				) {
 					if (rs.next()) {
 						media = new DLNAMediaInfo();
-						media.setIMDbID(rs.getString("IMDBID"));
-						media.setYear(rs.getString("MEDIA_YEAR"));
-						media.setMovieOrShowName(rs.getString("MOVIEORSHOWNAME"));
-						media.setSimplifiedMovieOrShowName(rs.getString("MOVIEORSHOWNAMESIMPLE"));
-						media.setExtraInformation(rs.getString("EXTRAINFORMATION"));
+						if (!StringUtils.isEmpty(rs.getString("MOVIEORSHOWNAME"))) {
+							DLNAMediaVideoMetadata videoMetadata = new DLNAMediaVideoMetadata();
+							videoMetadata.setIMDbID(rs.getString("IMDBID"));
+							videoMetadata.setYear(rs.getString("MEDIA_YEAR"));
+							videoMetadata.setMovieOrShowName(rs.getString("MOVIEORSHOWNAME"));
+							videoMetadata.setSimplifiedMovieOrShowName(rs.getString("MOVIEORSHOWNAMESIMPLE"));
+							videoMetadata.setExtraInformation(rs.getString("EXTRAINFORMATION"));
 
-						if (rs.getBoolean("ISTVEPISODE")) {
-							media.setTVSeason(rs.getString("TVSEASON"));
-							media.setTVEpisodeNumber(rs.getString("TVEPISODENUMBER"));
-							media.setTVEpisodeName(rs.getString("TVEPISODENAME"));
-							media.setIsTVEpisode(true);
-						} else {
-							media.setIsTVEpisode(false);
+							if (rs.getBoolean("ISTVEPISODE")) {
+								videoMetadata.setTVSeason(rs.getString("TVSEASON"));
+								videoMetadata.setTVEpisodeNumber(rs.getString("TVEPISODENUMBER"));
+								videoMetadata.setTVEpisodeName(rs.getString("TVEPISODENAME"));
+								videoMetadata.setIsTVEpisode(true);
+							} else {
+								videoMetadata.setIsTVEpisode(false);
+							}
+							media.setVideoMetadata(videoMetadata);
 						}
 						media.setMediaparsed(true);
 					}
@@ -880,15 +887,18 @@ public class MediaTableFiles extends MediaTable {
 							rs.updateString("PIXELASPECTRATIO", left(media.getPixelAspectRatio(), SIZE_MAX));
 							updateSerialized(rs, media.getScanType(), "SCANTYPE");
 							updateSerialized(rs, media.getScanOrder(), "SCANORDER");
-							rs.updateString("IMDBID", left(media.getIMDbID(), SIZE_IMDBID));
-							rs.updateString("MEDIA_YEAR", left(media.getYear(), SIZE_YEAR));
-							rs.updateString("MOVIEORSHOWNAME", left(media.getMovieOrShowName(), SIZE_MAX));
-							rs.updateString("MOVIEORSHOWNAMESIMPLE", left(media.getSimplifiedMovieOrShowName(), SIZE_MAX));
-							rs.updateString("TVSEASON", left(media.getTVSeason(), SIZE_TVSEASON));
-							rs.updateString("TVEPISODENUMBER", left(media.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
-							rs.updateString("TVEPISODENAME", left(media.getTVEpisodeName(), SIZE_MAX));
-							rs.updateBoolean("ISTVEPISODE", media.isTVEpisode());
-							rs.updateString("EXTRAINFORMATION", left(media.getExtraInformation(), SIZE_MAX));
+							if (media.hasVideoMetadata()) {
+								DLNAMediaVideoMetadata videoMetadata = media.getVideoMetadata();
+								rs.updateString("IMDBID", left(videoMetadata.getIMDbID(), SIZE_IMDBID));
+								rs.updateString("MEDIA_YEAR", left(videoMetadata.getYear(), SIZE_YEAR));
+								rs.updateString("MOVIEORSHOWNAME", left(videoMetadata.getMovieOrShowName(), SIZE_MAX));
+								rs.updateString("MOVIEORSHOWNAMESIMPLE", left(videoMetadata.getSimplifiedMovieOrShowName(), SIZE_MAX));
+								rs.updateString("TVSEASON", left(videoMetadata.getTVSeason(), SIZE_TVSEASON));
+								rs.updateString("TVEPISODENUMBER", left(videoMetadata.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
+								rs.updateString("TVEPISODENAME", left(videoMetadata.getTVEpisodeName(), SIZE_MAX));
+								rs.updateBoolean("ISTVEPISODE", videoMetadata.isTVEpisode());
+								rs.updateString("EXTRAINFORMATION", left(videoMetadata.getExtraInformation(), SIZE_MAX));
+							}
 						}
 						rs.updateRow();
 					}
@@ -959,15 +969,28 @@ public class MediaTableFiles extends MediaTable {
 						ps.setString(++databaseColumnIterator, left(media.getPixelAspectRatio(), SIZE_MAX));
 						insertSerialized(ps, media.getScanType(), ++databaseColumnIterator);
 						insertSerialized(ps, media.getScanOrder(), ++databaseColumnIterator);
-						ps.setString(++databaseColumnIterator, left(media.getIMDbID(), SIZE_IMDBID));
-						ps.setString(++databaseColumnIterator, left(media.getYear(), SIZE_YEAR));
-						ps.setString(++databaseColumnIterator, left(media.getMovieOrShowName(), SIZE_MAX));
-						ps.setString(++databaseColumnIterator, left(media.getSimplifiedMovieOrShowName(), SIZE_MAX));
-						ps.setString(++databaseColumnIterator, left(media.getTVSeason(), SIZE_TVSEASON));
-						ps.setString(++databaseColumnIterator, left(media.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
-						ps.setString(++databaseColumnIterator, left(media.getTVEpisodeName(), SIZE_MAX));
-						ps.setBoolean(++databaseColumnIterator, media.isTVEpisode());
-						ps.setString(++databaseColumnIterator, left(media.getExtraInformation(), SIZE_MAX));
+						if (media.hasVideoMetadata()) {
+							DLNAMediaVideoMetadata videoMetadata = media.getVideoMetadata();
+							ps.setString(++databaseColumnIterator, left(videoMetadata.getIMDbID(), SIZE_IMDBID));
+							ps.setString(++databaseColumnIterator, left(videoMetadata.getYear(), SIZE_YEAR));
+							ps.setString(++databaseColumnIterator, left(videoMetadata.getMovieOrShowName(), SIZE_MAX));
+							ps.setString(++databaseColumnIterator, left(videoMetadata.getSimplifiedMovieOrShowName(), SIZE_MAX));
+							ps.setString(++databaseColumnIterator, left(videoMetadata.getTVSeason(), SIZE_TVSEASON));
+							ps.setString(++databaseColumnIterator, left(videoMetadata.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
+							ps.setString(++databaseColumnIterator, left(videoMetadata.getTVEpisodeName(), SIZE_MAX));
+							ps.setBoolean(++databaseColumnIterator, videoMetadata.isTVEpisode());
+							ps.setString(++databaseColumnIterator, left(videoMetadata.getExtraInformation(), SIZE_MAX));
+						} else {
+							ps.setNull(++databaseColumnIterator, Types.VARCHAR);
+							ps.setNull(++databaseColumnIterator, Types.VARCHAR);
+							ps.setNull(++databaseColumnIterator, Types.VARCHAR);
+							ps.setNull(++databaseColumnIterator, Types.VARCHAR);
+							ps.setNull(++databaseColumnIterator, Types.VARCHAR);
+							ps.setNull(++databaseColumnIterator, Types.VARCHAR);
+							ps.setNull(++databaseColumnIterator, Types.VARCHAR);
+							ps.setBoolean(++databaseColumnIterator, false);
+							ps.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
 					} else {
 						ps.setString(++databaseColumnIterator, null);
 						ps.setInt(++databaseColumnIterator, 0);
@@ -1094,15 +1117,16 @@ public class MediaTableFiles extends MediaTable {
 			ps.setTimestamp(2, new Timestamp(modified));
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
-					rs.updateString("IMDBID", left(media.getIMDbID(), SIZE_IMDBID));
-					rs.updateString("MEDIA_YEAR", left(media.getYear(), SIZE_YEAR));
-					rs.updateString("MOVIEORSHOWNAME", left(media.getMovieOrShowName(), SIZE_MAX));
-					rs.updateString("MOVIEORSHOWNAMESIMPLE", left(media.getSimplifiedMovieOrShowName(), SIZE_MAX));
-					rs.updateString("TVSEASON", left(media.getTVSeason(), SIZE_TVSEASON));
-					rs.updateString("TVEPISODENUMBER", left(media.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
-					rs.updateString("TVEPISODENAME", left(media.getTVEpisodeName(), SIZE_MAX));
-					rs.updateBoolean("ISTVEPISODE", media.isTVEpisode());
-					rs.updateString("EXTRAINFORMATION", left(media.getExtraInformation(), SIZE_MAX));
+					DLNAMediaVideoMetadata videoMetadata = media.hasVideoMetadata() ? media.getVideoMetadata() : new DLNAMediaVideoMetadata();
+					rs.updateString("IMDBID", left(videoMetadata.getIMDbID(), SIZE_IMDBID));
+					rs.updateString("MEDIA_YEAR", left(videoMetadata.getYear(), SIZE_YEAR));
+					rs.updateString("MOVIEORSHOWNAME", left(videoMetadata.getMovieOrShowName(), SIZE_MAX));
+					rs.updateString("MOVIEORSHOWNAMESIMPLE", left(videoMetadata.getSimplifiedMovieOrShowName(), SIZE_MAX));
+					rs.updateString("TVSEASON", left(videoMetadata.getTVSeason(), SIZE_TVSEASON));
+					rs.updateString("TVEPISODENUMBER", left(videoMetadata.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
+					rs.updateString("TVEPISODENAME", left(videoMetadata.getTVEpisodeName(), SIZE_MAX));
+					rs.updateBoolean("ISTVEPISODE", videoMetadata.isTVEpisode());
+					rs.updateString("EXTRAINFORMATION", left(videoMetadata.getExtraInformation(), SIZE_MAX));
 					rs.updateString("VERSION", left(APIUtils.getApiDataVideoVersion(), SIZE_MAX));
 
 					// TMDB data, since v11

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -63,9 +63,13 @@ public class MediaTableFiles extends MediaTable {
 	public static final String TABLE_COL_THUMBID = TABLE_NAME + "." + COL_THUMBID;
 	public static final String TABLE_COL_STEREOSCOPY = TABLE_NAME + ".STEREOSCOPY";
 
+	public static final String SQL_LEFT_JOIN_TABLE_FILES_STATUS = "LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON " + TABLE_COL_FILENAME + " = " + MediaTableFilesStatus.TABLE_COL_FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_THUMBNAILS = "LEFT JOIN " + MediaTableThumbnails.TABLE_NAME + " ON " + TABLE_COL_THUMBID + " = " + MediaTableThumbnails.TABLE_COL_ID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_VIDEO_METADATA = "LEFT JOIN " + MediaTableVideoMetadata.TABLE_NAME + " ON " + TABLE_COL_ID + " = " + MediaTableVideoMetadata.TABLE_COL_FILEID + " ";
+
 	private static final String SQL_GET_ID_FILENAME = "SELECT " + TABLE_COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ? LIMIT 1";
 	private static final String SQL_GET_ID_FILENAME_MODIFIED = "SELECT " + TABLE_COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ? AND " + TABLE_COL_MODIFIED + " = ? LIMIT 1";
-	private static final String SQL_GET_ALL_FILENAME_MODIFIED = "SELECT * FROM " + TABLE_NAME + " " + MediaTableThumbnails.SQL_LEFT_JOIN_TABLE_FILES + " WHERE " + TABLE_COL_FILENAME + " = ? AND " + TABLE_COL_MODIFIED + " = ? LIMIT 1";
+	private static final String SQL_GET_ALL_FILENAME_MODIFIED = "SELECT * FROM " + TABLE_NAME + " " + SQL_LEFT_JOIN_TABLE_THUMBNAILS + " WHERE " + TABLE_COL_FILENAME + " = ? AND " + TABLE_COL_MODIFIED + " = ? LIMIT 1";
 
 	public static final String NONAME = "###";
 
@@ -1255,8 +1259,8 @@ public class MediaTableFiles extends MediaTable {
 		try {
 			String query = "SELECT " + MediaTableThumbnails.TABLE_COL_THUMBNAIL + " " +
 				"FROM " + TABLE_NAME + " " +
-				MediaTableThumbnails.SQL_LEFT_JOIN_TABLE_FILES +
-				MediaTableVideoMetadata.SQL_LEFT_JOIN_TABLE_FILES +
+				SQL_LEFT_JOIN_TABLE_THUMBNAILS +
+				SQL_LEFT_JOIN_TABLE_VIDEO_METADATA +
 				"WHERE " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAMESIMPLE + " = " + sqlQuote(simplifiedTitle) + " LIMIT 1";
 
 			if (trace) {

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -60,7 +60,7 @@ public class MediaTableFiles extends MediaTable {
 	public static final String WIDTH = TABLE_NAME + ".WIDTH";
 	public static final String HEIGHT = TABLE_NAME + ".HEIGHT";
 	public static final String THUMBID = TABLE_NAME + ".THUMBID";
-	public static final String STEREOSCOPY = TABLE_NAME + ".THUMBID";
+	public static final String STEREOSCOPY = TABLE_NAME + ".STEREOSCOPY";
 
 	public static final String NONAME = "###";
 

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -309,7 +309,7 @@ public class MediaTableFiles extends MediaTable {
 							String[] badJsonColumns = {"CREDITS", "EXTERNALIDS", "PRODUCTIONCOMPANIES", "PRODUCTIONCOUNTRIES"};
 							for (String badJsonColumn : badJsonColumns) {
 								if (isColumnExist(connection, TABLE_NAME, badJsonColumn)) {
-									executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET VERSION = '' WHERE RIGHT(" + badJsonColumn + ", 1) = ','");
+									executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET IMDBID = NULL WHERE RIGHT(" + badJsonColumn + ", 1) = ','");
 								}
 							}
 						}

--- a/src/main/java/net/pms/database/MediaTableFilesStatus.java
+++ b/src/main/java/net/pms/database/MediaTableFilesStatus.java
@@ -45,17 +45,17 @@ import net.pms.util.FileUtil;
 public final class MediaTableFilesStatus extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableFilesStatus.class);
 	public static final String TABLE_NAME = "FILES_STATUS";
-	public static final String BOOKMARK = TABLE_NAME + ".BOOKMARK";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String ISFULLYPLAYED = TABLE_NAME + ".ISFULLYPLAYED";
-	public static final String PLAYCOUNT = TABLE_NAME + ".PLAYCOUNT";
-	public static final String DATELASTPLAY = TABLE_NAME + ".DATELASTPLAY";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
-	private static final String SQL_GET_ALL = "SELECT * FROM " + TABLE_NAME + " WHERE " + FILENAME + " = ? LIMIT 1";
-	private static final String SQL_GET_BOOKMARK = "SELECT " + BOOKMARK + " FROM " + TABLE_NAME + " WHERE FILENAME = ? LIMIT 1";
-	private static final String SQL_GET_ISFULLYPLAYED = "SELECT " + ISFULLYPLAYED + " FROM " + TABLE_NAME + " WHERE " + FILENAME + " = ? LIMIT 1";
-	private static final String SQL_DELETE = "DELETE FROM " + TABLE_NAME + " WHERE " + FILENAME + " = ?";
-	private static final String SQL_DELETE_LIKE = "DELETE FROM " + TABLE_NAME + " WHERE " + FILENAME + " LIKE ?";
+	public static final String TABLE_COL_BOOKMARK = TABLE_NAME + ".BOOKMARK";
+	public static final String TABLE_COL_FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TABLE_COL_ISFULLYPLAYED = TABLE_NAME + ".ISFULLYPLAYED";
+	public static final String TABLE_COL_PLAYCOUNT = TABLE_NAME + ".PLAYCOUNT";
+	public static final String TABLE_COL_DATELASTPLAY = TABLE_NAME + ".DATELASTPLAY";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_COL_FILENAME + " ";
+	private static final String SQL_GET_ALL = "SELECT * FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ? LIMIT 1";
+	private static final String SQL_GET_BOOKMARK = "SELECT " + TABLE_COL_BOOKMARK + " FROM " + TABLE_NAME + " WHERE FILENAME = ? LIMIT 1";
+	private static final String SQL_GET_ISFULLYPLAYED = "SELECT " + TABLE_COL_ISFULLYPLAYED + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ? LIMIT 1";
+	private static final String SQL_DELETE = "DELETE FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ?";
+	private static final String SQL_DELETE_LIKE = "DELETE FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " LIKE ?";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -115,7 +115,7 @@ public final class MediaTableFilesStatus extends MediaTable {
 						statement.execute("ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT FILES_FILENAME_UNIQUE UNIQUE(FILENAME)");
 
 						Set<String> fileStatusEntries = new HashSet<>();
-						try (PreparedStatement stmt = connection.prepareStatement("SELECT " + MediaTableFiles.ID + " AS FILES_ID, " + MediaTableFiles.TABLE_NAME + ".FILENAME AS FILES_FILENAME FROM " + MediaTableFiles.TABLE_NAME + " LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_NAME + ".ID = " + TABLE_NAME + ".FILEID");
+						try (PreparedStatement stmt = connection.prepareStatement("SELECT " + MediaTableFiles.TABLE_COL_ID + " AS FILES_ID, " + MediaTableFiles.TABLE_NAME + ".FILENAME AS FILES_FILENAME FROM " + MediaTableFiles.TABLE_NAME + " LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_NAME + ".ID = " + TABLE_NAME + ".FILEID");
 								ResultSet rs = stmt.executeQuery()) {
 							String filename;
 							while (rs.next()) {

--- a/src/main/java/net/pms/database/MediaTableFilesStatus.java
+++ b/src/main/java/net/pms/database/MediaTableFilesStatus.java
@@ -45,6 +45,10 @@ import net.pms.util.FileUtil;
 public final class MediaTableFilesStatus extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableFilesStatus.class);
 	public static final String TABLE_NAME = "FILES_STATUS";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String ISFULLYPLAYED = TABLE_NAME + ".ISFULLYPLAYED";
+	public static final String PLAYCOUNT = TABLE_NAME + ".PLAYCOUNT";
+	public static final String DATELASTPLAY = TABLE_NAME + ".DATELASTPLAY";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableFilesStatus.java
+++ b/src/main/java/net/pms/database/MediaTableFilesStatus.java
@@ -50,7 +50,6 @@ public final class MediaTableFilesStatus extends MediaTable {
 	public static final String TABLE_COL_ISFULLYPLAYED = TABLE_NAME + ".ISFULLYPLAYED";
 	public static final String TABLE_COL_PLAYCOUNT = TABLE_NAME + ".PLAYCOUNT";
 	public static final String TABLE_COL_DATELASTPLAY = TABLE_NAME + ".DATELASTPLAY";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_COL_FILENAME + " ";
 	private static final String SQL_GET_ALL = "SELECT * FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ? LIMIT 1";
 	private static final String SQL_GET_BOOKMARK = "SELECT " + TABLE_COL_BOOKMARK + " FROM " + TABLE_NAME + " WHERE FILENAME = ? LIMIT 1";
 	private static final String SQL_GET_ISFULLYPLAYED = "SELECT " + TABLE_COL_ISFULLYPLAYED + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILENAME + " = ? LIMIT 1";

--- a/src/main/java/net/pms/database/MediaTableFilesStatus.java
+++ b/src/main/java/net/pms/database/MediaTableFilesStatus.java
@@ -49,6 +49,7 @@ public final class MediaTableFilesStatus extends MediaTable {
 	public static final String ISFULLYPLAYED = TABLE_NAME + ".ISFULLYPLAYED";
 	public static final String PLAYCOUNT = TABLE_NAME + ".PLAYCOUNT";
 	public static final String DATELASTPLAY = TABLE_NAME + ".DATELASTPLAY";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -108,7 +109,7 @@ public final class MediaTableFilesStatus extends MediaTable {
 						statement.execute("ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT FILES_FILENAME_UNIQUE UNIQUE(FILENAME)");
 
 						Set<String> fileStatusEntries = new HashSet<>();
-						try (PreparedStatement stmt = connection.prepareStatement("SELECT " + MediaTableFiles.TABLE_NAME + ".ID AS FILES_ID, " + MediaTableFiles.TABLE_NAME + ".FILENAME AS FILES_FILENAME FROM " + MediaTableFiles.TABLE_NAME + " LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_NAME + ".ID = " + TABLE_NAME + ".FILEID");
+						try (PreparedStatement stmt = connection.prepareStatement("SELECT " + MediaTableFiles.ID + " AS FILES_ID, " + MediaTableFiles.TABLE_NAME + ".FILENAME AS FILES_FILENAME FROM " + MediaTableFiles.TABLE_NAME + " LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_NAME + ".ID = " + TABLE_NAME + ".FILEID");
 								ResultSet rs = stmt.executeQuery()) {
 							String filename;
 							while (rs.next()) {

--- a/src/main/java/net/pms/database/MediaTableMusicBrainzReleaseLike.java
+++ b/src/main/java/net/pms/database/MediaTableMusicBrainzReleaseLike.java
@@ -13,6 +13,7 @@ public class MediaTableMusicBrainzReleaseLike extends MediaTable {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableMusicBrainzReleaseLike.class);
 	public static final String TABLE_NAME = "MUSIC_BRAINZ_RELEASE_LIKE";
+	public static final String MBID_RELEASE = TABLE_NAME + ".MBID_RELEASE";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableMusicBrainzReleaseLike.java
+++ b/src/main/java/net/pms/database/MediaTableMusicBrainzReleaseLike.java
@@ -13,7 +13,7 @@ public class MediaTableMusicBrainzReleaseLike extends MediaTable {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableMusicBrainzReleaseLike.class);
 	public static final String TABLE_NAME = "MUSIC_BRAINZ_RELEASE_LIKE";
-	public static final String MBID_RELEASE = TABLE_NAME + ".MBID_RELEASE";
+	public static final String TABLE_COL_MBID_RELEASE = TABLE_NAME + ".MBID_RELEASE";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableRegexpRules.java
+++ b/src/main/java/net/pms/database/MediaTableRegexpRules.java
@@ -32,6 +32,9 @@ import org.slf4j.LoggerFactory;
 public class MediaTableRegexpRules extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableRegexpRules.class);
 	public static final String TABLE_NAME = "REGEXP_RULES";
+	public static final String ID = TABLE_NAME + ".ID";
+	public static final String REGEXP_ORDER = TABLE_NAME + ".REGEXP_ORDER";
+	public static final String REGEXP_RULE = TABLE_NAME + ".REGEXP_RULE";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableRegexpRules.java
+++ b/src/main/java/net/pms/database/MediaTableRegexpRules.java
@@ -32,9 +32,9 @@ import org.slf4j.LoggerFactory;
 public class MediaTableRegexpRules extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableRegexpRules.class);
 	public static final String TABLE_NAME = "REGEXP_RULES";
-	public static final String ID = TABLE_NAME + ".ID";
-	public static final String REGEXP_ORDER = TABLE_NAME + ".REGEXP_ORDER";
-	public static final String REGEXP_RULE = TABLE_NAME + ".REGEXP_RULE";
+	public static final String TABLE_COL_ID = TABLE_NAME + ".ID";
+	public static final String TABLE_COL_REGEXP_ORDER = TABLE_NAME + ".REGEXP_ORDER";
+	public static final String TABLE_COL_REGEXP_RULE = TABLE_NAME + ".REGEXP_RULE";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableSubtracks.java
+++ b/src/main/java/net/pms/database/MediaTableSubtracks.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 public class MediaTableSubtracks extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableSubtracks.class);
 	public static final String TABLE_NAME = "SUBTRACKS";
-	public static final String FILEID = TABLE_NAME + ".FILEID";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + ".FILEID";
 
 	private static final int SIZE_LANG = 3;
 	private static final int SIZE_EXTERNALFILE = 1000;

--- a/src/main/java/net/pms/database/MediaTableSubtracks.java
+++ b/src/main/java/net/pms/database/MediaTableSubtracks.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 public class MediaTableSubtracks extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableSubtracks.class);
 	public static final String TABLE_NAME = "SUBTRACKS";
+	public static final String FILEID = TABLE_NAME + ".FILEID";
 
 	private static final int SIZE_LANG = 3;
 	private static final int SIZE_EXTERNALFILE = 1000;

--- a/src/main/java/net/pms/database/MediaTableTVSeries.java
+++ b/src/main/java/net/pms/database/MediaTableTVSeries.java
@@ -195,6 +195,16 @@ public final class MediaTableTVSeries extends MediaTable {
 					break;
 				case 6:
 					executeUpdate(connection, "CREATE INDEX IF NOT EXISTS " + TABLE_NAME + "_" + COL_THUMBID + "_IDX ON " + TABLE_NAME + "(" + COL_THUMBID + ")");
+
+					//set old json datas to be rescanned
+					if (isColumnExist(connection, TABLE_NAME, "VERSION")) {
+						String[] badJsonColumns = {"LANGUAGES", "ORIGINCOUNTRY"};
+						for (String badJsonColumn : badJsonColumns) {
+							if (isColumnExist(connection, TABLE_NAME, badJsonColumn)) {
+								executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET VERSION = '' WHERE RIGHT(" + badJsonColumn + ", 1) = ','");
+							}
+						}
+					}
 					break;
 				default:
 					throw new IllegalStateException(
@@ -624,14 +634,11 @@ public final class MediaTableTVSeries extends MediaTable {
 						result.addProperty("title", rs.getString("TITLE"));
 						result.addProperty("totalSeasons", rs.getDouble("TOTALSEASONS"));
 						result.addProperty("createdBy", rs.getString("CREATEDBY"));
-						//credits, genres, ratings and some other columns was not well saved by the api (not json).
-						//we should delete the IMDB or set this file to be parsed again at read end if a parse fail occurs.
 						addJsonElementToJsonObjectIfExists(result, "credits", rs.getString("CREDITS"));
 						addJsonElementToJsonObjectIfExists(result, "externalIDs", rs.getString("EXTERNALIDS"));
 						result.addProperty("firstAirDate", rs.getString("FIRSTAIRDATE"));
 						result.addProperty("homepage", rs.getString("HOMEPAGE"));
 						addJsonElementToJsonObjectIfExists(result, "images", rs.getString("IMAGES"));
-						addJsonElementToJsonObjectIfExists(result, "seriesImages", rs.getString("IMAGES"));
 						result.addProperty("inProduction", rs.getBoolean("INPRODUCTION"));
 						result.addProperty("homepage", rs.getString("HOMEPAGE"));
 						addJsonElementToJsonObjectIfExists(result, "languages", rs.getString("LANGUAGES"));

--- a/src/main/java/net/pms/database/MediaTableTVSeries.java
+++ b/src/main/java/net/pms/database/MediaTableTVSeries.java
@@ -45,8 +45,14 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public final class MediaTableTVSeries extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableTVSeries.class);
 	public static final String TABLE_NAME = "TV_SERIES";
+	/**
+	 * COLUMNS with table name
+	 */
 	public static final String ID = TABLE_NAME + ".ID";
+	public static final String IMDBID = TABLE_NAME + ".IMDBID";
 	public static final String TITLE = TABLE_NAME + ".TITLE";
+	public static final String SIMPLIFIEDTITLE = TABLE_NAME + ".SIMPLIFIEDTITLE";
+	public static final String THUMBID = TABLE_NAME + ".THUMBID";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -464,10 +470,10 @@ public final class MediaTableTVSeries extends MediaTable {
 		Integer thumbnailId = null;
 		Integer tvSeriesId = null;
 
-		String sql = "SELECT " + MediaTableThumbnails.TABLE_NAME + ".ID AS ThumbnailId, " + TABLE_NAME + ".ID as TVSeriesId, THUMBNAIL " +
+		String sql = "SELECT " + MediaTableThumbnails.ID + " AS ThumbnailId, " + ID + " as TVSeriesId, " + MediaTableThumbnails.THUMBNAIL +" " +
 			"FROM " + TABLE_NAME + " " +
-			"LEFT JOIN " + MediaTableThumbnails.TABLE_NAME + " ON " + TABLE_NAME + ".THUMBID = " + MediaTableThumbnails.TABLE_NAME + ".ID " +
-			"WHERE SIMPLIFIEDTITLE = " + sqlQuote(simplifiedTitle) + " LIMIT 1";
+			MediaTableThumbnails.SQL_LEFT_JOIN_TABLE_TV_SERIES +
+			"WHERE " + SIMPLIFIEDTITLE + " = " + sqlQuote(simplifiedTitle) + " LIMIT 1";
 
 		if (trace) {
 			LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", sql);
@@ -523,7 +529,7 @@ public final class MediaTableTVSeries extends MediaTable {
 
 	public static String getStartYearBySimplifiedTitle(final Connection connection, final String simplifiedTitle) {
 		String sql = "SELECT STARTYEAR FROM " + TABLE_NAME + " " +
-			" WHERE SIMPLIFIEDTITLE = " + sqlQuote(simplifiedTitle) + " LIMIT 1";
+			" WHERE " + SIMPLIFIEDTITLE + " = " + sqlQuote(simplifiedTitle) + " LIMIT 1";
 		try (
 			Statement statement = connection.createStatement();
 			ResultSet resultSet = statement.executeQuery(sql)
@@ -574,17 +580,17 @@ public final class MediaTableTVSeries extends MediaTable {
 		try {
 			String sql = "SELECT * " +
 				"FROM " + TABLE_NAME + " " +
-				"LEFT JOIN " + MediaTableVideoMetadataActors.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataActors.TABLE_NAME + ".TVSERIESID " +
-				"LEFT JOIN " + MediaTableVideoMetadataAwards.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataAwards.TABLE_NAME + ".TVSERIESID " +
-				"LEFT JOIN " + MediaTableVideoMetadataCountries.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataCountries.TABLE_NAME + ".TVSERIESID " +
-				"LEFT JOIN " + MediaTableVideoMetadataDirectors.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataDirectors.TABLE_NAME + ".TVSERIESID " +
-				"LEFT JOIN " + MediaTableVideoMetadataGenres.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataGenres.TABLE_NAME + ".TVSERIESID " +
-				"LEFT JOIN " + MediaTableVideoMetadataProduction.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataProduction.TABLE_NAME + ".TVSERIESID " +
-				"LEFT JOIN " + MediaTableVideoMetadataPosters.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataPosters.TABLE_NAME + ".TVSERIESID " +
-				"LEFT JOIN " + MediaTableVideoMetadataRated.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataRated.TABLE_NAME + ".TVSERIESID " +
-				"LEFT JOIN " + MediaTableVideoMetadataRatings.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataRatings.TABLE_NAME + ".TVSERIESID " +
-				"LEFT JOIN " + MediaTableVideoMetadataReleased.TABLE_NAME + " ON " + TABLE_NAME + ".ID = " + MediaTableVideoMetadataReleased.TABLE_NAME + ".TVSERIESID " +
-				"WHERE SIMPLIFIEDTITLE = " + sqlQuote(simplifiedTitle) + " and IMDBID != ''";
+				MediaTableVideoMetadataActors.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				MediaTableVideoMetadataAwards.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				MediaTableVideoMetadataCountries.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				MediaTableVideoMetadataDirectors.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				MediaTableVideoMetadataGenres.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				MediaTableVideoMetadataProduction.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				MediaTableVideoMetadataPosters.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				MediaTableVideoMetadataRated.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				MediaTableVideoMetadataRatings.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				MediaTableVideoMetadataReleased.SQL_LEFT_JOIN_TABLE_TV_SERIES + " " +
+				"WHERE " + SIMPLIFIEDTITLE + " = " + sqlQuote(simplifiedTitle) + " and " + IMDBID + " != ''";
 
 			if (trace) {
 				LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", sql);
@@ -645,7 +651,7 @@ public final class MediaTableTVSeries extends MediaTable {
 			PreparedStatement ps = connection.prepareStatement(
 				"SELECT * " +
 				"FROM " + TABLE_NAME + " " +
-				"WHERE SIMPLIFIEDTITLE = ?",
+				"WHERE " + SIMPLIFIEDTITLE + " = ?",
 				ResultSet.TYPE_FORWARD_ONLY,
 				ResultSet.CONCUR_UPDATABLE
 			)
@@ -780,12 +786,10 @@ public final class MediaTableTVSeries extends MediaTable {
 			 * This backwards logic is used for performance since we only have
 			 * to check one row instead of all rows.
 			 */
-			String sql = "SELECT " + MediaTableVideoMetadatas.TABLE_NAME + ".MOVIEORSHOWNAME " +
+			String sql = "SELECT " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " " +
 				"FROM " + MediaTableFiles.TABLE_NAME + " " +
-					"LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON " +
-					MediaTableFiles.FILENAME + " = " + MediaTableFilesStatus.FILENAME + " " +
-					"LEFT JOIN " + MediaTableVideoMetadatas.TABLE_NAME + " ON " +
-					MediaTableFiles.ID + " = " + MediaTableVideoMetadatas.FILEID + " " +
+					MediaTableFilesStatus.SQL_LEFT_JOIN_TABLE_FILES +
+					MediaTableVideoMetadatas.SQL_LEFT_JOIN_TABLE_FILES +
 				"WHERE " +
 					MediaTableFiles.FORMAT_TYPE + " = 4 AND " +
 					MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = " + sqlQuote(title) + " AND " +

--- a/src/main/java/net/pms/database/MediaTableTVSeries.java
+++ b/src/main/java/net/pms/database/MediaTableTVSeries.java
@@ -57,29 +57,29 @@ public final class MediaTableTVSeries extends MediaTable {
 	/**
 	 * COLUMNS with table name
 	 */
-	public static final String ID = TABLE_NAME + "." + COL_ID;
-	public static final String IMDBID = TABLE_NAME + ".IMDBID";
-	public static final String TITLE = TABLE_NAME + "." + COL_TITLE;
-	public static final String SIMPLIFIEDTITLE = TABLE_NAME + "." + COL_SIMPLIFIEDTITLE;
-	public static final String STARTYEAR = TABLE_NAME + ".STARTYEAR";
-	public static final String IMAGES = TABLE_NAME + "." + COL_IMAGES;
-	public static final String THUMBID = TABLE_NAME + "." + COL_THUMBID;
+	public static final String TABLE_COL_ID = TABLE_NAME + "." + COL_ID;
+	public static final String TABLE_COL_IMDBID = TABLE_NAME + ".IMDBID";
+	public static final String TABLE_COL_TITLE = TABLE_NAME + "." + COL_TITLE;
+	public static final String TABLE_COL_SIMPLIFIEDTITLE = TABLE_NAME + "." + COL_SIMPLIFIEDTITLE;
+	public static final String TABLE_COL_STARTYEAR = TABLE_NAME + ".STARTYEAR";
+	public static final String TABLE_COL_IMAGES = TABLE_NAME + "." + COL_IMAGES;
+	public static final String TABLE_COL_THUMBID = TABLE_NAME + "." + COL_THUMBID;
 
-	private static final String SQL_GET_BY_IMDBID = "SELECT * FROM " + TABLE_NAME + " WHERE " + IMDBID + " = ? LIMIT 1";
-	private static final String SQL_GET_BY_SIMPLIFIEDTITLE = "SELECT * FROM " + TABLE_NAME + " WHERE " + SIMPLIFIEDTITLE + " = ? LIMIT 1";
-	private static final String SQL_GET_ID_BY_SIMPLIFIEDTITLE = "SELECT " + ID + " FROM " + TABLE_NAME + " WHERE " + SIMPLIFIEDTITLE + " = ? LIMIT 1";
-	private static final String SQL_GET_TITLE_BY_IMDBID = "SELECT " + TITLE + " FROM " + TABLE_NAME + " WHERE " + IMDBID + " = ? LIMIT 1";
-	private static final String SQL_GET_TITLE_BY_IMDBID_API_VERSION = "SELECT " + TITLE + " FROM " + TABLE_NAME + " WHERE " + IMDBID + " = ? AND VERSION = ? LIMIT 1";
-	private static final String SQL_GET_IMAGES_BY_SIMPLIFIEDTITLE = "SELECT " + IMAGES + " FROM " + TABLE_NAME + " WHERE " + SIMPLIFIEDTITLE + " = ? LIMIT 1";
-	private static final String SQL_GET_THUMBNAIL_BY_SIMPLIFIEDTITLE = "SELECT " + THUMBID + ", " + ID + ", " + MediaTableThumbnails.THUMBNAIL + " FROM " + TABLE_NAME + " " + MediaTableThumbnails.SQL_LEFT_JOIN_TABLE_TV_SERIES + " WHERE " + SIMPLIFIEDTITLE + " = ? LIMIT 1";
-	private static final String SQL_GET_STARTYEAR_BY_SIMPLIFIEDTITLE = "SELECT " + STARTYEAR + " FROM " + TABLE_NAME + " WHERE " + SIMPLIFIEDTITLE + " = ? LIMIT 1";
-	private static final String SQL_GET_TITLE_BY_SIMPLIFIEDTITLE = "SELECT " + TITLE + " FROM " + TABLE_NAME + " WHERE " + SIMPLIFIEDTITLE + " = ? LIMIT 1";
-	private static final String SQL_GET_ISFULLYPLAYED = "SELECT " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " FROM " + MediaTableFiles.TABLE_NAME + " " + MediaTableFilesStatus.SQL_LEFT_JOIN_TABLE_FILES + MediaTableVideoMetadatas.SQL_LEFT_JOIN_TABLE_FILES + "WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = ? AND " + MediaTableVideoMetadatas.ISTVEPISODE + " AND " + MediaTableFilesStatus.ISFULLYPLAYED + " IS NOT TRUE LIMIT 1";
-	private static final String SQL_UPDATE_THUMBID = "UPDATE " + TABLE_NAME + " SET " + COL_THUMBID + " = ? WHERE " + ID + " = ?";
-	private static final String SQL_UPDATE_IMDBID_NULL = "UPDATE " + TABLE_NAME + " SET " + COL_IMDBID + " = null WHERE " + ID + " = ?";
+	private static final String SQL_GET_BY_IMDBID = "SELECT * FROM " + TABLE_NAME + " WHERE " + TABLE_COL_IMDBID + " = ? LIMIT 1";
+	private static final String SQL_GET_BY_SIMPLIFIEDTITLE = "SELECT * FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
+	private static final String SQL_GET_ID_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
+	private static final String SQL_GET_TITLE_BY_IMDBID = "SELECT " + TABLE_COL_TITLE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_IMDBID + " = ? LIMIT 1";
+	private static final String SQL_GET_TITLE_BY_IMDBID_API_VERSION = "SELECT " + TABLE_COL_TITLE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_IMDBID + " = ? AND VERSION = ? LIMIT 1";
+	private static final String SQL_GET_IMAGES_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_IMAGES + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
+	private static final String SQL_GET_THUMBNAIL_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_THUMBID + ", " + TABLE_COL_ID + ", " + MediaTableThumbnails.TABLE_COL_THUMBNAIL + " FROM " + TABLE_NAME + " " + MediaTableThumbnails.SQL_LEFT_JOIN_TABLE_TV_SERIES + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
+	private static final String SQL_GET_STARTYEAR_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_STARTYEAR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
+	private static final String SQL_GET_TITLE_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_TITLE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
+	private static final String SQL_GET_ISFULLYPLAYED = "SELECT " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " FROM " + MediaTableFiles.TABLE_NAME + " " + MediaTableFilesStatus.SQL_LEFT_JOIN_TABLE_FILES + MediaTableVideoMetadata.SQL_LEFT_JOIN_TABLE_FILES + "WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = ? AND " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + " AND " + MediaTableFilesStatus.TABLE_COL_ISFULLYPLAYED + " IS NOT TRUE LIMIT 1";
+	private static final String SQL_UPDATE_THUMBID = "UPDATE " + TABLE_NAME + " SET " + COL_THUMBID + " = ? WHERE " + TABLE_COL_ID + " = ?";
+	private static final String SQL_UPDATE_IMDBID_NULL = "UPDATE " + TABLE_NAME + " SET " + COL_IMDBID + " = null WHERE " + TABLE_COL_ID + " = ?";
 	private static final String SQL_INSERT_TITLE = "INSERT INTO " + TABLE_NAME + " (" + COL_SIMPLIFIEDTITLE + ", " + COL_TITLE + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_ALL = "INSERT INTO " + TABLE_NAME + " (" + BASIC_COLUMNS + ", " + TMDB_COLUMNS + ") VALUES (" + BASIC_COLUMNS_PLACEHOLDERS + ", " + TMDB_COLUMNS_PLACEHOLDERS + ")";
-	private static final String SQL_DELETE_IMDBID = "DELETE FROM " + TABLE_NAME + " WHERE " + IMDBID + " = ?";
+	private static final String SQL_DELETE_IMDBID = "DELETE FROM " + TABLE_NAME + " WHERE " + TABLE_COL_IMDBID + " = ?";
 
 	/**
 	 * Used by child tables
@@ -618,7 +618,7 @@ public final class MediaTableTVSeries extends MediaTable {
 		boolean trace = LOGGER.isTraceEnabled();
 
 		try {
-			String sql = "SELECT * FROM " + TABLE_NAME + " WHERE " + SIMPLIFIEDTITLE + " = ? LIMIT 1";
+			String sql = "SELECT * FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
 			try (PreparedStatement selectStatement = connection.prepareStatement(sql)) {
 				selectStatement.setString(1, simplifiedTitle);
 				if (trace) {

--- a/src/main/java/net/pms/database/MediaTableTVSeries.java
+++ b/src/main/java/net/pms/database/MediaTableTVSeries.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableTVSeries extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableTVSeries.class);
 	public static final String TABLE_NAME = "TV_SERIES";
+	public static final String COL_ID = "ID";
 	private static final String COL_IMDBID = "IMDBID";
 	private static final String COL_THUMBID = "THUMBID";
 	private static final String COL_SIMPLIFIEDTITLE = "SIMPLIFIEDTITLE";
@@ -57,7 +58,7 @@ public final class MediaTableTVSeries extends MediaTable {
 	/**
 	 * COLUMNS with table name
 	 */
-	public static final String ID = TABLE_NAME + ".ID";
+	public static final String ID = TABLE_NAME + "." + COL_ID;
 	public static final String IMDBID = TABLE_NAME + ".IMDBID";
 	public static final String TITLE = TABLE_NAME + "." + COL_TITLE;
 	public static final String SIMPLIFIEDTITLE = TABLE_NAME + "." + COL_SIMPLIFIEDTITLE;
@@ -78,11 +79,16 @@ public final class MediaTableTVSeries extends MediaTable {
 	private static final String SQL_DELETE_IMDBID = "DELETE FROM " + TABLE_NAME + " WHERE " + IMDBID + " = ?";
 
 	/**
+	 * Used by child tables
+	 */
+	public static final String CHILD_ID = "TVSERIESID";
+
+	/**
 	 * Table version must be increased every time a change is done to the table
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 6;
+	private static final int TABLE_VERSION = 7;
 
 
 	private static final Gson GSON = new Gson();
@@ -184,6 +190,9 @@ public final class MediaTableTVSeries extends MediaTable {
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN INPRODUCTION BOOLEAN");
 					}
 					break;
+				case 6:
+					executeUpdate(connection, "CREATE INDEX IF NOT EXISTS " + TABLE_NAME + "_" + COL_THUMBID + "_IDX ON " + TABLE_NAME + "(" + COL_THUMBID + ")");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -240,7 +249,8 @@ public final class MediaTableTVSeries extends MediaTable {
 			"CREATE INDEX IMDBID_IDX ON " + TABLE_NAME + "(IMDBID)",
 			"CREATE INDEX TITLE_IDX ON " + TABLE_NAME + "(TITLE)",
 			"CREATE INDEX SIMPLIFIEDTITLE_IDX ON " + TABLE_NAME + "(SIMPLIFIEDTITLE)",
-			"CREATE INDEX IMDBID_VERSION ON " + TABLE_NAME + "(IMDBID, VERSION)"
+			"CREATE INDEX IMDBID_VERSION ON " + TABLE_NAME + "(IMDBID, VERSION)",
+			"CREATE INDEX " + TABLE_NAME + "_" + COL_THUMBID + "_IDX ON " + TABLE_NAME + "(" + COL_THUMBID + ")"
 		);
 	}
 

--- a/src/main/java/net/pms/database/MediaTableTVSeries.java
+++ b/src/main/java/net/pms/database/MediaTableTVSeries.java
@@ -201,7 +201,7 @@ public final class MediaTableTVSeries extends MediaTable {
 						String[] badJsonColumns = {"LANGUAGES", "ORIGINCOUNTRY"};
 						for (String badJsonColumn : badJsonColumns) {
 							if (isColumnExist(connection, TABLE_NAME, badJsonColumn)) {
-								executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET VERSION = '' WHERE RIGHT(" + badJsonColumn + ", 1) = ','");
+								executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_IMDBID + " = NULL WHERE RIGHT(" + badJsonColumn + ", 1) = ','");
 							}
 						}
 					}

--- a/src/main/java/net/pms/database/MediaTableTVSeries.java
+++ b/src/main/java/net/pms/database/MediaTableTVSeries.java
@@ -40,6 +40,9 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableTVSeries extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableTVSeries.class);
 	public static final String TABLE_NAME = "TV_SERIES";
+	/**
+	 * COLUMNS
+	 */
 	public static final String COL_ID = "ID";
 	private static final String COL_IMAGES = "IMAGES";
 	private static final String COL_IMDBID = "IMDBID";
@@ -65,16 +68,21 @@ public final class MediaTableTVSeries extends MediaTable {
 	public static final String TABLE_COL_IMAGES = TABLE_NAME + "." + COL_IMAGES;
 	public static final String TABLE_COL_THUMBID = TABLE_NAME + "." + COL_THUMBID;
 
+	private static final String SQL_LEFT_JOIN_TABLE_THUMBNAILS = "LEFT JOIN " + MediaTableThumbnails.TABLE_NAME + " ON " + TABLE_COL_THUMBID + " = " + MediaTableThumbnails.TABLE_COL_ID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_VIDEO_METADATA_GENRES = "LEFT JOIN " + MediaTableVideoMetadataGenres.TABLE_NAME + " ON " + TABLE_COL_ID + " = " + MediaTableVideoMetadataGenres.TABLE_COL_TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_VIDEO_METADATA_IMDB_RATING = "LEFT JOIN " + MediaTableVideoMetadataIMDbRating.TABLE_NAME + " ON " + TABLE_COL_ID + " = " + MediaTableVideoMetadataIMDbRating.TABLE_COL_TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_VIDEO_METADATA_RATED = "LEFT JOIN " + MediaTableVideoMetadataRated.TABLE_NAME + " ON " + TABLE_COL_ID + " = " + MediaTableVideoMetadataRated.TABLE_COL_TVSERIESID + " ";
+
 	private static final String SQL_GET_BY_IMDBID = "SELECT * FROM " + TABLE_NAME + " WHERE " + TABLE_COL_IMDBID + " = ? LIMIT 1";
 	private static final String SQL_GET_BY_SIMPLIFIEDTITLE = "SELECT * FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
 	private static final String SQL_GET_ID_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
 	private static final String SQL_GET_TITLE_BY_IMDBID = "SELECT " + TABLE_COL_TITLE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_IMDBID + " = ? LIMIT 1";
 	private static final String SQL_GET_TITLE_BY_IMDBID_API_VERSION = "SELECT " + TABLE_COL_TITLE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_IMDBID + " = ? AND VERSION = ? LIMIT 1";
 	private static final String SQL_GET_IMAGES_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_IMAGES + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
-	private static final String SQL_GET_THUMBNAIL_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_THUMBID + ", " + TABLE_COL_ID + ", " + MediaTableThumbnails.TABLE_COL_THUMBNAIL + " FROM " + TABLE_NAME + " " + MediaTableThumbnails.SQL_LEFT_JOIN_TABLE_TV_SERIES + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
+	private static final String SQL_GET_THUMBNAIL_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_THUMBID + ", " + TABLE_COL_ID + ", " + MediaTableThumbnails.TABLE_COL_THUMBNAIL + " FROM " + TABLE_NAME + " " + SQL_LEFT_JOIN_TABLE_THUMBNAILS + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
 	private static final String SQL_GET_STARTYEAR_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_STARTYEAR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
 	private static final String SQL_GET_TITLE_BY_SIMPLIFIEDTITLE = "SELECT " + TABLE_COL_TITLE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_SIMPLIFIEDTITLE + " = ? LIMIT 1";
-	private static final String SQL_GET_ISFULLYPLAYED = "SELECT " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " FROM " + MediaTableFiles.TABLE_NAME + " " + MediaTableFilesStatus.SQL_LEFT_JOIN_TABLE_FILES + MediaTableVideoMetadata.SQL_LEFT_JOIN_TABLE_FILES + "WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = ? AND " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + " AND " + MediaTableFilesStatus.TABLE_COL_ISFULLYPLAYED + " IS NOT TRUE LIMIT 1";
+	private static final String SQL_GET_ISFULLYPLAYED = "SELECT " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " FROM " + MediaTableFiles.TABLE_NAME + " " + MediaTableFiles.SQL_LEFT_JOIN_TABLE_FILES_STATUS + MediaTableFiles.SQL_LEFT_JOIN_TABLE_VIDEO_METADATA + "WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = ? AND " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + " AND " + MediaTableFilesStatus.TABLE_COL_ISFULLYPLAYED + " IS NOT TRUE LIMIT 1";
 	private static final String SQL_UPDATE_THUMBID = "UPDATE " + TABLE_NAME + " SET " + COL_THUMBID + " = ? WHERE " + TABLE_COL_ID + " = ?";
 	private static final String SQL_UPDATE_IMDBID_NULL = "UPDATE " + TABLE_NAME + " SET " + COL_IMDBID + " = null WHERE " + TABLE_COL_ID + " = ?";
 	private static final String SQL_INSERT_TITLE = "INSERT INTO " + TABLE_NAME + " (" + COL_SIMPLIFIEDTITLE + ", " + COL_TITLE + ") VALUES (?, ?)";

--- a/src/main/java/net/pms/database/MediaTableThumbnails.java
+++ b/src/main/java/net/pms/database/MediaTableThumbnails.java
@@ -47,15 +47,15 @@ public final class MediaTableThumbnails extends MediaTable {
 	private static final String COL_ID = "ID";
 	private static final String COL_MD5 = "MD5";
 	private static final String COL_MODIFIED = "MODIFIED";
-	public static final String ID = TABLE_NAME + "." + COL_ID;
-	public static final String THUMBNAIL = TABLE_NAME + "." + COL_THUMBNAIL;
-	private static final String MD5 = TABLE_NAME + "." + COL_MD5;
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.THUMBID + " = " + ID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.THUMBID + " = " + ID + " ";
+	public static final String TABLE_COL_ID = TABLE_NAME + "." + COL_ID;
+	public static final String TABLE_COL_THUMBNAIL = TABLE_NAME + "." + COL_THUMBNAIL;
+	private static final String TABLE_COL_MD5 = TABLE_NAME + "." + COL_MD5;
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_THUMBID + " = " + TABLE_COL_ID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_THUMBID + " = " + TABLE_COL_ID + " ";
 
-	private static final String SQL_GET_ID_MD5 = "SELECT " + ID + " FROM " + TABLE_NAME + " WHERE " + MD5 + " = ? LIMIT 1";
+	private static final String SQL_GET_ID_MD5 = "SELECT " + TABLE_COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_MD5 + " = ? LIMIT 1";
 	private static final String SQL_INSERT_ID_MD5 = "INSERT INTO " + TABLE_NAME + " (" + COL_THUMBNAIL + ", " + COL_MODIFIED + ", " + COL_MD5 + ") VALUES (?, ?, ?)";
-	private static final String SQL_DELETE_ID = "DELETE FROM " + TABLE_NAME + " WHERE " + ID + " = ?";
+	private static final String SQL_DELETE_ID = "DELETE FROM " + TABLE_NAME + " WHERE " + TABLE_COL_ID + " = ?";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableThumbnails.java
+++ b/src/main/java/net/pms/database/MediaTableThumbnails.java
@@ -41,6 +41,10 @@ import org.apache.commons.codec.digest.DigestUtils;
 public final class MediaTableThumbnails extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableThumbnails.class);
 	public static final String TABLE_NAME = "THUMBNAILS";
+	public static final String ID = TABLE_NAME + ".ID";
+	public static final String THUMBNAIL = TABLE_NAME + ".THUMBNAIL";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.THUMBID + " = " + ID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.THUMBID + " = " + ID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -132,9 +136,16 @@ public final class MediaTableThumbnails extends MediaTable {
 		try {
 			connection = MediaDatabase.getConnectionIfAvailable();
 			if (connection != null) {
-				connection.setAutoCommit(false);
+				//handle autocommit
+				boolean currentAutoCommit = connection.getAutoCommit();
+				if (currentAutoCommit) {
+					connection.setAutoCommit(false);
+				}
 				setThumbnail(connection, thumbnail, fullPathToFile, tvSeriesID, false);
-				connection.commit();
+				if (currentAutoCommit) {
+					connection.commit();
+					connection.setAutoCommit(true);
+				}
 			}
 		} catch (SQLException e) {
 			LOGGER.trace("", e);

--- a/src/main/java/net/pms/database/MediaTableThumbnails.java
+++ b/src/main/java/net/pms/database/MediaTableThumbnails.java
@@ -50,8 +50,6 @@ public final class MediaTableThumbnails extends MediaTable {
 	public static final String TABLE_COL_ID = TABLE_NAME + "." + COL_ID;
 	public static final String TABLE_COL_THUMBNAIL = TABLE_NAME + "." + COL_THUMBNAIL;
 	private static final String TABLE_COL_MD5 = TABLE_NAME + "." + COL_MD5;
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_THUMBID + " = " + TABLE_COL_ID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_THUMBID + " = " + TABLE_COL_ID + " ";
 
 	private static final String SQL_GET_ID_MD5 = "SELECT " + TABLE_COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_MD5 + " = ? LIMIT 1";
 	private static final String SQL_INSERT_ID_MD5 = "INSERT INTO " + TABLE_NAME + " (" + COL_THUMBNAIL + ", " + COL_MODIFIED + ", " + COL_MD5 + ") VALUES (?, ?, ?)";

--- a/src/main/java/net/pms/database/MediaTableThumbnails.java
+++ b/src/main/java/net/pms/database/MediaTableThumbnails.java
@@ -20,7 +20,6 @@ package net.pms.database;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.Timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,10 +40,22 @@ import org.apache.commons.codec.digest.DigestUtils;
 public final class MediaTableThumbnails extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableThumbnails.class);
 	public static final String TABLE_NAME = "THUMBNAILS";
-	public static final String ID = TABLE_NAME + ".ID";
-	public static final String THUMBNAIL = TABLE_NAME + ".THUMBNAIL";
+	/**
+	 * COLUMNS NAMES
+	 */
+	private static final String COL_THUMBNAIL = "THUMBNAIL";
+	private static final String COL_ID = "ID";
+	private static final String COL_MD5 = "MD5";
+	private static final String COL_MODIFIED = "MODIFIED";
+	public static final String ID = TABLE_NAME + "." + COL_ID;
+	public static final String THUMBNAIL = TABLE_NAME + "." + COL_THUMBNAIL;
+	private static final String MD5 = TABLE_NAME + "." + COL_MD5;
 	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.THUMBID + " = " + ID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.THUMBID + " = " + ID + " ";
+
+	private static final String SQL_GET_ID_MD5 = "SELECT " + ID + " FROM " + TABLE_NAME + " WHERE " + MD5 + " = ? LIMIT 1";
+	private static final String SQL_INSERT_ID_MD5 = "INSERT INTO " + TABLE_NAME + " (" + COL_THUMBNAIL + ", " + COL_MODIFIED + ", " + COL_MD5 + ") VALUES (?, ?, ?)";
+	private static final String SQL_DELETE_ID = "DELETE FROM " + TABLE_NAME + " WHERE " + ID + " = ?";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -173,28 +184,23 @@ public final class MediaTableThumbnails extends MediaTable {
 			return;
 		}
 
-		String selectQuery;
 		String md5Hash = DigestUtils.md5Hex(thumbnail.getBytes(false));
 
 		try {
-			selectQuery = "SELECT ID FROM " + TABLE_NAME + " WHERE MD5 = " + sqlQuote(md5Hash) + " LIMIT 1";
-			LOGGER.trace("Searching for thumbnail in {} with \"{}\" before update", TABLE_NAME, selectQuery);
-
-			try (
-				PreparedStatement selectStatement = connection.prepareStatement(selectQuery, ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
-				ResultSet result = selectStatement.executeQuery()
-			) {
-				Integer existingId = null;
-				if (result.next()) {
-					existingId = result.getInt("ID");
-
-					if (!forceNew) {
-						if (fullPathToFile != null) {
-							LOGGER.trace("Found existing thumbnail with ID {} in {}, setting the THUMBID in the FILES table", existingId, TABLE_NAME);
-							MediaTableFiles.updateThumbnailId(connection, fullPathToFile, existingId);
-						} else {
-							LOGGER.trace("Found existing thumbnail with ID {} in {}, setting the THUMBID in the {} table", existingId, TABLE_NAME, MediaTableTVSeries.TABLE_NAME);
-							MediaTableTVSeries.updateThumbnailId(connection, tvSeriesID, existingId);
+			Integer existingId = null;
+			try (PreparedStatement statement = connection.prepareStatement(SQL_GET_ID_MD5)) {
+				statement.setString(1, md5Hash);
+				try (ResultSet resultSet = statement.executeQuery()) {
+					if (resultSet.next()) {
+						existingId = resultSet.getInt("ID");
+						if (!forceNew) {
+							if (fullPathToFile != null) {
+								LOGGER.trace("Found existing thumbnail with ID {} in {}, setting the THUMBID in the FILES table", existingId, TABLE_NAME);
+								MediaTableFiles.updateThumbnailId(connection, fullPathToFile, existingId);
+							} else {
+								LOGGER.trace("Found existing thumbnail with ID {} in {}, setting the THUMBID in the {} table", existingId, TABLE_NAME, MediaTableTVSeries.TABLE_NAME);
+								MediaTableTVSeries.updateThumbnailId(connection, tvSeriesID, existingId);
+							}
 						}
 					}
 				}
@@ -207,8 +213,7 @@ public final class MediaTableThumbnails extends MediaTable {
 						removeById(connection, existingId);
 					}
 
-					String insertQuery = "INSERT INTO " + TABLE_NAME + " (THUMBNAIL, MODIFIED, MD5) VALUES (?, ?, ?)";
-					try (PreparedStatement insertStatement = connection.prepareStatement(insertQuery, PreparedStatement.RETURN_GENERATED_KEYS)) {
+					try (PreparedStatement insertStatement = connection.prepareStatement(SQL_INSERT_ID_MD5, PreparedStatement.RETURN_GENERATED_KEYS)) {
 						insertStatement.setObject(1, thumbnail);
 						insertStatement.setTimestamp(2, new Timestamp(System.currentTimeMillis()));
 						insertStatement.setString(3, md5Hash);
@@ -243,9 +248,9 @@ public final class MediaTableThumbnails extends MediaTable {
 	 * @param id the ID to remove
 	 */
 	public static void removeById(final Connection connection, final Integer id) {
-		String query = "DELETE FROM " + TABLE_NAME + " WHERE ID = " + id;
-		try (Statement statement = connection.createStatement()) {
-			int rows = statement.executeUpdate(query);
+		try (PreparedStatement statement = connection.prepareStatement(SQL_DELETE_ID)) {
+			statement.setInt(1, id);
+			int rows = statement.executeUpdate();
 			LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for ID \"{}\"", rows, id);
 		} catch (SQLException e) {
 			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, id, e.getMessage());

--- a/src/main/java/net/pms/database/MediaTableVideoMetadata.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadata.java
@@ -40,10 +40,10 @@ import org.slf4j.LoggerFactory;
  * lookups, updates and inserts. All operations involving this table shall be
  * done with this class.
  */
-public class MediaTableVideoMetadatas extends MediaTable {
-	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadatas.class);
+public class MediaTableVideoMetadata extends MediaTable {
+	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadata.class);
 	private static final Gson GSON = new Gson();
-	public static final String TABLE_NAME = "VIDEO_METADATAS";
+	public static final String TABLE_NAME = "VIDEO_METADATA";
 	/**
 	 * COLUMNS NAMES
 	 */
@@ -77,30 +77,30 @@ public class MediaTableVideoMetadatas extends MediaTable {
 	/**
 	 * COLUMNS with table name
 	 */
-	public static final String API_VERSION = TABLE_NAME + "." + COL_API_VERSION;
-	public static final String EXTRAINFORMATION = TABLE_NAME + "." + COL_EXTRAINFORMATION;
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String IMDBID = TABLE_NAME + "." + COL_IMDBID;
-	public static final String ISTVEPISODE = TABLE_NAME + "." + COL_ISTVEPISODE;
-	public static final String MEDIA_YEAR = TABLE_NAME + "." + COL_MEDIA_YEAR;
-	public static final String MOVIEORSHOWNAME = TABLE_NAME + "." + COL_MOVIEORSHOWNAME;
-	public static final String MOVIEORSHOWNAMESIMPLE = TABLE_NAME + "." + COL_MOVIEORSHOWNAMESIMPLE;
-	public static final String TVEPISODENAME = TABLE_NAME + ".TVEPISODENAME";
-	public static final String TVEPISODENUMBER = TABLE_NAME + "." + COL_TVEPISODENUMBER;
-	public static final String TVSEASON = TABLE_NAME + "." + COL_TVSEASON;
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
+	public static final String TABLE_COL_API_VERSION = TABLE_NAME + "." + COL_API_VERSION;
+	public static final String TABLE_COL_EXTRAINFORMATION = TABLE_NAME + "." + COL_EXTRAINFORMATION;
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_IMDBID = TABLE_NAME + "." + COL_IMDBID;
+	public static final String TABLE_COL_ISTVEPISODE = TABLE_NAME + "." + COL_ISTVEPISODE;
+	public static final String TABLE_COL_MEDIA_YEAR = TABLE_NAME + "." + COL_MEDIA_YEAR;
+	public static final String TABLE_COL_MOVIEORSHOWNAME = TABLE_NAME + "." + COL_MOVIEORSHOWNAME;
+	public static final String TABLE_COL_MOVIEORSHOWNAMESIMPLE = TABLE_NAME + "." + COL_MOVIEORSHOWNAMESIMPLE;
+	public static final String TABLE_COL_TVEPISODENAME = TABLE_NAME + ".TVEPISODENAME";
+	public static final String TABLE_COL_TVEPISODENUMBER = TABLE_NAME + "." + COL_TVEPISODENUMBER;
+	public static final String TABLE_COL_TVSEASON = TABLE_NAME + "." + COL_TVSEASON;
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
 	private static final String SQL_GET_VIDEO_METADATA_BY_FILEID = "SELECT " + BASIC_COLUMNS + " FROM " + TABLE_NAME + " WHERE " + COL_FILEID + " = ?";
-	private static final String SQL_GET_VIDEO_METADATA_BY_FILEID_IMDBID = "SELECT * FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? and " + IMDBID + " IS NOT NULL LIMIT 1";
-	private static final String SQL_GET_API_METADATA_EXIST = "SELECT " + FILEID + " FROM " + TABLE_NAME + " " + " WHERE " + FILEID + " = ? LIMIT 1";
-	private static final String SQL_GET_API_METADATA_IMDBID_EXIST = "SELECT " + FILEID + " FROM " + TABLE_NAME + " " + " WHERE " + FILEID + " = ? AND " + IMDBID + " IS NOT NULL LIMIT 1";
-	private static final String SQL_GET_API_METADATA_API_IMDBID_VERSION_EXIST = "SELECT " + FILEID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + IMDBID + " IS NOT NULL AND " + API_VERSION + " = ? LIMIT 1";
+	private static final String SQL_GET_VIDEO_METADATA_BY_FILEID_IMDBID = "SELECT * FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? and " + TABLE_COL_IMDBID + " IS NOT NULL LIMIT 1";
+	private static final String SQL_GET_API_METADATA_EXIST = "SELECT " + TABLE_COL_FILEID + " FROM " + TABLE_NAME + " " + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_API_METADATA_IMDBID_EXIST = "SELECT " + TABLE_COL_FILEID + " FROM " + TABLE_NAME + " " + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_IMDBID + " IS NOT NULL LIMIT 1";
+	private static final String SQL_GET_API_METADATA_API_IMDBID_VERSION_EXIST = "SELECT " + TABLE_COL_FILEID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_IMDBID + " IS NOT NULL AND " + TABLE_COL_API_VERSION + " = ? LIMIT 1";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 2;
+	private static final int TABLE_VERSION = 3;
 	private static final int SIZE_IMDBID = 16;
 	private static final int SIZE_YEAR = 4;
 	private static final int SIZE_TVSEASON = 4;
@@ -138,6 +138,9 @@ public class MediaTableVideoMetadatas extends MediaTable {
 				case 1:
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_BUDGET + " SET DATA TYPE BIGINT");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_REVENUE + " SET DATA TYPE BIGINT");
+					break;
+				case 2:
+					executeUpdate(connection, "ALTER TABLE VIDEO_METADATAS IF EXISTS RENAME TO " + TABLE_NAME);
 					break;
 				default:
 					throw new IllegalStateException(

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
@@ -17,6 +17,7 @@
  */
 package net.pms.database;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -24,17 +25,26 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Iterator;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MediaTableVideoMetadataActors extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataActors.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_ACTORS";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String ACTOR = TABLE_NAME + ".ACTOR";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	private static final String COL_ACTOR = "ACTOR";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String ACTOR = TABLE_NAME + "." + COL_ACTOR;
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + ACTOR + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + ACTOR + " = ? LIMIT 1";
+	private static final String SQL_GET_ACTORS_FILEID = "SELECT " + ACTOR + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_ACTOR + ") VALUES (?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_ACTOR + ") VALUES (?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
@@ -42,7 +52,7 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 	/**
 	 * Checks and creates or upgrades the table as needed.
@@ -87,6 +97,20 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -101,9 +125,11 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
 				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER             DEFAULT -1  , " +
-				"FILENAME       VARCHAR(1024)       DEFAULT ''  , " +
-				"ACTOR          VARCHAR(1024)       NOT NULL      " +
+				"TVSERIESID     INTEGER                         , " +
+				"FILEID         INTEGER                         , " +
+				"ACTOR          VARCHAR(1024)       NOT NULL    , " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);
 	}
@@ -112,12 +138,25 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param actors
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final JsonElement actors, final long tvSeriesID) {
+	public static void set(final Connection connection, final Long fileId, final JsonElement actors, final Long tvSeriesID) {
 		if (actors == null || !actors.isJsonArray() || actors.getAsJsonArray().isEmpty()) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
@@ -126,44 +165,22 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 			while (i.hasNext()) {
 				String actor = i.next().getAsString();
 
-				try (
-					PreparedStatement ps = connection.prepareStatement(
-						"SELECT " +
-							"ID " +
-						"FROM " + TABLE_NAME + " " +
-						"WHERE " +
-							"TVSERIESID = ? AND " +
-							"FILENAME = ? AND " +
-							"ACTOR = ? " +
-						"LIMIT 1"
-					)
-				) {
-					ps.setLong(1, tvSeriesID);
-					ps.setString(2, left(fullPathToFile, 1024));
-					ps.setString(3, left(actor, 1024));
+				try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+					ps.setInt(1, id);
+					ps.setString(2, StringUtils.left(actor, 1024));
 					try (ResultSet rs = ps.executeQuery()) {
 						if (rs.next()) {
-							LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, actor);
+							LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, actor);
 						} else {
-							try (
-								PreparedStatement insertStatement = connection.prepareStatement(
-									"INSERT INTO " + TABLE_NAME + " (" +
-										"TVSERIESID, FILENAME, ACTOR" +
-									") VALUES (" +
-										"?, ?, ?" +
-									")",
-									Statement.RETURN_GENERATED_KEYS
-								)
-							) {
+							try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 								insertStatement.clearParameters();
-								insertStatement.setLong(1, tvSeriesID);
-								insertStatement.setString(2, left(fullPathToFile, 1024));
-								insertStatement.setString(3, left(actor, 1024));
+								insertStatement.setInt(1, id);
+								insertStatement.setString(2, StringUtils.left(actor, 1024));
 
 								insertStatement.executeUpdate();
 								try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 									if (rs2.next()) {
-										LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, actor);
+										LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, actor);
 									}
 								}
 							}
@@ -172,35 +189,27 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
+	public static JsonArray getJsonArrayForFile(final Connection connection, final Long fileId) {
+		JsonArray result = new JsonArray();
 		try {
-			String query =
-				"DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +
-					(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-				try (Statement statement = connection.createStatement()) {
-					int rows = statement.executeUpdate(query);
-					LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_ACTORS_FILEID)) {
+				ps.setLong(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						result.add(rs.getString(1));
+					}
 				}
+			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+		return result;
 	}
 
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
@@ -36,17 +36,17 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_ACTOR = "ACTOR";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String ACTOR = TABLE_NAME + "." + COL_ACTOR;
-	private static final String SQL_GET_ACTORS_FILEID = "SELECT " + ACTOR + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
-	private static final String SQL_GET_ACTORS_TVSERIESID = "SELECT " + ACTOR + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + ACTOR + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + ACTOR + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_ACTOR = TABLE_NAME + "." + COL_ACTOR;
+	private static final String SQL_GET_ACTORS_FILEID = "SELECT " + TABLE_COL_ACTOR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
+	private static final String SQL_GET_ACTORS_TVSERIESID = "SELECT " + TABLE_COL_ACTOR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_ACTOR + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_ACTOR + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_ACTOR + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_ACTOR + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -101,15 +101,15 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 				case 1:
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -129,7 +129,7 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 				"TVSERIESID     INTEGER                         , " +
 				"FILEID         INTEGER                         , " +
 				"ACTOR          VARCHAR(1024)       NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
@@ -32,7 +32,10 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataActors.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_ACTORS";
 	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
 	public static final String ACTOR = TABLE_NAME + ".ACTOR";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
@@ -37,7 +37,7 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_ACTOR = "ACTOR";
 	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	private static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String TABLE_COL_ACTOR = TABLE_NAME + "." + COL_ACTOR;
 	private static final String SQL_GET_ACTORS_FILEID = "SELECT " + TABLE_COL_ACTOR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
 	private static final String SQL_GET_ACTORS_TVSERIESID = "SELECT " + TABLE_COL_ACTOR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
@@ -45,8 +45,6 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_ACTOR + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_ACTOR + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_ACTOR + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -98,7 +96,7 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
 						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
@@ -111,11 +109,10 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -125,10 +122,10 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER                         , " +
-				"FILEID         INTEGER                         , " +
-				"ACTOR          VARCHAR(1024)       NOT NULL    , " +
+				COL_ID + "          IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "  INTEGER                         , " +
+				COL_FILEID + "      INTEGER                         , " +
+				COL_ACTOR + "       VARCHAR(1024)       NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
@@ -39,9 +39,10 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String ACTOR = TABLE_NAME + "." + COL_ACTOR;
+	private static final String SQL_GET_ACTORS_FILEID = "SELECT " + ACTOR + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
+	private static final String SQL_GET_ACTORS_TVSERIESID = "SELECT " + ACTOR + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + ACTOR + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + ACTOR + " = ? LIMIT 1";
-	private static final String SQL_GET_ACTORS_FILEID = "SELECT " + ACTOR + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_ACTOR + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_ACTOR + ") VALUES (?, ?)";
 	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
@@ -207,6 +208,24 @@ public final class MediaTableVideoMetadataActors extends MediaTable {
 			}
 		} catch (SQLException e) {
 			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return result;
+	}
+
+	public static JsonArray getJsonArrayForTvSerie(final Connection connection, final Long tvSerieId) {
+		JsonArray result = new JsonArray();
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_ACTORS_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						result.add(rs.getString(1));
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 		return result;

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataActors.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataActors extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataActors.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_ACTORS";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String ACTOR = TABLE_NAME + ".ACTOR";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
@@ -33,17 +33,17 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_AWARD = "AWARD";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String AWARD = TABLE_NAME + "." + COL_AWARD;
-	private static final String SQL_GET_AWARD_FILEID = "SELECT " + AWARD + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
-	private static final String SQL_GET_AWARD_TVSERIESID = "SELECT " + AWARD + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + AWARD + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + AWARD + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_AWARD = TABLE_NAME + "." + COL_AWARD;
+	private static final String SQL_GET_AWARD_FILEID = "SELECT " + TABLE_COL_AWARD + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_AWARD_TVSERIESID = "SELECT " + TABLE_COL_AWARD + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_AWARD + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_AWARD + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_AWARD + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_AWARD + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -100,15 +100,15 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_AWARD_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -128,7 +128,7 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 				"TVSERIESID   INTEGER                     , " +
 				"FILEID       INTEGER                     , " +
 				"AWARD        VARCHAR(1024)   NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
@@ -33,17 +33,15 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_AWARD = "AWARD";
-	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String TABLE_COL_AWARD = TABLE_NAME + "." + COL_AWARD;
+	private static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	private static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	private static final String TABLE_COL_AWARD = TABLE_NAME + "." + COL_AWARD;
 	private static final String SQL_GET_AWARD_FILEID = "SELECT " + TABLE_COL_AWARD + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
 	private static final String SQL_GET_AWARD_TVSERIESID = "SELECT " + TABLE_COL_AWARD + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_AWARD + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_AWARD + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_AWARD + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_AWARD + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -95,7 +93,7 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_AWARD_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
@@ -110,11 +108,10 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -124,10 +121,10 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID           IDENTITY        PRIMARY KEY , " +
-				"TVSERIESID   INTEGER                     , " +
-				"FILEID       INTEGER                     , " +
-				"AWARD        VARCHAR(1024)   NOT NULL    , " +
+				COL_ID + "          IDENTITY        PRIMARY KEY , " +
+				COL_TVSERIESID + "  INTEGER                     , " +
+				COL_FILEID + "      INTEGER                     , " +
+				COL_AWARD + "       VARCHAR(1024)   NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
@@ -37,6 +37,7 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String AWARD = TABLE_NAME + "." + COL_AWARD;
 	private static final String SQL_GET_AWARD_FILEID = "SELECT " + AWARD + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_AWARD_TVSERIESID = "SELECT " + AWARD + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + AWARD + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + AWARD + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_AWARD + ") VALUES (?, ?)";
@@ -198,6 +199,23 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 			}
 		} catch (SQLException e) {
 			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return null;
+	}
+
+	public static String getValueForTvSerie(final Connection connection, final Long tvSerieId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_AWARD_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 		return null;

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
@@ -22,17 +22,26 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MediaTableVideoMetadataAwards extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataAwards.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_AWARDS";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	private static final String COL_AWARD = "AWARD";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String AWARD = TABLE_NAME + "." + COL_AWARD;
+	private static final String SQL_GET_AWARD_FILEID = "SELECT " + AWARD + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + AWARD + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + AWARD + " = ? LIMIT 1";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_AWARD + ") VALUES (?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_AWARD + ") VALUES (?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
@@ -40,7 +49,7 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 	/**
 	 * Checks and creates or upgrades the table as needed.
@@ -85,6 +94,22 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					//index with all columns ??
+					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_AWARD_TVSERIESID_IDX");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -99,11 +124,12 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
 				"ID           IDENTITY        PRIMARY KEY , " +
-				"TVSERIESID   INTEGER         DEFAULT -1  , " +
-				"FILENAME     VARCHAR(1024)   DEFAULT ''  , " +
-				"AWARD        VARCHAR(1024)   NOT NULL      " +
-			")",
-			"CREATE UNIQUE INDEX FILENAME_AWARD_TVSERIESID_IDX ON " + TABLE_NAME + "(FILENAME, AWARD, TVSERIESID)"
+				"TVSERIESID   INTEGER                     , " +
+				"FILEID       INTEGER                     , " +
+				"AWARD        VARCHAR(1024)   NOT NULL    , " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
+			")"
 		);
 	}
 
@@ -111,88 +137,70 @@ public final class MediaTableVideoMetadataAwards extends MediaTable {
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param awards
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final String awards, final long tvSeriesID) {
-		if (isBlank(awards)) {
+	public static void set(final Connection connection, final Long fileId, final String awards, final Long tvSeriesID) {
+		if (StringUtils.isBlank(awards)) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
-		try (
-			PreparedStatement ps = connection.prepareStatement(
-				"SELECT " +
-					"ID " +
-				"FROM " + TABLE_NAME + " " +
-				"WHERE " +
-					"TVSERIESID = ? AND " +
-					"FILENAME = ? AND " +
-					"AWARD = ? " +
-				"LIMIT 1"
-			)
-		) {
-			ps.setLong(1, tvSeriesID);
-			ps.setString(2, left(fullPathToFile, 1024));
-			ps.setString(3, left(awards, 1024));
+		try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+			ps.setInt(1, id);
+			ps.setString(2, StringUtils.left(awards, 1024));
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
-					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, awards);
+					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, awards);
 				} else {
-					try (
-						PreparedStatement insertStatement = connection.prepareStatement(
-							"INSERT INTO " + TABLE_NAME + " (" +
-								"TVSERIESID, FILENAME, AWARD" +
-							") VALUES (" +
-								"?, ?, ?" +
-							")",
-							Statement.RETURN_GENERATED_KEYS
-						)
-					) {
+					try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 						insertStatement.clearParameters();
-						insertStatement.setLong(1, tvSeriesID);
-						insertStatement.setString(2, left(fullPathToFile, 1024));
-						insertStatement.setString(3, left(awards, 1024));
+						insertStatement.setInt(1, id);
+						insertStatement.setString(2, StringUtils.left(awards, 1024));
 
 						insertStatement.executeUpdate();
 						try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 							if (rs2.next()) {
-								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, awards);
+								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, awards);
 							}
 						}
 					}
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
+	public static String getValueForFile(final Connection connection, final Long fileId) {
 		try {
-			String query =
-				"DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +
-				(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-			try (Statement statement = connection.createStatement()) {
-				int rows = statement.executeUpdate(query);
-				LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_AWARD_FILEID)) {
+				ps.setLong(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+		return null;
 	}
 
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataAwards.java
@@ -30,6 +30,10 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataAwards extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataAwards.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_AWARDS";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataCountries extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataCountries.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_COUNTRIES";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String COUNTRY = TABLE_NAME + ".COUNTRY";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
@@ -40,6 +40,7 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String COUNTRY = TABLE_NAME + "." + COL_COUNTRY;
 	private static final String SQL_GET_COUNTRY_FILEID = "SELECT " + COUNTRY + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
+	private static final String SQL_GET_COUNTRY_TVSERIESID = "SELECT " + COUNTRY + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + COUNTRY + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + COUNTRY + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_COUNTRY + ") VALUES (?, ?)";
@@ -215,4 +216,21 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 		return result;
 	}
 
+	public static JsonArray getJsonArrayForTvSerie(final Connection connection, final Long tvSerieId) {
+		JsonArray result = new JsonArray();
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_COUNTRY_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						result.add(rs.getString(1));
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return result;
+	}
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
@@ -17,6 +17,7 @@
  */
 package net.pms.database;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -24,17 +25,26 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Iterator;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MediaTableVideoMetadataCountries extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataCountries.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_COUNTRIES";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String COUNTRY = TABLE_NAME + ".COUNTRY";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	private static final String COL_COUNTRY = "COUNTRY";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String COUNTRY = TABLE_NAME + "." + COL_COUNTRY;
+	private static final String SQL_GET_COUNTRY_FILEID = "SELECT " + COUNTRY + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + COUNTRY + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + COUNTRY + " = ? LIMIT 1";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_COUNTRY + ") VALUES (?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_COUNTRY + ") VALUES (?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
@@ -42,7 +52,7 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 
 	/**
@@ -88,6 +98,22 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					//index with all columns ??
+					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_COUNTRY_TVSERIESID_IDX");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -102,11 +128,12 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
 				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER             DEFAULT -1  , " +
-				"FILENAME       VARCHAR(1024)       DEFAULT ''  , " +
-				"COUNTRY        VARCHAR(1024)       NOT NULL      " +
-			")",
-			"CREATE UNIQUE INDEX FILENAME_COUNTRY_TVSERIESID_IDX ON " + TABLE_NAME + "(FILENAME, COUNTRY, TVSERIESID)"
+				"TVSERIESID     INTEGER                         , " +
+				"FILEID         INTEGER                         , " +
+				"COUNTRY        VARCHAR(1024)       NOT NULL    , " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
+			")"
 		);
 	}
 
@@ -114,12 +141,25 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param countries
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final JsonElement countries, final long tvSeriesID) {
+	public static void set(final Connection connection, final Long fileId, final JsonElement countries, final Long tvSeriesID) {
 		if (countries == null || !countries.isJsonArray() || countries.getAsJsonArray().isEmpty()) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
@@ -128,44 +168,22 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 			while (i.hasNext()) {
 				String country = i.next().getAsString();
 
-				try (
-					PreparedStatement ps = connection.prepareStatement(
-						"SELECT " +
-							"ID " +
-						"FROM " + TABLE_NAME + " " +
-						"WHERE " +
-							"TVSERIESID = ? AND " +
-							"FILENAME = ? AND " +
-							"COUNTRY = ? " +
-						"LIMIT 1"
-					)
-				) {
-					ps.setLong(1, tvSeriesID);
-					ps.setString(2, left(fullPathToFile, 1024));
-					ps.setString(3, left(country, 1024));
+				try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+					ps.setInt(1, id);
+					ps.setString(2, StringUtils.left(country, 1024));
 					try (ResultSet rs = ps.executeQuery()) {
 						if (rs.next()) {
-							LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, country);
+							LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, country);
 						} else {
-							try (
-								PreparedStatement insertStatement = connection.prepareStatement(
-									"INSERT INTO " + TABLE_NAME + " (" +
-										"TVSERIESID, FILENAME, COUNTRY" +
-									") VALUES (" +
-										"?, ?, ?" +
-									")",
-									Statement.RETURN_GENERATED_KEYS
-								)
-							) {
+							try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 								insertStatement.clearParameters();
-								insertStatement.setLong(1, tvSeriesID);
-								insertStatement.setString(2, left(fullPathToFile, 1024));
-								insertStatement.setString(3, left(country, 1024));
+								insertStatement.setInt(1, id);
+								insertStatement.setString(2, StringUtils.left(country, 1024));
 
 								insertStatement.executeUpdate();
 								try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 									if (rs2.next()) {
-										LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, country);
+										LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, country);
 									}
 								}
 							}
@@ -174,30 +192,27 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
-		String query = "DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +	(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-		try (Statement statement = connection.createStatement()) {
-			int rows = statement.executeUpdate(query);
-			LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
+	public static JsonArray getJsonArrayForFile(final Connection connection, final Long fileId) {
+		JsonArray result = new JsonArray();
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_COUNTRY_FILEID)) {
+				ps.setLong(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						result.add(rs.getString(1));
+					}
+				}
+			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+		return result;
 	}
+
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
@@ -37,7 +37,7 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_COUNTRY = "COUNTRY";
 	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	private static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String TABLE_COL_COUNTRY = TABLE_NAME + "." + COL_COUNTRY;
 	private static final String SQL_GET_COUNTRY_FILEID = "SELECT " + TABLE_COL_COUNTRY + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
 	private static final String SQL_GET_COUNTRY_TVSERIESID = "SELECT " + TABLE_COL_COUNTRY + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
@@ -45,8 +45,6 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_COUNTRY + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_COUNTRY + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_COUNTRY + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -99,7 +97,7 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_COUNTRY_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
@@ -114,11 +112,10 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -128,10 +125,10 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER                         , " +
-				"FILEID         INTEGER                         , " +
-				"COUNTRY        VARCHAR(1024)       NOT NULL    , " +
+				COL_ID + "          IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "  INTEGER                         , " +
+				COL_FILEID + "      INTEGER                         , " +
+				COL_COUNTRY + "     VARCHAR(1024)       NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
@@ -36,17 +36,17 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_COUNTRY = "COUNTRY";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String COUNTRY = TABLE_NAME + "." + COL_COUNTRY;
-	private static final String SQL_GET_COUNTRY_FILEID = "SELECT " + COUNTRY + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
-	private static final String SQL_GET_COUNTRY_TVSERIESID = "SELECT " + COUNTRY + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + COUNTRY + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + COUNTRY + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_COUNTRY = TABLE_NAME + "." + COL_COUNTRY;
+	private static final String SQL_GET_COUNTRY_FILEID = "SELECT " + TABLE_COL_COUNTRY + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
+	private static final String SQL_GET_COUNTRY_TVSERIESID = "SELECT " + TABLE_COL_COUNTRY + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_COUNTRY + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_COUNTRY + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_COUNTRY + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_COUNTRY + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -104,15 +104,15 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_COUNTRY_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -132,7 +132,7 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 				"TVSERIESID     INTEGER                         , " +
 				"FILEID         INTEGER                         , " +
 				"COUNTRY        VARCHAR(1024)       NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataCountries.java
@@ -32,7 +32,10 @@ public final class MediaTableVideoMetadataCountries extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataCountries.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_COUNTRIES";
 	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
 	public static final String COUNTRY = TABLE_NAME + ".COUNTRY";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
@@ -36,17 +36,17 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_DIRECTOR = "DIRECTOR";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String DIRECTOR = TABLE_NAME + "." + COL_DIRECTOR;
-	private static final String SQL_GET_DIRECTOR_FILEID = "SELECT " + DIRECTOR + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
-	private static final String SQL_GET_DIRECTOR_TVSERIESID = "SELECT " + DIRECTOR + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + DIRECTOR + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + DIRECTOR + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_DIRECTOR = TABLE_NAME + "." + COL_DIRECTOR;
+	private static final String SQL_GET_DIRECTOR_FILEID = "SELECT " + TABLE_COL_DIRECTOR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
+	private static final String SQL_GET_DIRECTOR_TVSERIESID = "SELECT " + TABLE_COL_DIRECTOR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_DIRECTOR + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_DIRECTOR + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_DIRECTOR + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_DIRECTOR + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -104,15 +104,15 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_DIRECTOR_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -132,7 +132,7 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 				"TVSERIESID     INTEGER                         , " +
 				"FILEID         INTEGER                         , " +
 				"DIRECTOR       VARCHAR(1024)       NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
@@ -32,7 +32,10 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataDirectors.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_DIRECTORS";
 	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
 	public static final String DIRECTOR = TABLE_NAME + ".DIRECTOR";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataDirectors extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataDirectors.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_DIRECTORS";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String DIRECTOR = TABLE_NAME + ".DIRECTOR";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
@@ -17,6 +17,7 @@
  */
 package net.pms.database;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -24,17 +25,26 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Iterator;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MediaTableVideoMetadataDirectors extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataDirectors.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_DIRECTORS";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String DIRECTOR = TABLE_NAME + ".DIRECTOR";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	private static final String COL_DIRECTOR = "DIRECTOR";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String DIRECTOR = TABLE_NAME + "." + COL_DIRECTOR;
+	private static final String SQL_GET_DIRECTOR_FILEID = "SELECT " + DIRECTOR + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + DIRECTOR + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + DIRECTOR + " = ? LIMIT 1";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_DIRECTOR + ") VALUES (?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_DIRECTOR + ") VALUES (?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
@@ -42,7 +52,7 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 
 	/**
@@ -88,6 +98,22 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					//index with all columns ??
+					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_DIRECTOR_TVSERIESID_IDX");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -102,11 +128,12 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
 				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER             DEFAULT -1  , " +
-				"FILENAME       VARCHAR(1024)       DEFAULT ''  , " +
-				"DIRECTOR       VARCHAR(1024)       NOT NULL      " +
-			")",
-			"CREATE UNIQUE INDEX FILENAME_DIRECTOR_TVSERIESID_IDX ON " + TABLE_NAME + "(FILENAME, DIRECTOR, TVSERIESID)"
+				"TVSERIESID     INTEGER                         , " +
+				"FILEID         INTEGER                         , " +
+				"DIRECTOR       VARCHAR(1024)       NOT NULL    , " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
+			")"
 		);
 	}
 
@@ -114,12 +141,25 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param directors
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final JsonElement directors, final long tvSeriesID) {
+	public static void set(final Connection connection, final Long fileId, final JsonElement directors, final Long tvSeriesID) {
 		if (directors == null || !directors.isJsonArray() || directors.getAsJsonArray().isEmpty()) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
@@ -128,44 +168,22 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 			while (i.hasNext()) {
 				String director = i.next().getAsString();
 
-				try (
-					PreparedStatement ps = connection.prepareStatement(
-						"SELECT " +
-							"ID " +
-						"FROM " + TABLE_NAME + " " +
-						"WHERE " +
-							"TVSERIESID = ? AND " +
-							"FILENAME = ? AND " +
-							"DIRECTOR = ? " +
-						"LIMIT 1"
-					)
-				) {
-					ps.setLong(1, tvSeriesID);
-					ps.setString(2, left(fullPathToFile, 1024));
-					ps.setString(3, left(director, 1024));
+				try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+					ps.setInt(1, id);
+					ps.setString(2, StringUtils.left(director, 1024));
 					try (ResultSet rs = ps.executeQuery()) {
 						if (rs.next()) {
-							LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, director);
+							LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, director);
 						} else {
-							try (
-								PreparedStatement insertStatement = connection.prepareStatement(
-									"INSERT INTO " + TABLE_NAME + " (" +
-										"TVSERIESID, FILENAME, DIRECTOR" +
-									") VALUES (" +
-										"?, ?, ?" +
-									")",
-									Statement.RETURN_GENERATED_KEYS
-								)
-							) {
+							try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 								insertStatement.clearParameters();
-								insertStatement.setLong(1, tvSeriesID);
-								insertStatement.setString(2, left(fullPathToFile, 1024));
-								insertStatement.setString(3, left(director, 1024));
+								insertStatement.setLong(1, id);
+								insertStatement.setString(2, StringUtils.left(director, 1024));
 
 								insertStatement.executeUpdate();
 								try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 									if (rs2.next()) {
-										LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, director);
+										LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, director);
 									}
 								}
 							}
@@ -174,31 +192,27 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
-		String query = "DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +	(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-		try (Statement statement = connection.createStatement()) {
-			int rows = statement.executeUpdate(query);
-			LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
+	public static JsonArray getJsonArrayForFile(final Connection connection, final int fileId) {
+		JsonArray result = new JsonArray();
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_DIRECTOR_FILEID)) {
+				ps.setInt(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						result.add(rs.getString(1));
+					}
+				}
+			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+		return result;
 	}
 
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
@@ -40,6 +40,7 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String DIRECTOR = TABLE_NAME + "." + COL_DIRECTOR;
 	private static final String SQL_GET_DIRECTOR_FILEID = "SELECT " + DIRECTOR + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
+	private static final String SQL_GET_DIRECTOR_TVSERIESID = "SELECT " + DIRECTOR + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + DIRECTOR + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + DIRECTOR + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_DIRECTOR + ") VALUES (?, ?)";
@@ -197,11 +198,11 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 		}
 	}
 
-	public static JsonArray getJsonArrayForFile(final Connection connection, final int fileId) {
+	public static JsonArray getJsonArrayForFile(final Connection connection, final long fileId) {
 		JsonArray result = new JsonArray();
 		try {
 			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_DIRECTOR_FILEID)) {
-				ps.setInt(1, fileId);
+				ps.setLong(1, fileId);
 				try (ResultSet rs = ps.executeQuery()) {
 					while (rs.next()) {
 						result.add(rs.getString(1));
@@ -210,6 +211,24 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 			}
 		} catch (SQLException e) {
 			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return result;
+	}
+
+	public static JsonArray getJsonArrayForTvSerie(final Connection connection, final long tvSerieId) {
+		JsonArray result = new JsonArray();
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_DIRECTOR_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						result.add(rs.getString(1));
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 		return result;

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataDirectors.java
@@ -37,7 +37,7 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_DIRECTOR = "DIRECTOR";
 	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	private static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String TABLE_COL_DIRECTOR = TABLE_NAME + "." + COL_DIRECTOR;
 	private static final String SQL_GET_DIRECTOR_FILEID = "SELECT " + TABLE_COL_DIRECTOR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
 	private static final String SQL_GET_DIRECTOR_TVSERIESID = "SELECT " + TABLE_COL_DIRECTOR + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
@@ -45,8 +45,6 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_DIRECTOR + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_DIRECTOR + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_DIRECTOR + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -99,7 +97,7 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_DIRECTOR_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
@@ -114,11 +112,10 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -128,10 +125,10 @@ public final class MediaTableVideoMetadataDirectors extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER                         , " +
-				"FILEID         INTEGER                         , " +
-				"DIRECTOR       VARCHAR(1024)       NOT NULL    , " +
+				COL_ID + "          IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "  INTEGER                         , " +
+				COL_FILEID + "      INTEGER                         , " +
+				COL_DIRECTOR + "    VARCHAR(1024)       NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
@@ -41,6 +41,7 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String GENRE = TABLE_NAME + "." + COL_GENRE;
 	private static final String SQL_GET_GENRE_FILEID = "SELECT " + GENRE + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
+	private static final String SQL_GET_GENRE_TVSERIESID = "SELECT " + GENRE + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + GENRE + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + GENRE + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_GENRE + ") VALUES (?, ?)";
@@ -241,6 +242,24 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 			}
 		} catch (SQLException e) {
 			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return result;
+	}
+
+	public static JsonArray getJsonArrayForTvSerie(final Connection connection, final Long tvSerieId) {
+		JsonArray result = new JsonArray();
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_GENRE_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						result.add(rs.getString(1));
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 		return result;

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
@@ -36,17 +36,17 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	public static final String COL_GENRE = "GENRE";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String GENRE = TABLE_NAME + "." + COL_GENRE;
-	private static final String SQL_GET_GENRE_FILEID = "SELECT " + GENRE + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
-	private static final String SQL_GET_GENRE_TVSERIESID = "SELECT " + GENRE + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + GENRE + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + GENRE + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_GENRE = TABLE_NAME + "." + COL_GENRE;
+	private static final String SQL_GET_GENRE_FILEID = "SELECT " + TABLE_COL_GENRE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
+	private static final String SQL_GET_GENRE_TVSERIESID = "SELECT " + TABLE_COL_GENRE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_GENRE + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_GENRE + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_GENRE + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_GENRE + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -103,15 +103,15 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_GENRE_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -131,7 +131,7 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 				"TVSERIESID     INTEGER                         , " +
 				"FILEID         INTEGER                         , " +
 				"GENRE          VARCHAR(1024)       NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
@@ -24,7 +24,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.HashSet;
 import java.util.Iterator;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
@@ -39,14 +39,16 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
 	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String TABLE_COL_GENRE = TABLE_NAME + "." + COL_GENRE;
+
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + TABLE_COL_TVSERIESID + " = " + MediaTableTVSeries.TABLE_COL_ID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_VIDEO_METADATA = "LEFT JOIN " + MediaTableVideoMetadata.TABLE_NAME + " ON " + TABLE_COL_FILEID + " = " + MediaTableVideoMetadata.TABLE_COL_FILEID + " ";
+
 	private static final String SQL_GET_GENRE_FILEID = "SELECT " + TABLE_COL_GENRE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
 	private static final String SQL_GET_GENRE_TVSERIESID = "SELECT " + TABLE_COL_GENRE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_GENRE + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_GENRE + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_GENRE + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_GENRE + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -98,7 +100,7 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_GENRE_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
@@ -113,11 +115,10 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -127,10 +128,10 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER                         , " +
-				"FILEID         INTEGER                         , " +
-				"GENRE          VARCHAR(1024)       NOT NULL    , " +
+				COL_ID + "          IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "  INTEGER                         , " +
+				COL_FILEID + "      INTEGER                         , " +
+				COL_GENRE + "       VARCHAR(1024)       NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
@@ -139,37 +139,6 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 	}
 
 	/**
-	 * @param connection the db connection
-	 * @param tvSeriesTitle
-	 * @return all data in this table for a TV series, if it has an IMDb ID stored.
-	 */
-	public static HashSet getByTVSeriesName(final Connection connection, final String tvSeriesTitle) {
-		boolean trace = LOGGER.isTraceEnabled();
-
-		try {
-			String query = "SELECT GENRE FROM " + TABLE_NAME + " " +
-				"LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + TABLE_NAME + ".TVSERIESID = " + MediaTableTVSeries.TABLE_NAME + ".ID " +
-				"WHERE " + MediaTableTVSeries.TABLE_NAME + ".TITLE = " + sqlQuote(tvSeriesTitle);
-
-			if (trace) {
-				LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", query);
-			}
-
-			try (
-				Statement statement = connection.createStatement();
-				ResultSet resultSet = statement.executeQuery(query)
-			) {
-				return convertResultSetToHashSet(resultSet);
-			}
-		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "reading genres", TABLE_NAME, tvSeriesTitle, e.getMessage());
-			LOGGER.trace("", e);
-		}
-
-		return null;
-	}
-
-	/**
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
@@ -36,6 +36,8 @@ public final class MediaTableVideoMetadataGenres extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
 	public static final String FILENAME = TABLE_NAME + ".FILENAME";
 	public static final String GENRE = TABLE_NAME + "." + COL_GENRE_NAME;
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataGenres.java
@@ -32,6 +32,10 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataGenres extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataGenres.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_GENRES";
+	public static final String COL_GENRE_NAME = "GENRE";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String GENRE = TABLE_NAME + "." + COL_GENRE_NAME;
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
@@ -37,6 +37,7 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String IMDBRATING = TABLE_NAME + "." + COL_IMDBRATING;
 	private static final String SQL_GET_IMDBRATING_FILEID = "SELECT " + IMDBRATING + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_IMDBRATING_TVSERIESID = "SELECT " + IMDBRATING + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + IMDBRATING + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + IMDBRATING + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_IMDBRATING + ") VALUES (?, ?)";
@@ -204,6 +205,23 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 			}
 		} catch (SQLException e) {
 			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return null;
+	}
+
+	public static String getValueForTvSerie(final Connection connection, final Long tvSerieId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_IMDBRATING_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 		return null;

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
@@ -42,8 +42,6 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_IMDBRATING + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_IMDBRATING + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_IMDBRATING + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -95,7 +93,7 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_IMDBRATING_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
@@ -110,17 +108,16 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
 					//api settvseriesinfo had both filled filename and tvserieId ending in multiple row for nothing.
 					executeUpdate(connection,
-						"DELETE FROM " + TABLE_NAME + " WHERE EXISTS (SELECT " + COL_ID + " FROM " + TABLE_NAME + " T2 WHERE T2." + COL_TVSERIESID + " = " + TABLE_COL_TVSERIESID + " AND " +
-						"T2." + COL_FILEID + " IS NULL AND T2." + COL_ID + " != " + TABLE_NAME + "." + COL_ID + " AND T2." + COL_IMDBRATING + " = " + TABLE_COL_IMDBRATING + " AND " +
-						TABLE_NAME + "." + COL_ID + " != (SELECT MIN(T3." + COL_ID + ") FROM " + TABLE_NAME + " T3 WHERE T3." + COL_TVSERIESID + " = T2." + COL_TVSERIESID + "))");
+					"DELETE FROM " + TABLE_NAME + " WHERE EXISTS (SELECT " + COL_ID + " FROM " + TABLE_NAME + " T2 WHERE T2." + COL_TVSERIESID + " = " + TABLE_COL_TVSERIESID + " AND " +
+					"T2." + COL_FILEID + " IS NULL AND T2." + COL_ID + " != " + TABLE_NAME + "." + COL_ID + " AND T2." + COL_IMDBRATING + " = " + TABLE_COL_IMDBRATING + " AND " +
+					TABLE_NAME + "." + COL_ID + " != (SELECT MIN(T3." + COL_ID + ") FROM " + TABLE_NAME + " T3 WHERE T3." + COL_TVSERIESID + " = T2." + COL_TVSERIESID + "))");
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -130,10 +127,10 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID           IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID   INTEGER                         , " +
-				"FILEID       INTEGER                         , " +
-				"IMDBRATING   VARCHAR(1024)       NOT NULL    , " +
+				COL_ID + "          IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "  INTEGER                         , " +
+				COL_FILEID + "      INTEGER                         , " +
+				COL_IMDBRATING + "  VARCHAR(1024)       NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
@@ -22,24 +22,33 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataIMDbRating.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_IMDB_RATING";
-	public static final String IMDBRATING = TABLE_NAME + ".IMDBRATING";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	private static final String COL_IMDBRATING = "IMDBRATING";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String IMDBRATING = TABLE_NAME + "." + COL_IMDBRATING;
+	private static final String SQL_GET_IMDBRATING_FILEID = "SELECT " + IMDBRATING + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + IMDBRATING + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + IMDBRATING + " = ? LIMIT 1";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_IMDBRATING + ") VALUES (?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_IMDBRATING + ") VALUES (?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 	/**
 	 * Checks and creates or upgrades the table as needed.
@@ -84,6 +93,28 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					//index with all columns ??
+					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_IMDBRATING_TVSERIESID_IDX");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TVSERIESID + " IS NOT NULL");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					//api settvseriesinfo had both filled filename and tvserieId ending in multiple row for nothing.
+					executeUpdate(connection,
+						"DELETE FROM " + TABLE_NAME + " WHERE EXISTS (SELECT " + COL_ID + " FROM " + TABLE_NAME + " T2 WHERE T2." + COL_TVSERIESID + " = " + TVSERIESID + " AND " +
+						"T2." + COL_FILEID + " IS NULL AND T2." + COL_ID + " != " + TABLE_NAME + "." + COL_ID + " AND T2." + COL_IMDBRATING + " = " + IMDBRATING + " AND " +
+						TABLE_NAME + "." + COL_ID + " != (SELECT MIN(T3." + COL_ID + ") FROM " + TABLE_NAME + " T3 WHERE T3." + COL_TVSERIESID + " = T2." + COL_TVSERIESID + "))");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -97,12 +128,13 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER             DEFAULT -1  , " +
-				"FILENAME       VARCHAR(1024)       DEFAULT ''  , " +
-				"IMDBRATING     VARCHAR(1024)       NOT NULL      " +
-			")",
-			"CREATE UNIQUE INDEX FILENAME_IMDBRATING_TVSERIESID_IDX ON " + TABLE_NAME + "(FILENAME, IMDBRATING, TVSERIESID)"
+				"ID           IDENTITY            PRIMARY KEY , " +
+				"TVSERIESID   INTEGER                         , " +
+				"FILEID       INTEGER                         , " +
+				"IMDBRATING   VARCHAR(1024)       NOT NULL    , " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
+			")"
 		);
 	}
 
@@ -110,83 +142,70 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param imdbRating
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final String imdbRating, final long tvSeriesID) {
-		if (isBlank(imdbRating)) {
+	public static void set(final Connection connection, final Long fileId, final String imdbRating, final Long tvSeriesID) {
+		if (StringUtils.isBlank(imdbRating)) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
-		try (
-			PreparedStatement ps = connection.prepareStatement(
-				"SELECT " +
-					"ID " +
-				"FROM " + TABLE_NAME + " " +
-				"WHERE " +
-					"TVSERIESID = ? AND " +
-					"FILENAME = ? AND " +
-					"IMDBRATING = ? " +
-				"LIMIT 1"
-			)
-		) {
-			ps.setLong(1, tvSeriesID);
-			ps.setString(2, left(fullPathToFile, 1024));
-			ps.setString(3, left(imdbRating, 1024));
+		try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+			ps.setInt(1, id);
+			ps.setString(2, StringUtils.left(imdbRating, 1024));
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
-					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, imdbRating);
+					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, imdbRating);
 				} else {
-					try (
-						PreparedStatement insertStatement = connection.prepareStatement(
-							"INSERT INTO " + TABLE_NAME + " (" +
-								"TVSERIESID, FILENAME, IMDBRATING" +
-							") VALUES (" +
-								"?, ?, ?" +
-							")",
-							Statement.RETURN_GENERATED_KEYS
-						)
-					) {
+					try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 						insertStatement.clearParameters();
-						insertStatement.setLong(1, tvSeriesID);
-						insertStatement.setString(2, left(fullPathToFile, 1024));
-						insertStatement.setString(3, left(imdbRating, 1024));
+						insertStatement.setInt(1, id);
+						insertStatement.setString(2, StringUtils.left(imdbRating, 1024));
 
 						insertStatement.executeUpdate();
 						try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 							if (rs2.next()) {
-								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, imdbRating);
+								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, imdbRating);
 							}
 						}
 					}
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
-		String query = "DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +	(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-		try (Statement statement = connection.createStatement()) {
-			int rows = statement.executeUpdate(query);
-			LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
+	public static String getValueForFile(final Connection connection, final Long fileId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_IMDBRATING_FILEID)) {
+				ps.setLong(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+		return null;
 	}
+
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
@@ -42,6 +42,7 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_IMDBRATING + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_IMDBRATING + ") VALUES (?, ?)";
 	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
@@ -30,6 +30,9 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataIMDbRating.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_IMDB_RATING";
+	public static final String IMDBRATING = TABLE_NAME + ".IMDBRATING";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataIMDbRating.java
@@ -33,17 +33,17 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_IMDBRATING = "IMDBRATING";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String IMDBRATING = TABLE_NAME + "." + COL_IMDBRATING;
-	private static final String SQL_GET_IMDBRATING_FILEID = "SELECT " + IMDBRATING + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
-	private static final String SQL_GET_IMDBRATING_TVSERIESID = "SELECT " + IMDBRATING + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + IMDBRATING + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + IMDBRATING + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_IMDBRATING = TABLE_NAME + "." + COL_IMDBRATING;
+	private static final String SQL_GET_IMDBRATING_FILEID = "SELECT " + TABLE_COL_IMDBRATING + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_IMDBRATING_TVSERIESID = "SELECT " + TABLE_COL_IMDBRATING + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_IMDBRATING + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_IMDBRATING + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_IMDBRATING + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_IMDBRATING + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -100,21 +100,21 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_IMDBRATING_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TVSERIESID + " IS NOT NULL");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " IS NOT NULL");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
 					//api settvseriesinfo had both filled filename and tvserieId ending in multiple row for nothing.
 					executeUpdate(connection,
-						"DELETE FROM " + TABLE_NAME + " WHERE EXISTS (SELECT " + COL_ID + " FROM " + TABLE_NAME + " T2 WHERE T2." + COL_TVSERIESID + " = " + TVSERIESID + " AND " +
-						"T2." + COL_FILEID + " IS NULL AND T2." + COL_ID + " != " + TABLE_NAME + "." + COL_ID + " AND T2." + COL_IMDBRATING + " = " + IMDBRATING + " AND " +
+						"DELETE FROM " + TABLE_NAME + " WHERE EXISTS (SELECT " + COL_ID + " FROM " + TABLE_NAME + " T2 WHERE T2." + COL_TVSERIESID + " = " + TABLE_COL_TVSERIESID + " AND " +
+						"T2." + COL_FILEID + " IS NULL AND T2." + COL_ID + " != " + TABLE_NAME + "." + COL_ID + " AND T2." + COL_IMDBRATING + " = " + TABLE_COL_IMDBRATING + " AND " +
 						TABLE_NAME + "." + COL_ID + " != (SELECT MIN(T3." + COL_ID + ") FROM " + TABLE_NAME + " T3 WHERE T3." + COL_TVSERIESID + " = T2." + COL_TVSERIESID + "))");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -134,7 +134,7 @@ public final class MediaTableVideoMetadataIMDbRating extends MediaTable {
 				"TVSERIESID   INTEGER                         , " +
 				"FILEID       INTEGER                         , " +
 				"IMDBRATING   VARCHAR(1024)       NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
@@ -37,6 +37,7 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String POSTER = TABLE_NAME + "." + COL_POSTER;
 	private static final String SQL_GET_POSTER_FILEID = "SELECT " + POSTER + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_POSTER_TVSERIESID = "SELECT " + POSTER + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + POSTER + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + POSTER + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_POSTER + ") VALUES (?, ?)";
@@ -255,6 +256,40 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+	}
+
+	public static String getValueForFile(final Connection connection, final Long fileId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_POSTER_FILEID)) {
+				ps.setLong(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return null;
+	}
+
+	public static String getValueForTvSerie(final Connection connection, final Long tvSerieId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_POSTER_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return null;
 	}
 
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
@@ -22,17 +22,26 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MediaTableVideoMetadataPosters extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataPosters.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_POSTERS";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	private static final String COL_POSTER = "POSTER";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String POSTER = TABLE_NAME + "." + COL_POSTER;
+	private static final String SQL_GET_POSTER_FILEID = "SELECT " + POSTER + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + POSTER + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + POSTER + " = ? LIMIT 1";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_POSTER + ") VALUES (?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_POSTER + ") VALUES (?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
@@ -40,7 +49,7 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 	/**
 	 * Checks and creates or upgrades the table as needed.
@@ -85,6 +94,22 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					//index with all columns ??
+					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_POSTER_TVSERIESID_IDX");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -99,11 +124,12 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
 				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER             DEFAULT -1  , " +
-				"FILENAME       VARCHAR(1024)       DEFAULT ''  , " +
-				"POSTER         VARCHAR(1024)       NOT NULL      " +
-			")",
-			"CREATE UNIQUE INDEX FILENAME_POSTER_TVSERIESID_IDX ON " + TABLE_NAME + "(FILENAME, TVSERIESID)"
+				"TVSERIESID     INTEGER                         , " +
+				"FILEID         INTEGER                         , " +
+				"POSTER         VARCHAR(1024)       NOT NULL    , " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
+			")"
 		);
 	}
 
@@ -117,7 +143,7 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 
 		try {
 			String query = "SELECT POSTER, TVSERIESID FROM " + TABLE_NAME + " " +
-				"LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + TABLE_NAME + ".TVSERIESID = " + MediaTableTVSeries.TABLE_NAME + ".ID " +
+				SQL_LEFT_JOIN_TABLE_TV_SERIES +
 				"WHERE " + MediaTableTVSeries.TABLE_NAME + ".TITLE = " + sqlQuote(tvSeriesTitle) + " " +
 				"LIMIT 1";
 
@@ -154,8 +180,8 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 
 		try {
 			String query = "SELECT POSTER FROM " + TABLE_NAME + " " +
-				"LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + TABLE_NAME + ".FILENAME = " + MediaTableFiles.TABLE_NAME + ".FILENAME " +
-				"WHERE " + MediaTableFiles.TABLE_NAME + ".FILENAME = " + sqlQuote(filename) + " " +
+				SQL_LEFT_JOIN_TABLE_FILES +
+				"WHERE " + MediaTableFiles.FILENAME + " = " + sqlQuote(filename) + " " +
 				"LIMIT 1";
 
 			if (trace) {
@@ -182,83 +208,53 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param poster
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final String poster, final long tvSeriesID) {
-		if (isBlank(poster)) {
+	public static void set(final Connection connection, final Long fileId, final String poster, final Long tvSeriesID) {
+		if (StringUtils.isBlank(poster)) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
-		try (
-			PreparedStatement ps = connection.prepareStatement(
-				"SELECT " +
-					"ID " +
-				"FROM " + TABLE_NAME + " " +
-				"WHERE " +
-					"TVSERIESID = ? AND " +
-					"FILENAME = ? AND " +
-					"POSTER = ? " +
-				"LIMIT 1"
-			)
-		) {
-			ps.setLong(1, tvSeriesID);
-			ps.setString(2, left(fullPathToFile, 1024));
-			ps.setString(3, left(poster, 1024));
+		try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+			ps.setInt(1, id);
+			ps.setString(2, StringUtils.left(poster, 1024));
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
-					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, poster);
+					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, poster);
 				} else {
-					try (
-						PreparedStatement insertStatement = connection.prepareStatement(
-							"INSERT INTO " + TABLE_NAME + " (" +
-								"TVSERIESID, FILENAME, POSTER" +
-							") VALUES (" +
-								"?, ?, ?" +
-							")",
-							Statement.RETURN_GENERATED_KEYS
-						)
-					) {
+					try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 						insertStatement.clearParameters();
-						insertStatement.setLong(1, tvSeriesID);
-						insertStatement.setString(2, left(fullPathToFile, 1024));
-						insertStatement.setString(3, left(poster, 1024));
+						insertStatement.setInt(1, id);
+						insertStatement.setString(2, StringUtils.left(poster, 1024));
 
 						insertStatement.executeUpdate();
 						try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 							if (rs2.next()) {
-								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, poster);
+								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, poster);
 							}
 						}
 					}
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
-		String query = "DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +	(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-		try (Statement statement = connection.createStatement()) {
-			int rows = statement.executeUpdate(query);
-			LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
-		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
-			LOGGER.trace("", e);
-		}
-	}
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
@@ -33,17 +33,17 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_POSTER = "POSTER";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String POSTER = TABLE_NAME + "." + COL_POSTER;
-	private static final String SQL_GET_POSTER_FILEID = "SELECT " + POSTER + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
-	private static final String SQL_GET_POSTER_TVSERIESID = "SELECT " + POSTER + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + POSTER + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + POSTER + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_POSTER = TABLE_NAME + "." + COL_POSTER;
+	private static final String SQL_GET_POSTER_FILEID = "SELECT " + TABLE_COL_POSTER + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_POSTER_TVSERIESID = "SELECT " + TABLE_COL_POSTER + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_POSTER + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_POSTER + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_POSTER + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_POSTER + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -100,15 +100,15 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_POSTER_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -128,7 +128,7 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 				"TVSERIESID     INTEGER                         , " +
 				"FILEID         INTEGER                         , " +
 				"POSTER         VARCHAR(1024)       NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);
@@ -182,7 +182,7 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 		try {
 			String query = "SELECT POSTER FROM " + TABLE_NAME + " " +
 				SQL_LEFT_JOIN_TABLE_FILES +
-				"WHERE " + MediaTableFiles.FILENAME + " = " + sqlQuote(filename) + " " +
+				"WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + sqlQuote(filename) + " " +
 				"LIMIT 1";
 
 			if (trace) {

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
@@ -30,6 +30,10 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataPosters extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataPosters.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_POSTERS";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataPosters.java
@@ -33,17 +33,21 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_POSTER = "POSTER";
-	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String TABLE_COL_POSTER = TABLE_NAME + "." + COL_POSTER;
+	private static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	private static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	private static final String TABLE_COL_POSTER = TABLE_NAME + "." + COL_POSTER;
+
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + TABLE_COL_TVSERIESID + " = " + MediaTableTVSeries.TABLE_COL_ID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + TABLE_COL_FILEID + " = " + MediaTableFiles.TABLE_COL_ID + " ";
+
 	private static final String SQL_GET_POSTER_FILEID = "SELECT " + TABLE_COL_POSTER + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
 	private static final String SQL_GET_POSTER_TVSERIESID = "SELECT " + TABLE_COL_POSTER + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_POSTER + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_POSTER + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_POSTER + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_POSTER + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
+	private static final String SQL_GET_POSTER_TV_SERIES_TITLE = "SELECT " + TABLE_COL_POSTER + ", " + TABLE_COL_TVSERIESID + " FROM " + TABLE_NAME + " " + SQL_LEFT_JOIN_TABLE_TV_SERIES + "WHERE " + MediaTableTVSeries.TABLE_COL_TITLE + " = ? LIMIT 1";
+	private static final String SQL_GET_POSTER_FILE_FILENAME = "SELECT " + TABLE_COL_POSTER + " FROM " + TABLE_NAME + " " + SQL_LEFT_JOIN_TABLE_FILES + "WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = ? LIMIT 1";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -95,7 +99,7 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_POSTER_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
@@ -110,11 +114,10 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -124,10 +127,10 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER                         , " +
-				"FILEID         INTEGER                         , " +
-				"POSTER         VARCHAR(1024)       NOT NULL    , " +
+				COL_ID + "          IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "  INTEGER                         , " +
+				COL_FILEID + "      INTEGER                         , " +
+				COL_POSTER + "      VARCHAR(1024)       NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
@@ -143,24 +146,18 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 		boolean trace = LOGGER.isTraceEnabled();
 
 		try {
-			String query = "SELECT POSTER, TVSERIESID FROM " + TABLE_NAME + " " +
-				SQL_LEFT_JOIN_TABLE_TV_SERIES +
-				"WHERE " + MediaTableTVSeries.TABLE_NAME + ".TITLE = " + sqlQuote(tvSeriesTitle) + " " +
-				"LIMIT 1";
-
-			if (trace) {
-				LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", query);
-			}
-
-			try (
-				Statement statement = connection.createStatement();
-				ResultSet resultSet = statement.executeQuery(query)
-			) {
-				if (resultSet.next()) {
-					return new Object[] {
-						resultSet.getString(1),
-						resultSet.getLong(2)
-					};
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_POSTER_TV_SERIES_TITLE)) {
+				ps.setString(1, tvSeriesTitle);
+				if (trace) {
+					LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", ps);
+				}
+				try (ResultSet resultSet = ps.executeQuery()) {
+					if (resultSet.next()) {
+						return new Object[] {
+							resultSet.getString(1),
+							resultSet.getLong(2)
+						};
+					}
 				}
 			}
 		} catch (SQLException e) {
@@ -180,21 +177,15 @@ public final class MediaTableVideoMetadataPosters extends MediaTable {
 		boolean trace = LOGGER.isTraceEnabled();
 
 		try {
-			String query = "SELECT POSTER FROM " + TABLE_NAME + " " +
-				SQL_LEFT_JOIN_TABLE_FILES +
-				"WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + sqlQuote(filename) + " " +
-				"LIMIT 1";
-
-			if (trace) {
-				LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", query);
-			}
-
-			try (
-				Statement statement = connection.createStatement();
-				ResultSet resultSet = statement.executeQuery(query)
-			) {
-				if (resultSet.next()) {
-					return resultSet.getString(1);
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_POSTER_FILE_FILENAME)) {
+				ps.setString(1, filename);
+				if (trace) {
+					LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", ps);
+				}
+				try (ResultSet resultSet = ps.executeQuery()) {
+					if (resultSet.next()) {
+						return resultSet.getString(1);
+					}
 				}
 			}
 		} catch (SQLException e) {

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
@@ -33,17 +33,15 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_PRODUCTION = "PRODUCTION";
-	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String TABLE_COL_PRODUCTION = TABLE_NAME + "." + COL_PRODUCTION;
+	private static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	private static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	private static final String TABLE_COL_PRODUCTION = TABLE_NAME + "." + COL_PRODUCTION;
 	private static final String SQL_GET_PRODUCTION_FILEID = "SELECT " + TABLE_COL_PRODUCTION + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
 	private static final String SQL_GET_PRODUCTION_TVSERIESID = "SELECT " + TABLE_COL_PRODUCTION + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_PRODUCTION + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_PRODUCTION + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_PRODUCTION + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_PRODUCTION + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -95,7 +93,7 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_PRODUCTION_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
@@ -110,11 +108,10 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -124,10 +121,10 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID           IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID   INTEGER                         , " +
-				"FILEID       INTEGER                         , " +
-				"PRODUCTION   VARCHAR(1024)       NOT NULL    ,  " +
+				COL_ID + "          IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "  INTEGER                         , " +
+				COL_FILEID + "      INTEGER                         , " +
+				COL_PRODUCTION + "  VARCHAR(1024)       NOT NULL    ,  " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
@@ -30,6 +30,10 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataProduction extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataProduction.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_PRODUCTION";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
@@ -33,17 +33,17 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	private static final String COL_PRODUCTION = "PRODUCTION";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String PRODUCTION = TABLE_NAME + "." + COL_PRODUCTION;
-	private static final String SQL_GET_PRODUCTION_FILEID = "SELECT " + PRODUCTION + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
-	private static final String SQL_GET_PRODUCTION_TVSERIESID = "SELECT " + PRODUCTION + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + PRODUCTION + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + PRODUCTION + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_PRODUCTION = TABLE_NAME + "." + COL_PRODUCTION;
+	private static final String SQL_GET_PRODUCTION_FILEID = "SELECT " + TABLE_COL_PRODUCTION + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_PRODUCTION_TVSERIESID = "SELECT " + TABLE_COL_PRODUCTION + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_PRODUCTION + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_PRODUCTION + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_PRODUCTION + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_PRODUCTION + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -100,15 +100,15 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_PRODUCTION_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -128,7 +128,7 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 				"TVSERIESID   INTEGER                         , " +
 				"FILEID       INTEGER                         , " +
 				"PRODUCTION   VARCHAR(1024)       NOT NULL    ,  " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
@@ -22,17 +22,26 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MediaTableVideoMetadataProduction extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataProduction.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_PRODUCTION";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	private static final String COL_PRODUCTION = "PRODUCTION";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String PRODUCTION = TABLE_NAME + "." + COL_PRODUCTION;
+	private static final String SQL_GET_PRODUCTION_FILEID = "SELECT " + PRODUCTION + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + PRODUCTION + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + PRODUCTION + " = ? LIMIT 1";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_PRODUCTION + ") VALUES (?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_PRODUCTION + ") VALUES (?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
@@ -40,7 +49,7 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 	/**
 	 * Checks and creates or upgrades the table as needed.
@@ -85,6 +94,22 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					//index with all columns ??
+					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_PRODUCTION_TVSERIESID_IDX");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -98,12 +123,13 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID           IDENTITY         PRIMARY KEY , " +
-				"TVSERIESID   INTEGER          DEFAULT -1  , " +
-				"FILENAME     VARCHAR(1024)    DEFAULT ''  , " +
-				"PRODUCTION   VARCHAR(1024)    NOT NULL      " +
-			")",
-			"CREATE UNIQUE INDEX FILENAME_PRODUCTION_TVSERIESID_IDX ON " + TABLE_NAME + "(FILENAME, PRODUCTION, TVSERIESID)"
+				"ID           IDENTITY            PRIMARY KEY , " +
+				"TVSERIESID   INTEGER                         , " +
+				"FILEID       INTEGER                         , " +
+				"PRODUCTION   VARCHAR(1024)       NOT NULL    ,  " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
+			")"
 		);
 	}
 
@@ -111,84 +137,70 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param production
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final String production, final long tvSeriesID) {
-		if (isBlank(production)) {
+	public static void set(final Connection connection, final Long fileId, final String production, final Long tvSeriesID) {
+		if (StringUtils.isBlank(production)) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
-		try (
-			PreparedStatement ps = connection.prepareStatement(
-				"SELECT " +
-					"ID " +
-				"FROM " + TABLE_NAME + " " +
-				"WHERE " +
-					"TVSERIESID = ? AND " +
-					"FILENAME = ? AND " +
-					"PRODUCTION = ? " +
-				"LIMIT 1"
-			)
-		) {
-			ps.setLong(1, tvSeriesID);
-			ps.setString(2, left(fullPathToFile, 1024));
-			ps.setString(3, left(production, 1024));
+		try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+			ps.setInt(1, id);
+			ps.setString(2, StringUtils.left(production, 1024));
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
-					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, production);
+					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, production);
 				} else {
-					try (
-						PreparedStatement insertStatement = connection.prepareStatement(
-							"INSERT INTO " + TABLE_NAME + " (" +
-								"TVSERIESID, FILENAME, PRODUCTION" +
-							") VALUES (" +
-								"?, ?, ?" +
-							")",
-							Statement.RETURN_GENERATED_KEYS
-						)
-					) {
+					try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 						insertStatement.clearParameters();
-						insertStatement.setLong(1, tvSeriesID);
-						insertStatement.setString(2, left(fullPathToFile, 1024));
-						insertStatement.setString(3, left(production, 1024));
+						insertStatement.setInt(1, id);
+						insertStatement.setString(2, StringUtils.left(production, 1024));
 
 						insertStatement.executeUpdate();
 						try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 							if (rs2.next()) {
-								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, production);
+								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, production);
 							}
 						}
 					}
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
-		String query = "DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +	(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-		try (Statement statement = connection.createStatement()) {
-			int rows = statement.executeUpdate(query);
-			LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
+	public static String getValueForFile(final Connection connection, final Long fileId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_PRODUCTION_FILEID)) {
+				ps.setLong(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+		return null;
 	}
 
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataProduction.java
@@ -37,6 +37,7 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String PRODUCTION = TABLE_NAME + "." + COL_PRODUCTION;
 	private static final String SQL_GET_PRODUCTION_FILEID = "SELECT " + PRODUCTION + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_PRODUCTION_TVSERIESID = "SELECT " + PRODUCTION + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + PRODUCTION + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + PRODUCTION + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_PRODUCTION + ") VALUES (?, ?)";
@@ -198,6 +199,23 @@ public final class MediaTableVideoMetadataProduction extends MediaTable {
 			}
 		} catch (SQLException e) {
 			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return null;
+	}
+
+	public static String getValueForTvSerie(final Connection connection, final Long tvSerieId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_PRODUCTION_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 		return null;

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
@@ -33,17 +33,17 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	public static final String COL_RATED = "RATED";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String RATED = TABLE_NAME + "." + COL_RATED;
-	private static final String SQL_GET_RATED_FILEID = "SELECT " + RATED + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
-	private static final String SQL_GET_RATED_TVSERIESID = "SELECT " + RATED + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + RATED + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + RATED + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_RATED = TABLE_NAME + "." + COL_RATED;
+	private static final String SQL_GET_RATED_FILEID = "SELECT " + TABLE_COL_RATED + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_RATED_TVSERIESID = "SELECT " + TABLE_COL_RATED + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_RATED + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_RATED + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RATED + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_RATED + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -102,15 +102,15 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS RATING RENAME TO " + COL_RATED);
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -130,7 +130,7 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 				"TVSERIESID     INTEGER                         , " +
 				"FILEID         INTEGER                         , " +
 				"RATED          VARCHAR(1024)       NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
@@ -34,6 +34,8 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
 	public static final String FILENAME = TABLE_NAME + ".FILENAME";
 	public static final String RATING = TABLE_NAME + "." + COL_RATING_NAME;
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
@@ -37,6 +37,7 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String RATED = TABLE_NAME + "." + COL_RATED;
 	private static final String SQL_GET_RATED_FILEID = "SELECT " + RATED + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_RATED_TVSERIESID = "SELECT " + RATED + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + RATED + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + RATED + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RATED + ") VALUES (?, ?)";
@@ -200,6 +201,23 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 			}
 		} catch (SQLException e) {
 			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return null;
+	}
+
+	public static String getValueForTvSerie(final Connection connection, final Long tvSerieId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_RATED_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 		return null;

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
@@ -22,19 +22,26 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MediaTableVideoMetadataRated extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataRated.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_RATED";
-	public static final String COL_RATING_NAME = "RATING";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String RATING = TABLE_NAME + "." + COL_RATING_NAME;
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	public static final String COL_RATED = "RATED";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String RATED = TABLE_NAME + "." + COL_RATED;
+	private static final String SQL_GET_RATED_FILEID = "SELECT " + RATED + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + RATED + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + RATED + " = ? LIMIT 1";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RATED + ") VALUES (?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_RATED + ") VALUES (?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
@@ -42,7 +49,7 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 	/**
 	 * Checks and creates or upgrades the table as needed.
@@ -87,6 +94,24 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					//index with all columns ??
+					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_RATED_TVSERIESID_IDX");
+					//rename to rated to avoid confusion with table rating
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS RATING RENAME TO " + COL_RATED);
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -101,130 +126,83 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
 				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER             DEFAULT -1  , " +
-				"FILENAME       VARCHAR(1024)       DEFAULT ''  , " +
-				"RATING         VARCHAR(1024)       NOT NULL      " +
-			")",
-			"CREATE UNIQUE INDEX FILENAME_RATED_TVSERIESID_IDX ON " + TABLE_NAME + "(FILENAME, RATING, TVSERIESID)"
+				"TVSERIESID     INTEGER                         , " +
+				"FILEID         INTEGER                         , " +
+				"RATED          VARCHAR(1024)       NOT NULL    , " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
+			")"
 		);
-	}
-
-	/**
-	 * @param connection the db connection
-	 * @param tvSeriesTitle
-	 * @return the rating for a TV series, if it has an IMDb ID stored.
-	 */
-	public static String getByTVSeriesName(final Connection connection, final String tvSeriesTitle) {
-		boolean trace = LOGGER.isTraceEnabled();
-
-		try {
-			String query = "SELECT RATING FROM " + TABLE_NAME + " " +
-				"LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + TABLE_NAME + ".TVSERIESID = " + MediaTableTVSeries.TABLE_NAME + ".ID " +
-				"WHERE " + MediaTableTVSeries.TABLE_NAME + ".TITLE = " + sqlQuote(tvSeriesTitle) + " " +
-				"LIMIT 1";
-
-			if (trace) {
-				LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", query);
-			}
-
-			try (
-				Statement statement = connection.createStatement();
-				ResultSet resultSet = statement.executeQuery(query)
-			) {
-				if (resultSet.next()) {
-					return resultSet.getString(1);
-				}
-			}
-		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "reading rating", TABLE_NAME, tvSeriesTitle, e.getMessage());
-			LOGGER.trace("", e);
-		}
-
-		return null;
 	}
 
 	/**
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param rated
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final String rated, final long tvSeriesID) {
-		if (isBlank(rated)) {
+	public static void set(final Connection connection, final Long fileId, final String rated, final Long tvSeriesID) {
+		if (StringUtils.isBlank(rated)) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
-		try (
-			PreparedStatement ps = connection.prepareStatement(
-				"SELECT " +
-					"ID " +
-				"FROM " + TABLE_NAME + " " +
-				"WHERE " +
-					"TVSERIESID = ? AND " +
-					"FILENAME = ? AND " +
-					"RATING = ? " +
-				"LIMIT 1"
-			)
-		) {
-			ps.setLong(1, tvSeriesID);
-			ps.setString(2, left(fullPathToFile, 1024));
-			ps.setString(3, left(rated, 1024));
+		try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+			ps.setInt(1, id);
+			ps.setString(2, StringUtils.left(rated, 1024));
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
-					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, rated);
+					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, rated);
 				} else {
-					try (
-						PreparedStatement insertStatement = connection.prepareStatement(
-							"INSERT INTO " + TABLE_NAME + " (" +
-								"TVSERIESID, FILENAME, RATING" +
-							") VALUES (" +
-								"?, ?, ?" +
-							")",
-							Statement.RETURN_GENERATED_KEYS
-						)
-					) {
+					try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 						insertStatement.clearParameters();
-						insertStatement.setLong(1, tvSeriesID);
-						insertStatement.setString(2, left(fullPathToFile, 1024));
-						insertStatement.setString(3, left(rated, 1024));
+						insertStatement.setInt(1, id);
+						insertStatement.setString(2, StringUtils.left(rated, 1024));
 
 						insertStatement.executeUpdate();
 						try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 							if (rs2.next()) {
-								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, rated);
+								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, rated);
 							}
 						}
 					}
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
-		String query = "DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +	(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-		try (Statement statement = connection.createStatement()) {
-			int rows = statement.executeUpdate(query);
-			LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
+	public static String getValueForFile(final Connection connection, final Long fileId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_RATED_FILEID)) {
+				ps.setLong(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+		return null;
 	}
 
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
@@ -36,14 +36,17 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
 	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String TABLE_COL_RATED = TABLE_NAME + "." + COL_RATED;
+
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + TABLE_COL_TVSERIESID + " = " + MediaTableTVSeries.TABLE_COL_ID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_VIDEO_METADATA = "LEFT JOIN " + MediaTableVideoMetadata.TABLE_NAME + " ON " + TABLE_COL_FILEID + " = " + MediaTableVideoMetadata.TABLE_COL_FILEID + " ";
+
 	private static final String SQL_GET_RATED_FILEID = "SELECT " + TABLE_COL_RATED + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
 	private static final String SQL_GET_RATED_TVSERIESID = "SELECT " + TABLE_COL_RATED + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
+
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_RATED + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_RATED + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RATED + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_RATED + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -95,7 +98,7 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_RATED_TVSERIESID_IDX");
 					//rename to rated to avoid confusion with table rating
@@ -112,11 +115,10 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -126,10 +128,10 @@ public final class MediaTableVideoMetadataRated extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER                         , " +
-				"FILEID         INTEGER                         , " +
-				"RATED          VARCHAR(1024)       NOT NULL    , " +
+				COL_ID + "           IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "   INTEGER                         , " +
+				COL_FILEID + "       INTEGER                         , " +
+				COL_RATED + "        VARCHAR(1024)       NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRated.java
@@ -30,6 +30,10 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataRated extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataRated.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_RATED";
+	public static final String COL_RATING_NAME = "RATING";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String RATING = TABLE_NAME + "." + COL_RATING_NAME;
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
@@ -17,6 +17,7 @@
  */
 package net.pms.database;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.sql.Connection;
@@ -25,7 +26,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Iterator;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,9 +34,21 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataRatings.class);
 
 	public static final String TABLE_NAME = "VIDEO_METADATA_RATINGS";
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	public static final String COL_RATINGSOURCE = "RATINGSOURCE";
+	public static final String COL_RATINGVALUE = "RATINGVALUE";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String RATINGSOURCE = TABLE_NAME + "." + COL_RATINGSOURCE;
+	public static final String RATINGVALUE = TABLE_NAME + "." + COL_RATINGVALUE;
+	private static final String SQL_GET_RATING_FILEID = "SELECT " + RATINGSOURCE + ", " + RATINGVALUE + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + RATINGSOURCE + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + RATINGSOURCE + " = ? LIMIT 1";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RATINGSOURCE + ", " + COL_RATINGVALUE + ") VALUES (?, ?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_RATINGSOURCE + ", " + COL_RATINGVALUE + ") VALUES (?, ?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
@@ -43,7 +56,7 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 	/**
 	 * Checks and creates or upgrades the table as needed.
@@ -88,6 +101,29 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					//index with all columns ??
+					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_RATINGSOURCE_TVSERIESID_IDX");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TVSERIESID + " IS NOT NULL");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					//api settvseriesinfo had both filled filename and tvserieId ending in multiple row for nothing.
+					executeUpdate(connection,
+						"DELETE FROM " + TABLE_NAME + " WHERE EXISTS (SELECT " + COL_ID + " FROM " + TABLE_NAME + " T2 WHERE T2." + COL_TVSERIESID + " = " + TVSERIESID + " AND " +
+						"T2." + COL_FILEID + " IS NULL AND T2." + COL_ID + " != " + TABLE_NAME + "." + COL_ID + " AND " +
+						"T2." + COL_RATINGSOURCE + " = " + RATINGSOURCE + " AND T2." + COL_RATINGVALUE + " = " + RATINGVALUE + " AND " +
+						TABLE_NAME + "." + COL_ID + " != (SELECT MIN(T3." + COL_ID + ") FROM " + TABLE_NAME + " T3 WHERE T3." + COL_TVSERIESID + " = T2." + COL_TVSERIESID + "))");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -102,12 +138,13 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
 				"ID                 IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID         INTEGER             DEFAULT -1  , " +
-				"FILENAME           VARCHAR(1024)       DEFAULT ''  , " +
+				"TVSERIESID         INTEGER                         , " +
+				"FILEID             INTEGER                         , " +
 				"RATINGSOURCE       VARCHAR(1024)       NOT NULL    , " +
-				"RATINGVALUE        VARCHAR(1024)       NOT NULL      " +
-			")",
-			"CREATE UNIQUE INDEX FILENAME_RATINGSOURCE_TVSERIESID_IDX ON " + TABLE_NAME + "(FILENAME, RATINGSOURCE, TVSERIESID)"
+				"RATINGVALUE        VARCHAR(1024)       NOT NULL    , " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
+			")"
 		);
 	}
 
@@ -115,12 +152,25 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param ratings
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final JsonElement ratings, final long tvSeriesID) {
+	public static void set(final Connection connection, final Long fileId, final JsonElement ratings, final Long tvSeriesID) {
 		if (ratings == null || !ratings.isJsonArray() || ratings.getAsJsonArray().isEmpty()) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
@@ -131,45 +181,23 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 				String source = rating.has("Source") ? rating.get("Source").getAsString() : null;
 				String value = rating.has("Value") ? rating.get("Value").getAsString() : null;
 
-				try (
-					PreparedStatement ps = connection.prepareStatement(
-						"SELECT " +
-							"ID " +
-						"FROM " + TABLE_NAME + " " +
-						"WHERE " +
-							"TVSERIESID = ? AND " +
-							"FILENAME = ? AND " +
-							"RATINGSOURCE = ? " +
-						"LIMIT 1"
-					)
-				) {
-					ps.setLong(1, tvSeriesID);
-					ps.setString(2, left(fullPathToFile, 1024));
-					ps.setString(3, left(source, 1024));
+				try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+					ps.setInt(1, id);
+					ps.setString(2, StringUtils.left(source, 1024));
 					try (ResultSet rs = ps.executeQuery()) {
 						if (rs.next()) {
-							LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, rating);
+							LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, rating);
 						} else {
-							try (
-								PreparedStatement insertStatement = connection.prepareStatement(
-									"INSERT INTO " + TABLE_NAME + " (" +
-										"TVSERIESID, FILENAME, RATINGSOURCE, RATINGVALUE" +
-									") VALUES (" +
-										"?, ?, ?, ?" +
-									")",
-									Statement.RETURN_GENERATED_KEYS
-								)
-							) {
+							try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 								insertStatement.clearParameters();
-								insertStatement.setLong(1, tvSeriesID);
-								insertStatement.setString(2, left(fullPathToFile, 1024));
-								insertStatement.setString(3, left(source, 1024));
-								insertStatement.setString(4, left(value, 1024));
+								insertStatement.setInt(1, id);
+								insertStatement.setString(2, StringUtils.left(source, 1024));
+								insertStatement.setString(3, StringUtils.left(value, 1024));
 
 								insertStatement.executeUpdate();
 								try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 									if (rs2.next()) {
-										LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, rating);
+										LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, rating);
 									}
 								}
 							}
@@ -178,31 +206,29 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
-		String query = "DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +	(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-		try (Statement statement = connection.createStatement()) {
-			int rows = statement.executeUpdate(query);
-			LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
+	public static JsonArray getJsonArrayForFile(final Connection connection, final Long fileId) {
+		JsonArray result = new JsonArray();
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_RATING_FILEID)) {
+				ps.setLong(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						JsonObject jObject = new JsonObject();
+						jObject.addProperty("source", rs.getString(1));
+						jObject.addProperty("value", rs.getString(2));
+						result.add(jObject);
+					}
+				}
+			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+		return result;
 	}
-
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
@@ -37,20 +37,18 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 	private static final String COL_ID = "ID";
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
-	public static final String COL_RATINGSOURCE = "RATINGSOURCE";
-	public static final String COL_RATINGVALUE = "RATINGVALUE";
-	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String TABLE_COL_RATINGSOURCE = TABLE_NAME + "." + COL_RATINGSOURCE;
-	public static final String TABLE_COL_RATINGVALUE = TABLE_NAME + "." + COL_RATINGVALUE;
+	private static final String COL_RATINGSOURCE = "RATINGSOURCE";
+	private static final String COL_RATINGVALUE = "RATINGVALUE";
+	private static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	private static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	private static final String TABLE_COL_RATINGSOURCE = TABLE_NAME + "." + COL_RATINGSOURCE;
+	private static final String TABLE_COL_RATINGVALUE = TABLE_NAME + "." + COL_RATINGVALUE;
 	private static final String SQL_GET_RATING_FILEID = "SELECT " + TABLE_COL_RATINGSOURCE + ", " + TABLE_COL_RATINGVALUE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
 	private static final String SQL_GET_RATING_TVSERIESID = "SELECT " + TABLE_COL_RATINGSOURCE + ", " + TABLE_COL_RATINGVALUE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_RATINGSOURCE + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_RATINGSOURCE + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RATINGSOURCE + ", " + COL_RATINGVALUE + ") VALUES (?, ?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_RATINGSOURCE + ", " + COL_RATINGVALUE + ") VALUES (?, ?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -102,7 +100,7 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_RATINGSOURCE_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
@@ -124,11 +122,10 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -138,11 +135,11 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID                 IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID         INTEGER                         , " +
-				"FILEID             INTEGER                         , " +
-				"RATINGSOURCE       VARCHAR(1024)       NOT NULL    , " +
-				"RATINGVALUE        VARCHAR(1024)       NOT NULL    , " +
+				COL_ID + "           IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "   INTEGER                         , " +
+				COL_FILEID + "       INTEGER                         , " +
+				COL_RATINGSOURCE + " VARCHAR(1024)       NOT NULL    , " +
+				COL_RATINGVALUE + "  VARCHAR(1024)       NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
@@ -39,18 +39,18 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	public static final String COL_RATINGSOURCE = "RATINGSOURCE";
 	public static final String COL_RATINGVALUE = "RATINGVALUE";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String RATINGSOURCE = TABLE_NAME + "." + COL_RATINGSOURCE;
-	public static final String RATINGVALUE = TABLE_NAME + "." + COL_RATINGVALUE;
-	private static final String SQL_GET_RATING_FILEID = "SELECT " + RATINGSOURCE + ", " + RATINGVALUE + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
-	private static final String SQL_GET_RATING_TVSERIESID = "SELECT " + RATINGSOURCE + ", " + RATINGVALUE + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + RATINGSOURCE + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + RATINGSOURCE + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_RATINGSOURCE = TABLE_NAME + "." + COL_RATINGSOURCE;
+	public static final String TABLE_COL_RATINGVALUE = TABLE_NAME + "." + COL_RATINGVALUE;
+	private static final String SQL_GET_RATING_FILEID = "SELECT " + TABLE_COL_RATINGSOURCE + ", " + TABLE_COL_RATINGVALUE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ?";
+	private static final String SQL_GET_RATING_TVSERIESID = "SELECT " + TABLE_COL_RATINGSOURCE + ", " + TABLE_COL_RATINGVALUE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ?";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_RATINGSOURCE + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_RATINGSOURCE + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RATINGSOURCE + ", " + COL_RATINGVALUE + ") VALUES (?, ?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_RATINGSOURCE + ", " + COL_RATINGVALUE + ") VALUES (?, ?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -107,22 +107,22 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_RATINGSOURCE_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TVSERIESID + " IS NOT NULL");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " IS NOT NULL");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
 					//api settvseriesinfo had both filled filename and tvserieId ending in multiple row for nothing.
 					executeUpdate(connection,
-						"DELETE FROM " + TABLE_NAME + " WHERE EXISTS (SELECT " + COL_ID + " FROM " + TABLE_NAME + " T2 WHERE T2." + COL_TVSERIESID + " = " + TVSERIESID + " AND " +
+						"DELETE FROM " + TABLE_NAME + " WHERE EXISTS (SELECT " + COL_ID + " FROM " + TABLE_NAME + " T2 WHERE T2." + COL_TVSERIESID + " = " + TABLE_COL_TVSERIESID + " AND " +
 						"T2." + COL_FILEID + " IS NULL AND T2." + COL_ID + " != " + TABLE_NAME + "." + COL_ID + " AND " +
-						"T2." + COL_RATINGSOURCE + " = " + RATINGSOURCE + " AND T2." + COL_RATINGVALUE + " = " + RATINGVALUE + " AND " +
+						"T2." + COL_RATINGSOURCE + " = " + TABLE_COL_RATINGSOURCE + " AND T2." + COL_RATINGVALUE + " = " + TABLE_COL_RATINGVALUE + " AND " +
 						TABLE_NAME + "." + COL_ID + " != (SELECT MIN(T3." + COL_ID + ") FROM " + TABLE_NAME + " T3 WHERE T3." + COL_TVSERIESID + " = T2." + COL_TVSERIESID + "))");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -143,7 +143,7 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 				"FILEID             INTEGER                         , " +
 				"RATINGSOURCE       VARCHAR(1024)       NOT NULL    , " +
 				"RATINGVALUE        VARCHAR(1024)       NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
@@ -33,6 +33,10 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataRatings.class);
 
 	public static final String TABLE_NAME = "VIDEO_METADATA_RATINGS";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataRatings.java
@@ -44,6 +44,7 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 	public static final String RATINGSOURCE = TABLE_NAME + "." + COL_RATINGSOURCE;
 	public static final String RATINGVALUE = TABLE_NAME + "." + COL_RATINGVALUE;
 	private static final String SQL_GET_RATING_FILEID = "SELECT " + RATINGSOURCE + ", " + RATINGVALUE + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ?";
+	private static final String SQL_GET_RATING_TVSERIESID = "SELECT " + RATINGSOURCE + ", " + RATINGVALUE + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ?";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + RATINGSOURCE + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + RATINGSOURCE + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RATINGSOURCE + ", " + COL_RATINGVALUE + ") VALUES (?, ?, ?)";
@@ -231,4 +232,26 @@ public final class MediaTableVideoMetadataRatings extends MediaTable {
 		}
 		return result;
 	}
+
+	public static JsonArray getJsonArrayForTvSerie(final Connection connection, final Long tvSerieId) {
+		JsonArray result = new JsonArray();
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_RATING_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						JsonObject jObject = new JsonObject();
+						jObject.addProperty("source", rs.getString(1));
+						jObject.addProperty("value", rs.getString(2));
+						result.add(jObject);
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return result;
+	}
+
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
@@ -32,9 +32,9 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 	private static final String COL_ID = "ID";
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
-	public static final String COL_RELEASEDATE = "RELEASEDATE";
+	private static final String COL_RELEASEDATE = "RELEASEDATE";
 	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	private static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String TABLE_COL_RELEASEDATE = TABLE_NAME + "." + COL_RELEASEDATE;
 	private static final String SQL_GET_RELEASEDATE_FILEID = "SELECT " + TABLE_COL_RELEASEDATE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
 	private static final String SQL_GET_RELEASEDATE_TVSERIESID = "SELECT " + TABLE_COL_RELEASEDATE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
@@ -42,8 +42,6 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_RELEASEDATE + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RELEASEDATE + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_RELEASEDATE + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -95,7 +93,7 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
-				case 1:
+				case 1 -> {
 					//index with all columns ??
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_RELEASEDATE_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
@@ -110,11 +108,10 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
-					break;
-				default:
-					throw new IllegalStateException(
-						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
-					);
+				}
+				default -> {
+					throw new IllegalStateException(getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION));
+				}
 			}
 		}
 		MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
@@ -124,10 +121,10 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
-				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER                         , " +
-				"FILEID         INTEGER                         , " +
-				"RELEASEDATE    VARCHAR(1024)       NOT NULL    , " +
+				COL_ID + "          IDENTITY            PRIMARY KEY , " +
+				COL_TVSERIESID + "  INTEGER                         , " +
+				COL_FILEID + "      INTEGER                         , " +
+				COL_RELEASEDATE + " VARCHAR(1024)       NOT NULL    , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
@@ -33,17 +33,17 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 	private static final String COL_FILEID = "FILEID";
 	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
 	public static final String COL_RELEASEDATE = "RELEASEDATE";
-	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
-	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
-	public static final String RELEASEDATE = TABLE_NAME + "." + COL_RELEASEDATE;
-	private static final String SQL_GET_RELEASEDATE_FILEID = "SELECT " + RELEASEDATE + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
-	private static final String SQL_GET_RELEASEDATE_TVSERIESID = "SELECT " + RELEASEDATE + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
-	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + RELEASEDATE + " = ? LIMIT 1";
-	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + RELEASEDATE + " = ? LIMIT 1";
+	public static final String TABLE_COL_FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TABLE_COL_TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String TABLE_COL_RELEASEDATE = TABLE_NAME + "." + COL_RELEASEDATE;
+	private static final String SQL_GET_RELEASEDATE_FILEID = "SELECT " + TABLE_COL_RELEASEDATE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_RELEASEDATE_TVSERIESID = "SELECT " + TABLE_COL_RELEASEDATE + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_TVSERIESID + " = ? AND " + TABLE_COL_RELEASEDATE + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_COL_FILEID + " = ? AND " + TABLE_COL_RELEASEDATE + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RELEASEDATE + ") VALUES (?, ?)";
 	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_RELEASEDATE + ") VALUES (?, ?)";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
-	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + TABLE_COL_FILEID + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + TABLE_COL_TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table
@@ -100,15 +100,15 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_RELEASEDATE_TVSERIESID_IDX");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
 					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
-						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.TABLE_COL_ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
 						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
 					}
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
 
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
-					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + TABLE_COL_FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TABLE_COL_TVSERIESID + " = -1");
 
-					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE");
 					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
 					break;
 				default:
@@ -128,7 +128,7 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 				"TVSERIESID     INTEGER                         , " +
 				"FILEID         INTEGER                         , " +
 				"RELEASEDATE    VARCHAR(1024)       NOT NULL    , " +
-				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadata.TABLE_NAME + "(" + MediaTableVideoMetadata.COL_FILEID + ") ON DELETE CASCADE, " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
 			")"
 		);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
@@ -30,7 +30,13 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataReleased extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataReleased.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_RELEASED";
+	/**
+	 * COLUMNS with table name
+	 */
 	public static final String FILENAME = TABLE_NAME + ".FILENAME";
+	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 public final class MediaTableVideoMetadataReleased extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataReleased.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_RELEASED";
+	public static final String FILENAME = TABLE_NAME + ".FILENAME";
 
 	/**
 	 * Table version must be increased every time a change is done to the table

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
@@ -37,6 +37,7 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
 	public static final String RELEASEDATE = TABLE_NAME + "." + COL_RELEASEDATE;
 	private static final String SQL_GET_RELEASEDATE_FILEID = "SELECT " + RELEASEDATE + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_RELEASEDATE_TVSERIESID = "SELECT " + RELEASEDATE + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? LIMIT 1";
 	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + RELEASEDATE + " = ? LIMIT 1";
 	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + RELEASEDATE + " = ? LIMIT 1";
 	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RELEASEDATE + ") VALUES (?, ?)";
@@ -198,6 +199,23 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 			}
 		} catch (SQLException e) {
 			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return null;
+	}
+
+	public static String getValueForTvSerie(final Connection connection, final Long tvSerieId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_RELEASEDATE_TVSERIESID)) {
+				ps.setLong(1, tvSerieId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", tvSerieId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 		return null;

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataReleased.java
@@ -22,20 +22,26 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.left;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MediaTableVideoMetadataReleased extends MediaTable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadataReleased.class);
 	public static final String TABLE_NAME = "VIDEO_METADATA_RELEASED";
-	/**
-	 * COLUMNS with table name
-	 */
-	public static final String FILENAME = TABLE_NAME + ".FILENAME";
-	public static final String TVSERIESID = TABLE_NAME + ".TVSERIESID";
-	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + FILENAME + " ";
+	private static final String COL_ID = "ID";
+	private static final String COL_FILEID = "FILEID";
+	private static final String COL_TVSERIESID = MediaTableTVSeries.CHILD_ID;
+	public static final String COL_RELEASEDATE = "RELEASEDATE";
+	public static final String FILEID = TABLE_NAME + "." + COL_FILEID;
+	public static final String TVSERIESID = TABLE_NAME + "." + COL_TVSERIESID;
+	public static final String RELEASEDATE = TABLE_NAME + "." + COL_RELEASEDATE;
+	private static final String SQL_GET_RELEASEDATE_FILEID = "SELECT " + RELEASEDATE + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? LIMIT 1";
+	private static final String SQL_GET_TVSERIESID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + TVSERIESID + " = ? AND " + RELEASEDATE + " = ? LIMIT 1";
+	private static final String SQL_GET_FILEID_EXISTS = "SELECT " + COL_ID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + RELEASEDATE + " = ? LIMIT 1";
+	private static final String SQL_INSERT_TVSERIESID = "INSERT INTO " + TABLE_NAME + " (" + COL_TVSERIESID + ", " + COL_RELEASEDATE + ") VALUES (?, ?)";
+	private static final String SQL_INSERT_FILEID = "INSERT INTO " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_RELEASEDATE + ") VALUES (?, ?)";
+	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	public static final String SQL_LEFT_JOIN_TABLE_TV_SERIES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + TVSERIESID + " ";
 
 	/**
@@ -43,7 +49,7 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 
 	/**
 	 * Checks and creates or upgrades the table as needed.
@@ -88,6 +94,22 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					//index with all columns ??
+					executeUpdate(connection, "DROP INDEX IF EXISTS FILENAME_RELEASEDATE_TVSERIESID_IDX");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD COLUMN IF NOT EXISTS " + COL_FILEID + " INTEGER");
+					if (isColumnExist(connection, TABLE_NAME, "FILENAME")) {
+						executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + "=(SELECT " + MediaTableFiles.ID + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FILENAME + " = " + TABLE_NAME + ".FILENAME) WHERE " + TABLE_NAME + ".FILENAME != ''");
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " DROP COLUMN IF EXISTS FILENAME");
+					}
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_TVSERIESID + " DROP DEFAULT");
+
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_FILEID + " = NULL WHERE " + FILEID + " = -1");
+					executeUpdate(connection, "UPDATE " + TABLE_NAME + " SET " + COL_TVSERIESID + " = NULL WHERE " + TVSERIESID + " = -1");
+
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -102,11 +124,12 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 		execute(connection,
 			"CREATE TABLE " + TABLE_NAME + "(" +
 				"ID             IDENTITY            PRIMARY KEY , " +
-				"TVSERIESID     INTEGER             DEFAULT -1  , " +
-				"FILENAME       VARCHAR(1024)       DEFAULT ''  , " +
-				"RELEASEDATE    VARCHAR(1024)       NOT NULL      " +
-			")",
-			"CREATE UNIQUE INDEX FILENAME_RELEASEDATE_TVSERIESID_IDX ON " + TABLE_NAME + "(FILENAME, RELEASEDATE, TVSERIESID)"
+				"TVSERIESID     INTEGER                         , " +
+				"FILEID         INTEGER                         , " +
+				"RELEASEDATE    VARCHAR(1024)       NOT NULL    , " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY (" + COL_FILEID + ") REFERENCES " + MediaTableVideoMetadatas.TABLE_NAME + "(" + MediaTableVideoMetadatas.COL_FILEID + ") ON DELETE CASCADE, " +
+				"CONSTRAINT " + TABLE_NAME + "_" + COL_TVSERIESID + "_FK FOREIGN KEY (" + COL_TVSERIESID + ") REFERENCES " + MediaTableTVSeries.TABLE_NAME + "(" + MediaTableTVSeries.COL_ID + ") ON DELETE CASCADE " +
+			")"
 		);
 	}
 
@@ -114,84 +137,70 @@ public final class MediaTableVideoMetadataReleased extends MediaTable {
 	 * Sets a new row if it doesn't already exist.
 	 *
 	 * @param connection the db connection
-	 * @param fullPathToFile
+	 * @param fileId
 	 * @param released
 	 * @param tvSeriesID
 	 */
-	public static void set(final Connection connection, final String fullPathToFile, final String released, final long tvSeriesID) {
-		if (isBlank(released)) {
+	public static void set(final Connection connection, final Long fileId, final String released, final Long tvSeriesID) {
+		if (StringUtils.isBlank(released)) {
+			return;
+		}
+		final String sqlSelect, sqlInsert;
+		final int id;
+		if (tvSeriesID != null) {
+			sqlSelect = SQL_GET_TVSERIESID_EXISTS;
+			sqlInsert = SQL_INSERT_TVSERIESID;
+			id = tvSeriesID.intValue();
+		} else if (fileId != null) {
+			sqlSelect = SQL_GET_FILEID_EXISTS;
+			sqlInsert = SQL_INSERT_FILEID;
+			id = fileId.intValue();
+		} else {
 			return;
 		}
 
-		try (
-			PreparedStatement ps = connection.prepareStatement(
-				"SELECT " +
-					"ID " +
-				"FROM " + TABLE_NAME + " " +
-				"WHERE " +
-					"TVSERIESID = ? AND " +
-					"FILENAME = ? AND " +
-					"RELEASEDATE = ? " +
-				"LIMIT 1"
-			)
-		) {
-			ps.setLong(1, tvSeriesID);
-			ps.setString(2, left(fullPathToFile, 1024));
-			ps.setString(3, left(released, 1024));
+		try (PreparedStatement ps = connection.prepareStatement(sqlSelect)) {
+			ps.setInt(1, id);
+			ps.setString(2, StringUtils.left(released, 1024));
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
-					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fullPathToFile, released);
+					LOGGER.trace("Record already exists {} {} {}", tvSeriesID, fileId, released);
 				} else {
-					try (
-						PreparedStatement insertStatement = connection.prepareStatement(
-							"INSERT INTO " + TABLE_NAME + " (" +
-								"TVSERIESID, FILENAME, RELEASEDATE" +
-							") VALUES (" +
-								"?, ?, ?" +
-							")",
-							Statement.RETURN_GENERATED_KEYS
-						)
-					) {
+					try (PreparedStatement insertStatement = connection.prepareStatement(sqlInsert, Statement.RETURN_GENERATED_KEYS)) {
 						insertStatement.clearParameters();
-						insertStatement.setLong(1, tvSeriesID);
-						insertStatement.setString(2, left(fullPathToFile, 1024));
-						insertStatement.setString(3, left(released, 1024));
+						insertStatement.setInt(1, id);
+						insertStatement.setString(2, StringUtils.left(released, 1024));
 
 						insertStatement.executeUpdate();
 						try (ResultSet rs2 = insertStatement.getGeneratedKeys()) {
 							if (rs2.next()) {
-								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fullPathToFile, tvSeriesID, released);
+								LOGGER.trace("Set new entry successfully in " + TABLE_NAME + " with \"{}\", \"{}\" and \"{}\"", fileId, tvSeriesID, released);
 							}
 						}
 					}
 				}
 			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fullPathToFile, e.getMessage());
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "writing", TABLE_NAME, fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
 	}
 
-	/**
-	 * Removes an entry or entries based on its FILENAME. If {@code useLike} is
-	 * {@code true}, {@code filename} must be properly escaped.
-	 *
-	 * @see Tables#sqlLikeEscape(String)
-	 *
-	 * @param connection the db connection
-	 * @param filename the filename to remove
-	 * @param useLike {@code true} if {@code LIKE} should be used as the compare
-	 *            operator, {@code false} if {@code =} should be used.
-	 */
-	public static void remove(final Connection connection, final String filename, boolean useLike) {
-		String query = "DELETE FROM " + TABLE_NAME + " WHERE FILENAME " +	(useLike ? "LIKE " : "= ") + sqlQuote(filename);
-		try (Statement statement = connection.createStatement()) {
-			int rows = statement.executeUpdate(query);
-			LOGGER.trace("Removed entries {} in " + TABLE_NAME + " for filename \"{}\"", rows, filename);
+	public static String getValueForFile(final Connection connection, final Long fileId) {
+		try {
+			try (PreparedStatement ps = connection.prepareStatement(SQL_GET_RELEASEDATE_FILEID)) {
+				ps.setLong(1, fileId);
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next()) {
+						return rs.getString(1);
+					}
+				}
+			}
 		} catch (SQLException e) {
-			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "removing entries", TABLE_NAME, filename, e.getMessage());
+			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", fileId, e.getMessage());
 			LOGGER.trace("", e);
 		}
+		return null;
 	}
 
 }

--- a/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
@@ -80,6 +80,7 @@ public class MediaTableVideoMetadatas extends MediaTable {
 	public static final String TVSEASON = TABLE_NAME + "." + COL_TVSEASON;
 	public static final String SQL_LEFT_JOIN_TABLE_FILES = "LEFT JOIN " + TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + FILEID + " ";
 	private static final String SQL_GET_VIDEO_METADATA_BY_FILEID = "SELECT " + BASIC_COLUMNS + " FROM " + TABLE_NAME + " WHERE " + COL_FILEID + " = ?";
+	private static final String SQL_GET_VIDEO_METADATA_BY_FILEID_IMDBID = "SELECT * FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? and " + IMDBID + " IS NOT NULL LIMIT 1";
 	private static final String SQL_GET_API_METADATA_EXIST = "SELECT " + FILEID + " FROM " + TABLE_NAME + " " + " WHERE " + FILEID + " = ? LIMIT 1";
 	private static final String SQL_GET_API_METADATA_IMDBID_EXIST = "SELECT " + FILEID + " FROM " + TABLE_NAME + " " + " WHERE " + FILEID + " = ? AND " + IMDBID + " IS NOT NULL LIMIT 1";
 	private static final String SQL_GET_API_METADATA_API_IMDBID_VERSION_EXIST = "SELECT " + FILEID + " FROM " + TABLE_NAME + " WHERE " + FILEID + " = ? AND " + IMDBID + " IS NOT NULL AND " + API_VERSION + " = ? LIMIT 1";
@@ -412,9 +413,8 @@ public class MediaTableVideoMetadatas extends MediaTable {
 			return null;
 		}
 		boolean trace = LOGGER.isTraceEnabled();
-		String sql = "SELECT * FROM " + TABLE_NAME + "WHERE " + FILEID + " = ? and " + IMDBID + " IS NOT NULL LIMIT 1";
 		try {
-			try (PreparedStatement selectStatement = connection.prepareStatement(sql)) {
+			try (PreparedStatement selectStatement = connection.prepareStatement(SQL_GET_VIDEO_METADATA_BY_FILEID_IMDBID)) {
 				selectStatement.setLong(1, fileId);
 				if (trace) {
 					LOGGER.trace("Searching " + TABLE_NAME + " with \"{}\"", selectStatement);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
@@ -206,7 +206,7 @@ public class MediaTableVideoMetadatas extends MediaTable {
 		) {
 			updateStatement.setLong(1, fileId);
 			try (ResultSet rs = updateStatement.executeQuery()) {
-				if (rs.next()) {					
+				if (rs.next()) {
 					rs.updateString(COL_IMDBID, StringUtils.left(videoMetadata.getIMDbID(), SIZE_IMDBID));
 					rs.updateString(COL_MEDIA_YEAR, StringUtils.left(videoMetadata.getYear(), SIZE_YEAR));
 					rs.updateString(COL_MOVIEORSHOWNAME, StringUtils.left(videoMetadata.getMovieOrShowName(), SIZE_MAX));

--- a/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
@@ -1,0 +1,473 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.database;
+
+import com.google.gson.JsonObject;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import static net.pms.database.DatabaseHelper.SIZE_MAX;
+import static net.pms.database.DatabaseHelper.sqlEscape;
+import static net.pms.database.DatabaseHelper.sqlQuote;
+import net.pms.dlna.DLNAMediaInfo;
+import net.pms.dlna.DLNAMediaVideoMetadata;
+import net.pms.util.APIUtils;
+import org.apache.commons.lang3.StringUtils;
+import static org.apache.commons.lang3.StringUtils.left;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is responsible for managing the Video Metadatas table. It
+ * does everything from creating, checking and upgrading the table to performing
+ * lookups, updates and inserts. All operations involving this table shall be
+ * done with this class.
+ */
+public class MediaTableVideoMetadatas extends MediaTable {
+	private static final Logger LOGGER = LoggerFactory.getLogger(MediaTableVideoMetadatas.class);
+	private static final String BASIC_COLUMNS = "IMDBID, MEDIA_YEAR, MOVIEORSHOWNAME, MOVIEORSHOWNAMESIMPLE, TVSEASON, TVEPISODENUMBER, TVEPISODENAME, ISTVEPISODE, EXTRAINFORMATION";
+	/**
+	 * The columns we added from TMDB in V11
+	 */
+	private static final String TMDB_COLUMNS = "BUDGET, CREDITS, EXTERNALIDS, HOMEPAGE, IMAGES, ORIGINALLANGUAGE, ORIGINALTITLE, PRODUCTIONCOMPANIES, PRODUCTIONCOUNTRIES, REVENUE";
+
+	public static final String TABLE_NAME = "VIDEO_METADATAS";
+	public static final String FILEID = TABLE_NAME + ".FILEID";
+	public static final String ISTVEPISODE = TABLE_NAME + ".ISTVEPISODE";
+	public static final String TVSEASON = TABLE_NAME + ".TVSEASON";
+	public static final String TVEPISODENUMBER = TABLE_NAME + ".TVEPISODENUMBER";
+	public static final String MOVIEORSHOWNAME = TABLE_NAME + ".MOVIEORSHOWNAME";
+	public static final String MEDIA_YEAR = TABLE_NAME + ".MEDIA_YEAR";
+
+	/**
+	 * Table version must be increased every time a change is done to the table
+	 * definition. Table upgrade SQL must also be added to
+	 * {@link #upgradeTable(Connection, int)}
+	 */
+	private static final int TABLE_VERSION = 1;
+	private static final int SIZE_IMDBID = 16;
+	private static final int SIZE_YEAR = 4;
+	private static final int SIZE_TVSEASON = 4;
+	private static final int SIZE_TVEPISODENUMBER = 8;
+
+	/**
+	 * Checks and creates or upgrades the table as needed.
+	 *
+	 * @param connection the {@link Connection} to use
+	 *
+	 * @throws SQLException
+	 */
+	protected static void checkTable(final Connection connection) throws SQLException {
+		if (tableExists(connection, TABLE_NAME)) {
+			Integer version = MediaTableTablesVersions.getTableVersion(connection, TABLE_NAME);
+			if (version == null) {
+				version = 1;
+			}
+			if (version < TABLE_VERSION) {
+				upgradeTable(connection, version);
+			} else if (version > TABLE_VERSION) {
+				LOGGER.warn(LOG_TABLE_NEWER_VERSION_DELETEDB, DATABASE_NAME, TABLE_NAME, DATABASE.getDatabaseFilename());
+			}
+		} else {
+			createTable(connection);
+			MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
+		}
+	}
+
+	private static void upgradeTable(Connection connection, Integer currentVersion) throws SQLException {
+		LOGGER.info(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, currentVersion, TABLE_VERSION);
+		for (int version = currentVersion; version < TABLE_VERSION; version++) {
+			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
+			switch (version) {
+				default:
+					throw new IllegalStateException(
+						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
+					);
+			}
+		}
+		try {
+			MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
+		} catch (SQLException e) {
+			LOGGER.error("Failed setting the table version of the {} for {}", TABLE_NAME, e.getMessage());
+			LOGGER.error("Please use the 'Reset the cache' button on the 'Navigation Settings' tab, close UMS and start it again.");
+			throw new SQLException(e);
+		}
+	}
+
+	private static void createTable(final Connection connection) throws SQLException {
+		LOGGER.debug(LOG_CREATING_TABLE, DATABASE_NAME, TABLE_NAME);
+		execute(connection,
+			"CREATE TABLE " + TABLE_NAME + " (" +
+				"FILEID                  INTEGER                              PRIMARY KEY , " +
+				"IMDBID                  VARCHAR(" + SIZE_IMDBID + ")                     , " +
+				"MEDIA_YEAR              VARCHAR(" + SIZE_YEAR + ")                       , " +
+				"MOVIEORSHOWNAME         VARCHAR(" + SIZE_MAX + ")                        , " +
+				"MOVIEORSHOWNAMESIMPLE   VARCHAR(" + SIZE_MAX + ")                        , " +
+				"TVSEASON                VARCHAR(" + SIZE_TVSEASON + ")                   , " +
+				"TVEPISODENUMBER         VARCHAR(" + SIZE_TVEPISODENUMBER + ")            , " +
+				"TVEPISODENAME           VARCHAR(" + SIZE_MAX + ")                        , " +
+				"ISTVEPISODE             BOOLEAN                                          , " +
+				"EXTRAINFORMATION        VARCHAR(" + SIZE_MAX + ")                        , " +
+				"API_VERSION             VARCHAR(" + SIZE_IMDBID + ")                     , " +
+				"BUDGET                  DOUBLE PRECISION                                 , " +
+				"CREDITS                 VARCHAR                                          , " +
+				"EXTERNALIDS             VARCHAR                                          , " +
+				"HOMEPAGE                VARCHAR                                          , " +
+				"IMAGES                  VARCHAR                                          , " +
+				"ORIGINALLANGUAGE        VARCHAR                                          , " +
+				"ORIGINALTITLE           VARCHAR                                          , " +
+				"PRODUCTIONCOMPANIES     VARCHAR                                          , " +
+				"PRODUCTIONCOUNTRIES     VARCHAR                                          , " +
+				"REVENUE                 VARCHAR                                          , " +
+				"FOREIGN KEY(FILEID) REFERENCES " + MediaTableFiles.TABLE_NAME + "(ID) ON DELETE CASCADE" +
+			")"
+		);
+	}
+
+	/**
+	 * Updates an existing row with information either extracted from the filename
+	 * or from our API.
+	 *
+	 * @param connection the db connection
+	 * @param fileId the file id from FILES table.
+	 * @param media the {@link DLNAMediaInfo} VideoMetadata row to update.
+	 * @param apiExtendedMetadata JsonObject from metadata
+	 * @throws SQLException if an SQL error occurs during the operation.
+	 */
+	protected static void insertOrUpdateVideoMetadata(final Connection connection, final long fileId, final DLNAMediaInfo media, final JsonObject apiExtendedMetadata) throws SQLException {
+		if (connection == null || fileId < 0 || media == null || !media.hasVideoMetadata()) {
+			return;
+		}
+		String columns = "FILEID, " + BASIC_COLUMNS;
+		if (apiExtendedMetadata != null) {
+			columns += ", API_VERSION, " + TMDB_COLUMNS;
+		}
+		DLNAMediaVideoMetadata videoMetadata = media.getVideoMetadata();
+		try (
+			PreparedStatement updateStatement = connection.prepareStatement(
+				"SELECT " + columns + " " +
+				"FROM " + TABLE_NAME + " " +
+				"WHERE " +
+					"FILEID = ?",
+				ResultSet.TYPE_FORWARD_ONLY,
+				ResultSet.CONCUR_UPDATABLE
+			);
+			PreparedStatement insertStatement = connection.prepareStatement(
+				"INSERT INTO " + TABLE_NAME + " (" + columns +	")" +
+				createDefaultValueForInsertStatement(columns)
+			);
+		) {
+			updateStatement.setLong(1, fileId);
+			try (ResultSet rs = updateStatement.executeQuery()) {
+				if (rs.next()) {
+					rs.updateString("IMDBID", left(videoMetadata.getIMDbID(), SIZE_IMDBID));
+					rs.updateString("MEDIA_YEAR", left(videoMetadata.getYear(), SIZE_YEAR));
+					rs.updateString("MOVIEORSHOWNAME", left(videoMetadata.getMovieOrShowName(), SIZE_MAX));
+					rs.updateString("MOVIEORSHOWNAMESIMPLE", left(videoMetadata.getSimplifiedMovieOrShowName(), SIZE_MAX));
+					rs.updateString("TVSEASON", left(videoMetadata.getTVSeason(), SIZE_TVSEASON));
+					rs.updateString("TVEPISODENUMBER", left(videoMetadata.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
+					rs.updateString("TVEPISODENAME", left(videoMetadata.getTVEpisodeName(), SIZE_MAX));
+					rs.updateBoolean("ISTVEPISODE", videoMetadata.isTVEpisode());
+					rs.updateString("EXTRAINFORMATION", left(videoMetadata.getExtraInformation(), SIZE_MAX));
+					if (apiExtendedMetadata != null) {
+						rs.updateString("API_VERSION", left(APIUtils.getApiDataVideoVersion(), SIZE_MAX));
+						if (apiExtendedMetadata.has("budget")) {
+							rs.updateDouble("BUDGET", apiExtendedMetadata.get("budget").getAsDouble());
+						}
+						if (apiExtendedMetadata.has("credits")) {
+							rs.updateString("CREDITS", apiExtendedMetadata.get("credits").toString());
+						}
+						if (apiExtendedMetadata.has("externalIDs")) {
+							rs.updateString("EXTERNALIDS", apiExtendedMetadata.get("externalIDs").toString());
+						}
+						rs.updateString("HOMEPAGE", APIUtils.getStringOrNull(apiExtendedMetadata, "homepage"));
+						if (apiExtendedMetadata.has("images")) {
+							rs.updateString("IMAGES", apiExtendedMetadata.get("images").toString());
+						}
+						rs.updateString("ORIGINALLANGUAGE", APIUtils.getStringOrNull(apiExtendedMetadata, "originalLanguage"));
+						rs.updateString("ORIGINALTITLE", APIUtils.getStringOrNull(apiExtendedMetadata, "originalTitle"));
+						if (apiExtendedMetadata.has("productionCompanies")) {
+							rs.updateString("PRODUCTIONCOMPANIES", apiExtendedMetadata.get("productionCompanies").toString());
+						}
+						if (apiExtendedMetadata.has("productionCountries")) {
+							rs.updateString("PRODUCTIONCOUNTRIES", apiExtendedMetadata.get("productionCountries").toString());
+						}
+						rs.updateString("REVENUE", APIUtils.getStringOrNull(apiExtendedMetadata, "revenue"));
+					}
+					rs.updateRow();
+				} else {
+					insertStatement.clearParameters();
+					int databaseColumnIterator = 0;
+					insertStatement.setLong(++databaseColumnIterator, fileId);
+					insertStatement.setString(++databaseColumnIterator, left(videoMetadata.getIMDbID(), SIZE_IMDBID));
+					insertStatement.setString(++databaseColumnIterator, left(videoMetadata.getYear(), SIZE_YEAR));
+					insertStatement.setString(++databaseColumnIterator, left(videoMetadata.getMovieOrShowName(), SIZE_MAX));
+					insertStatement.setString(++databaseColumnIterator, left(videoMetadata.getSimplifiedMovieOrShowName(), SIZE_MAX));
+					insertStatement.setString(++databaseColumnIterator, left(videoMetadata.getTVSeason(), SIZE_TVSEASON));
+					insertStatement.setString(++databaseColumnIterator, left(videoMetadata.getTVEpisodeNumber(), SIZE_TVEPISODENUMBER));
+					insertStatement.setString(++databaseColumnIterator, left(videoMetadata.getTVEpisodeName(), SIZE_MAX));
+					insertStatement.setBoolean(++databaseColumnIterator, videoMetadata.isTVEpisode());
+					insertStatement.setString(++databaseColumnIterator, left(videoMetadata.getExtraInformation(), SIZE_MAX));
+					if (apiExtendedMetadata != null) {
+						insertStatement.setString(++databaseColumnIterator, left(APIUtils.getApiDataVideoVersion(), SIZE_MAX));
+						if (apiExtendedMetadata.has("budget")) {
+							insertStatement.setDouble(++databaseColumnIterator, apiExtendedMetadata.get("budget").getAsDouble());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.DOUBLE);
+						}
+						if (apiExtendedMetadata.has("credits")) {
+							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("credits").toString());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
+						if (apiExtendedMetadata.has("externalIDs")) {
+							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("externalIDs").toString());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
+						if (apiExtendedMetadata.has("homepage")) {
+							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("homepage").getAsString());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
+						if (apiExtendedMetadata.has("images")) {
+							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("images").toString());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
+						if (apiExtendedMetadata.has("originalLanguage")) {
+							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("originalLanguage").getAsString());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
+						if (apiExtendedMetadata.has("originalTitle")) {
+							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("originalTitle").getAsString());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
+						if (apiExtendedMetadata.has("productionCompanies")) {
+							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("productionCompanies").toString());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
+						if (apiExtendedMetadata.has("productionCountries")) {
+							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("productionCountries").toString());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
+						if (apiExtendedMetadata.has("revenue")) {
+							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("revenue").getAsString());
+						} else {
+							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
+						}
+					}
+					insertStatement.executeUpdate();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Updates an existing row with information either extracted from the filename
+	 * or from our API.
+	 *
+	 * @param connection the db connection
+	 * @param path the full path of the media.
+	 * @param modified the current {@code lastModified} value of the media file.
+	 * @param media the {@link DLNAMediaInfo} row to update.
+	 * @param apiExtendedMetadata JsonObject from metadata
+	 * @throws SQLException if an SQL error occurs during the operation.
+	 */
+	public static void insertVideoMetadata(final Connection connection, String path, long modified, DLNAMediaInfo media, final JsonObject apiExtendedMetadata) throws SQLException {
+		if (StringUtils.isBlank(path)) {
+			LOGGER.warn("Couldn't write metadata for \"{}\" to the database because the media cannot be identified", path);
+			return;
+		}
+		if (media == null) {
+			LOGGER.warn("Couldn't write metadata for \"{}\" to the database because there is no media information", path);
+			return;
+		}
+
+		int fileId = MediaTableFiles.getFileId(connection, path, modified);
+		if (fileId < 0) {
+			LOGGER.trace("Couldn't find \"{}\" in the database when trying to store metadata", path);
+		} else {
+			insertOrUpdateVideoMetadata(connection, fileId, media, apiExtendedMetadata);
+		}
+	}
+
+	public static DLNAMediaVideoMetadata getVideoMetadataByFileId(Connection connection, long fileId) {
+		if (connection == null || fileId < 0) {
+			return null;
+		}
+		try (PreparedStatement selectStatement = connection.prepareStatement("SELECT * FROM " + TABLE_NAME + " WHERE FILEID = ?")) {
+			selectStatement.setLong(1, fileId);
+			try (ResultSet rs = selectStatement.executeQuery()) {
+				if (rs.next()) {
+					DLNAMediaVideoMetadata videoMetadata = new DLNAMediaVideoMetadata();
+					videoMetadata.setIMDbID(rs.getString("IMDBID"));
+					videoMetadata.setYear(rs.getString("MEDIA_YEAR"));
+					videoMetadata.setMovieOrShowName(rs.getString("MOVIEORSHOWNAME"));
+					videoMetadata.setSimplifiedMovieOrShowName(rs.getString("MOVIEORSHOWNAMESIMPLE"));
+					videoMetadata.setExtraInformation(rs.getString("EXTRAINFORMATION"));
+
+					if (rs.getBoolean("ISTVEPISODE")) {
+						videoMetadata.setTVSeason(rs.getString("TVSEASON"));
+						videoMetadata.setTVEpisodeNumber(rs.getString("TVEPISODENUMBER"));
+						videoMetadata.setTVEpisodeName(rs.getString("TVEPISODENAME"));
+						videoMetadata.setIsTVEpisode(true);
+						// Fields from TV Series table
+						videoMetadata.setTVSeriesStartYear(MediaTableTVSeries.getStartYearBySimplifiedTitle(connection, videoMetadata.getSimplifiedMovieOrShowName()));
+					} else {
+						videoMetadata.setIsTVEpisode(false);
+					}
+				}
+			}
+		} catch (SQLException ex) {
+			LOGGER.error(
+				LOG_ERROR_WHILE_IN_FOR,
+				DATABASE_NAME,
+				"reading",
+				TABLE_NAME,
+				fileId,
+				ex.getMessage()
+			);
+			LOGGER.trace("", ex);
+		}
+		return null;
+	}
+
+	/**
+	 * Checks whether the latest data from our API has been written to the
+	 * database for this video.
+	 * If we could not fetch the latest version from the API, it will check
+	 * whether any version exists in the database.
+	 *
+	 * @param connection the db connection
+	 * @param name the full path of the video.
+	 * @param modified the current {@code lastModified} value of the media file.
+	 * @return whether the latest API metadata exists for this video.
+	 */
+	public static boolean doesLatestApiMetadataExist(final Connection connection, String name, long modified) {
+		StringBuilder sql = new StringBuilder();
+		sql.append("SELECT FILEID FROM ").append(TABLE_NAME);
+		sql.append(" LEFT JOIN ").append(MediaTableFiles.TABLE_NAME);
+		sql.append(" ON ").append(TABLE_NAME).append(".FILEID").append("=");
+		sql.append(MediaTableFiles.TABLE_NAME).append(".ID");
+		sql.append(" WHERE FILENAME = ? AND MODIFIED = ?");
+		String latestVersion = null;
+		if (CONFIGURATION.getExternalNetwork()) {
+			latestVersion = APIUtils.getApiDataVideoVersion();
+			if (latestVersion != null) {
+				sql.append(" AND API_VERSION = ?");
+			}
+		}
+		sql.append(" AND ").append(TABLE_NAME).append(".IMDBID IS NOT NULL LIMIT 1");
+
+		try {
+			try (PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+				statement.setString(1, name);
+				statement.setTimestamp(2, new Timestamp(modified));
+				if (latestVersion != null) {
+					statement.setString(3, latestVersion);
+				}
+				try (ResultSet resultSet = statement.executeQuery()) {
+					if (resultSet.next()) {
+						return true;
+					}
+				}
+			}
+		} catch (SQLException se) {
+			LOGGER.error(LOG_ERROR_WHILE_IN_FOR, DATABASE_NAME, "checking if API metadata exists for", TABLE_NAME, name, se.getMessage());
+			LOGGER.trace("", se);
+		}
+
+		return false;
+	}
+
+
+	/**
+	 * Updates the name of a movie or TV series for existing entries in the database.
+	 *
+	 * @param connection the db connection
+	 * @param oldName the existing movie or show name.
+	 * @param newName the new movie or show name.
+	 */
+	public static void updateMovieOrShowName(final Connection connection, String oldName, String newName) {
+		try {
+			updateRowsInTable(connection, oldName, newName, "MOVIEORSHOWNAME", SIZE_MAX, true);
+		} catch (SQLException e) {
+			LOGGER.error(
+				"Failed to update MOVIEORSHOWNAME from \"{}\" to \"{}\": {}",
+				oldName,
+				newName,
+				e.getMessage()
+			);
+			LOGGER.trace("", e);
+		}
+	}
+
+	/**
+	 * Updates a row or rows in the table.
+	 *
+	 * @param connection the db connection
+	 * @param oldValue the value to match, can be {@code null}.
+	 * @param newValue the value to store, can be {@code null}.
+	 * @param columnName the column to update.
+	 * @param size the maximum size of the data if {@code isString} is
+	 *            {@code true}.
+	 * @param isString whether or not the value is a SQL char/string and should
+	 *            be quoted and length limited.
+	 * @throws SQLException if an SQL error occurs during the operation.
+	 */
+	private static void updateRowsInTable(final Connection connection, String oldValue, String newValue, String columnName, int size, boolean isString) throws SQLException {
+		if (isString && size < 1) {
+			throw new IllegalArgumentException("size must be positive");
+		}
+		if (StringUtils.isEmpty(columnName)) {
+			LOGGER.error("Couldn't update rows in " + TABLE_NAME + " table because columnName is blank");
+			return;
+		}
+
+		// Sanitize values
+		oldValue = isString ? sqlQuote(oldValue) : sqlEscape(oldValue);
+		newValue = isString ? sqlQuote(newValue) : sqlEscape(newValue);
+
+		LOGGER.trace(
+			"Updating rows in " + TABLE_NAME + " table from \"{}\" to \"{}\" in column {}",
+			oldValue,
+			newValue,
+			columnName
+		);
+		try (Statement statement = connection.createStatement()) {
+			int rows = statement.executeUpdate(
+				"UPDATE " + TABLE_NAME + " SET " +
+					columnName +  " = " + (newValue == null ? "NULL" : (isString ? left(newValue, size) : newValue)) +
+				" WHERE " +
+					columnName + (oldValue == null ? " IS NULL" : " = " + (isString ? left(oldValue, size) : oldValue))
+			);
+			LOGGER.trace("Updated {} rows in " + TABLE_NAME + " table", rows);
+		}
+	}
+
+
+}

--- a/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
@@ -423,8 +423,6 @@ public class MediaTableVideoMetadatas extends MediaTable {
 					if (rs.next()) {
 						JsonObject result = new JsonObject();
 						result.addProperty("imdbID", rs.getString(COL_IMDBID));
-						//credits, genres, ratings and some other columns was not well saved by the api (not json).
-						//we should delete the IMDB or set this file to be parsed again at read end if a parse fail occurs.
 						addJsonElementToJsonObjectIfExists(result, "credits", rs.getString("CREDITS"));
 						addJsonElementToJsonObjectIfExists(result, "externalIDs", rs.getString("EXTERNALIDS"));
 						result.addProperty("homepage", rs.getString("HOMEPAGE"));
@@ -458,16 +456,14 @@ public class MediaTableVideoMetadatas extends MediaTable {
 		return null;
 	}
 
-	private static boolean addJsonElementToJsonObjectIfExists(final JsonObject dest, final String property, final String jsonString) {
+	private static void addJsonElementToJsonObjectIfExists(final JsonObject dest, final String property, final String jsonString) {
 		if (StringUtils.isEmpty(jsonString)) {
-			return true;
+			return;
 		}
 		try {
 			JsonElement element = GSON.fromJson(jsonString, JsonElement.class);
 			dest.add(property, element);
-			return true;
 		} catch (JsonSyntaxException e) {
-			return false;
 		}
 	}
 

--- a/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadatas.java
@@ -62,7 +62,17 @@ public class MediaTableVideoMetadatas extends MediaTable {
 	/**
 	 * The columns we added from TMDB in V11
 	 */
-	private static final String TMDB_COLUMNS = "BUDGET, CREDITS, EXTERNALIDS, HOMEPAGE, IMAGES, ORIGINALLANGUAGE, ORIGINALTITLE, PRODUCTIONCOMPANIES, PRODUCTIONCOUNTRIES, REVENUE";
+	private static final String COL_BUDGET = "BUDGET";
+	private static final String COL_CREDITS = "CREDITS";
+	private static final String COL_EXTERNALIDS = "EXTERNALIDS";
+	private static final String COL_HOMEPAGE = "HOMEPAGE";
+	private static final String COL_IMAGES = "IMAGES";
+	private static final String COL_ORIGINALLANGUAGE = "ORIGINALLANGUAGE";
+	private static final String COL_ORIGINALTITLE = "ORIGINALTITLE";
+	private static final String COL_PRODUCTIONCOMPANIES = "PRODUCTIONCOMPANIES";
+	private static final String COL_PRODUCTIONCOUNTRIES = "PRODUCTIONCOUNTRIES";
+	private static final String COL_REVENUE = "REVENUE";
+	private static final String TMDB_COLUMNS = COL_BUDGET + ", " + COL_CREDITS + ", " + COL_EXTERNALIDS + ", " + COL_HOMEPAGE + ", " + COL_IMAGES + ", " + COL_ORIGINALLANGUAGE + ", " + COL_ORIGINALTITLE + ", " + COL_PRODUCTIONCOMPANIES + ", " + COL_PRODUCTIONCOUNTRIES + ", " + COL_REVENUE;
 
 	/**
 	 * COLUMNS with table name
@@ -90,7 +100,7 @@ public class MediaTableVideoMetadatas extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 1;
+	private static final int TABLE_VERSION = 2;
 	private static final int SIZE_IMDBID = 16;
 	private static final int SIZE_YEAR = 4;
 	private static final int SIZE_TVSEASON = 4;
@@ -125,6 +135,10 @@ public class MediaTableVideoMetadatas extends MediaTable {
 		for (int version = currentVersion; version < TABLE_VERSION; version++) {
 			LOGGER.trace(LOG_UPGRADING_TABLE, DATABASE_NAME, TABLE_NAME, version, version + 1);
 			switch (version) {
+				case 1:
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_BUDGET + " SET DATA TYPE BIGINT");
+					executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ALTER COLUMN IF EXISTS " + COL_REVENUE + " SET DATA TYPE BIGINT");
+					break;
 				default:
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -155,7 +169,7 @@ public class MediaTableVideoMetadatas extends MediaTable {
 				"ISTVEPISODE             BOOLEAN                                          , " +
 				"EXTRAINFORMATION        VARCHAR(" + SIZE_MAX + ")                        , " +
 				"API_VERSION             VARCHAR(" + SIZE_IMDBID + ")                     , " +
-				"BUDGET                  INTEGER                                          , " +
+				"BUDGET                  BIGINT                                           , " +
 				"CREDITS                 CLOB                                             , " +
 				"EXTERNALIDS             CLOB                                             , " +
 				"HOMEPAGE                VARCHAR                                          , " +
@@ -164,7 +178,7 @@ public class MediaTableVideoMetadatas extends MediaTable {
 				"ORIGINALTITLE           VARCHAR                                          , " +
 				"PRODUCTIONCOMPANIES     CLOB                                             , " +
 				"PRODUCTIONCOUNTRIES     CLOB                                             , " +
-				"REVENUE                 INTEGER                                          , " +
+				"REVENUE                 BIGINT                                           , " +
 				"CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY(" + COL_FILEID + ") REFERENCES " + MediaTableFiles.TABLE_NAME + "(" + MediaTableFiles.COL_ID + ") ON DELETE CASCADE" +
 			")"
 		);
@@ -220,28 +234,28 @@ public class MediaTableVideoMetadatas extends MediaTable {
 					if (apiExtendedMetadata != null) {
 						rs.updateString(COL_API_VERSION, StringUtils.left(APIUtils.getApiDataVideoVersion(), SIZE_IMDBID));
 						if (apiExtendedMetadata.has("budget")) {
-							rs.updateInt("BUDGET", apiExtendedMetadata.get("budget").getAsInt());
+							rs.updateLong(COL_BUDGET, apiExtendedMetadata.get("budget").getAsLong());
 						}
 						if (apiExtendedMetadata.has("credits")) {
-							rs.updateString("CREDITS", apiExtendedMetadata.get("credits").toString());
+							rs.updateString(COL_CREDITS, apiExtendedMetadata.get("credits").toString());
 						}
 						if (apiExtendedMetadata.has("externalIDs")) {
-							rs.updateString("EXTERNALIDS", apiExtendedMetadata.get("externalIDs").toString());
+							rs.updateString(COL_EXTERNALIDS, apiExtendedMetadata.get("externalIDs").toString());
 						}
-						rs.updateString("HOMEPAGE", APIUtils.getStringOrNull(apiExtendedMetadata, "homepage"));
+						rs.updateString(COL_HOMEPAGE, APIUtils.getStringOrNull(apiExtendedMetadata, "homepage"));
 						if (apiExtendedMetadata.has("images")) {
-							rs.updateString("IMAGES", apiExtendedMetadata.get("images").toString());
+							rs.updateString(COL_IMAGES, apiExtendedMetadata.get("images").toString());
 						}
-						rs.updateString("ORIGINALLANGUAGE", APIUtils.getStringOrNull(apiExtendedMetadata, "originalLanguage"));
-						rs.updateString("ORIGINALTITLE", APIUtils.getStringOrNull(apiExtendedMetadata, "originalTitle"));
+						rs.updateString(COL_ORIGINALLANGUAGE, APIUtils.getStringOrNull(apiExtendedMetadata, "originalLanguage"));
+						rs.updateString(COL_ORIGINALTITLE, APIUtils.getStringOrNull(apiExtendedMetadata, "originalTitle"));
 						if (apiExtendedMetadata.has("productionCompanies")) {
-							rs.updateString("PRODUCTIONCOMPANIES", apiExtendedMetadata.get("productionCompanies").toString());
+							rs.updateString(COL_PRODUCTIONCOMPANIES, apiExtendedMetadata.get("productionCompanies").toString());
 						}
 						if (apiExtendedMetadata.has("productionCountries")) {
-							rs.updateString("PRODUCTIONCOUNTRIES", apiExtendedMetadata.get("productionCountries").toString());
+							rs.updateString(COL_PRODUCTIONCOUNTRIES, apiExtendedMetadata.get("productionCountries").toString());
 						}
 						if (apiExtendedMetadata.has("revenue")) {
-							rs.updateInt("REVENUE", apiExtendedMetadata.get("revenue").getAsInt());
+							rs.updateLong("REVENUE", apiExtendedMetadata.get("revenue").getAsLong());
 						}
 					}
 					rs.updateRow();
@@ -261,9 +275,9 @@ public class MediaTableVideoMetadatas extends MediaTable {
 					if (apiExtendedMetadata != null) {
 						insertStatement.setString(++databaseColumnIterator, StringUtils.left(APIUtils.getApiDataVideoVersion(), SIZE_IMDBID));
 						if (apiExtendedMetadata.has("budget")) {
-							insertStatement.setInt(++databaseColumnIterator, apiExtendedMetadata.get("budget").getAsInt());
+							insertStatement.setLong(++databaseColumnIterator, apiExtendedMetadata.get("budget").getAsLong());
 						} else {
-							insertStatement.setNull(++databaseColumnIterator, Types.INTEGER);
+							insertStatement.setNull(++databaseColumnIterator, Types.BIGINT);
 						}
 						if (apiExtendedMetadata.has("credits")) {
 							insertStatement.setString(++databaseColumnIterator, apiExtendedMetadata.get("credits").toString());
@@ -306,9 +320,9 @@ public class MediaTableVideoMetadatas extends MediaTable {
 							insertStatement.setNull(++databaseColumnIterator, Types.VARCHAR);
 						}
 						if (apiExtendedMetadata.has("revenue")) {
-							insertStatement.setInt(++databaseColumnIterator, apiExtendedMetadata.get("revenue").getAsInt());
+							insertStatement.setLong(++databaseColumnIterator, apiExtendedMetadata.get("revenue").getAsLong());
 						} else {
-							insertStatement.setNull(++databaseColumnIterator, Types.INTEGER);
+							insertStatement.setNull(++databaseColumnIterator, Types.BIGINT);
 						}
 					}
 					insertStatement.executeUpdate();
@@ -423,10 +437,10 @@ public class MediaTableVideoMetadatas extends MediaTable {
 					if (rs.next()) {
 						JsonObject result = new JsonObject();
 						result.addProperty("imdbID", rs.getString(COL_IMDBID));
-						addJsonElementToJsonObjectIfExists(result, "credits", rs.getString("CREDITS"));
-						addJsonElementToJsonObjectIfExists(result, "externalIDs", rs.getString("EXTERNALIDS"));
-						result.addProperty("homepage", rs.getString("HOMEPAGE"));
-						addJsonElementToJsonObjectIfExists(result, "images", rs.getString("IMAGES"));
+						addJsonElementToJsonObjectIfExists(result, "credits", rs.getString(COL_CREDITS));
+						addJsonElementToJsonObjectIfExists(result, "externalIDs", rs.getString(COL_EXTERNALIDS));
+						result.addProperty("homepage", rs.getString(COL_HOMEPAGE));
+						addJsonElementToJsonObjectIfExists(result, "images", rs.getString(COL_IMAGES));
 						result.add("actors", MediaTableVideoMetadataActors.getJsonArrayForFile(connection, fileId));
 						result.addProperty("award", MediaTableVideoMetadataAwards.getValueForFile(connection, fileId));
 						result.add("countries", MediaTableVideoMetadataCountries.getJsonArrayForFile(connection, fileId));
@@ -438,8 +452,8 @@ public class MediaTableVideoMetadatas extends MediaTable {
 						result.addProperty("rated", MediaTableVideoMetadataRated.getValueForFile(connection, fileId));
 						result.add("ratings", MediaTableVideoMetadataRatings.getJsonArrayForFile(connection, fileId));
 						result.addProperty("released", MediaTableVideoMetadataReleased.getValueForFile(connection, fileId));
-						if (rs.getBoolean("ISTVEPISODE")) {
-							String showName = rs.getString("MOVIEORSHOWNAME");
+						if (rs.getBoolean(COL_ISTVEPISODE)) {
+							String showName = rs.getString(COL_MOVIEORSHOWNAME);
 							if (StringUtils.isNotBlank(showName)) {
 								addJsonElementToJsonObjectIfExists(result, "seriesImages", MediaTableTVSeries.getImagesByTitle(connection, showName));
 							}
@@ -529,7 +543,7 @@ public class MediaTableVideoMetadatas extends MediaTable {
 	 */
 	public static void updateMovieOrShowName(final Connection connection, String oldName, String newName) {
 		try {
-			updateRowsInTable(connection, oldName, newName, "MOVIEORSHOWNAME", SIZE_MAX, true);
+			updateRowsInTable(connection, oldName, newName, COL_MOVIEORSHOWNAME, SIZE_MAX, true);
 		} catch (SQLException e) {
 			LOGGER.error(
 				"Failed to update MOVIEORSHOWNAME from \"{}\" to \"{}\": {}",

--- a/src/main/java/net/pms/dlna/DLNAImage.java
+++ b/src/main/java/net/pms/dlna/DLNAImage.java
@@ -17,15 +17,12 @@
  */
 package net.pms.dlna;
 
+import com.drew.metadata.Metadata;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.drew.metadata.Metadata;
 import net.pms.dlna.DLNAImageProfile.DLNAComplianceResult;
 import net.pms.image.Image;
 import net.pms.image.ImageFormat;
@@ -33,6 +30,9 @@ import net.pms.image.ImageInfo;
 import net.pms.image.ImagesUtil;
 import net.pms.image.ImagesUtil.ScaleType;
 import net.pms.util.ParseException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is simply a byte array for holding an {@link ImageIO} supported
@@ -68,7 +68,7 @@ public class DLNAImage extends Image {
 		boolean copy
 	) throws DLNAProfileException {
 		super(image, copy);
-		this.profile = profile != null ? profile : findMatchingProfile(this instanceof DLNAThumbnail);
+		this.profile = profile != null ? profile : findMatchingProfile(imageInfo, this instanceof DLNAThumbnail);
 		if (this.profile == null) {
 			throw new NullPointerException("DLNAImage: profile cannot be null");
 		}
@@ -94,7 +94,7 @@ public class DLNAImage extends Image {
 		boolean copy
 	) throws DLNAProfileException {
 		super(bytes, imageInfo, copy);
-		this.profile = profile != null ? profile : findMatchingProfile(this instanceof DLNAThumbnail);
+		this.profile = profile != null ? profile : findMatchingProfile(imageInfo, this instanceof DLNAThumbnail);
 		if (this.profile == null) {
 			throw new NullPointerException("DLNAImage: profile cannot be null");
 		}
@@ -129,7 +129,7 @@ public class DLNAImage extends Image {
 		boolean copy
 	) throws DLNAProfileException, ParseException {
 		super(bytes, width, height, format, colorModel, metadata, true, copy);
-		this.profile = profile != null ? profile : findMatchingProfile(this instanceof DLNAThumbnail);
+		this.profile = profile != null ? profile : findMatchingProfile(imageInfo, this instanceof DLNAThumbnail);
 		if (this.profile == null) {
 			throw new NullPointerException("DLNAImage: profile cannot be null");
 		}
@@ -162,11 +162,100 @@ public class DLNAImage extends Image {
 		boolean copy
 	) throws DLNAProfileException, ParseException {
 		super(bytes, format, bufferedImage, metadata, copy);
-		this.profile = profile != null ? profile : findMatchingProfile(this instanceof DLNAThumbnail);
+		this.profile = profile != null ? profile : findMatchingProfile(imageInfo, this instanceof DLNAThumbnail);
 		if (this.profile == null) {
 			throw new NullPointerException("DLNAImage: profile cannot be null");
 		}
 		checkCompliance();
+	}
+
+	/**
+	 * Verifies that this {@link DLNAImage} is DLNA compliant.
+	 *
+	 * @throws DLNAProfileException If non-compliance is found.
+	 */
+	private void checkCompliance() throws DLNAProfileException {
+		DLNAComplianceResult result = profile.checkCompliance(imageInfo);
+		if (result.isAllCorrect()) {
+			return;
+		}
+		StringBuilder sb = new StringBuilder(150);
+		sb.append(this.getClass().getSimpleName()).
+			append(": Compliance check failed for ").append(profile);
+
+		List<String> failures = result.getFailures();
+		if (!failures.isEmpty()) {
+			if (LOGGER.isDebugEnabled()) {
+				sb.append(" with the following failures:\n").
+				append(StringUtils.join(failures, "\n"));
+			} else {
+				sb.append(" for: ").
+				append(StringUtils.join(failures, ", "));
+			}
+		}
+		throw new DLNAProfileException(sb.toString());
+	}
+
+	/**
+	 * Attempts to find a matching {@link DLNAImageProfile} based on this
+	 * {@link DLNAImage}'s {@link ImageInfo} instance.
+	 *
+	 * @param imageInfo information about the given image
+	 * @param dlnaThumbnail if {@code true} restricts the profile search to
+	 *            valid thumbnail profiles.
+	 * @return The matching {@link DLNAImageProfile} or {@code null} if no match
+	 *         was found.
+	 */
+	private static DLNAImageProfile findMatchingProfile(ImageInfo imageInfo, boolean dlnaThumbnail) {
+		if (
+			imageInfo == null || imageInfo.getFormat() == null ||
+			imageInfo.getWidth() < 1 || imageInfo.getHeight() < 1
+		) {
+			return null;
+		}
+		DLNAComplianceResult result;
+		switch (imageInfo.getFormat()) {
+			case GIF:
+				if (dlnaThumbnail) {
+					return null;
+				}
+				if (DLNAImageProfile.GIF_LRG.checkCompliance(imageInfo).isAllCorrect()) {
+					return DLNAImageProfile.GIF_LRG;
+				}
+				return null;
+			case JPEG:
+				result = DLNAImageProfile.JPEG_TN.checkCompliance(imageInfo);
+				if (result.isAllCorrect()) {
+					return DLNAImageProfile.JPEG_TN;
+				} else if (result.isColorsCorrect() && result.isFormatCorrect()) {
+					if (DLNAImageProfile.JPEG_SM.isResolutionCorrect(imageInfo)) {
+						return DLNAImageProfile.JPEG_SM;
+					}
+					if (DLNAImageProfile.JPEG_MED.isResolutionCorrect(imageInfo)) {
+						return DLNAImageProfile.JPEG_MED;
+					}
+					if (DLNAImageProfile.JPEG_LRG.isResolutionCorrect(imageInfo)) {
+						return DLNAImageProfile.JPEG_LRG;
+					}
+					return DLNAImageProfile.createJPEG_RES_H_V(imageInfo.getWidth(), imageInfo.getHeight());
+				}
+				return null;
+			case PNG:
+				result = DLNAImageProfile.PNG_TN.checkCompliance(imageInfo);
+				if (result.isAllCorrect()) {
+					return DLNAImageProfile.PNG_TN;
+				} else if (
+					result.isColorsCorrect() &&
+					result.isFormatCorrect() &&
+					DLNAImageProfile.PNG_LRG.isResolutionCorrect(imageInfo)
+				) {
+					return DLNAImageProfile.PNG_LRG;
+				}
+				return null;
+			default:
+
+		}
+		return null;
 	}
 
 	/**
@@ -464,37 +553,6 @@ public class DLNAImage extends Image {
 	}
 
 	/**
-	 * Converts and scales the image according to the given
-	 * {@link DLNAImageProfile}. Preserves aspect ratio. Format support is
-	 * limited to that of {@link ImageIO}.
-	 *
-	 * @param outputProfile the {@link DLNAImageProfile} to adhere to for the
-	 *                      output.
-	 * @param dlnaThumbnail whether or not the output image should be
-	 *                      restricted to DLNA thumbnail compliance. This also
-	 *                      means that the output can be safely cast to
-	 *                      {@link DLNAThumbnail}.
-	 * @param padToSize Whether padding should be used if source aspect doesn't
-	 *                  match target aspect.
-	 * @return The scaled and/or converted thumbnail, {@code null} if the
-	 *         source is {@code null}.
-	 * @exception IOException if the operation fails.
-	 */
-	public DLNAImage transcode(
-		DLNAImageProfile outputProfile,
-		boolean dlnaThumbnail,
-		boolean padToSize
-	) throws IOException {
-		return (DLNAImage) ImagesUtil.transcodeImage(
-			this,
-			outputProfile,
-			dlnaThumbnail,
-			padToSize,
-			null
-		);
-	}
-
-	/**
 	 * @return The {@link DLNAImageProfile} this {@link DLNAImage} adheres to.
 	 */
 	public DLNAImageProfile getDLNAImageProfile() {
@@ -513,98 +571,11 @@ public class DLNAImage extends Image {
 		}
 	}
 
-	/**
-	 * Attempts to find a matching {@link DLNAImageProfile} based on this
-	 * {@link DLNAImage}'s {@link ImageInfo} instance.
-	 *
-	 * @param dlnaThumbnail if {@code true} restricts the profile search to
-	 *            valid thumbnail profiles.
-	 * @return The matching {@link DLNAImageProfile} or {@code null} if no match
-	 *         was found.
-	 */
-	protected DLNAImageProfile findMatchingProfile(boolean dlnaThumbnail) {
-		if (
-			imageInfo == null || imageInfo.getFormat() == null ||
-			imageInfo.getWidth() < 1 || imageInfo.getHeight() < 1
-		) {
-			return null;
-		}
-		DLNAComplianceResult result;
-		switch (imageInfo.getFormat()) {
-			case GIF:
-				if (dlnaThumbnail) {
-					return null;
-				}
-				if (DLNAImageProfile.GIF_LRG.checkCompliance(imageInfo).isAllCorrect()) {
-					return DLNAImageProfile.GIF_LRG;
-				}
-				return null;
-			case JPEG:
-				result = DLNAImageProfile.JPEG_TN.checkCompliance(imageInfo);
-				if (result.isAllCorrect()) {
-					return DLNAImageProfile.JPEG_TN;
-				} else if (result.isColorsCorrect() && result.isFormatCorrect()) {
-					if (DLNAImageProfile.JPEG_SM.isResolutionCorrect(imageInfo)) {
-						return DLNAImageProfile.JPEG_SM;
-					}
-					if (DLNAImageProfile.JPEG_MED.isResolutionCorrect(imageInfo)) {
-						return DLNAImageProfile.JPEG_MED;
-					}
-					if (DLNAImageProfile.JPEG_LRG.isResolutionCorrect(imageInfo)) {
-						return DLNAImageProfile.JPEG_LRG;
-					}
-					return DLNAImageProfile.createJPEG_RES_H_V(imageInfo.getWidth(), imageInfo.getHeight());
-				}
-				return null;
-			case PNG:
-				result = DLNAImageProfile.PNG_TN.checkCompliance(imageInfo);
-				if (result.isAllCorrect()) {
-					return DLNAImageProfile.PNG_TN;
-				} else if (
-					result.isColorsCorrect() &&
-					result.isFormatCorrect() &&
-					DLNAImageProfile.PNG_LRG.isResolutionCorrect(imageInfo)
-				) {
-					return DLNAImageProfile.PNG_LRG;
-				}
-				return null;
-			default:
-
-		}
-		return null;
-	}
-
-	/**
-	 * Verifies that this {@link DLNAImage} is DLNA compliant.
-	 *
-	 * @throws DLNAProfileException If non-compliance is found.
-	 */
-	protected void checkCompliance() throws DLNAProfileException {
-		DLNAComplianceResult result = profile.checkCompliance(imageInfo);
-		if (result.isAllCorrect()) {
-			return;
-		}
-		StringBuilder sb = new StringBuilder(150);
-		sb.append(this.getClass().getSimpleName()).
-			append(": Compliance check failed for ").append(profile);
-
-		List<String> failures = result.getFailures();
-		if (!failures.isEmpty()) {
-			if (LOGGER.isDebugEnabled()) {
-				sb.append(" with the following failures:\n").
-				append(StringUtils.join(failures, "\n"));
-			} else {
-				sb.append(" for: ").
-				append(StringUtils.join(failures, ", "));
-			}
-		}
-		throw new DLNAProfileException(sb.toString());
-	}
-
 	@Override
 	protected void buildToString(StringBuilder sb) {
 		if (profile != null) {
 			sb.append(", DLNA Profile = ").append(profile);
 		}
 	}
+
 }

--- a/src/main/java/net/pms/dlna/DLNAImageInputStream.java
+++ b/src/main/java/net/pms/dlna/DLNAImageInputStream.java
@@ -17,16 +17,11 @@
  */
 package net.pms.dlna;
 
-import java.awt.color.ColorSpace;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import net.pms.image.BufferedImageFilterChain;
-import net.pms.image.ColorSpaceType;
 import net.pms.image.ImageFormat;
 import net.pms.image.ImageInfo;
-import net.pms.image.ImagesUtil;
 import net.pms.image.ImagesUtil.ScaleType;
 
 /**
@@ -41,6 +36,21 @@ public class DLNAImageInputStream extends ByteArrayInputStream {
 
 	/** The {@link DLNAImageProfile} for this {@link DLNAImageInputStream} */
 	protected final DLNAImageProfile profile;
+
+	/**
+	 * Don't call this from outside this class or subclass, use
+	 * {@link DLNAImageInputStream#toImageInputStream(DLNAImage)}
+	 * which handles {@code null} input.
+	 *
+	 * @param image the input image
+	 *
+	 * @throws NullPointerException if {@code image} is {@code null}.
+	 */
+	protected DLNAImageInputStream(DLNAImage image) {
+		super(image.getBytes(false));
+		this.imageInfo = image.getImageInfo();
+		this.profile = image.getDLNAImageProfile();
+	}
 
 	/**
 	 * Creates a {@link DLNAImageInputStream} where it uses
@@ -230,169 +240,6 @@ public class DLNAImageInputStream extends ByteArrayInputStream {
 		return image != null ? new DLNAImageInputStream(image) : null;
 	}
 
-	/**
-	 * Don't call this from outside this class or subclass, use
-	 * {@link DLNAImageInputStream#toImageInputStream(DLNAImage)}
-	 * which handles {@code null} input.
-	 *
-	 * @param image the input image
-	 *
-	 * @throws NullPointerException if {@code image} is {@code null}.
-	 */
-	protected DLNAImageInputStream(DLNAImage image) {
-		super(image.getBytes(false));
-		this.imageInfo = image.getImageInfo();
-		this.profile = image.getDLNAImageProfile();
-	}
-
-	/**
-	 * Converts and scales a image according to the given
-	 * {@link DLNAImageProfile}. Preserves aspect ratio. Format support is
-	 * limited to that of {@link ImageIO}.
-	 *
-	 * @param outputProfile the DLNA media profile to adhere to for the output.
-	 * @param padToSize Whether padding should be used if source aspect doesn't
-	 *                  match target aspect.
-	 * @param filterChain a {@link BufferedImageFilterChain} to apply during the
-	 *            operation or {@code null}.
-	 * @return The scaled and/or converted image, {@code null} if the
-	 *         source is {@code null}.
-	 * @exception IOException if the operation fails.
-	 */
-	public DLNAImageInputStream transcode(
-		DLNAImageProfile outputProfile,
-		boolean padToSize,
-		BufferedImageFilterChain filterChain
-	) throws IOException {
-		DLNAImage image;
-		image = (DLNAImage) ImagesUtil.transcodeImage(
-			this.getBytes(false),
-			outputProfile,
-			false,
-			padToSize,
-			filterChain
-		);
-		return image != null ? new DLNAImageInputStream(image) : null;
-	}
-
-	/**
-	 * Returns the byte array with the image data.
-	 *
-	 * @param copy if {@code true} a copy of the array is returned, if
-	 *            {@code false} a reference to the existing array is returned.
-	 * @return The bytes of this image.
-	 */
-	@SuppressFBWarnings("EI_EXPOSE_REP")
-	public byte[] getBytes(boolean copy) {
-		if (copy) {
-			byte[] result = new byte[buf.length];
-			System.arraycopy(buf, 0, result, 0, buf.length);
-			return result;
-		}
-		return buf;
-	}
-
-	/**
-	 * @return A {@link DLNAImage} sharing the the underlying buffer.
-	 * @throws DLNAProfileException If the image isn't compliant.
-	 */
-	public DLNAImage getDLNAImage() throws DLNAProfileException {
-		return new DLNAImage(buf, imageInfo, profile, false);
-	}
-
-	/**
-	 * @return The {@link ImageInfo} for this image.
-	 */
-	public ImageInfo getImageInfo() {
-		return imageInfo;
-	}
-
-	/**
-	 * @return The width of this image.
-	 */
-	public int getWidth() {
-		return imageInfo != null ? imageInfo.getWidth() : -1;
-	}
-
-	/**
-	 * @return The height of this image.
-	 */
-	public int getHeight() {
-		return imageInfo != null ? imageInfo.getHeight() : -1;
-	}
-
-	/**
-	 * @return The {@link ImageFormat} for this image.
-	 */
-	public ImageFormat getFormat() {
-		return imageInfo != null ? imageInfo.getFormat() : null;
-	}
-
-	/**
-	 * @return the size of this image in bytes.
-	 */
-	public long getSize() {
-		return buf != null ? buf.length : 0;
-	}
-
-	/**
-	 * @return The {@link ColorSpace} for this image.
-	 */
-	public ColorSpace getColorSpace() {
-		return imageInfo != null ? imageInfo.getColorSpace() : null;
-	}
-
-	/**
-	 * @return The {@link ColorSpaceType} for this image.
-	 */
-	public ColorSpaceType getColorSpaceType() {
-		return imageInfo != null ? imageInfo.getColorSpaceType() : null;
-	}
-
-	/**
-	 * @return The bits per pixel for this image.
-	 *
-	 * @see #getBitDepth()
-	 */
-	public int getBitPerPixel() {
-		return imageInfo != null ? imageInfo.getBitsPerPixel() : -1;
-	}
-
-	/**
-	 * The number of components describe how many "channels" the color model
-	 * has. A grayscale image without alpha has 1, a RGB image without alpha
-	 * has 3, a RGP image with alpha has 4 etc.
-	 *
-	 * @return The number of components for this image.
-	 */
-	public int getNumComponents() {
-		return imageInfo != null ? imageInfo.getNumComponents() : -1;
-	}
-
-	/**
-	 * @return The number of bits per color "channel" for this image.
-	 *
-	 * @see #getBitPerPixel()
-	 * @see #getNumColorComponents()
-	 */
-	public int getBitDepth() {
-		return imageInfo != null ? imageInfo.getBitDepth() : -1;
-	}
-
-	/**
-	 * @return Whether or not {@link ImageIO} can read/parse this image.
-	 */
-	public boolean isImageIOSupported() {
-		return imageInfo != null ? imageInfo.isImageIOSupported() : false;
-	}
-
-	/**
-	 * @return The {@link DLNAImageProfile} this image adheres to.
-	 */
-	public DLNAImageProfile getDLNAImageProfile() {
-		return profile;
-	}
-
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(90);
@@ -403,11 +250,4 @@ public class DLNAImageInputStream extends ByteArrayInputStream {
 		return sb.toString();
 	}
 
-	/**
-	 * Resets the buffer to the start position and clears any marks.
-	 */
-	public synchronized void fullReset() {
-		pos = 0;
-		mark = 0;
-	}
 }

--- a/src/main/java/net/pms/dlna/DLNAImageProfile.java
+++ b/src/main/java/net/pms/dlna/DLNAImageProfile.java
@@ -168,46 +168,6 @@ public class DLNAImageProfile implements Comparable<DLNAImageProfile>, Serializa
 	 */
 	public static final DLNAImageProfile PNG_TN = new DLNAImageProfile(PNG_TN_INT, PNG_TN_STRING, 160, 160, null);
 
-	/**
-	 * Creates a new {@link #JPEG_RES_H_V} profile instance with the exact
-	 * resolution H x V. Set {@code H} and {@code V} for this instance. The
-	 * default mime-type {@code image/jpeg} is used. Not applicable for other
-	 * profiles.
-	 *
-	 * @param horizontal the {@code H} value.
-	 * @param vertical the {@code V} value.
-	 * @return The new {@link #JPEG_RES_H_V} instance.
-	 */
-	public static DLNAImageProfile createJPEG_RES_H_V(int horizontal, int vertical) {
-		return new DLNAImageProfile(
-			JPEG_RES_H_V_INT,
-			"JPEG_RES_" + Integer.toString(horizontal) + "_" + Integer.toString(vertical),
-			horizontal,
-			vertical,
-			null
-		);
-	}
-
-	/**
-	 * Creates a new {@link #JPEG_RES_H_V} profile instance with the exact
-	 * resolution H x V. Set {@code H} and {@code V} for this instance. Not
-	 * applicable for other profiles.
-	 *
-	 * @param horizontal the {@code H} value.
-	 * @param vertical the {@code V} value.
-	 * @param mimeType the {@link MimeType} for this profile.
-	 * @return The new {@link #JPEG_RES_H_V} instance.
-	 */
-	public static DLNAImageProfile createJPEG_RES_H_V(int horizontal, int vertical, MimeType mimeType) {
-		return new DLNAImageProfile(
-			JPEG_RES_H_V_INT,
-			"JPEG_RES_" + Integer.toString(horizontal) + "_" + Integer.toString(vertical),
-			horizontal,
-			vertical,
-			mimeType
-		);
-	}
-
 	/** This profile's integer value */
 	protected final int imageProfileInt;
 
@@ -274,6 +234,192 @@ public class DLNAImageProfile implements Comparable<DLNAImageProfile>, Serializa
 				throw new IllegalStateException(
 					"Profile value " + imageProfileInt + "is not implemented in DLNAImageProfile.getDefaultExtension()");
 		}
+	}
+
+
+	/**
+	 * @return The {@link ImageFormat} for this {@link DLNAImageProfile}.
+	 */
+	public ImageFormat getFormat() {
+		switch (imageProfileInt) {
+			case GIF_LRG_INT:
+				return ImageFormat.GIF;
+			case JPEG_LRG_INT:
+			case JPEG_MED_INT:
+			case JPEG_RES_H_V_INT:
+			case JPEG_SM_INT:
+			case JPEG_TN_INT:
+				return ImageFormat.JPEG;
+			case PNG_LRG_INT:
+			case PNG_TN_INT:
+				return ImageFormat.PNG;
+			default:
+				throw new IllegalStateException("Profile is missing from switch statement");
+		}
+	}
+
+	/**
+	 * @return The {@link MimeType} for this {@link DLNAImageProfile}.
+	 */
+	public MimeType getMimeType() {
+		if (mimeType != null) {
+			return mimeType;
+		}
+		return getDefaultMimeType();
+	}
+
+	/**
+	 * @return The default {@link MimeType} for this
+	 *         {@link DLNAImageProfile}.
+	 */
+	public MimeType getDefaultMimeType() {
+		switch (getFormat()) {
+			case GIF:
+				return MIMETYPE_GIF;
+			case JPEG:
+				return MIMETYPE_JPEG;
+			case PNG:
+				return MIMETYPE_PNG;
+			default:
+				throw new IllegalStateException("Format is missing from switch statement");
+		}
+	}
+
+	/**
+	 * @return The formatted mime-type {@link String} for this
+	 *         {@link DLNAImageProfile}.
+	 */
+	public String getMimeTypeString() {
+		return getMimeType().toStringWithoutParameters();
+	}
+
+	/**
+	 * Gets the maximum image width for the given {@link DLNAImageProfile}.
+	 *
+	 * @return The value in pixels.
+	 */
+	public int getMaxWidth() {
+		return horizontal;
+	}
+
+	/**
+	 * Get {@code H} for the {@code JPEG_RES_H_V} profile.
+	 *
+	 * @return The {@code H} value in pixels.
+	 */
+	public int getH() {
+		return horizontal;
+	}
+
+	/**
+	 * Gets the maximum image height for the given {@link DLNAImageProfile}.
+	 *
+	 * @return The value in pixels.
+	 */
+	public int getMaxHeight() {
+		return vertical;
+	}
+
+	/**
+	 * Get {@code V} for the {@code JPEG_RES_H_V} profile.
+	 *
+	 * @return The {@code V} value in pixels.
+	 */
+	public int getV() {
+		return vertical;
+	}
+
+	/**
+	 * Get the {@link Dimension} of the maximum image resolution for the given
+	 * {@link DLNAImageProfile}.
+	 *
+	 * @return The {@link Dimension}.
+	 */
+	public Dimension getMaxResolution() {
+		if (horizontal >= 0 && vertical >= 0) {
+			return new Dimension(horizontal, vertical);
+		}
+		return new Dimension();
+	}
+
+	/**
+	 * Evaluates whether the thumbnail or the image itself should be used as
+	 * the source for the given profile when two sources are available. This is
+	 * typically only relevant for image resources.
+	 *
+	 * @param imageInfo the {@link ImageInfo} for the non-thumbnail source.
+	 * @param thumbnailImageInfo the {@link ImageInfo} for the thumbnail source.
+	 * @return The evaluation result.
+	 */
+	public boolean useThumbnailSource(ImageInfo imageInfo, ImageInfo thumbnailImageInfo) {
+		if (DLNAImageProfile.JPEG_TN.equals(this) || DLNAImageProfile.PNG_TN.equals(this)) {
+			// These should always use thumbnail as the source
+			return true;
+		}
+
+		if (
+			imageInfo == null || imageInfo.getWidth() < 1 || imageInfo.getHeight() < 1 ||
+			thumbnailImageInfo == null || thumbnailImageInfo.getWidth() < 1 || thumbnailImageInfo.getHeight() < 1
+		) {
+			// Impossible to do a valid evaluation under these circumstances
+			return false;
+		}
+
+		boolean thumbIsSmaller =
+			thumbnailImageInfo.getWidth() < imageInfo.getWidth() ||
+			thumbnailImageInfo.getHeight() < imageInfo.getHeight();
+		if (!thumbIsSmaller) {
+			// Thumbnail has as good a resolution as the source, we might as
+			// well use the thumbnail if the format matches
+			return getFormat() == thumbnailImageInfo.getFormat() || getFormat() != imageInfo.getFormat();
+		}
+
+		// At this point we know that the thumbnail is smaller than the source.
+		// Only use the thumbnail if it's bigger or equal in size to this profile.
+		return
+			getMaxWidth() <= thumbnailImageInfo.getWidth() &&
+			getMaxHeight() <= thumbnailImageInfo.getHeight();
+	}
+
+
+	/**
+	 * Creates a new {@link #JPEG_RES_H_V} profile instance with the exact
+	 * resolution H x V. Set {@code H} and {@code V} for this instance. The
+	 * default mime-type {@code image/jpeg} is used. Not applicable for other
+	 * profiles.
+	 *
+	 * @param horizontal the {@code H} value.
+	 * @param vertical the {@code V} value.
+	 * @return The new {@link #JPEG_RES_H_V} instance.
+	 */
+	public static DLNAImageProfile createJPEG_RES_H_V(int horizontal, int vertical) {
+		return new DLNAImageProfile(
+			JPEG_RES_H_V_INT,
+			"JPEG_RES_" + Integer.toString(horizontal) + "_" + Integer.toString(vertical),
+			horizontal,
+			vertical,
+			null
+		);
+	}
+
+	/**
+	 * Creates a new {@link #JPEG_RES_H_V} profile instance with the exact
+	 * resolution H x V. Set {@code H} and {@code V} for this instance. Not
+	 * applicable for other profiles.
+	 *
+	 * @param horizontal the {@code H} value.
+	 * @param vertical the {@code V} value.
+	 * @param mimeType the {@link MimeType} for this profile.
+	 * @return The new {@link #JPEG_RES_H_V} instance.
+	 */
+	public static DLNAImageProfile createJPEG_RES_H_V(int horizontal, int vertical, MimeType mimeType) {
+		return new DLNAImageProfile(
+			JPEG_RES_H_V_INT,
+			"JPEG_RES_" + Integer.toString(horizontal) + "_" + Integer.toString(vertical),
+			horizontal,
+			vertical,
+			mimeType
+		);
 	}
 
 	/**
@@ -584,150 +730,6 @@ public class DLNAImageProfile implements Comparable<DLNAImageProfile>, Serializa
 			}
 		}
 		return result;
-	}
-
-	/**
-	 * @return The {@link ImageFormat} for this {@link DLNAImageProfile}.
-	 */
-	public ImageFormat getFormat() {
-		switch (imageProfileInt) {
-			case GIF_LRG_INT:
-				return ImageFormat.GIF;
-			case JPEG_LRG_INT:
-			case JPEG_MED_INT:
-			case JPEG_RES_H_V_INT:
-			case JPEG_SM_INT:
-			case JPEG_TN_INT:
-				return ImageFormat.JPEG;
-			case PNG_LRG_INT:
-			case PNG_TN_INT:
-				return ImageFormat.PNG;
-			default:
-				throw new IllegalStateException("Profile is missing from switch statement");
-		}
-	}
-
-	/**
-	 * @return The {@link MimeType} for this {@link DLNAImageProfile}.
-	 */
-	public MimeType getMimeType() {
-		if (mimeType != null) {
-			return mimeType;
-		}
-		return getDefaultMimeType();
-	}
-
-	/**
-	 * @return The default {@link MimeType} for this
-	 *         {@link DLNAImageProfile}.
-	 */
-	public MimeType getDefaultMimeType() {
-		switch (getFormat()) {
-			case GIF:
-				return MIMETYPE_GIF;
-			case JPEG:
-				return MIMETYPE_JPEG;
-			case PNG:
-				return MIMETYPE_PNG;
-			default:
-				throw new IllegalStateException("Format is missing from switch statement");
-		}
-	}
-
-	/**
-	 * @return The formatted mime-type {@link String} for this
-	 *         {@link DLNAImageProfile}.
-	 */
-	public String getMimeTypeString() {
-		return getMimeType().toStringWithoutParameters();
-	}
-
-	/**
-	 * Gets the maximum image width for the given {@link DLNAImageProfile}.
-	 *
-	 * @return The value in pixels.
-	 */
-	public int getMaxWidth() {
-		return horizontal;
-	}
-
-	/**
-	 * Get {@code H} for the {@code JPEG_RES_H_V} profile.
-	 *
-	 * @return The {@code H} value in pixels.
-	 */
-	public int getH() {
-		return horizontal;
-	}
-
-	/**
-	 * Gets the maximum image height for the given {@link DLNAImageProfile}.
-	 *
-	 * @return The value in pixels.
-	 */
-	public int getMaxHeight() {
-		return vertical;
-	}
-
-	/**
-	 * Get {@code V} for the {@code JPEG_RES_H_V} profile.
-	 *
-	 * @return The {@code V} value in pixels.
-	 */
-	public int getV() {
-		return vertical;
-	}
-
-	/**
-	 * Get the {@link Dimension} of the maximum image resolution for the given
-	 * {@link DLNAImageProfile}.
-	 *
-	 * @return The {@link Dimension}.
-	 */
-	public Dimension getMaxResolution() {
-		if (horizontal >= 0 && vertical >= 0) {
-			return new Dimension(horizontal, vertical);
-		}
-		return new Dimension();
-	}
-
-	/**
-	 * Evaluates whether the thumbnail or the image itself should be used as
-	 * the source for the given profile when two sources are available. This is
-	 * typically only relevant for image resources.
-	 *
-	 * @param imageInfo the {@link ImageInfo} for the non-thumbnail source.
-	 * @param thumbnailImageInfo the {@link ImageInfo} for the thumbnail source.
-	 * @return The evaluation result.
-	 */
-	public boolean useThumbnailSource(ImageInfo imageInfo, ImageInfo thumbnailImageInfo) {
-		if (DLNAImageProfile.JPEG_TN.equals(this) || DLNAImageProfile.PNG_TN.equals(this)) {
-			// These should always use thumbnail as the source
-			return true;
-		}
-
-		if (
-			imageInfo == null || imageInfo.getWidth() < 1 || imageInfo.getHeight() < 1 ||
-			thumbnailImageInfo == null || thumbnailImageInfo.getWidth() < 1 || thumbnailImageInfo.getHeight() < 1
-		) {
-			// Impossible to do a valid evaluation under these circumstances
-			return false;
-		}
-
-		boolean thumbIsSmaller =
-			thumbnailImageInfo.getWidth() < imageInfo.getWidth() ||
-			thumbnailImageInfo.getHeight() < imageInfo.getHeight();
-		if (!thumbIsSmaller) {
-			// Thumbnail has as good a resolution as the source, we might as
-			// well use the thumbnail if the format matches
-			return getFormat() == thumbnailImageInfo.getFormat() || getFormat() != imageInfo.getFormat();
-		}
-
-		// At this point we know that the thumbnail is smaller than the source.
-		// Only use the thumbnail if it's bigger or equal in size to this profile.
-		return
-			getMaxWidth() <= thumbnailImageInfo.getWidth() &&
-			getMaxHeight() <= thumbnailImageInfo.getHeight();
 	}
 
 	/**
@@ -1206,7 +1208,7 @@ public class DLNAImageProfile implements Comparable<DLNAImageProfile>, Serializa
 	 * @param height the number of vertical pixels for this resolution.
 	 * @return {@code true} if the resolution is valid, {@code false} otherwise.
 	 */
-	public boolean isResolutionCorrect(int width, int height) {
+	private boolean isResolutionCorrect(int width, int height) {
 		if (width < 1 || height < 1) {
 			return false;
 		}
@@ -1470,7 +1472,7 @@ public class DLNAImageProfile implements Comparable<DLNAImageProfile>, Serializa
 	 * Internal mutable compliance result data structure.
 	 */
 	@SuppressWarnings({"checkstyle:VisibilityModifier", "JavadocVariable"})
-	protected static class InternalComplianceResult {
+	private static class InternalComplianceResult {
 		public boolean resolutionCorrect = false;
 		public boolean formatCorrect = false;
 		public boolean colorsCorrect = false;

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -149,19 +149,7 @@ public class DLNAMediaInfo implements Cloneable {
 
 	private volatile DLNAThumbnail thumb = null;
 
-	/**
-	 * Metadata gathered from either the filename or our API.
-	 */
-	private String imdbID;
-	private String year;
-	private String tvShowName;
-	private String simplifiedTvShowName;
-	private String tvSeason;
-	private String tvEpisodeNumber;
-	private String tvEpisodeName;
-	private String tvSeriesStartYear;
-	private String extraInformation;
-	private boolean isTVEpisode;
+	private DLNAMediaVideoMetadata videoMetadata;
 
 	private volatile ImageInfo imageInfo = null;
 	private String mimeType;
@@ -1770,20 +1758,22 @@ public class DLNAMediaInfo implements Cloneable {
 			if (subtitleTracks != null && !subtitleTracks.isEmpty()) {
 				appendSubtitleTracks(result);
 			}
-			if (isNotBlank(getIMDbID())) {
-				result.append(", IMDb ID: ").append(getIMDbID());
-			}
-			if (isNotBlank(getYear())) {
-				result.append(", Year: ").append(getYear());
-			}
-			if (isNotBlank(getMovieOrShowName())) {
-				result.append(", Movie/TV series name: ").append(getMovieOrShowName());
-			}
-			if (isTVEpisode()) {
-				result.append(", TV season: ").append(getTVSeason());
-				result.append(", TV episode number: ").append(getTVEpisodeNumber());
-				if (isNotBlank(getVideoTrackTitleFromMetadata())) {
-					result.append(", TV episode name: ").append(getTVEpisodeName());
+			if (hasVideoMetadata()) {
+				if (isNotBlank(videoMetadata.getIMDbID())) {
+					result.append(", IMDb ID: ").append(videoMetadata.getIMDbID());
+				}
+				if (isNotBlank(videoMetadata.getYear())) {
+					result.append(", Year: ").append(videoMetadata.getYear());
+				}
+				if (isNotBlank(videoMetadata.getMovieOrShowName())) {
+					result.append(", Movie/TV series name: ").append(videoMetadata.getMovieOrShowName());
+				}
+				if (videoMetadata.isTVEpisode()) {
+					result.append(", TV season: ").append(videoMetadata.getTVSeason());
+					result.append(", TV episode number: ").append(videoMetadata.getTVEpisodeNumber());
+					if (isNotBlank(getVideoTrackTitleFromMetadata())) {
+						result.append(", TV episode name: ").append(videoMetadata.getTVEpisodeName());
+					}
 				}
 			}
 		} else if (getAudioTrackCount() > 0) {
@@ -2213,7 +2203,7 @@ public class DLNAMediaInfo implements Cloneable {
 	public void setLastPlaybackTime(String value) {
 		this.lastPlaybackTime = value;
 	}
-
+/*
 	public String getIMDbID() {
 		return imdbID;
 	}
@@ -2292,26 +2282,18 @@ public class DLNAMediaInfo implements Cloneable {
 	public void setIsTVEpisode(boolean value) {
 		this.isTVEpisode = value;
 	}
+*/
 
-	/**
-	 * Any extra information like movie edition or whether it is a
-	 * sample video.
-	 *
-	 * Example: "(Director's Cut) (Sample)"
-	 * @return
-	 */
-	public String getExtraInformation() {
-		return extraInformation;
+	public boolean hasVideoMetadata() {
+		return videoMetadata != null;
 	}
 
-	/*
-	 * Any extra information like movie edition or whether it is a
-	 * sample video.
-	 *
-	 * Example: "(Director's Cut) (Sample)"
-	 */
-	public void setExtraInformation(String value) {
-		this.extraInformation = value;
+	public DLNAMediaVideoMetadata getVideoMetadata() {
+		return videoMetadata;
+	}
+
+	public void setVideoMetadata(DLNAMediaVideoMetadata value) {
+		videoMetadata = value;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAMediaVideoMetadata.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaVideoMetadata.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.pms.dlna;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * This class keeps track of the chapter properties of media.
+ */
+public class DLNAMediaVideoMetadata {
+	/**
+	 * Metadata gathered from either the filename or our API.
+	 */
+	private String imdbID;
+	private String year;
+	private String tvShowName;
+	private String simplifiedTvShowName;
+	private String tvSeason;
+	private String tvEpisodeNumber;
+	private String tvEpisodeName;
+	private String tvSeriesStartYear;
+	private String extraInformation;
+	private boolean isTVEpisode;
+
+	public String getIMDbID() {
+		return imdbID;
+	}
+
+	public void setIMDbID(String value) {
+		this.imdbID = value;
+	}
+
+	public String getYear() {
+		return year;
+	}
+
+	public void setYear(String value) {
+		this.year = value;
+	}
+
+	public String getTVSeriesStartYear() {
+		return tvSeriesStartYear;
+	}
+
+	public void setTVSeriesStartYear(String value) {
+		this.tvSeriesStartYear = value;
+	}
+
+	public String getMovieOrShowName() {
+		return tvShowName;
+	}
+
+	public void setMovieOrShowName(String value) {
+		this.tvShowName = value;
+	}
+
+	public String getSimplifiedMovieOrShowName() {
+		return simplifiedTvShowName;
+	}
+
+	public void setSimplifiedMovieOrShowName(String value) {
+		this.simplifiedTvShowName = value;
+	}
+
+	public String getTVSeason() {
+		return tvSeason;
+	}
+
+	public void setTVSeason(String value) {
+		this.tvSeason = value;
+	}
+
+	public String getTVEpisodeNumber() {
+		return tvEpisodeNumber;
+	}
+
+	public String getTVEpisodeNumberUnpadded() {
+		if (StringUtils.isNotBlank(tvEpisodeNumber) && tvEpisodeNumber.length() > 1 && tvEpisodeNumber.startsWith("0")) {
+			return tvEpisodeNumber.substring(1);
+		}
+		return tvEpisodeNumber;
+	}
+
+	public void setTVEpisodeNumber(String value) {
+		this.tvEpisodeNumber = value;
+	}
+
+	public String getTVEpisodeName() {
+		return tvEpisodeName;
+	}
+
+	public void setTVEpisodeName(String value) {
+		this.tvEpisodeName = value;
+	}
+
+	public boolean isTVEpisode() {
+		return isTVEpisode;
+	}
+
+	public void setIsTVEpisode(boolean value) {
+		this.isTVEpisode = value;
+	}
+
+	/**
+	 * Any extra information like movie edition or whether it is a
+	 * sample video.
+	 *
+	 * Example: "(Director's Cut) (Sample)"
+	 * @return
+	 */
+	public String getExtraInformation() {
+		return extraInformation;
+	}
+
+	/*
+	 * Any extra information like movie edition or whether it is a
+	 * sample video.
+	 *
+	 * Example: "(Director's Cut) (Sample)"
+	 */
+	public void setExtraInformation(String value) {
+		this.extraInformation = value;
+	}
+
+}

--- a/src/main/java/net/pms/dlna/DLNAProfileException.java
+++ b/src/main/java/net/pms/dlna/DLNAProfileException.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * of the License only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package net.pms.dlna;
 
 import java.io.IOException;

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -72,7 +72,7 @@ import net.pms.database.MediaTableFilesStatus;
 import net.pms.database.MediaTableMetadata;
 import net.pms.database.MediaTableTVSeries;
 import net.pms.database.MediaTableThumbnails;
-import net.pms.database.MediaTableVideoMetadatas;
+import net.pms.database.MediaTableVideoMetadata;
 import net.pms.dlna.DLNAImageProfile.HypotheticalResult;
 import net.pms.dlna.virtual.TranscodeVirtualFolder;
 import net.pms.dlna.virtual.VirtualFolder;
@@ -5076,7 +5076,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 								}
 							}
 							media.setVideoMetadata(videoMetadata);
-							MediaTableVideoMetadatas.insertVideoMetadata(connection, file.getAbsolutePath(), file.lastModified(), media, null);
+							MediaTableVideoMetadata.insertVideoMetadata(connection, file.getAbsolutePath(), file.lastModified(), media, null);
 
 							// Creates a minimal TV series row with just the title, that
 							// might be enhanced later by the API

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -72,6 +72,7 @@ import net.pms.database.MediaTableFilesStatus;
 import net.pms.database.MediaTableMetadata;
 import net.pms.database.MediaTableTVSeries;
 import net.pms.database.MediaTableThumbnails;
+import net.pms.database.MediaTableVideoMetadatas;
 import net.pms.dlna.DLNAImageProfile.HypotheticalResult;
 import net.pms.dlna.virtual.TranscodeVirtualFolder;
 import net.pms.dlna.virtual.VirtualFolder;
@@ -5069,9 +5070,8 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 									videoMetadata.setMovieOrShowName(titleFromDatabase);
 								}
 							}
-							// TODO: Make sure this does not happen if ANY version already exists, before doing this
 							media.setVideoMetadata(videoMetadata);
-							MediaTableFiles.insertVideoMetadata(connection, file.getAbsolutePath(), file.lastModified(), media, null);
+							MediaTableVideoMetadatas.insertVideoMetadata(connection, file.getAbsolutePath(), file.lastModified(), media, null);
 
 							// Creates a minimal TV series row with just the title, that
 							// might be enhanced later by the API

--- a/src/main/java/net/pms/dlna/DVDISOFile.java
+++ b/src/main/java/net/pms/dlna/DVDISOFile.java
@@ -28,12 +28,15 @@ import net.pms.formats.Format;
 import net.pms.io.OutputParams;
 import net.pms.io.ProcessWrapperImpl;
 import net.pms.util.ProcessUtil;
+import net.pms.util.UMSUtils;
 
 public class DVDISOFile extends VirtualFolder {
 	private static final String NAME = "[DVD ISO] %s";
+
+	private final File file;
+	private final boolean isVideoTS;
+
 	private String volumeId;
-	private File file;
-	private boolean isVideoTS;
 
 	private static String getName(File file) {
 		return String.format(NAME, getFileName(file));
@@ -115,10 +118,7 @@ public class DVDISOFile extends VirtualFolder {
 		params.setLog(true);
 		final ProcessWrapperImpl pw = new ProcessWrapperImpl(cmd, params, true, false);
 		Runnable r = () -> {
-			try {
-				Thread.sleep(10000);
-			} catch (InterruptedException e) {
-			}
+			UMSUtils.sleep(10000);
 			pw.stopProcess();
 		};
 

--- a/src/main/java/net/pms/dlna/DVDISOTitle.java
+++ b/src/main/java/net/pms/dlna/DVDISOTitle.java
@@ -43,6 +43,7 @@ import net.pms.util.MPlayerDvdAudioStreamChannels;
 import net.pms.util.MPlayerDvdAudioStreamTypes;
 import net.pms.util.ProcessUtil;
 import net.pms.util.StringUtil;
+import net.pms.util.UMSUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,10 +58,11 @@ public class DVDISOTitle extends DLNAResource {
 		"^subtitle \\( sid \\): (?<StreamNumber>\\d+) language: (?<Language>\\w*)$"
 	);
 
-	private File file;
-	private int title;
+	private final File file;
+	private final int title;
+	private final String parentName;
+
 	private long length;
-	private String parentName;
 
 	public DVDISOTitle(File file, String parentName, int title) {
 		this.file = file;
@@ -130,10 +132,7 @@ public class DVDISOTitle extends DLNAResource {
 
 		final ProcessWrapperImpl pw = new ProcessWrapperImpl(cmd, params, true, false);
 		Runnable r = () -> {
-			try {
-				Thread.sleep(10000);
-			} catch (InterruptedException e) {
-			}
+			UMSUtils.sleep(10000);
 			pw.stopProcess();
 		};
 
@@ -357,7 +356,6 @@ public class DVDISOTitle extends DLNAResource {
 				thumbFolder = new File(configuration.getAlternateThumbFolder());
 
 				if (!thumbFolder.isDirectory()) {
-					thumbFolder = null;
 					break;
 				}
 			}

--- a/src/main/java/net/pms/dlna/DbIdResourceLocator.java
+++ b/src/main/java/net/pms/dlna/DbIdResourceLocator.java
@@ -40,19 +40,14 @@ import net.pms.dlna.virtual.VirtualFolderDbId;
  * This class resolves DLNA objects identified by databaseID's.
  */
 public class DbIdResourceLocator {
-
 	private static final Logger LOGGER = LoggerFactory.getLogger(DbIdResourceLocator.class);
 
-
-	public DbIdResourceLocator() {
-	}
-
-	public DLNAResource locateResource(String id) {
+	public static DLNAResource locateResource(String id) {
 		DLNAResource resource = getDLNAResourceByDBID(DbIdMediaType.getTypeIdentByDbid(id));
 		return resource;
 	}
 
-	public String encodeDbid(DbIdTypeAndIdent2 typeIdent) {
+	public static String encodeDbid(DbIdTypeAndIdent2 typeIdent) {
 		try {
 			return String.format("%s%s%s", DbIdMediaType.GENERAL_PREFIX, typeIdent.type.dbidPrefix,
 				URLEncoder.encode(typeIdent.ident, StandardCharsets.UTF_8.toString()));
@@ -70,7 +65,7 @@ public class DbIdResourceLocator {
 	 *         and resolved. In case of a container, the container will be
 	 *         created and populated.
 	 */
-	public DLNAResource getDLNAResourceByDBID(DbIdTypeAndIdent2 typeAndIdent) {
+	public static DLNAResource getDLNAResourceByDBID(DbIdTypeAndIdent2 typeAndIdent) {
 		DLNAResource res = null;
 		Connection connection = null;
 		try {
@@ -286,7 +281,7 @@ public class DbIdResourceLocator {
 	 * @param album
 	 * @param albumFolder
 	 */
-	public void appendAlbumInformation(MusicBrainzAlbum album, VirtualFolderDbId albumFolder) {
+	public static void appendAlbumInformation(MusicBrainzAlbum album, VirtualFolderDbId albumFolder) {
 		DLNAMediaAudio audioInf =  new DLNAMediaAudio();
 		audioInf.setAlbum(album.album);
 		audioInf.setArtist(album.artist);

--- a/src/main/java/net/pms/dlna/DbIdResourceLocator.java
+++ b/src/main/java/net/pms/dlna/DbIdResourceLocator.java
@@ -80,7 +80,7 @@ public class DbIdResourceLocator {
 						case TYPE_AUDIO:
 						case TYPE_VIDEO:
 						case TYPE_IMAGE:
-							sql = String.format("SELECT " + MediaTableFiles.FILENAME + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = %s", typeAndIdent.ident);
+							sql = String.format("SELECT " + MediaTableFiles.TABLE_COL_FILENAME + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = %s", typeAndIdent.ident);
 							if (LOGGER.isTraceEnabled()) {
 								LOGGER.trace(String.format("SQL AUDIO/VIDEO/IMAGE : %s", sql));
 							}
@@ -93,7 +93,7 @@ public class DbIdResourceLocator {
 							break;
 
 						case TYPE_PLAYLIST:
-							sql = String.format("SELECT " + MediaTableFiles.FILENAME + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = %s", typeAndIdent.ident);
+							sql = String.format("SELECT " + MediaTableFiles.TABLE_COL_FILENAME + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = %s", typeAndIdent.ident);
 							if (LOGGER.isTraceEnabled()) {
 								LOGGER.trace(String.format("SQL PLAYLIST : %s", sql));
 							}
@@ -109,8 +109,8 @@ public class DbIdResourceLocator {
 
 						case TYPE_ALBUM:
 							sql = String.format(
-								"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.ID + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " LEFT OUTER JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " " +
-									"WHERE ( " + MediaTableFiles.FORMAT_TYPE + " = 1  AND  " + MediaTableAudiotracks.ALBUM + " = '%s')",
+								"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_ID + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " LEFT OUTER JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " " +
+									"WHERE ( " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1  AND  " + MediaTableAudiotracks.TABLE_COL_ALBUM + " = '%s')",
 								typeAndIdent.ident);
 							if (LOGGER.isTraceEnabled()) {
 								LOGGER.trace(String.format("SQL AUDIO-ALBUM : %s", sql));
@@ -130,8 +130,8 @@ public class DbIdResourceLocator {
 
 						case TYPE_MUSICBRAINZ_RECORDID:
 							sql = String.format(
-								"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableAudiotracks.MBID_TRACK + ", " + MediaTableFiles.ID + ", " + MediaTableAudiotracks.ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + " LEFT OUTER JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " " +
-									"WHERE ( " + MediaTableFiles.FORMAT_TYPE + " = 1 and " + MediaTableAudiotracks.MBID_RECORD + " = '%s' ) ORDER BY " + MediaTableAudiotracks.MBID_TRACK,
+								"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableAudiotracks.TABLE_COL_MBID_TRACK + ", " + MediaTableFiles.TABLE_COL_ID + ", " + MediaTableAudiotracks.TABLE_COL_ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + " LEFT OUTER JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " " +
+									"WHERE ( " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 and " + MediaTableAudiotracks.TABLE_COL_MBID_RECORD + " = '%s' ) ORDER BY " + MediaTableAudiotracks.TABLE_COL_MBID_TRACK,
 								typeAndIdent.ident);
 							if (LOGGER.isTraceEnabled()) {
 								LOGGER.trace(String.format("SQL TYPE_MUSICBRAINZ_RECORDID : %s", sql));
@@ -160,7 +160,7 @@ public class DbIdResourceLocator {
 							}
 							break;
 						case TYPE_MYMUSIC_ALBUM:
-							sql = "SELECT " + MediaTableMusicBrainzReleaseLike.MBID_RELEASE + ", " + MediaTableAudiotracks.ALBUM + ", " + MediaTableAudiotracks.ARTIST + ", " + MediaTableAudiotracks.MEDIA_YEAR + " FROM " + MediaTableMusicBrainzReleaseLike.TABLE_NAME + " JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableMusicBrainzReleaseLike.MBID_RELEASE + " = " + MediaTableAudiotracks.MBID_RECORD + ";";
+							sql = "SELECT " + MediaTableMusicBrainzReleaseLike.TABLE_COL_MBID_RELEASE + ", " + MediaTableAudiotracks.TABLE_COL_ALBUM + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ", " + MediaTableAudiotracks.TABLE_COL_MEDIA_YEAR + " FROM " + MediaTableMusicBrainzReleaseLike.TABLE_NAME + " JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableMusicBrainzReleaseLike.TABLE_COL_MBID_RELEASE + " = " + MediaTableAudiotracks.TABLE_COL_MBID_RECORD + ";";
 							if (LOGGER.isTraceEnabled()) {
 								LOGGER.trace(String.format("SQL TYPE_MYMUSIC_ALBUM : %s", sql));
 							}
@@ -196,8 +196,8 @@ public class DbIdResourceLocator {
 							break;
 						case TYPE_PERSON_ALL_FILES:
 							sql = String.format(
-								"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.ID + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " LEFT OUTER JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " " +
-									"WHERE (" + MediaTableAudiotracks.ALBUMARTIST + " = '%s' OR " + MediaTableAudiotracks.ARTIST + " = '%s')",
+								"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_ID + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " LEFT OUTER JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " " +
+									"WHERE (" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + " = '%s' OR " + MediaTableAudiotracks.TABLE_COL_ARTIST + " = '%s')",
 								typeAndIdent.ident, typeAndIdent.ident);
 							if (LOGGER.isTraceEnabled()) {
 								LOGGER.trace(String.format("SQL PERSON : %s", sql));
@@ -228,7 +228,7 @@ public class DbIdResourceLocator {
 							break;
 
 						case TYPE_PERSON_ALBUM:
-							sql = String.format("SELECT DISTINCT(" + MediaTableAudiotracks.ALBUM + ") FROM " + MediaTableAudiotracks.TABLE_NAME + " WHERE COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") = '%s'",
+							sql = String.format("SELECT DISTINCT(" + MediaTableAudiotracks.TABLE_COL_ALBUM + ") FROM " + MediaTableAudiotracks.TABLE_NAME + " WHERE COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") = '%s'",
 								typeAndIdent.ident);
 							res = new VirtualFolderDbId(
 								typeAndIdent.ident,
@@ -248,8 +248,8 @@ public class DbIdResourceLocator {
 						case TYPE_PERSON_ALBUM_FILES:
 							String[] identSplitted = typeAndIdent.ident.split(DbIdMediaType.SPLIT_CHARS);
 							sql = String.format(
-								"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.ID + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " LEFT OUTER JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " " +
-									"WHERE (" + MediaTableAudiotracks.ALBUM + " = '%s') AND (" + MediaTableAudiotracks.ALBUMARTIST + " = '%s' OR " + MediaTableAudiotracks.ARTIST + " = '%s')",
+								"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_ID + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " LEFT OUTER JOIN " + MediaTableAudiotracks.TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " " +
+									"WHERE (" + MediaTableAudiotracks.TABLE_COL_ALBUM + " = '%s') AND (" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + " = '%s' OR " + MediaTableAudiotracks.TABLE_COL_ARTIST + " = '%s')",
 								identSplitted[1], identSplitted[0], identSplitted[0]);
 							try (ResultSet resultSet = statement.executeQuery(sql)) {
 								res = new VirtualFolderDbId(identSplitted[1],

--- a/src/main/java/net/pms/dlna/Feed.java
+++ b/src/main/java/net/pms/dlna/Feed.java
@@ -66,7 +66,7 @@ public class Feed extends DLNAResource {
 		if (b != null) {
 			SyndFeed feed = input.build(new XmlReader(new ByteArrayInputStream(b)));
 			name = feed.getTitle();
-			if (feed.getCategories() != null && feed.getCategories().size() > 0) {
+			if (feed.getCategories() != null && !feed.getCategories().isEmpty()) {
 				SyndCategory category = feed.getCategories().get(0);
 				tempCategory = category.getName();
 			}

--- a/src/main/java/net/pms/dlna/FeedItem.java
+++ b/src/main/java/net/pms/dlna/FeedItem.java
@@ -21,6 +21,20 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class FeedItem extends DLNAResource {
+	private final String title;
+	private final String itemURL;
+	private final String thumbURL;
+
+	private long length;
+
+	public FeedItem(String title, String itemURL, String thumbURL, DLNAMediaInfo media, int type) {
+		super(type);
+		this.title = title;
+		this.itemURL = itemURL;
+		this.thumbURL = thumbURL;
+		this.setMedia(media);
+	}
+
 	@Override
 	protected String getThumbnailURL(DLNAImageProfile profile) {
 		if (thumbURL == null) {
@@ -32,19 +46,6 @@ public class FeedItem extends DLNAResource {
 	@Override
 	public DLNAThumbnailInputStream getThumbnailInputStream() throws IOException {
 		return DLNAThumbnailInputStream.toThumbnailInputStream(downloadAndSend(thumbURL, true));
-	}
-
-	private String title;
-	private String itemURL;
-	private String thumbURL;
-	private long length;
-
-	public FeedItem(String title, String itemURL, String thumbURL, DLNAMediaInfo media, int type) {
-		super(type);
-		this.title = title;
-		this.itemURL = itemURL;
-		this.thumbURL = thumbURL;
-		this.setMedia(media);
 	}
 
 	@Override
@@ -78,9 +79,6 @@ public class FeedItem extends DLNAResource {
 	@Override
 	public String getSystemName() {
 		return itemURL;
-	}
-
-	public void parse(String content) {
 	}
 
 	@Override

--- a/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
+++ b/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
@@ -75,7 +75,7 @@ public class FileTranscodeVirtualFolder extends TranscodeVirtualFolder {
 	 */
 	private static class ResourceSort implements Comparator<DLNAResource> {
 
-		private ArrayList<Player> players;
+		private final ArrayList<Player> players;
 
 		ResourceSort(ArrayList<Player> players) {
 			this.players = players;
@@ -130,10 +130,7 @@ public class FileTranscodeVirtualFolder extends TranscodeVirtualFolder {
 	private static boolean isSeekable(DLNAResource dlna) {
 		Player player = dlna.getPlayer();
 
-		if ((player == null) || player.isTimeSeekable()) {
-			return true;
-		}
-		return false;
+		return (player == null) || player.isTimeSeekable();
 	}
 
 	private void addChapterFolder(DLNAResource dlna) {
@@ -169,7 +166,7 @@ public class FileTranscodeVirtualFolder extends TranscodeVirtualFolder {
 	public DLNAThumbnailInputStream getThumbnailInputStream() throws IOException {
 		try {
 			return originalResource.getThumbnailInputStream();
-		} catch (Exception e) {
+		} catch (IOException e) {
 			return super.getThumbnailInputStream();
 		}
 	}

--- a/src/main/java/net/pms/dlna/FolderLimit.java
+++ b/src/main/java/net/pms/dlna/FolderLimit.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 
 public class FolderLimit extends VirtualFolder {
 	private static final Logger LOGGER = LoggerFactory.getLogger(FolderLimit.class);
-	private ArrayList<FolderLimitLevel> levels;
+	private final ArrayList<FolderLimitLevel> levels;
 	private boolean discover;
 
 	public FolderLimit() {

--- a/src/main/java/net/pms/dlna/FolderLimitLevel.java
+++ b/src/main/java/net/pms/dlna/FolderLimitLevel.java
@@ -3,7 +3,7 @@ package net.pms.dlna;
 import net.pms.dlna.virtual.VirtualFolder;
 
 public class FolderLimitLevel extends VirtualFolder {
-	private int level;
+	private final int level;
 	private DLNAResource start;
 
 	public FolderLimitLevel(int level) {

--- a/src/main/java/net/pms/dlna/ImagesFeed.java
+++ b/src/main/java/net/pms/dlna/ImagesFeed.java
@@ -20,6 +20,11 @@ package net.pms.dlna;
 import net.pms.formats.Format;
 
 public class ImagesFeed extends Feed {
+
+	public ImagesFeed(String url) {
+		super("" + System.currentTimeMillis(), url, Format.IMAGE);
+	}
+
 	@Override
 	protected void manageItem() {
 		// Picasa Web Albums Support
@@ -30,7 +35,4 @@ public class ImagesFeed extends Feed {
 		}
 	}
 
-	public ImagesFeed(String url) {
-		super("" + System.currentTimeMillis(), url, Format.IMAGE);
-	}
 }

--- a/src/main/java/net/pms/dlna/InputFile.java
+++ b/src/main/java/net/pms/dlna/InputFile.java
@@ -10,22 +10,6 @@ public class InputFile {
 	private Long size = null;
 
 	/**
-	 * Return the string representation of this InputFile.
-	 */
-	@Override
-	public String toString() {
-		if (file != null) {
-			return file.getName();
-		} else {
-			if (push != null) {
-				return "pipe";
-			} else {
-				return "";
-			}
-		}
-	}
-
-	/**
 	 * @return the file
 	 * @since 1.50
 	 */
@@ -91,4 +75,21 @@ public class InputFile {
 	public void setSize(long size) {
 		this.size = size;
 	}
+
+	/**
+	 * Return the string representation of this InputFile.
+	 */
+	@Override
+	public String toString() {
+		if (file != null) {
+			return file.getName();
+		} else {
+			if (push != null) {
+				return "pipe";
+			} else {
+				return "";
+			}
+		}
+	}
+
 }

--- a/src/main/java/net/pms/dlna/RealFile.java
+++ b/src/main/java/net/pms/dlna/RealFile.java
@@ -310,6 +310,7 @@ public class RealFile extends MapFile {
 				try {
 					if (connection != null) {
 						connection.commit();
+						connection.setAutoCommit(true);
 					}
 				} catch (SQLException e) {
 					LOGGER.error("Error in commit in RealFile.resolve: {}", e.getMessage());

--- a/src/main/java/net/pms/dlna/RealFileDbId.java
+++ b/src/main/java/net/pms/dlna/RealFileDbId.java
@@ -28,20 +28,18 @@ import net.pms.formats.PLAYLIST;
  */
 public final class RealFileDbId extends RealFile {
 
-	private final DbIdResourceLocator dbid = new DbIdResourceLocator();
-
 	public RealFileDbId(File file) {
 		super(file);
 	}
 
 	public RealFileDbId(DbIdTypeAndIdent2 typeIdent, File file) {
 		super(file);
-		setId(dbid.encodeDbid(typeIdent));
+		setId(DbIdResourceLocator.encodeDbid(typeIdent));
 	}
 
 	public RealFileDbId(DbIdTypeAndIdent2 typeIdent, File file, String name) {
 		super(file, name);
-		setId(dbid.encodeDbid(typeIdent));
+		setId(DbIdResourceLocator.encodeDbid(typeIdent));
 	}
 
 	@Override

--- a/src/main/java/net/pms/dlna/virtual/MediaLibrary.java
+++ b/src/main/java/net/pms/dlna/virtual/MediaLibrary.java
@@ -5,7 +5,7 @@ import net.pms.database.MediaTableAudiotracks;
 import net.pms.database.MediaTableFiles;
 import net.pms.database.MediaTableFilesStatus;
 import net.pms.database.MediaTableRegexpRules;
-import net.pms.database.MediaTableVideoMetadatas;
+import net.pms.database.MediaTableVideoMetadata;
 import net.pms.util.FullyPlayedAction;
 
 /**
@@ -67,99 +67,99 @@ public class MediaLibrary extends VirtualFolder {
 		//String sqlJoinStart = "SELECT * FROM FILES LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON FILES.FILENAME = " + MediaTableFilesStatus.TABLE_NAME + ".FILENAME WHERE ";
 
 		// All videos that are unwatched
-		String movieCondition = " AND NOT " + MediaTableVideoMetadatas.ISTVEPISODE + " AND " + MediaTableVideoMetadatas.MEDIA_YEAR + " != '' AND DURATION > " + FORTY_MINUTES_IN_SECONDS;
-		String unwatchedCondition = " AND " + MediaTableFilesStatus.ISFULLYPLAYED + " IS NOT TRUE";
+		String movieCondition = " AND NOT " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + " AND " + MediaTableVideoMetadata.TABLE_COL_MEDIA_YEAR + " != '' AND DURATION > " + FORTY_MINUTES_IN_SECONDS;
+		String unwatchedCondition = " AND " + MediaTableFilesStatus.TABLE_COL_ISFULLYPLAYED + " IS NOT TRUE";
 		MediaLibraryFolder unwatchedTvShowsFolder = new MediaLibraryFolder(
 			Messages.getString("TvShows"),
 			new String[]{
-				"SELECT DISTINCT " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + MediaLibraryFolder.FROM_FILES_STATUS_VIDEOMETA + "WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + unwatchedCondition + "                                    ORDER BY " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " ASC",
-				SELECT_FILES_STATUS_VIDEO_WHERE +                                                                      MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + unwatchedCondition + " AND " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' ORDER BY " + MediaTableVideoMetadatas.TVSEASON + ", " + MediaTableVideoMetadatas.TVEPISODENUMBER
+				"SELECT DISTINCT " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + MediaLibraryFolder.FROM_FILES_STATUS_VIDEOMETA + "WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + unwatchedCondition + "                                    ORDER BY " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " ASC",
+				SELECT_FILES_STATUS_VIDEO_WHERE +                                                                      MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + unwatchedCondition + " AND " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = '${0}' ORDER BY " + MediaTableVideoMetadata.TABLE_COL_TVSEASON + ", " + MediaTableVideoMetadata.TABLE_COL_TVEPISODENUMBER
 			},
 			new int[]{MediaLibraryFolder.TVSERIES_WITH_FILTERS, MediaLibraryFolder.EPISODES}
 		);
 
-		MediaLibraryFolder unwatchedMoviesFolder = new MediaLibraryFolder(Messages.getString("Movies"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 " + movieCondition + " AND " + MediaTableFiles.STEREOSCOPY + " = ''" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedMovies3DFolder = new MediaLibraryFolder(Messages.getString("3dMovies"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 " + movieCondition + " AND " + MediaTableFiles.STEREOSCOPY + " != ''" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedUnsortedFolder = new MediaLibraryFolder(Messages.getString("Unsorted"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND NOT " + MediaTableVideoMetadatas.ISTVEPISODE + " AND (" + MediaTableVideoMetadatas.MEDIA_YEAR + " IS NULL OR " + MediaTableVideoMetadatas.MEDIA_YEAR + " = '')" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedRecentlyAddedVideos = new MediaLibraryFolder(Messages.getString("RecentlyAdded"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4" + unwatchedCondition + " ORDER BY " + MediaTableFiles.MODIFIED + " DESC LIMIT 100", MediaLibraryFolder.FILES_NOSORT);
-		MediaLibraryFolder unwatchedAllVideosFolder = new MediaLibraryFolder(Messages.getString("AllVideos"), SELECT_FILES_STATUS_WHERE  + MediaTableFiles.FORMAT_TYPE + " = 4" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedMoviesFolder = new MediaLibraryFolder(Messages.getString("Movies"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 " + movieCondition + " AND " + MediaTableFiles.TABLE_COL_STEREOSCOPY + " = ''" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedMovies3DFolder = new MediaLibraryFolder(Messages.getString("3dMovies"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 " + movieCondition + " AND " + MediaTableFiles.TABLE_COL_STEREOSCOPY + " != ''" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedUnsortedFolder = new MediaLibraryFolder(Messages.getString("Unsorted"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND NOT " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + " AND (" + MediaTableVideoMetadata.TABLE_COL_MEDIA_YEAR + " IS NULL OR " + MediaTableVideoMetadata.TABLE_COL_MEDIA_YEAR + " = '')" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedRecentlyAddedVideos = new MediaLibraryFolder(Messages.getString("RecentlyAdded"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_MODIFIED + " DESC LIMIT 100", MediaLibraryFolder.FILES_NOSORT);
+		MediaLibraryFolder unwatchedAllVideosFolder = new MediaLibraryFolder(Messages.getString("AllVideos"), SELECT_FILES_STATUS_WHERE  + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC", MediaLibraryFolder.FILES);
 		MediaLibraryFolder unwatchedMlfVideo02 = new MediaLibraryFolder(
 			Messages.getString("ByDate"),
 			new String[]{
-				"SELECT FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') " + MediaLibraryFolder.FROM_FILES_STATUS_VIDEOMETA + "WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4" + unwatchedCondition + " ORDER BY " + MediaTableFiles.MODIFIED + " DESC",
-				SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') = '${0}'" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC"
+				"SELECT FORMATDATETIME(" + MediaTableFiles.TABLE_COL_MODIFIED + ", 'yyyy MM d') " + MediaLibraryFolder.FROM_FILES_STATUS_VIDEOMETA + "WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_MODIFIED + " DESC",
+				SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND FORMATDATETIME(" + MediaTableFiles.TABLE_COL_MODIFIED + ", 'yyyy MM d') = '${0}'" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS_NOSORT, MediaLibraryFolder.FILES}
 		);
-		MediaLibraryFolder unwatchedMlfVideo03 = new MediaLibraryFolder(Messages.getString("HdVideos"), SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.WIDTH + " > 864 OR " + MediaTableFiles.HEIGHT + " > 576)" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedMlfVideo04 = new MediaLibraryFolder(Messages.getString("SdVideos"), SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.WIDTH + " <= 864 AND " + MediaTableFiles.HEIGHT + " <= 576)" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedMlfVideo05 = new MediaLibraryFolder(Messages.getString("DvdImages"), SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 32" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.ISOS);
+		MediaLibraryFolder unwatchedMlfVideo03 = new MediaLibraryFolder(Messages.getString("HdVideos"), SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.TABLE_COL_WIDTH + " > 864 OR " + MediaTableFiles.TABLE_COL_HEIGHT + " > 576)" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedMlfVideo04 = new MediaLibraryFolder(Messages.getString("SdVideos"), SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.TABLE_COL_WIDTH + " <= 864 AND " + MediaTableFiles.TABLE_COL_HEIGHT + " <= 576)" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedMlfVideo05 = new MediaLibraryFolder(Messages.getString("DvdImages"), SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 32" + unwatchedCondition + " ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC", MediaLibraryFolder.ISOS);
 
 		// The following block contains all videos regardless of fully played status
 		tvShowsFolder = new MediaLibraryFolder(
 			Messages.getString("TvShows"),
 			new String[]{
-				"SELECT DISTINCT " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + "                              ORDER BY " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " ASC",
-				"SELECT          *               " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + " AND " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' ORDER BY TVSEASON, TVEPISODENUMBER"
+				"SELECT DISTINCT " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + " WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + "                              ORDER BY " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " ASC",
+				"SELECT          *               " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + " WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + " AND " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = '${0}' ORDER BY TVSEASON, TVEPISODENUMBER"
 			},
 			new int[]{MediaLibraryFolder.TVSERIES_WITH_FILTERS, MediaLibraryFolder.EPISODES}
 		);
 		MediaLibraryFolder moviesFolder = new MediaLibraryFolder(
 			Messages.getString("Movies"),
-			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 " + movieCondition + " AND " + MediaTableFiles.STEREOSCOPY + " = '' ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 " + movieCondition + " AND " + MediaTableFiles.TABLE_COL_STEREOSCOPY + " = '' ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder movies3DFolder = new MediaLibraryFolder(
 			Messages.getString("3dMovies"),
-			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 " + movieCondition + " AND " + MediaTableFiles.STEREOSCOPY + " != '' ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 " + movieCondition + " AND " + MediaTableFiles.TABLE_COL_STEREOSCOPY + " != '' ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder unsortedFolder = new MediaLibraryFolder(
 			Messages.getString("Unsorted"),
-			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND NOT " + MediaTableVideoMetadatas.ISTVEPISODE + " AND (" + MediaTableVideoMetadatas.MEDIA_YEAR + " IS NULL OR " + MediaTableVideoMetadatas.MEDIA_YEAR + " = '') ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND NOT " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + " AND (" + MediaTableVideoMetadata.TABLE_COL_MEDIA_YEAR + " IS NULL OR " + MediaTableVideoMetadata.TABLE_COL_MEDIA_YEAR + " = '') ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder allVideosFolder = new MediaLibraryFolder(
 			Messages.getString("AllVideos"),
-			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder recentlyAddedVideos = new MediaLibraryFolder(
 			Messages.getString("RecentlyAdded"),
-			new String[]{"SELECT * " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 ORDER BY " + MediaTableFiles.MODIFIED + " DESC LIMIT 100"},
+			new String[]{"SELECT * " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + " WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 ORDER BY " + MediaTableFiles.TABLE_COL_MODIFIED + " DESC LIMIT 100"},
 			new int[]{MediaLibraryFolder.FILES_NOSORT}
 		);
 		MediaLibraryFolder inProgressVideos = new MediaLibraryFolder(
 			Messages.getString("InProgress"),
-			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableFilesStatus.DATELASTPLAY + " IS NOT NULL" + unwatchedCondition + " ORDER BY " + MediaTableFilesStatus.DATELASTPLAY + " DESC LIMIT 100",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableFilesStatus.TABLE_COL_DATELASTPLAY + " IS NOT NULL" + unwatchedCondition + " ORDER BY " + MediaTableFilesStatus.TABLE_COL_DATELASTPLAY + " DESC LIMIT 100",
 			MediaLibraryFolder.FILES_NOSORT
 		);
 		MediaLibraryFolder mostPlayedVideos = new MediaLibraryFolder(
 			Messages.getString("MostPlayed"),
-			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableFilesStatus.DATELASTPLAY + " IS NOT NULL ORDER BY " + MediaTableFilesStatus.PLAYCOUNT + " DESC LIMIT 100",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableFilesStatus.TABLE_COL_DATELASTPLAY + " IS NOT NULL ORDER BY " + MediaTableFilesStatus.TABLE_COL_PLAYCOUNT + " DESC LIMIT 100",
 			MediaLibraryFolder.FILES_NOSORT
 		);
 		MediaLibraryFolder mlfVideo02 = new MediaLibraryFolder(
 			Messages.getString("ByDate"),
 			new String[]{
-				"SELECT FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 ORDER BY " + MediaTableFiles.MODIFIED + " DESC",
-				MediaTableFiles.FORMAT_TYPE + " = 4 AND FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') = '${0}' ORDER BY " + MediaTableFiles.FILENAME + " ASC"
+				"SELECT FORMATDATETIME(" + MediaTableFiles.TABLE_COL_MODIFIED + ", 'yyyy MM d') FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 ORDER BY " + MediaTableFiles.TABLE_COL_MODIFIED + " DESC",
+				MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND FORMATDATETIME(" + MediaTableFiles.TABLE_COL_MODIFIED + ", 'yyyy MM d') = '${0}' ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS_NOSORT_WITH_FILTERS, MediaLibraryFolder.FILES}
 		);
 		MediaLibraryFolder mlfVideo03 = new MediaLibraryFolder(
 			Messages.getString("HdVideos"),
-			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.WIDTH + " > 864 OR " + MediaTableFiles.HEIGHT + " > 576)    ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.TABLE_COL_WIDTH + " > 864 OR " + MediaTableFiles.TABLE_COL_HEIGHT + " > 576)    ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder mlfVideo04 = new MediaLibraryFolder(
 			Messages.getString("SdVideos"),
-			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.WIDTH + " <= 864 AND " + MediaTableFiles.HEIGHT + " <= 576) ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.TABLE_COL_WIDTH + " <= 864 AND " + MediaTableFiles.TABLE_COL_HEIGHT + " <= 576) ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder mlfVideo05 = new MediaLibraryFolder(
 			Messages.getString("DvdImages"),
-			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 32                                     ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 32                                     ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.ISOS_WITH_FILTERS
 		);
 
@@ -186,7 +186,7 @@ public class MediaLibrary extends VirtualFolder {
 			if (configuration.isShowRecentlyPlayedFolder()) {
 				MediaLibraryFolder recentlyPlayedVideos = new MediaLibraryFolder(
 					Messages.getString("RecentlyPlayed"),
-					SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableFilesStatus.DATELASTPLAY + " IS NOT NULL ORDER BY " + MediaTableFilesStatus.DATELASTPLAY + " DESC LIMIT 100",
+					SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableFilesStatus.TABLE_COL_DATELASTPLAY + " IS NOT NULL ORDER BY " + MediaTableFilesStatus.TABLE_COL_DATELASTPLAY + " DESC LIMIT 100",
 					MediaLibraryFolder.FILES_NOSORT
 				);
 				vfVideo.addChild(recentlyPlayedVideos);
@@ -204,21 +204,21 @@ public class MediaLibrary extends VirtualFolder {
 		vfAudio = new VirtualFolder(Messages.getString("Audio"), null);
 		allFolder = new MediaLibraryFolder(
 			Messages.getString("AllAudioTracks"),
-			"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.FILES
 		);
 		vfAudio.addChild(allFolder);
 		playlistFolder = new MediaLibraryFolder(
 			Messages.getString("AllAudioPlaylists"),
-			"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 16 ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 16 ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.PLAYLISTS
 		);
 		vfAudio.addChild(playlistFolder);
 		artistFolder = new MediaLibraryFolder(
 			Messages.getString("ByArtist"),
 			new String[]{
-				"SELECT DISTINCT COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 ORDER BY ARTIST ASC",
-				"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + "  FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") = '${0}'"
+				"SELECT DISTINCT COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 ORDER BY ARTIST ASC",
+				"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + "  FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") = '${0}'"
 			},
 			new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES}
 		);
@@ -226,8 +226,8 @@ public class MediaLibrary extends VirtualFolder {
 		albumFolder = new MediaLibraryFolder(
 			Messages.getString("ByAlbum"),
 			new String[]{
-				"SELECT DISTINCT " + MediaTableAudiotracks.ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 ORDER BY " + MediaTableAudiotracks.ALBUM + " ASC",
-				"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.ALBUM + " = '${0}'"
+				"SELECT DISTINCT " + MediaTableAudiotracks.TABLE_COL_ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 ORDER BY " + MediaTableAudiotracks.TABLE_COL_ALBUM + " ASC",
+				"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.TABLE_COL_ALBUM + " = '${0}'"
 			},
 			new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES}
 		);
@@ -235,8 +235,8 @@ public class MediaLibrary extends VirtualFolder {
 		genreFolder = new MediaLibraryFolder(
 			Messages.getString("ByGenre"),
 			new String[]{
-				"SELECT DISTINCT " + MediaTableAudiotracks.GENRE + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 ORDER BY " + MediaTableAudiotracks.GENRE + " ASC",
-				"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.GENRE + " = '${0}'"
+				"SELECT DISTINCT " + MediaTableAudiotracks.TABLE_COL_GENRE + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 ORDER BY " + MediaTableAudiotracks.TABLE_COL_GENRE + " ASC",
+				"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.TABLE_COL_GENRE + " = '${0}'"
 			},
 			new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES}
 		);
@@ -244,9 +244,9 @@ public class MediaLibrary extends VirtualFolder {
 		MediaLibraryFolder mlf6 = new MediaLibraryFolder(
 			Messages.getString("ByArtistAlbum"),
 			new String[]{
-				"SELECT DISTINCT COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 ORDER BY ARTIST ASC",
-				"SELECT DISTINCT " + MediaTableAudiotracks.ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") = '${0}' ORDER BY " + MediaTableAudiotracks.ALBUM + " ASC",
-				"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") = '${1}' AND " + MediaTableAudiotracks.ALBUM + " = '${0}' ORDER BY " + MediaTableAudiotracks.TRACK + " ASC, " + MediaTableFiles.FILENAME + " ASC"
+				"SELECT DISTINCT COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 ORDER BY ARTIST ASC",
+				"SELECT DISTINCT " + MediaTableAudiotracks.TABLE_COL_ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") = '${0}' ORDER BY " + MediaTableAudiotracks.TABLE_COL_ALBUM + " ASC",
+				"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") = '${1}' AND " + MediaTableAudiotracks.TABLE_COL_ALBUM + " = '${0}' ORDER BY " + MediaTableAudiotracks.TABLE_COL_TRACK + " ASC, " + MediaTableFiles.TABLE_COL_FILENAME + " ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES}
 		);
@@ -254,10 +254,10 @@ public class MediaLibrary extends VirtualFolder {
 		MediaLibraryFolder mlf7 = new MediaLibraryFolder(
 			Messages.getString("ByGenreArtistAlbum"),
 			new String[]{
-				"SELECT DISTINCT " + MediaTableAudiotracks.GENRE + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 ORDER BY " + MediaTableAudiotracks.GENRE + " ASC",
-				"SELECT DISTINCT COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.GENRE + " = '${0}' ORDER BY ARTIST ASC",
-				"SELECT DISTINCT " + MediaTableAudiotracks.ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.GENRE + " = '${1}' AND COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") = '${0}' ORDER BY " + MediaTableAudiotracks.ALBUM + " ASC",
-				"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.GENRE + " = '${2}' AND COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") = '${1}' AND " + MediaTableAudiotracks.ALBUM + " = '${0}' ORDER BY " + MediaTableAudiotracks.TRACK + " ASC, " + MediaTableFiles.FILENAME + " ASC"
+				"SELECT DISTINCT " + MediaTableAudiotracks.TABLE_COL_GENRE + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 ORDER BY " + MediaTableAudiotracks.TABLE_COL_GENRE + " ASC",
+				"SELECT DISTINCT COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.TABLE_COL_GENRE + " = '${0}' ORDER BY ARTIST ASC",
+				"SELECT DISTINCT " + MediaTableAudiotracks.TABLE_COL_ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.TABLE_COL_GENRE + " = '${1}' AND COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") = '${0}' ORDER BY " + MediaTableAudiotracks.TABLE_COL_ALBUM + " ASC",
+				"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND " + MediaTableAudiotracks.TABLE_COL_GENRE + " = '${2}' AND COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") = '${1}' AND " + MediaTableAudiotracks.TABLE_COL_ALBUM + " = '${0}' ORDER BY " + MediaTableAudiotracks.TABLE_COL_TRACK + " ASC, " + MediaTableFiles.TABLE_COL_FILENAME + " ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES}
 		);
@@ -265,8 +265,8 @@ public class MediaLibrary extends VirtualFolder {
 		MediaLibraryFolder mlfAudioDate = new MediaLibraryFolder(
 			Messages.getString("ByDate"),
 			new String[]{
-				"SELECT FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 ORDER BY " + MediaTableFiles.MODIFIED + " DESC",
-				"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') = '${0}' ORDER BY " + MediaTableAudiotracks.TRACK + " ASC, " + MediaTableFiles.FILENAME + " ASC"
+				"SELECT FORMATDATETIME(" + MediaTableFiles.TABLE_COL_MODIFIED + ", 'yyyy MM d') FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 ORDER BY " + MediaTableFiles.TABLE_COL_MODIFIED + " DESC",
+				"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND FORMATDATETIME(" + MediaTableFiles.TABLE_COL_MODIFIED + ", 'yyyy MM d') = '${0}' ORDER BY " + MediaTableAudiotracks.TABLE_COL_TRACK + " ASC, " + MediaTableFiles.TABLE_COL_FILENAME + " ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS_NOSORT, MediaLibraryFolder.FILES}
 		);
@@ -275,10 +275,10 @@ public class MediaLibrary extends VirtualFolder {
 		MediaLibraryFolder mlf8 = new MediaLibraryFolder(
 			Messages.getString("ByLetterArtistAlbum"),
 			new String[]{
-				"SELECT " + MediaTableRegexpRules.ID + " FROM " + MediaTableRegexpRules.TABLE_NAME + " ORDER BY " + MediaTableRegexpRules.REGEXP_ORDER + " ASC",
-				"SELECT DISTINCT COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND ARTIST REGEXP (SELECT " + MediaTableRegexpRules.REGEXP_RULE + " FROM " + MediaTableRegexpRules.TABLE_NAME + " WHERE " + MediaTableRegexpRules.ID + " = '${0}') ORDER BY ARTIST ASC",
-				"SELECT DISTINCT " + MediaTableAudiotracks.ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") = '${0}' ORDER BY " + MediaTableAudiotracks.ALBUM + " ASC",
-				"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") = '${1}' AND " + MediaTableAudiotracks.ALBUM + " = '${0}'"
+				"SELECT " + MediaTableRegexpRules.TABLE_COL_ID + " FROM " + MediaTableRegexpRules.TABLE_NAME + " ORDER BY " + MediaTableRegexpRules.TABLE_COL_REGEXP_ORDER + " ASC",
+				"SELECT DISTINCT COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND ARTIST REGEXP (SELECT " + MediaTableRegexpRules.TABLE_COL_REGEXP_RULE + " FROM " + MediaTableRegexpRules.TABLE_NAME + " WHERE " + MediaTableRegexpRules.TABLE_COL_ID + " = '${0}') ORDER BY ARTIST ASC",
+				"SELECT DISTINCT " + MediaTableAudiotracks.TABLE_COL_ALBUM + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") = '${0}' ORDER BY " + MediaTableAudiotracks.TABLE_COL_ALBUM + " ASC",
+				"SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableAudiotracks.TABLE_COL_FILEID + " AND " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.TABLE_COL_ALBUMARTIST + ", " + MediaTableAudiotracks.TABLE_COL_ARTIST + ") = '${1}' AND " + MediaTableAudiotracks.TABLE_COL_ALBUM + " = '${0}'"
 			},
 			new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES}
 		);
@@ -288,15 +288,15 @@ public class MediaLibrary extends VirtualFolder {
 		VirtualFolder vfImage = new VirtualFolder(Messages.getString("Photo"), null);
 		MediaLibraryFolder mlfPhoto01 = new MediaLibraryFolder(
 			Messages.getString("AllPhotos"),
-			MediaTableFiles.FORMAT_TYPE + " = 2 ORDER BY " + MediaTableFiles.FILENAME + " ASC",
+			MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 2 ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC",
 			MediaLibraryFolder.FILES
 		);
 		vfImage.addChild(mlfPhoto01);
 		MediaLibraryFolder mlfPhoto02 = new MediaLibraryFolder(
 			Messages.getString("ByDate"),
 			new String[]{
-				"SELECT FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 2 ORDER BY " + MediaTableFiles.MODIFIED + " DESC",
-				MediaTableFiles.FORMAT_TYPE + " = 2 AND FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') = '${0}' ORDER BY " + MediaTableFiles.FILENAME + " ASC"
+				"SELECT FORMATDATETIME(" + MediaTableFiles.TABLE_COL_MODIFIED + ", 'yyyy MM d') FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 2 ORDER BY " + MediaTableFiles.TABLE_COL_MODIFIED + " DESC",
+				MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 2 AND FORMATDATETIME(" + MediaTableFiles.TABLE_COL_MODIFIED + ", 'yyyy MM d') = '${0}' ORDER BY " + MediaTableFiles.TABLE_COL_FILENAME + " ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS_NOSORT, MediaLibraryFolder.FILES}
 		);

--- a/src/main/java/net/pms/dlna/virtual/MediaLibrary.java
+++ b/src/main/java/net/pms/dlna/virtual/MediaLibrary.java
@@ -1,7 +1,10 @@
 package net.pms.dlna.virtual;
 
 import net.pms.Messages;
+import net.pms.database.MediaTableAudiotracks;
+import net.pms.database.MediaTableFiles;
 import net.pms.database.MediaTableFilesStatus;
+import net.pms.database.MediaTableVideoMetadatas;
 import net.pms.util.FullyPlayedAction;
 
 /**
@@ -18,6 +21,11 @@ public class MediaLibrary extends VirtualFolder {
 	 * @see https://www.bfi.org.uk/bfi-national-archive/research-bfi-archive/bfi-filmography/bfi-filmography-faq
 	 */
 	private static final Double FORTY_MINUTES_IN_SECONDS = 2400.0;
+	//private static final String SQL_FILES_START = "SELECT * FROM " + MediaTableFiles.TABLE_NAME + " LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON FILES.FILENAME = " + MediaTableFilesStatus.TABLE_NAME + ".FILENAME WHERE ";
+	private static final String SELECT_FILES_STATUS_WHERE = "SELECT * " + MediaLibraryFolder.FROM_FILES_STATUS + "WHERE ";
+	private static final String SELECT_FILES_VIDEO_WHERE = "SELECT * " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + "WHERE ";
+	private static final String SELECT_FILES_STATUS_VIDEO_WHERE = "SELECT * " + MediaLibraryFolder.FROM_FILES_STATUS_VIDEOMETA + "WHERE ";
+
 	private boolean enabled;
 
 	private MediaLibraryFolder allFolder;
@@ -57,102 +65,102 @@ public class MediaLibrary extends VirtualFolder {
 		// Videos folder
 		VirtualFolder vfVideo = new VirtualFolder(Messages.getString("Video"), null);
 
-		String sqlJoinStart = "SELECT * FROM FILES LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON FILES.FILENAME = " + MediaTableFilesStatus.TABLE_NAME + ".FILENAME WHERE ";
+		//String sqlJoinStart = "SELECT * FROM FILES LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON FILES.FILENAME = " + MediaTableFilesStatus.TABLE_NAME + ".FILENAME WHERE ";
 
 		// All videos that are unwatched
-		String movieCondition = " AND NOT ISTVEPISODE AND MEDIA_YEAR != '' AND DURATION > " + FORTY_MINUTES_IN_SECONDS;
-		String unwatchedCondition = " AND " + MediaTableFilesStatus.TABLE_NAME + ".ISFULLYPLAYED IS NOT TRUE";
+		String movieCondition = " AND NOT " + MediaTableVideoMetadatas.ISTVEPISODE + " AND " + MediaTableVideoMetadatas.MEDIA_YEAR + " != '' AND DURATION > " + FORTY_MINUTES_IN_SECONDS;
+		String unwatchedCondition = " AND " + MediaTableFilesStatus.ISFULLYPLAYED + " IS NOT TRUE";
 		MediaLibraryFolder unwatchedTvShowsFolder = new MediaLibraryFolder(
 			Messages.getString("TvShows"),
 			new String[]{
-				"SELECT DISTINCT FILES.MOVIEORSHOWNAME FROM FILES LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON FILES.FILENAME = " + MediaTableFilesStatus.TABLE_NAME + ".FILENAME WHERE FILES.FORMAT_TYPE = 4 AND FILES.ISTVEPISODE" + unwatchedCondition + "                                    ORDER BY FILES.MOVIEORSHOWNAME ASC",
-				sqlJoinStart +                                                                                                                                                        "FILES.FORMAT_TYPE = 4 AND FILES.ISTVEPISODE" + unwatchedCondition + " AND FILES.MOVIEORSHOWNAME = '${0}' ORDER BY FILES.TVSEASON, FILES.TVEPISODENUMBER"
+				"SELECT DISTINCT " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + MediaLibraryFolder.FROM_FILES_STATUS_VIDEOMETA + "WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + unwatchedCondition + "                                    ORDER BY " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " ASC",
+				SELECT_FILES_STATUS_VIDEO_WHERE +                                                                      MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + unwatchedCondition + " AND " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' ORDER BY " + MediaTableVideoMetadatas.TVSEASON + ", " + MediaTableVideoMetadatas.TVEPISODENUMBER
 			},
 			new int[]{MediaLibraryFolder.TVSERIES_WITH_FILTERS, MediaLibraryFolder.EPISODES}
 		);
 
-		MediaLibraryFolder unwatchedMoviesFolder = new MediaLibraryFolder(Messages.getString("Movies"), sqlJoinStart + "FILES.FORMAT_TYPE = 4 " + movieCondition + " AND STEREOSCOPY = ''" + unwatchedCondition + " ORDER BY FILENAME ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedMovies3DFolder = new MediaLibraryFolder(Messages.getString("3dMovies"), sqlJoinStart + "FILES.FORMAT_TYPE = 4 " + movieCondition + " AND STEREOSCOPY != ''" + unwatchedCondition + " ORDER BY FILENAME ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedUnsortedFolder = new MediaLibraryFolder(Messages.getString("Unsorted"), sqlJoinStart + "FILES.FORMAT_TYPE = 4 AND NOT ISTVEPISODE AND (MEDIA_YEAR IS NULL OR MEDIA_YEAR = '')" + unwatchedCondition + " ORDER BY FILENAME ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedRecentlyAddedVideos = new MediaLibraryFolder(Messages.getString("RecentlyAdded"), sqlJoinStart + "FILES.FORMAT_TYPE = 4" + unwatchedCondition + " ORDER BY FILES.MODIFIED DESC LIMIT 100", MediaLibraryFolder.FILES_NOSORT);
-		MediaLibraryFolder unwatchedAllVideosFolder = new MediaLibraryFolder(Messages.getString("AllVideos"), sqlJoinStart + "FILES.FORMAT_TYPE = 4" + unwatchedCondition + " ORDER BY FILENAME ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedMoviesFolder = new MediaLibraryFolder(Messages.getString("Movies"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 " + movieCondition + " AND STEREOSCOPY = ''" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedMovies3DFolder = new MediaLibraryFolder(Messages.getString("3dMovies"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 " + movieCondition + " AND STEREOSCOPY != ''" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedUnsortedFolder = new MediaLibraryFolder(Messages.getString("Unsorted"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND NOT " + MediaTableVideoMetadatas.ISTVEPISODE + " AND (" + MediaTableVideoMetadatas.MEDIA_YEAR + " IS NULL OR " + MediaTableVideoMetadatas.MEDIA_YEAR + " = '')" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedRecentlyAddedVideos = new MediaLibraryFolder(Messages.getString("RecentlyAdded"), SELECT_FILES_STATUS_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4" + unwatchedCondition + " ORDER BY " + MediaTableFiles.MODIFIED + " DESC LIMIT 100", MediaLibraryFolder.FILES_NOSORT);
+		MediaLibraryFolder unwatchedAllVideosFolder = new MediaLibraryFolder(Messages.getString("AllVideos"), SELECT_FILES_STATUS_WHERE  + MediaTableFiles.FORMAT_TYPE + " = 4" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
 		MediaLibraryFolder unwatchedMlfVideo02 = new MediaLibraryFolder(
 			Messages.getString("ByDate"),
 			new String[]{
-				"SELECT FORMATDATETIME(FILES.MODIFIED, 'yyyy MM d') FROM FILES LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON FILES.FILENAME = " + MediaTableFilesStatus.TABLE_NAME + ".FILENAME WHERE FILES.FORMAT_TYPE = 4" + unwatchedCondition + " ORDER BY FILES.MODIFIED DESC",
-				sqlJoinStart + "FILES.FORMAT_TYPE = 4 AND FORMATDATETIME(FILES.MODIFIED, 'yyyy MM d') = '${0}'" + unwatchedCondition + " ORDER BY FILENAME ASC"
+				"SELECT FORMATDATETIME(FILES.MODIFIED, 'yyyy MM d') " + MediaLibraryFolder.FROM_FILES_STATUS_VIDEOMETA + "WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4" + unwatchedCondition + " ORDER BY " + MediaTableFiles.MODIFIED + " DESC",
+				SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') = '${0}'" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS_NOSORT, MediaLibraryFolder.FILES}
 		);
-		MediaLibraryFolder unwatchedMlfVideo03 = new MediaLibraryFolder(Messages.getString("HdVideos"), sqlJoinStart + "FILES.FORMAT_TYPE = 4 AND (WIDTH > 864 OR HEIGHT > 576)" + unwatchedCondition + " ORDER BY FILENAME ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedMlfVideo04 = new MediaLibraryFolder(Messages.getString("SdVideos"), sqlJoinStart + "FILES.FORMAT_TYPE = 4 AND (WIDTH <= 864 AND HEIGHT <= 576)" + unwatchedCondition + " ORDER BY FILENAME ASC", MediaLibraryFolder.FILES);
-		MediaLibraryFolder unwatchedMlfVideo05 = new MediaLibraryFolder(Messages.getString("DvdImages"), sqlJoinStart + "FILES.FORMAT_TYPE = 32" + unwatchedCondition + " ORDER BY FILENAME ASC", MediaLibraryFolder.ISOS);
+		MediaLibraryFolder unwatchedMlfVideo03 = new MediaLibraryFolder(Messages.getString("HdVideos"), SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.WIDTH + " > 864 OR " + MediaTableFiles.HEIGHT + " > 576)" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedMlfVideo04 = new MediaLibraryFolder(Messages.getString("SdVideos"), SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.WIDTH + " <= 864 AND " + MediaTableFiles.HEIGHT + " <= 576)" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
+		MediaLibraryFolder unwatchedMlfVideo05 = new MediaLibraryFolder(Messages.getString("DvdImages"), SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 32" + unwatchedCondition + " ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.ISOS);
 
 		// The following block contains all videos regardless of fully played status
 		tvShowsFolder = new MediaLibraryFolder(
 			Messages.getString("TvShows"),
 			new String[]{
-				"SELECT DISTINCT MOVIEORSHOWNAME FROM FILES WHERE FORMAT_TYPE = 4 AND ISTVEPISODE                              ORDER BY MOVIEORSHOWNAME ASC",
-				"SELECT          *               FROM FILES WHERE FORMAT_TYPE = 4 AND ISTVEPISODE AND MOVIEORSHOWNAME = '${0}' ORDER BY TVSEASON, TVEPISODENUMBER"
+				"SELECT DISTINCT " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + "                              ORDER BY " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " ASC",
+				"SELECT          *               " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + " AND " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' ORDER BY TVSEASON, TVEPISODENUMBER"
 			},
 			new int[]{MediaLibraryFolder.TVSERIES_WITH_FILTERS, MediaLibraryFolder.EPISODES}
 		);
 		MediaLibraryFolder moviesFolder = new MediaLibraryFolder(
 			Messages.getString("Movies"),
-			"FORMAT_TYPE = 4 " + movieCondition + " AND STEREOSCOPY = '' ORDER BY FILENAME ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 " + movieCondition + " AND STEREOSCOPY = '' ORDER BY " + MediaTableFiles.FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder movies3DFolder = new MediaLibraryFolder(
 			Messages.getString("3dMovies"),
-			"FORMAT_TYPE = 4 " + movieCondition + " AND STEREOSCOPY != '' ORDER BY FILENAME ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 " + movieCondition + " AND STEREOSCOPY != '' ORDER BY " + MediaTableFiles.FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder unsortedFolder = new MediaLibraryFolder(
 			Messages.getString("Unsorted"),
-			"FORMAT_TYPE = 4 AND NOT ISTVEPISODE AND (MEDIA_YEAR IS NULL OR MEDIA_YEAR = '') ORDER BY FILENAME ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND NOT " + MediaTableVideoMetadatas.ISTVEPISODE + " AND (" + MediaTableVideoMetadatas.MEDIA_YEAR + " IS NULL OR " + MediaTableVideoMetadatas.MEDIA_YEAR + " = '') ORDER BY " + MediaTableFiles.FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder allVideosFolder = new MediaLibraryFolder(
 			Messages.getString("AllVideos"),
-			"FORMAT_TYPE = 4 ORDER BY FILENAME ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 ORDER BY " + MediaTableFiles.FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder recentlyAddedVideos = new MediaLibraryFolder(
 			Messages.getString("RecentlyAdded"),
-			new String[]{"SELECT * FROM FILES WHERE FORMAT_TYPE = 4 ORDER BY FILES.MODIFIED DESC LIMIT 100"},
+			new String[]{"SELECT * " + MediaLibraryFolder.FROM_FILES_VIDEOMETA + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 ORDER BY " + MediaTableFiles.MODIFIED + " DESC LIMIT 100"},
 			new int[]{MediaLibraryFolder.FILES_NOSORT}
 		);
 		MediaLibraryFolder inProgressVideos = new MediaLibraryFolder(
 			Messages.getString("InProgress"),
-			sqlJoinStart + "FILES.FORMAT_TYPE = 4 AND " + MediaTableFilesStatus.TABLE_NAME + ".DATELASTPLAY IS NOT NULL" + unwatchedCondition + " ORDER BY " + MediaTableFilesStatus.TABLE_NAME + ".DATELASTPLAY DESC LIMIT 100",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableFilesStatus.DATELASTPLAY + " IS NOT NULL" + unwatchedCondition + " ORDER BY " + MediaTableFilesStatus.DATELASTPLAY + " DESC LIMIT 100",
 			MediaLibraryFolder.FILES_NOSORT
 		);
 		MediaLibraryFolder mostPlayedVideos = new MediaLibraryFolder(
 			Messages.getString("MostPlayed"),
-			sqlJoinStart + "FILES.FORMAT_TYPE = 4 AND " + MediaTableFilesStatus.TABLE_NAME + ".DATELASTPLAY IS NOT NULL ORDER BY " + MediaTableFilesStatus.TABLE_NAME + ".PLAYCOUNT DESC LIMIT 100",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableFilesStatus.DATELASTPLAY + " IS NOT NULL ORDER BY " + MediaTableFilesStatus.PLAYCOUNT + " DESC LIMIT 100",
 			MediaLibraryFolder.FILES_NOSORT
 		);
 		MediaLibraryFolder mlfVideo02 = new MediaLibraryFolder(
 			Messages.getString("ByDate"),
 			new String[]{
-				"SELECT FORMATDATETIME(FILES.MODIFIED, 'yyyy MM d') FROM FILES WHERE FORMAT_TYPE = 4 ORDER BY FILES.MODIFIED DESC",
-				"FORMAT_TYPE = 4 AND FORMATDATETIME(FILES.MODIFIED, 'yyyy MM d') = '${0}' ORDER BY FILES.FILENAME ASC"
+				"SELECT FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 ORDER BY " + MediaTableFiles.MODIFIED + " DESC",
+				MediaTableFiles.FORMAT_TYPE + " = 4 AND FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') = '${0}' ORDER BY " + MediaTableFiles.FILENAME + " ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS_NOSORT_WITH_FILTERS, MediaLibraryFolder.FILES}
 		);
 		MediaLibraryFolder mlfVideo03 = new MediaLibraryFolder(
 			Messages.getString("HdVideos"),
-			"FORMAT_TYPE = 4 AND (WIDTH > 864 OR HEIGHT > 576)    ORDER BY FILENAME ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.WIDTH + " > 864 OR " + MediaTableFiles.HEIGHT + " > 576)    ORDER BY " + MediaTableFiles.FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder mlfVideo04 = new MediaLibraryFolder(
 			Messages.getString("SdVideos"),
-			"FORMAT_TYPE = 4 AND (WIDTH <= 864 AND HEIGHT <= 576) ORDER BY FILENAME ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND (" + MediaTableFiles.WIDTH + " <= 864 AND " + MediaTableFiles.HEIGHT + " <= 576) ORDER BY " + MediaTableFiles.FILENAME + " ASC",
 			MediaLibraryFolder.FILES_WITH_FILTERS
 		);
 		MediaLibraryFolder mlfVideo05 = new MediaLibraryFolder(
 			Messages.getString("DvdImages"),
-			"FORMAT_TYPE = 32                                     ORDER BY FILENAME ASC",
+			SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 32                                     ORDER BY " + MediaTableFiles.FILENAME + " ASC",
 			MediaLibraryFolder.ISOS_WITH_FILTERS
 		);
 
@@ -179,7 +187,7 @@ public class MediaLibrary extends VirtualFolder {
 			if (configuration.isShowRecentlyPlayedFolder()) {
 				MediaLibraryFolder recentlyPlayedVideos = new MediaLibraryFolder(
 					Messages.getString("RecentlyPlayed"),
-					sqlJoinStart + "FILES.FORMAT_TYPE = 4 AND " + MediaTableFilesStatus.TABLE_NAME + ".DATELASTPLAY IS NOT NULL ORDER BY " + MediaTableFilesStatus.TABLE_NAME + ".DATELASTPLAY DESC LIMIT 100",
+					SELECT_FILES_STATUS_VIDEO_WHERE + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableFilesStatus.DATELASTPLAY + " IS NOT NULL ORDER BY " + MediaTableFilesStatus.DATELASTPLAY + " DESC LIMIT 100",
 					MediaLibraryFolder.FILES_NOSORT
 				);
 				vfVideo.addChild(recentlyPlayedVideos);
@@ -195,32 +203,32 @@ public class MediaLibrary extends VirtualFolder {
 		addChild(vfVideo);
 
 		vfAudio = new VirtualFolder(Messages.getString("Audio"), null);
-		allFolder = new MediaLibraryFolder(Messages.getString("AllAudioTracks"), "select FILENAME, MODIFIED from FILES F, AUDIOTRACKS A where F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY F.FILENAME ASC", MediaLibraryFolder.FILES);
+		allFolder = new MediaLibraryFolder(Messages.getString("AllAudioTracks"), "SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 ORDER BY " + MediaTableFiles.FILENAME + " ASC", MediaLibraryFolder.FILES);
 		vfAudio.addChild(allFolder);
-		playlistFolder = new MediaLibraryFolder(Messages.getString("AllAudioPlaylists"), "select FILENAME, MODIFIED from FILES F WHERE F.FORMAT_TYPE = 16 ORDER BY F.FILENAME ASC", MediaLibraryFolder.PLAYLISTS);
+		playlistFolder = new MediaLibraryFolder(Messages.getString("AllAudioPlaylists"), "SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " F WHERE F.FORMAT_TYPE = 16 ORDER BY F.FILENAME ASC", MediaLibraryFolder.PLAYLISTS);
 		vfAudio.addChild(playlistFolder);
-		artistFolder = new MediaLibraryFolder(Messages.getString("ByArtist"), new String[]{"SELECT DISTINCT COALESCE(A.ALBUMARTIST, A.ARTIST) as ARTIST FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY ARTIST ASC", "select FILENAME, MODIFIED  from FILES F, AUDIOTRACKS A where F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${0}'"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
+		artistFolder = new MediaLibraryFolder(Messages.getString("ByArtist"), new String[]{"SELECT DISTINCT COALESCE(A.ALBUMARTIST, A.ARTIST) AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY ARTIST ASC", "SELECT FILENAME, MODIFIED  FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${0}'"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
 		vfAudio.addChild(artistFolder);
-		albumFolder = new MediaLibraryFolder(Messages.getString("ByAlbum"), new String[]{"SELECT DISTINCT A.ALBUM FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY A.ALBUM ASC", "select FILENAME, MODIFIED from FILES F, AUDIOTRACKS A where F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND A.ALBUM = '${0}'"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
+		albumFolder = new MediaLibraryFolder(Messages.getString("ByAlbum"), new String[]{"SELECT DISTINCT A.ALBUM FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY A.ALBUM ASC", "SELECT FILENAME, MODIFIED FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND A.ALBUM = '${0}'"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
 		vfAudio.addChild(albumFolder);
-		genreFolder = new MediaLibraryFolder(Messages.getString("ByGenre"), new String[]{"SELECT DISTINCT A.GENRE FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY A.GENRE ASC", "select FILENAME, MODIFIED from FILES F, AUDIOTRACKS A where F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND A.GENRE = '${0}'"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
+		genreFolder = new MediaLibraryFolder(Messages.getString("ByGenre"), new String[]{"SELECT DISTINCT A.GENRE FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY A.GENRE ASC", "SELECT FILENAME, MODIFIED FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND A.GENRE = '${0}'"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
 		vfAudio.addChild(genreFolder);
 		MediaLibraryFolder mlf6 = new MediaLibraryFolder(Messages.getString("ByArtistAlbum"), new String[]{
-				"SELECT DISTINCT COALESCE(A.ALBUMARTIST, A.ARTIST) as ARTIST FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY ARTIST ASC",
-				"SELECT DISTINCT A.ALBUM FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${0}' ORDER BY A.ALBUM ASC",
-				"select FILENAME, MODIFIED from FILES F, AUDIOTRACKS A where F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${1}' AND A.ALBUM = '${0}' ORDER BY A.TRACK ASC, F.FILENAME ASC"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
+				"SELECT DISTINCT COALESCE(A.ALBUMARTIST, A.ARTIST) AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY ARTIST ASC",
+				"SELECT DISTINCT A.ALBUM FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${0}' ORDER BY A.ALBUM ASC",
+				"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableFiles.ID + " = " + MediaTableAudiotracks.FILEID + " AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND COALESCE(" + MediaTableAudiotracks.ALBUMARTIST + ", " + MediaTableAudiotracks.ARTIST + ") = '${1}' AND " + MediaTableAudiotracks.ALBUM + " = '${0}' ORDER BY " + MediaTableAudiotracks.TRACK + " ASC, " + MediaTableFiles.FILENAME + " ASC"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
 		vfAudio.addChild(mlf6);
 		MediaLibraryFolder mlf7 = new MediaLibraryFolder(Messages.getString("ByGenreArtistAlbum"), new String[]{
-				"SELECT DISTINCT A.GENRE FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY A.GENRE ASC",
-				"SELECT DISTINCT COALESCE(A.ALBUMARTIST, A.ARTIST) as ARTIST FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND A.GENRE = '${0}' ORDER BY ARTIST ASC",
-				"SELECT DISTINCT A.ALBUM FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND A.GENRE = '${1}' AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${0}' ORDER BY A.ALBUM ASC",
-				"select FILENAME, MODIFIED from FILES F, AUDIOTRACKS A where F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND A.GENRE = '${2}' AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${1}' AND A.ALBUM = '${0}' ORDER BY A.TRACK ASC, F.FILENAME ASC"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
+				"SELECT DISTINCT A.GENRE FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY A.GENRE ASC",
+				"SELECT DISTINCT COALESCE(A.ALBUMARTIST, A.ARTIST) AS ARTIST FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND A.GENRE = '${0}' ORDER BY ARTIST ASC",
+				"SELECT DISTINCT A.ALBUM FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND A.GENRE = '${1}' AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${0}' ORDER BY A.ALBUM ASC",
+				"SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + ", AUDIOTRACKS A where " + MediaTableFiles.ID + " = A.FILEID AND " + MediaTableFiles.FORMAT_TYPE + " = 1 AND A.GENRE = '${2}' AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${1}' AND A.ALBUM = '${0}' ORDER BY A.TRACK ASC, " + MediaTableFiles.FILENAME + " ASC"}, new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES});
 		vfAudio.addChild(mlf7);
 		MediaLibraryFolder mlfAudioDate = new MediaLibraryFolder(
 			Messages.getString("ByDate"),
 			new String[]{
-				"SELECT FORMATDATETIME(MODIFIED, 'yyyy MM d') FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY F.MODIFIED DESC",
-				"select FILENAME, MODIFIED from FILES F, AUDIOTRACKS A where F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND FORMATDATETIME(MODIFIED, 'yyyy MM d') = '${0}' ORDER BY A.TRACK ASC, F.FILENAME ASC"
+				"SELECT FORMATDATETIME(MODIFIED, 'yyyy MM d') FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 ORDER BY F.MODIFIED DESC",
+				"SELECT FILENAME, MODIFIED from " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A where F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND FORMATDATETIME(MODIFIED, 'yyyy MM d') = '${0}' ORDER BY A.TRACK ASC, F.FILENAME ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS_NOSORT, MediaLibraryFolder.FILES}
 		);
@@ -230,9 +238,9 @@ public class MediaLibrary extends VirtualFolder {
 			Messages.getString("ByLetterArtistAlbum"),
 			new String[]{
 				"SELECT ID FROM REGEXP_RULES ORDER BY REGEXP_ORDER ASC",
-				"SELECT DISTINCT COALESCE(A.ALBUMARTIST, A.ARTIST) as ARTIST FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND ARTIST REGEXP (SELECT REGEXP_RULE FROM REGEXP_RULES WHERE ID = '${0}') ORDER BY ARTIST ASC",
-				"SELECT DISTINCT A.ALBUM FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${0}' ORDER BY A.ALBUM ASC",
-				"SELECT FILENAME, MODIFIED FROM FILES F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${1}' AND A.ALBUM = '${0}'"
+				"SELECT DISTINCT COALESCE(A.ALBUMARTIST, A.ARTIST) as ARTIST FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND ARTIST REGEXP (SELECT REGEXP_RULE FROM REGEXP_RULES WHERE ID = '${0}') ORDER BY ARTIST ASC",
+				"SELECT DISTINCT A.ALBUM FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${0}' ORDER BY A.ALBUM ASC",
+				"SELECT FILENAME, MODIFIED FROM " + MediaTableFiles.TABLE_NAME + " F, AUDIOTRACKS A WHERE F.ID = A.FILEID AND F.FORMAT_TYPE = 1 AND COALESCE(A.ALBUMARTIST, A.ARTIST) = '${1}' AND A.ALBUM = '${0}'"
 			},
 			new int[]{MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.TEXTS, MediaLibraryFolder.FILES}
 		);
@@ -242,15 +250,15 @@ public class MediaLibrary extends VirtualFolder {
 		VirtualFolder vfImage = new VirtualFolder(Messages.getString("Photo"), null);
 		MediaLibraryFolder mlfPhoto01 = new MediaLibraryFolder(
 			Messages.getString("AllPhotos"),
-			"FORMAT_TYPE = 2 ORDER BY FILENAME ASC",
+			MediaTableFiles.FORMAT_TYPE + " = 2 ORDER BY " + MediaTableFiles.FILENAME + " ASC",
 			MediaLibraryFolder.FILES
 		);
 		vfImage.addChild(mlfPhoto01);
 		MediaLibraryFolder mlfPhoto02 = new MediaLibraryFolder(
 			Messages.getString("ByDate"),
 			new String[]{
-				"SELECT FORMATDATETIME(MODIFIED, 'yyyy MM d') FROM FILES WHERE FORMAT_TYPE = 2 ORDER BY MODIFIED DESC",
-				"FORMAT_TYPE = 2 AND FORMATDATETIME(MODIFIED, 'yyyy MM d') = '${0}' ORDER BY FILENAME ASC"
+				"SELECT FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + MediaTableFiles.FORMAT_TYPE + " = 2 ORDER BY " + MediaTableFiles.MODIFIED + " DESC",
+				MediaTableFiles.FORMAT_TYPE + " = 2 AND FORMATDATETIME(" + MediaTableFiles.MODIFIED + ", 'yyyy MM d') = '${0}' ORDER BY " + MediaTableFiles.FILENAME + " ASC"
 			},
 			new int[]{MediaLibraryFolder.TEXTS_NOSORT, MediaLibraryFolder.FILES}
 		);

--- a/src/main/java/net/pms/dlna/virtual/MediaLibraryFolder.java
+++ b/src/main/java/net/pms/dlna/virtual/MediaLibraryFolder.java
@@ -175,8 +175,8 @@ public class MediaLibraryFolder extends VirtualFolder {
 
 	private static List<String> getTVSeriesQueries(String tableName, String columnName) {
 		List<String> queries = new ArrayList<>();
-		queries.add("SELECT " + columnName + " FROM " + tableName + " WHERE TVSERIESID > -1 ORDER BY " + columnName + " ASC");
-		queries.add("SELECT TITLE              FROM " + MediaTableTVSeries.TABLE_NAME + " LEFT JOIN " + tableName + " ON " + MediaTableTVSeries.ID + " = " + tableName + ".TVSERIESID WHERE " + tableName + "." + columnName + " = '${0}' ORDER BY " + MediaTableTVSeries.TITLE + " ASC");
+		queries.add("SELECT " + columnName + " FROM " + tableName + " WHERE " + MediaTableTVSeries.CHILD_ID + " IS NOT NULL ORDER BY " + columnName + " ASC");
+		queries.add("SELECT " + MediaTableTVSeries.TITLE + " FROM " + MediaTableTVSeries.TABLE_NAME + " LEFT JOIN " + tableName + " ON " + MediaTableTVSeries.ID + " = " + tableName + ".TVSERIESID WHERE " + columnName + " = '${0}' ORDER BY " + MediaTableTVSeries.TITLE + " ASC");
 		queries.add("SELECT          *     " + FROM_FILES_VIDEOMETA + "WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + " AND " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' ORDER BY " + MediaTableVideoMetadatas.TVEPISODENUMBER);
 		return queries;
 	}
@@ -185,15 +185,15 @@ public class MediaLibraryFolder extends VirtualFolder {
 		String orderByString = "ORDER BY ";
 		int indexAfterFromInFirstQuery = firstSql.indexOf(FROM_FILES) + FROM_FILES.length();
 
-		String selectSection = "SELECT DISTINCT " + tableName + "." + columnName + " FROM FILES ";
-		String orderBySection = "ORDER BY " + tableName + "." + columnName + " ASC";
+		String selectSection = "SELECT DISTINCT " + columnName + " FROM FILES ";
+		String orderBySection = "ORDER BY " + columnName + " ASC";
 
 		// These queries join tables
 		StringBuilder query = new StringBuilder(firstSql);
 
 		// If the query does not already join the right metadata table, do that now
 		if (!firstSql.contains("LEFT JOIN " + tableName)) {
-			String joinSection = "LEFT JOIN " + tableName + " ON " + MediaTableFiles.FILENAME + " = " + tableName + ".FILENAME ";
+			String joinSection = "LEFT JOIN " + tableName + " ON " + MediaTableFiles.ID + " = " + tableName + "." + MediaTableVideoMetadatas.COL_FILEID + " ";
 			query.insert(indexAfterFromInFirstQuery, joinSection);
 		}
 
@@ -211,9 +211,9 @@ public class MediaLibraryFolder extends VirtualFolder {
 		StringBuilder query = new StringBuilder(sql);
 		String whereString = "WHERE ";
 		int indexAfterFrom = sql.indexOf(FROM_FILES) + FROM_FILES.length();
-		String condition = tableName + "." + columnName + " = '${0}' AND ";
+		String condition = columnName + " = '${0}' AND ";
 		if (!sql.contains("LEFT JOIN " + tableName)) {
-			String joinSection = "LEFT JOIN " + tableName + " ON FILES.FILENAME = " + tableName + ".FILENAME ";
+			String joinSection = "LEFT JOIN " + tableName + " ON " + MediaTableFiles.ID + " = " + tableName + "." + MediaTableVideoMetadatas.COL_FILEID + " ";
 			query.insert(indexAfterFrom, joinSection);
 		}
 		int indexAfterWhere = query.indexOf(whereString) + whereString.length();
@@ -334,19 +334,19 @@ public class MediaLibraryFolder extends VirtualFolder {
 									 * attempt to modify the incoming statements to make filtering versions.
 									 */
 									if (expectedOutput == TVSERIES_WITH_FILTERS) {
-										actorsSqls = getTVSeriesQueries(MediaTableVideoMetadataActors.TABLE_NAME, "ACTOR");
-										countriesSqls = getTVSeriesQueries(MediaTableVideoMetadataCountries.TABLE_NAME, "COUNTRY");
-										directorsSqls = getTVSeriesQueries(MediaTableVideoMetadataDirectors.TABLE_NAME, "DIRECTOR");
-										genresSqls = getTVSeriesQueries(MediaTableVideoMetadataGenres.TABLE_NAME, "GENRE");
-										ratedSqls = getTVSeriesQueries(MediaTableVideoMetadataRated.TABLE_NAME, "RATING");
-										releasedSqls = getTVSeriesQueries(MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(RELEASEDATE, 'yyyy')");
+										actorsSqls = getTVSeriesQueries(MediaTableVideoMetadataActors.TABLE_NAME, MediaTableVideoMetadataActors.ACTOR);
+										countriesSqls = getTVSeriesQueries(MediaTableVideoMetadataCountries.TABLE_NAME, MediaTableVideoMetadataCountries.COUNTRY);
+										directorsSqls = getTVSeriesQueries(MediaTableVideoMetadataDirectors.TABLE_NAME, MediaTableVideoMetadataDirectors.DIRECTOR);
+										genresSqls = getTVSeriesQueries(MediaTableVideoMetadataGenres.TABLE_NAME, MediaTableVideoMetadataGenres.GENRE);
+										ratedSqls = getTVSeriesQueries(MediaTableVideoMetadataRated.TABLE_NAME, MediaTableVideoMetadataRated.RATED);
+										releasedSqls = getTVSeriesQueries(MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(" + MediaTableVideoMetadataReleased.RELEASEDATE + ", 'yyyy')");
 									} else {
-										actorsSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataActors.TABLE_NAME, "ACTOR"));
-										countriesSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataCountries.TABLE_NAME, "COUNTRY"));
-										directorsSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataDirectors.TABLE_NAME, "DIRECTOR"));
-										genresSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataGenres.TABLE_NAME, "GENRE"));
-										ratedSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataRated.TABLE_NAME, "RATING"));
-										releasedSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(RELEASEDATE, 'yyyy')"));
+										actorsSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataActors.TABLE_NAME, MediaTableVideoMetadataActors.ACTOR));
+										countriesSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataCountries.TABLE_NAME, MediaTableVideoMetadataCountries.COUNTRY));
+										directorsSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataDirectors.TABLE_NAME, MediaTableVideoMetadataDirectors.DIRECTOR));
+										genresSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataGenres.TABLE_NAME, MediaTableVideoMetadataGenres.GENRE));
+										ratedSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataRated.TABLE_NAME, MediaTableVideoMetadataRated.RATED));
+										releasedSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(" + MediaTableVideoMetadataReleased.RELEASEDATE + ", 'yyyy')"));
 									}
 								}
 
@@ -382,12 +382,12 @@ public class MediaLibraryFolder extends VirtualFolder {
 
 									// Adds modified versions of the query that filter by metadata
 									if (configuration.isUseInfoFromIMDb() && expectedOutput != TVSERIES_WITH_FILTERS) {
-										actorsSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataActors.TABLE_NAME, "ACTOR", i));
-										countriesSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataCountries.TABLE_NAME, "COUNTRY", i));
-										directorsSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataDirectors.TABLE_NAME, "DIRECTOR", i));
-										genresSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataGenres.TABLE_NAME, "GENRE", i));
-										ratedSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataRated.TABLE_NAME, "RATING", i));
-										releasedSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(RELEASEDATE, 'yyyy')", i));
+										actorsSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataActors.TABLE_NAME, MediaTableVideoMetadataActors.ACTOR, i));
+										countriesSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataCountries.TABLE_NAME, MediaTableVideoMetadataCountries.COUNTRY, i));
+										directorsSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataDirectors.TABLE_NAME, MediaTableVideoMetadataDirectors.DIRECTOR, i));
+										genresSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataGenres.TABLE_NAME, MediaTableVideoMetadataGenres.GENRE, i));
+										ratedSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataRated.TABLE_NAME, MediaTableVideoMetadataRated.RATED, i));
+										releasedSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(" + MediaTableVideoMetadataReleased.RELEASEDATE + ", 'yyyy')", i));
 									}
 									i++;
 								}
@@ -560,32 +560,32 @@ public class MediaLibraryFolder extends VirtualFolder {
 						if (resource.getName() != null && "###".equals(virtualFolderName)) {
 							if (resource.getName().equals(Messages.getString("Actors"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataActors.ACTOR + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataActors.FILENAME + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataActors.ACTOR + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataActors.FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Country"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataCountries.COUNTRY + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataCountries.FILENAME + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataCountries.COUNTRY + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataCountries.FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Director"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataDirectors.DIRECTOR + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataDirectors.FILENAME + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataDirectors.DIRECTOR + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataDirectors.FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Genres"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataGenres.GENRE + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataGenres.FILENAME + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataGenres.GENRE + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataGenres.FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Rated"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataRated.RATING + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataRated.FILENAME + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataRated.RATED + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataRated.FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Released"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE FORMATDATETIME(" + MediaTableVideoMetadataReleased.TABLE_NAME + ".RELEASEDATE, 'yyyy') = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataReleased.FILENAME + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE FORMATDATETIME(" + MediaTableVideoMetadataReleased.TABLE_NAME + ".RELEASEDATE, 'yyyy') = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataReleased.FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							}
@@ -604,7 +604,7 @@ public class MediaLibraryFolder extends VirtualFolder {
 				Messages.getString("Recommendations"),
 				new String[]{
 					"WITH ratedSubquery AS (" +
-						"SELECT " + MediaTableVideoMetadataRated.RATING + " FROM " + MediaTableVideoMetadataRated.TABLE_NAME + " " +
+						"SELECT " + MediaTableVideoMetadataRated.RATED + " FROM " + MediaTableVideoMetadataRated.TABLE_NAME + " " +
 						"LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + MediaTableVideoMetadataRated.TVSERIESID + " = " + MediaTableTVSeries.ID + " " +
 						"WHERE " + MediaTableTVSeries.TITLE + " = " + MediaDatabase.sqlQuote(getName()) + " " +
 						"LIMIT 1" +
@@ -618,7 +618,7 @@ public class MediaLibraryFolder extends VirtualFolder {
 						"DISTINCT " + MediaTableTVSeries.TITLE + ", " +
 						MediaTableVideoMetadataIMDbRating.IMDBRATING + ", " +
 						MediaTableVideoMetadataGenres.GENRE + ", " +
-						MediaTableVideoMetadataRated.RATING + " " +
+						MediaTableVideoMetadataRated.RATED + " " +
 					"FROM " +
 						"ratedSubquery, " +
 						"genresSubquery, " +
@@ -628,8 +628,8 @@ public class MediaLibraryFolder extends VirtualFolder {
 							"LEFT JOIN " + MediaTableVideoMetadataIMDbRating.TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + MediaTableVideoMetadataIMDbRating.TVSERIESID + " " +
 					"WHERE " +
 						MediaTableTVSeries.TITLE + " != " + MediaDatabase.sqlQuote(getName()) + " AND " +
-						MediaTableVideoMetadataGenres.GENRE + " IN (genresSubquery." + MediaTableVideoMetadataGenres.COL_GENRE_NAME + ") AND " +
-						MediaTableVideoMetadataRated.RATING  + " = ratedSubquery." + MediaTableVideoMetadataRated.COL_RATING_NAME + " " +
+						MediaTableVideoMetadataGenres.GENRE + " IN (genresSubquery." + MediaTableVideoMetadataGenres.COL_GENRE + ") AND " +
+						MediaTableVideoMetadataRated.RATED  + " = ratedSubquery." + MediaTableVideoMetadataRated.COL_RATED + " " +
 					"ORDER BY " + MediaTableVideoMetadataIMDbRating.IMDBRATING + " DESC",
 					"SELECT * " + FROM_FILES_VIDEOMETA + "WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + " AND " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' ORDER BY " + MediaTableVideoMetadatas.TVSEASON + ", " + MediaTableVideoMetadatas.TVEPISODENUMBER
 				},
@@ -647,15 +647,15 @@ public class MediaLibraryFolder extends VirtualFolder {
 					new String[]{
 						firstSql,
 						"WITH ratedSubquery AS (" +
-							"SELECT " + MediaTableVideoMetadataRated.RATING + " FROM " + MediaTableVideoMetadataRated.TABLE_NAME + " " +
-							"LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + MediaTableVideoMetadataRated.FILENAME + " = " + MediaTableFiles.FILENAME + " " +
+							"SELECT " + MediaTableVideoMetadataRated.RATED + " FROM " + MediaTableVideoMetadataRated.TABLE_NAME + " " +
+							MediaTableVideoMetadataRated.SQL_LEFT_JOIN_TABLE_FILES +
 							JOIN_VIDEO_METADATAS +
 							"WHERE " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' " +
 							"LIMIT 1" +
 						"), " +
 						"genresSubquery AS (" +
 							"SELECT " + MediaTableVideoMetadataGenres.GENRE + " FROM " + MediaTableVideoMetadataGenres.TABLE_NAME + " " +
-							"LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + MediaTableVideoMetadataGenres.FILENAME + " = " + MediaTableFiles.FILENAME + " " +
+							MediaTableVideoMetadataGenres.SQL_LEFT_JOIN_TABLE_FILES +
 							JOIN_VIDEO_METADATAS +
 							"WHERE " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}'" +
 						") " +
@@ -664,19 +664,19 @@ public class MediaLibraryFolder extends VirtualFolder {
 							MediaTableFiles.TABLE_NAME + ".*, " +
 							MediaTableVideoMetadataIMDbRating.IMDBRATING + ", " +
 							MediaTableVideoMetadataGenres.GENRE + ", " +
-							MediaTableVideoMetadataRated.RATING + " " +
+							MediaTableVideoMetadataRated.RATED + " " +
 						"FROM " +
 							"ratedSubquery, " +
 							"genresSubquery, " +
 							MediaTableFiles.TABLE_NAME + " " +
 								JOIN_VIDEO_METADATAS +
-								"LEFT JOIN " + MediaTableVideoMetadataGenres.TABLE_NAME +     " ON " + MediaTableFiles.FILENAME + " = " + MediaTableVideoMetadataGenres.FILENAME     + " " +
-								"LEFT JOIN " + MediaTableVideoMetadataRated.TABLE_NAME +      " ON " + MediaTableFiles.FILENAME + " = " + MediaTableVideoMetadataRated.FILENAME      + " " +
-								"LEFT JOIN " + MediaTableVideoMetadataIMDbRating.TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + MediaTableVideoMetadataIMDbRating.FILENAME + " " +
+								MediaTableVideoMetadataGenres.SQL_LEFT_JOIN_TABLE_FILES +
+								MediaTableVideoMetadataRated.SQL_LEFT_JOIN_TABLE_FILES +
+								MediaTableVideoMetadataIMDbRating.SQL_LEFT_JOIN_TABLE_FILES +
 						"WHERE " +
 							MediaTableVideoMetadatas.MOVIEORSHOWNAME + " != '${0}' AND " +
-							MediaTableVideoMetadataGenres.GENRE + " IN (genresSubquery." + MediaTableVideoMetadataGenres.COL_GENRE_NAME + ") AND " +
-							MediaTableVideoMetadataRated.RATING  + " = ratedSubquery. " + MediaTableVideoMetadataRated.COL_RATING_NAME + " " +
+							MediaTableVideoMetadataGenres.GENRE + " IN (genresSubquery." + MediaTableVideoMetadataGenres.COL_GENRE + ") AND " +
+							MediaTableVideoMetadataRated.RATED  + " = ratedSubquery." + MediaTableVideoMetadataRated.COL_RATED + " " +
 
 						"ORDER BY " + MediaTableVideoMetadataIMDbRating.IMDBRATING + " DESC"
 					},

--- a/src/main/java/net/pms/dlna/virtual/MediaLibraryFolder.java
+++ b/src/main/java/net/pms/dlna/virtual/MediaLibraryFolder.java
@@ -20,7 +20,7 @@ import net.pms.database.MediaTableVideoMetadataGenres;
 import net.pms.database.MediaTableVideoMetadataIMDbRating;
 import net.pms.database.MediaTableVideoMetadataRated;
 import net.pms.database.MediaTableVideoMetadataReleased;
-import net.pms.database.MediaTableVideoMetadatas;
+import net.pms.database.MediaTableVideoMetadata;
 import net.pms.dlna.*;
 import net.pms.util.UMSUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -37,14 +37,14 @@ import org.slf4j.LoggerFactory;
  */
 public class MediaLibraryFolder extends VirtualFolder {
 	protected static final String FROM_FILES = "FROM " + MediaTableFiles.TABLE_NAME + " ";
-	protected static final String JOIN_VIDEO_METADATAS = "LEFT JOIN " + MediaTableVideoMetadatas.TABLE_NAME + " ON " + MediaTableFiles.ID + " = " + MediaTableVideoMetadatas.FILEID + " ";
-	protected static final String JOIN_FILES_STATUS = "LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON " + MediaTableFiles.FILENAME + " = " + MediaTableFilesStatus.FILENAME + " ";
+	protected static final String JOIN_VIDEO_METADATAS = "LEFT JOIN " + MediaTableVideoMetadata.TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + MediaTableVideoMetadata.TABLE_COL_FILEID + " ";
+	protected static final String JOIN_FILES_STATUS = "LEFT JOIN " + MediaTableFilesStatus.TABLE_NAME + " ON " + MediaTableFiles.TABLE_COL_FILENAME + " = " + MediaTableFilesStatus.TABLE_COL_FILENAME + " ";
 	protected static final String FROM_FILES_VIDEOMETA = FROM_FILES + JOIN_VIDEO_METADATAS;
 	protected static final String FROM_FILES_STATUS = FROM_FILES + JOIN_FILES_STATUS;
 	protected static final String FROM_FILES_STATUS_VIDEOMETA = FROM_FILES + JOIN_FILES_STATUS + JOIN_VIDEO_METADATAS;
-	private static final String UNWATCHED_CONDITION = MediaTableFilesStatus.ISFULLYPLAYED + " IS NOT TRUE AND ";
-	private static final String WATCHED_CONDITION = MediaTableFilesStatus.ISFULLYPLAYED + " IS TRUE AND ";
-	private static final String SELECT_DISTINCT_TVSEASON = "SELECT DISTINCT " + MediaTableVideoMetadatas.TVSEASON + " " + FROM_FILES_VIDEOMETA;
+	private static final String UNWATCHED_CONDITION = MediaTableFilesStatus.TABLE_COL_ISFULLYPLAYED + " IS NOT TRUE AND ";
+	private static final String WATCHED_CONDITION = MediaTableFilesStatus.TABLE_COL_ISFULLYPLAYED + " IS TRUE AND ";
+	private static final String SELECT_DISTINCT_TVSEASON = "SELECT DISTINCT " + MediaTableVideoMetadata.TABLE_COL_TVSEASON + " " + FROM_FILES_VIDEOMETA;
 
 	public static final int FILES = 0;
 	public static final int TEXTS = 1;
@@ -176,8 +176,8 @@ public class MediaLibraryFolder extends VirtualFolder {
 	private static List<String> getTVSeriesQueries(String tableName, String columnName) {
 		List<String> queries = new ArrayList<>();
 		queries.add("SELECT " + columnName + " FROM " + tableName + " WHERE " + MediaTableTVSeries.CHILD_ID + " IS NOT NULL ORDER BY " + columnName + " ASC");
-		queries.add("SELECT " + MediaTableTVSeries.TITLE + " FROM " + MediaTableTVSeries.TABLE_NAME + " LEFT JOIN " + tableName + " ON " + MediaTableTVSeries.ID + " = " + tableName + ".TVSERIESID WHERE " + columnName + " = '${0}' ORDER BY " + MediaTableTVSeries.TITLE + " ASC");
-		queries.add("SELECT          *     " + FROM_FILES_VIDEOMETA + "WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + " AND " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' ORDER BY " + MediaTableVideoMetadatas.TVEPISODENUMBER);
+		queries.add("SELECT " + MediaTableTVSeries.TABLE_COL_TITLE + " FROM " + MediaTableTVSeries.TABLE_NAME + " LEFT JOIN " + tableName + " ON " + MediaTableTVSeries.TABLE_COL_ID + " = " + tableName + ".TVSERIESID WHERE " + columnName + " = '${0}' ORDER BY " + MediaTableTVSeries.TABLE_COL_TITLE + " ASC");
+		queries.add("SELECT          *     " + FROM_FILES_VIDEOMETA + "WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + " AND " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = '${0}' ORDER BY " + MediaTableVideoMetadata.TABLE_COL_TVEPISODENUMBER);
 		return queries;
 	}
 
@@ -193,7 +193,7 @@ public class MediaLibraryFolder extends VirtualFolder {
 
 		// If the query does not already join the right metadata table, do that now
 		if (!firstSql.contains("LEFT JOIN " + tableName)) {
-			String joinSection = "LEFT JOIN " + tableName + " ON " + MediaTableFiles.ID + " = " + tableName + "." + MediaTableVideoMetadatas.COL_FILEID + " ";
+			String joinSection = "LEFT JOIN " + tableName + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + tableName + "." + MediaTableVideoMetadata.COL_FILEID + " ";
 			query.insert(indexAfterFromInFirstQuery, joinSection);
 		}
 
@@ -213,7 +213,7 @@ public class MediaLibraryFolder extends VirtualFolder {
 		int indexAfterFrom = sql.indexOf(FROM_FILES) + FROM_FILES.length();
 		String condition = columnName + " = '${0}' AND ";
 		if (!sql.contains("LEFT JOIN " + tableName)) {
-			String joinSection = "LEFT JOIN " + tableName + " ON " + MediaTableFiles.ID + " = " + tableName + "." + MediaTableVideoMetadatas.COL_FILEID + " ";
+			String joinSection = "LEFT JOIN " + tableName + " ON " + MediaTableFiles.TABLE_COL_ID + " = " + tableName + "." + MediaTableVideoMetadata.COL_FILEID + " ";
 			query.insert(indexAfterFrom, joinSection);
 		}
 		int indexAfterWhere = query.indexOf(whereString) + whereString.length();
@@ -284,7 +284,7 @@ public class MediaLibraryFolder extends VirtualFolder {
 								if (firstSql.indexOf(JOIN_VIDEO_METADATAS) > 0) {
 									indexAfterFromInFirstQuery = firstSql.indexOf(JOIN_VIDEO_METADATAS) + JOIN_VIDEO_METADATAS.length();
 								}
-								String orderBySection = "ORDER BY " + MediaTableVideoMetadatas.TVSEASON;
+								String orderBySection = "ORDER BY " + MediaTableVideoMetadata.TABLE_COL_TVSEASON;
 
 								seasonsQuery.append(firstSql);
 								seasonsQuery.replace(0, indexAfterFromInFirstQuery, SELECT_DISTINCT_TVSEASON);
@@ -320,10 +320,10 @@ public class MediaLibraryFolder extends VirtualFolder {
 
 								if (!firstSql.toLowerCase().startsWith("select")) {
 									if (expectedOutput == TEXTS_NOSORT_WITH_FILTERS || expectedOutput == TEXTS_WITH_FILTERS || expectedOutput == TVSERIES_WITH_FILTERS) {
-										firstSql = "SELECT " + MediaTableFiles.FILENAME + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + firstSql;
+										firstSql = "SELECT " + MediaTableFiles.TABLE_COL_FILENAME + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + firstSql;
 									}
 									if (expectedOutput == FILES_WITH_FILTERS || expectedOutput == ISOS_WITH_FILTERS) {
-										firstSql = "SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + firstSql;
+										firstSql = "SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + firstSql;
 									}
 								}
 
@@ -334,19 +334,19 @@ public class MediaLibraryFolder extends VirtualFolder {
 									 * attempt to modify the incoming statements to make filtering versions.
 									 */
 									if (expectedOutput == TVSERIES_WITH_FILTERS) {
-										actorsSqls = getTVSeriesQueries(MediaTableVideoMetadataActors.TABLE_NAME, MediaTableVideoMetadataActors.ACTOR);
-										countriesSqls = getTVSeriesQueries(MediaTableVideoMetadataCountries.TABLE_NAME, MediaTableVideoMetadataCountries.COUNTRY);
-										directorsSqls = getTVSeriesQueries(MediaTableVideoMetadataDirectors.TABLE_NAME, MediaTableVideoMetadataDirectors.DIRECTOR);
-										genresSqls = getTVSeriesQueries(MediaTableVideoMetadataGenres.TABLE_NAME, MediaTableVideoMetadataGenres.GENRE);
-										ratedSqls = getTVSeriesQueries(MediaTableVideoMetadataRated.TABLE_NAME, MediaTableVideoMetadataRated.RATED);
-										releasedSqls = getTVSeriesQueries(MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(" + MediaTableVideoMetadataReleased.RELEASEDATE + ", 'yyyy')");
+										actorsSqls = getTVSeriesQueries(MediaTableVideoMetadataActors.TABLE_NAME, MediaTableVideoMetadataActors.TABLE_COL_ACTOR);
+										countriesSqls = getTVSeriesQueries(MediaTableVideoMetadataCountries.TABLE_NAME, MediaTableVideoMetadataCountries.TABLE_COL_COUNTRY);
+										directorsSqls = getTVSeriesQueries(MediaTableVideoMetadataDirectors.TABLE_NAME, MediaTableVideoMetadataDirectors.TABLE_COL_DIRECTOR);
+										genresSqls = getTVSeriesQueries(MediaTableVideoMetadataGenres.TABLE_NAME, MediaTableVideoMetadataGenres.TABLE_COL_GENRE);
+										ratedSqls = getTVSeriesQueries(MediaTableVideoMetadataRated.TABLE_NAME, MediaTableVideoMetadataRated.TABLE_COL_RATED);
+										releasedSqls = getTVSeriesQueries(MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(" + MediaTableVideoMetadataReleased.TABLE_COL_RELEASEDATE + ", 'yyyy')");
 									} else {
-										actorsSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataActors.TABLE_NAME, MediaTableVideoMetadataActors.ACTOR));
-										countriesSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataCountries.TABLE_NAME, MediaTableVideoMetadataCountries.COUNTRY));
-										directorsSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataDirectors.TABLE_NAME, MediaTableVideoMetadataDirectors.DIRECTOR));
-										genresSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataGenres.TABLE_NAME, MediaTableVideoMetadataGenres.GENRE));
-										ratedSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataRated.TABLE_NAME, MediaTableVideoMetadataRated.RATED));
-										releasedSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(" + MediaTableVideoMetadataReleased.RELEASEDATE + ", 'yyyy')"));
+										actorsSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataActors.TABLE_NAME, MediaTableVideoMetadataActors.TABLE_COL_ACTOR));
+										countriesSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataCountries.TABLE_NAME, MediaTableVideoMetadataCountries.TABLE_COL_COUNTRY));
+										directorsSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataDirectors.TABLE_NAME, MediaTableVideoMetadataDirectors.TABLE_COL_DIRECTOR));
+										genresSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataGenres.TABLE_NAME, MediaTableVideoMetadataGenres.TABLE_COL_GENRE));
+										ratedSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataRated.TABLE_NAME, MediaTableVideoMetadataRated.TABLE_COL_RATED));
+										releasedSqls.add(getFirstNonTVSeriesQuery(firstSql, MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(" + MediaTableVideoMetadataReleased.TABLE_COL_RELEASEDATE + ", 'yyyy')"));
 									}
 								}
 
@@ -355,10 +355,10 @@ public class MediaLibraryFolder extends VirtualFolder {
 								for (String sql : sqls) {
 									if (!sql.toLowerCase().startsWith("select") && !sql.toLowerCase().startsWith("with")) {
 										if (expectedOutput == TEXTS_NOSORT_WITH_FILTERS || expectedOutput == TEXTS_WITH_FILTERS || expectedOutput == TVSERIES_WITH_FILTERS) {
-											sql = "SELECT " + MediaTableFiles.FILENAME + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + sql;
+											sql = "SELECT " + MediaTableFiles.TABLE_COL_FILENAME + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + sql;
 										}
 										if (expectedOutput == FILES_WITH_FILTERS || expectedOutput == ISOS_WITH_FILTERS) {
-											sql = "SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + sql;
+											sql = "SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED + " FROM " + MediaTableFiles.TABLE_NAME + " WHERE " + sql;
 										}
 									}
 									String whereString = "WHERE ";
@@ -382,12 +382,12 @@ public class MediaLibraryFolder extends VirtualFolder {
 
 									// Adds modified versions of the query that filter by metadata
 									if (configuration.isUseInfoFromIMDb() && expectedOutput != TVSERIES_WITH_FILTERS) {
-										actorsSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataActors.TABLE_NAME, MediaTableVideoMetadataActors.ACTOR, i));
-										countriesSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataCountries.TABLE_NAME, MediaTableVideoMetadataCountries.COUNTRY, i));
-										directorsSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataDirectors.TABLE_NAME, MediaTableVideoMetadataDirectors.DIRECTOR, i));
-										genresSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataGenres.TABLE_NAME, MediaTableVideoMetadataGenres.GENRE, i));
-										ratedSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataRated.TABLE_NAME, MediaTableVideoMetadataRated.RATED, i));
-										releasedSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(" + MediaTableVideoMetadataReleased.RELEASEDATE + ", 'yyyy')", i));
+										actorsSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataActors.TABLE_NAME, MediaTableVideoMetadataActors.TABLE_COL_ACTOR, i));
+										countriesSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataCountries.TABLE_NAME, MediaTableVideoMetadataCountries.TABLE_COL_COUNTRY, i));
+										directorsSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataDirectors.TABLE_NAME, MediaTableVideoMetadataDirectors.TABLE_COL_DIRECTOR, i));
+										genresSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataGenres.TABLE_NAME, MediaTableVideoMetadataGenres.TABLE_COL_GENRE, i));
+										ratedSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataRated.TABLE_NAME, MediaTableVideoMetadataRated.TABLE_COL_RATED, i));
+										releasedSqls.add(getSubsequentNonTVSeriesQuery(sql, MediaTableVideoMetadataReleased.TABLE_NAME, "FORMATDATETIME(" + MediaTableVideoMetadataReleased.TABLE_COL_RELEASEDATE + ", 'yyyy')", i));
 									}
 									i++;
 								}
@@ -538,7 +538,7 @@ public class MediaLibraryFolder extends VirtualFolder {
 
 						String whereString = "WHERE ";
 						int indexAfterWhere = episodesWithinSeasonQuery.indexOf(whereString) + whereString.length();
-						String condition = MediaTableVideoMetadatas.TVSEASON + " = '" + virtualFolderName + "' AND ";
+						String condition = MediaTableVideoMetadata.TABLE_COL_TVSEASON + " = '" + virtualFolderName + "' AND ";
 						episodesWithinSeasonQuery.insert(indexAfterWhere, condition);
 
 						sqls2 = new String[] {transformSQL(episodesWithinSeasonQuery.toString())};
@@ -560,32 +560,32 @@ public class MediaLibraryFolder extends VirtualFolder {
 						if (resource.getName() != null && "###".equals(virtualFolderName)) {
 							if (resource.getName().equals(Messages.getString("Actors"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataActors.ACTOR + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataActors.FILEID + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataActors.TABLE_COL_ACTOR + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataActors.TABLE_COL_FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Country"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataCountries.COUNTRY + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataCountries.FILEID + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataCountries.TABLE_COL_COUNTRY + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataCountries.TABLE_COL_FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Director"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataDirectors.DIRECTOR + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataDirectors.FILEID + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataDirectors.TABLE_COL_DIRECTOR + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataDirectors.TABLE_COL_FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Genres"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataGenres.GENRE + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataGenres.FILEID + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataGenres.TABLE_COL_GENRE + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataGenres.TABLE_COL_FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Rated"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataRated.RATED + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataRated.FILEID + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE " + MediaTableVideoMetadataRated.TABLE_COL_RATED + " = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataRated.TABLE_COL_FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							} else if (resource.getName().equals(Messages.getString("Released"))) {
 								for (int i = 0; i < sqls2.length; i++) {
-									sqls2[i] = sqls2[i].replace("WHERE FORMATDATETIME(" + MediaTableVideoMetadataReleased.TABLE_NAME + ".RELEASEDATE, 'yyyy') = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataReleased.FILEID + " IS NULL");
+									sqls2[i] = sqls2[i].replace("WHERE FORMATDATETIME(" + MediaTableVideoMetadataReleased.TABLE_NAME + ".RELEASEDATE, 'yyyy') = '${" + i + "}'", "WHERE " + MediaTableVideoMetadataReleased.TABLE_COL_FILEID + " IS NULL");
 								}
 								nameToDisplay = "Unknown";
 							}
@@ -604,21 +604,21 @@ public class MediaLibraryFolder extends VirtualFolder {
 				Messages.getString("Recommendations"),
 				new String[]{
 					"WITH ratedSubquery AS (" +
-						"SELECT " + MediaTableVideoMetadataRated.RATED + " FROM " + MediaTableVideoMetadataRated.TABLE_NAME + " " +
-						"LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + MediaTableVideoMetadataRated.TVSERIESID + " = " + MediaTableTVSeries.ID + " " +
-						"WHERE " + MediaTableTVSeries.TITLE + " = " + MediaDatabase.sqlQuote(getName()) + " " +
+						"SELECT " + MediaTableVideoMetadataRated.TABLE_COL_RATED + " FROM " + MediaTableVideoMetadataRated.TABLE_NAME + " " +
+						"LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + MediaTableVideoMetadataRated.TABLE_COL_TVSERIESID + " = " + MediaTableTVSeries.TABLE_COL_ID + " " +
+						"WHERE " + MediaTableTVSeries.TABLE_COL_TITLE + " = " + MediaDatabase.sqlQuote(getName()) + " " +
 						"LIMIT 1" +
 					"), " +
 					"genresSubquery AS (" +
-						"SELECT " + MediaTableVideoMetadataGenres.GENRE + " FROM " + MediaTableVideoMetadataGenres.TABLE_NAME + " " +
-						"LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + MediaTableVideoMetadataGenres.TVSERIESID + " = " + MediaTableTVSeries.ID + " " +
-						"WHERE " + MediaTableTVSeries.TITLE + " = " + MediaDatabase.sqlQuote(getName()) +
+						"SELECT " + MediaTableVideoMetadataGenres.TABLE_COL_GENRE + " FROM " + MediaTableVideoMetadataGenres.TABLE_NAME + " " +
+						"LEFT JOIN " + MediaTableTVSeries.TABLE_NAME + " ON " + MediaTableVideoMetadataGenres.TABLE_COL_TVSERIESID + " = " + MediaTableTVSeries.TABLE_COL_ID + " " +
+						"WHERE " + MediaTableTVSeries.TABLE_COL_TITLE + " = " + MediaDatabase.sqlQuote(getName()) +
 					") " +
 					"SELECT " +
-						"DISTINCT " + MediaTableTVSeries.TITLE + ", " +
-						MediaTableVideoMetadataIMDbRating.IMDBRATING + ", " +
-						MediaTableVideoMetadataGenres.GENRE + ", " +
-						MediaTableVideoMetadataRated.RATED + " " +
+						"DISTINCT " + MediaTableTVSeries.TABLE_COL_TITLE + ", " +
+						MediaTableVideoMetadataIMDbRating.TABLE_COL_IMDBRATING + ", " +
+						MediaTableVideoMetadataGenres.TABLE_COL_GENRE + ", " +
+						MediaTableVideoMetadataRated.TABLE_COL_RATED + " " +
 					"FROM " +
 						"ratedSubquery, " +
 						"genresSubquery, " +
@@ -627,19 +627,19 @@ public class MediaLibraryFolder extends VirtualFolder {
 						MediaTableVideoMetadataRated.SQL_LEFT_JOIN_TABLE_TV_SERIES +
 						MediaTableVideoMetadataIMDbRating.SQL_LEFT_JOIN_TABLE_TV_SERIES +
 					"WHERE " +
-						MediaTableTVSeries.TITLE + " != " + MediaDatabase.sqlQuote(getName()) + " AND " +
-						MediaTableVideoMetadataGenres.GENRE + " IN (genresSubquery." + MediaTableVideoMetadataGenres.COL_GENRE + ") AND " +
-						MediaTableVideoMetadataRated.RATED  + " = ratedSubquery." + MediaTableVideoMetadataRated.COL_RATED + " " +
-					"ORDER BY " + MediaTableVideoMetadataIMDbRating.IMDBRATING + " DESC",
-					"SELECT * " + FROM_FILES_VIDEOMETA + "WHERE " + MediaTableFiles.FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadatas.ISTVEPISODE + " AND " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' ORDER BY " + MediaTableVideoMetadatas.TVSEASON + ", " + MediaTableVideoMetadatas.TVEPISODENUMBER
+						MediaTableTVSeries.TABLE_COL_TITLE + " != " + MediaDatabase.sqlQuote(getName()) + " AND " +
+						MediaTableVideoMetadataGenres.TABLE_COL_GENRE + " IN (genresSubquery." + MediaTableVideoMetadataGenres.COL_GENRE + ") AND " +
+						MediaTableVideoMetadataRated.TABLE_COL_RATED  + " = ratedSubquery." + MediaTableVideoMetadataRated.COL_RATED + " " +
+					"ORDER BY " + MediaTableVideoMetadataIMDbRating.TABLE_COL_IMDBRATING + " DESC",
+					"SELECT * " + FROM_FILES_VIDEOMETA + "WHERE " + MediaTableFiles.TABLE_COL_FORMAT_TYPE + " = 4 AND " + MediaTableVideoMetadata.TABLE_COL_ISTVEPISODE + " AND " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = '${0}' ORDER BY " + MediaTableVideoMetadata.TABLE_COL_TVSEASON + ", " + MediaTableVideoMetadata.TABLE_COL_TVEPISODENUMBER
 				},
 				new int[]{MediaLibraryFolder.TVSERIES_NOSORT, MediaLibraryFolder.EPISODES}
 			);
 			addChild(recommendations);
 		} else if (expectedOutput == FILES_WITH_FILTERS) {
 			if (firstSql != null) {
-				if (firstSql.startsWith("SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED)) {
-					firstSql = firstSql.replaceFirst("SELECT " + MediaTableFiles.FILENAME + ", " + MediaTableFiles.MODIFIED, "SELECT " + MediaTableVideoMetadatas.MOVIEORSHOWNAME);
+				if (firstSql.startsWith("SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED)) {
+					firstSql = firstSql.replaceFirst("SELECT " + MediaTableFiles.TABLE_COL_FILENAME + ", " + MediaTableFiles.TABLE_COL_MODIFIED, "SELECT " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME);
 				}
 
 				VirtualFolder recommendations = new MediaLibraryFolder(
@@ -647,24 +647,24 @@ public class MediaLibraryFolder extends VirtualFolder {
 					new String[]{
 						firstSql,
 						"WITH ratedSubquery AS (" +
-							"SELECT " + MediaTableVideoMetadataRated.RATED + " FROM " + MediaTableVideoMetadataRated.TABLE_NAME + " " +
-							"LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + MediaTableVideoMetadataRated.FILEID + " = " + MediaTableFiles.ID + " " +
+							"SELECT " + MediaTableVideoMetadataRated.TABLE_COL_RATED + " FROM " + MediaTableVideoMetadataRated.TABLE_NAME + " " +
+							"LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + MediaTableVideoMetadataRated.TABLE_COL_FILEID + " = " + MediaTableFiles.TABLE_COL_ID + " " +
 							JOIN_VIDEO_METADATAS +
-							"WHERE " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' " +
+							"WHERE " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = '${0}' " +
 							"LIMIT 1" +
 						"), " +
 						"genresSubquery AS (" +
-							"SELECT " + MediaTableVideoMetadataGenres.GENRE + " FROM " + MediaTableVideoMetadataGenres.TABLE_NAME + " " +
-							"LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + MediaTableVideoMetadataGenres.FILEID + " = " + MediaTableFiles.ID + " " +
+							"SELECT " + MediaTableVideoMetadataGenres.TABLE_COL_GENRE + " FROM " + MediaTableVideoMetadataGenres.TABLE_NAME + " " +
+							"LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + MediaTableVideoMetadataGenres.TABLE_COL_FILEID + " = " + MediaTableFiles.TABLE_COL_ID + " " +
 							JOIN_VIDEO_METADATAS +
-							"WHERE " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}'" +
+							"WHERE " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = '${0}'" +
 						") " +
 						"SELECT " +
-							"DISTINCT " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + ", " +
+							"DISTINCT " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + ", " +
 							MediaTableFiles.TABLE_NAME + ".*, " +
-							MediaTableVideoMetadataIMDbRating.IMDBRATING + ", " +
-							MediaTableVideoMetadataGenres.GENRE + ", " +
-							MediaTableVideoMetadataRated.RATED + " " +
+							MediaTableVideoMetadataIMDbRating.TABLE_COL_IMDBRATING + ", " +
+							MediaTableVideoMetadataGenres.TABLE_COL_GENRE + ", " +
+							MediaTableVideoMetadataRated.TABLE_COL_RATED + " " +
 						"FROM " +
 							"ratedSubquery, " +
 							"genresSubquery, " +
@@ -674,11 +674,11 @@ public class MediaLibraryFolder extends VirtualFolder {
 								MediaTableVideoMetadataRated.SQL_LEFT_JOIN_TABLE_FILES +
 								MediaTableVideoMetadataIMDbRating.SQL_LEFT_JOIN_TABLE_FILES +
 						"WHERE " +
-							MediaTableVideoMetadatas.MOVIEORSHOWNAME + " != '${0}' AND " +
-							MediaTableVideoMetadataGenres.GENRE + " IN (genresSubquery." + MediaTableVideoMetadataGenres.COL_GENRE + ") AND " +
-							MediaTableVideoMetadataRated.RATED  + " = ratedSubquery." + MediaTableVideoMetadataRated.COL_RATED + " " +
+							MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " != '${0}' AND " +
+							MediaTableVideoMetadataGenres.TABLE_COL_GENRE + " IN (genresSubquery." + MediaTableVideoMetadataGenres.COL_GENRE + ") AND " +
+							MediaTableVideoMetadataRated.TABLE_COL_RATED  + " = ratedSubquery." + MediaTableVideoMetadataRated.COL_RATED + " " +
 
-						"ORDER BY " + MediaTableVideoMetadataIMDbRating.IMDBRATING + " DESC"
+						"ORDER BY " + MediaTableVideoMetadataIMDbRating.TABLE_COL_IMDBRATING + " DESC"
 					},
 					new int[]{MediaLibraryFolder.MOVIE_FOLDERS, MediaLibraryFolder.FILES_NOSORT_DEDUPED}
 				);

--- a/src/main/java/net/pms/dlna/virtual/MediaLibraryFolder.java
+++ b/src/main/java/net/pms/dlna/virtual/MediaLibraryFolder.java
@@ -623,9 +623,9 @@ public class MediaLibraryFolder extends VirtualFolder {
 						"ratedSubquery, " +
 						"genresSubquery, " +
 						MediaTableTVSeries.TABLE_NAME + " " +
-							"LEFT JOIN " + MediaTableVideoMetadataGenres.TABLE_NAME +     " ON " + MediaTableTVSeries.ID + " = " + MediaTableVideoMetadataGenres.TVSERIESID     + " " +
-							"LEFT JOIN " + MediaTableVideoMetadataRated.TABLE_NAME +      " ON " + MediaTableTVSeries.ID + " = " + MediaTableVideoMetadataRated.TVSERIESID      + " " +
-							"LEFT JOIN " + MediaTableVideoMetadataIMDbRating.TABLE_NAME + " ON " + MediaTableTVSeries.ID + " = " + MediaTableVideoMetadataIMDbRating.TVSERIESID + " " +
+						MediaTableVideoMetadataGenres.SQL_LEFT_JOIN_TABLE_TV_SERIES +
+						MediaTableVideoMetadataRated.SQL_LEFT_JOIN_TABLE_TV_SERIES +
+						MediaTableVideoMetadataIMDbRating.SQL_LEFT_JOIN_TABLE_TV_SERIES +
 					"WHERE " +
 						MediaTableTVSeries.TITLE + " != " + MediaDatabase.sqlQuote(getName()) + " AND " +
 						MediaTableVideoMetadataGenres.GENRE + " IN (genresSubquery." + MediaTableVideoMetadataGenres.COL_GENRE + ") AND " +
@@ -648,14 +648,14 @@ public class MediaLibraryFolder extends VirtualFolder {
 						firstSql,
 						"WITH ratedSubquery AS (" +
 							"SELECT " + MediaTableVideoMetadataRated.RATED + " FROM " + MediaTableVideoMetadataRated.TABLE_NAME + " " +
-							MediaTableVideoMetadataRated.SQL_LEFT_JOIN_TABLE_FILES +
+							"LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + MediaTableVideoMetadataRated.FILEID + " = " + MediaTableFiles.ID + " " +
 							JOIN_VIDEO_METADATAS +
 							"WHERE " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}' " +
 							"LIMIT 1" +
 						"), " +
 						"genresSubquery AS (" +
 							"SELECT " + MediaTableVideoMetadataGenres.GENRE + " FROM " + MediaTableVideoMetadataGenres.TABLE_NAME + " " +
-							MediaTableVideoMetadataGenres.SQL_LEFT_JOIN_TABLE_FILES +
+							"LEFT JOIN " + MediaTableFiles.TABLE_NAME + " ON " + MediaTableVideoMetadataGenres.FILEID + " = " + MediaTableFiles.ID + " " +
 							JOIN_VIDEO_METADATAS +
 							"WHERE " + MediaTableVideoMetadatas.MOVIEORSHOWNAME + " = '${0}'" +
 						") " +

--- a/src/main/java/net/pms/dlna/virtual/MediaLibraryFolder.java
+++ b/src/main/java/net/pms/dlna/virtual/MediaLibraryFolder.java
@@ -652,7 +652,7 @@ public class MediaLibraryFolder extends VirtualFolder {
 						"), " +
 						"genresSubquery AS (" +
 							"SELECT " + MediaTableVideoMetadataGenres.TABLE_COL_GENRE + " FROM " + MediaTableVideoMetadataGenres.TABLE_NAME + " " +
-							MediaTableVideoMetadataGenres.SQL_LEFT_JOIN_TABLE_VIDEO_METADATA + 
+							MediaTableVideoMetadataGenres.SQL_LEFT_JOIN_TABLE_VIDEO_METADATA +
 							"WHERE " + MediaTableVideoMetadata.TABLE_COL_MOVIEORSHOWNAME + " = '${0}'" +
 						") " +
 						"SELECT " +

--- a/src/main/java/net/pms/dlna/virtual/VirtualFolder.java
+++ b/src/main/java/net/pms/dlna/virtual/VirtualFolder.java
@@ -49,6 +49,7 @@ public class VirtualFolder extends DLNAResource {
 	 * Because a container cannot be streamed, this function always returns null.
 	 *
 	 * @return null
+	 * @throws java.io.IOException
 	 * @see net.pms.dlna.DLNAResource#getInputStream()
 	 */
 	@Override
@@ -81,6 +82,7 @@ public class VirtualFolder extends DLNAResource {
 	/**
 	 * Returns zero as this is a folder (container).
 	 *
+	 * @return 0
 	 * @see net.pms.dlna.DLNAResource#length()
 	 */
 	@Override

--- a/src/main/java/net/pms/dlna/virtual/VirtualFolderDbId.java
+++ b/src/main/java/net/pms/dlna/virtual/VirtualFolderDbId.java
@@ -34,15 +34,14 @@ import net.pms.dlna.DbIdMediaType;
  * This VirtualFolder implements support for RealFileDbId's database backed IDs.
  */
 public class VirtualFolderDbId extends VirtualFolder {
-
 	private static final Logger LOG = LoggerFactory.getLogger(VirtualFolderDbId.class.getName());
-	private final DbIdResourceLocator dbIdResourceLocator = new DbIdResourceLocator();
+
 	private final DbIdTypeAndIdent2 typeIdent;
 
 	public VirtualFolderDbId(String folderName, DbIdTypeAndIdent2 typeIdent, String thumbnailIcon) {
 		super(folderName, thumbnailIcon);
 		this.typeIdent = typeIdent;
-		String id = dbIdResourceLocator.encodeDbid(typeIdent);
+		String id = DbIdResourceLocator.encodeDbid(typeIdent);
 		setId(id);
 		setDefaultRenderer(RendererConfiguration.getDefaultConf());
 	}
@@ -81,7 +80,7 @@ public class VirtualFolderDbId extends VirtualFolder {
 	}
 
 	@Override
-	protected void setId(String id) {
+	protected final void setId(String id) {
 		if (id.startsWith(DbIdMediaType.GENERAL_PREFIX)) {
 			super.setId(id);
 		} else {

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -2268,9 +2268,7 @@ public class MEncoderVideo extends Player {
 				pw.attachProcess(audioPipeProcess);
 				videoPipeProcess.runInNewThread();
 				audioPipeProcess.runInNewThread();
-				try {
-					Thread.sleep(50);
-				} catch (InterruptedException e) { }
+				UMSUtils.sleep(50);
 				videoPipe.deleteLater();
 				audioPipe.deleteLater();
 			} else {
@@ -2441,10 +2439,7 @@ public class MEncoderVideo extends Player {
 				pw.attachProcess(pipeProcess);
 				pipeProcess.runInNewThread();
 
-				try {
-					Thread.sleep(50);
-				} catch (InterruptedException e) {
-				}
+				UMSUtils.sleep(50);
 
 				pipe.deleteLater();
 				params.getInputPipes()[0] = pipe;
@@ -2453,10 +2448,7 @@ public class MEncoderVideo extends Player {
 				pw.attachProcess(ffPipeProcess);
 				ffPipeProcess.runInNewThread();
 
-				try {
-					Thread.sleep(50);
-				} catch (InterruptedException e) {
-				}
+				UMSUtils.sleep(50);
 
 				ffAudioPipe.deleteLater();
 				pw.attachProcess(ffAudio);
@@ -2501,10 +2493,7 @@ public class MEncoderVideo extends Player {
 
 		pw.runInNewThread();
 
-		try {
-			Thread.sleep(100);
-		} catch (InterruptedException e) {
-		}
+		UMSUtils.sleep(100);
 
 		configuration = prev;
 		return pw;

--- a/src/main/java/net/pms/encoders/MEncoderWebVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderWebVideo.java
@@ -28,6 +28,7 @@ import net.pms.io.PipeProcess;
 import net.pms.io.ProcessWrapper;
 import net.pms.io.ProcessWrapperImpl;
 import net.pms.util.PlayerUtil;
+import net.pms.util.UMSUtils;
 
 public class MEncoderWebVideo extends MEncoderVideo {
 	public static final PlayerId ID = StandardPlayerId.MENCODER_WEB_VIDEO;
@@ -128,10 +129,7 @@ public class MEncoderWebVideo extends MEncoderVideo {
 		pw.runInNewThread();
 
 		// Not sure what good this 50ms wait will do for the calling method.
-		try {
-			Thread.sleep(50);
-		} catch (InterruptedException e) {
-		}
+		UMSUtils.sleep(50);
 		configuration = prev;
 		return pw;
 	}

--- a/src/main/java/net/pms/encoders/TsMuxeRVideo.java
+++ b/src/main/java/net/pms/encoders/TsMuxeRVideo.java
@@ -55,6 +55,7 @@ import net.pms.platform.windows.NTStatus;
 import net.pms.util.CodecUtil;
 import net.pms.util.FormLayoutUtil;
 import net.pms.util.PlayerUtil;
+import net.pms.util.UMSUtils;
 import net.pms.util.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -670,47 +671,32 @@ public class TsMuxeRVideo extends Player {
 		p.attachProcess(pipeProcess);
 		pipeProcess.runInNewThread();
 
-		try {
-			Thread.sleep(50);
-		} catch (InterruptedException e) {
-		}
+		UMSUtils.sleep(50);
 		tsPipe.deleteLater();
 
 		ProcessWrapper ffPipeProcess = ffVideoPipe.getPipeProcess();
 		p.attachProcess(ffPipeProcess);
 		ffPipeProcess.runInNewThread();
-		try {
-			Thread.sleep(50);
-		} catch (InterruptedException e) {
-		}
+		UMSUtils.sleep(50);
 		ffVideoPipe.deleteLater();
 
 		p.attachProcess(ffVideo);
 		ffVideo.runInNewThread();
-		try {
-			Thread.sleep(50);
-		} catch (InterruptedException e) {
-		}
+		UMSUtils.sleep(50);
 
 		if (ffAudioPipe != null && params.getAid() != null) {
 			for (int i = 0; i < ffAudioPipe.length; i++) {
 				ffPipeProcess = ffAudioPipe[i].getPipeProcess();
 				p.attachProcess(ffPipeProcess);
 				ffPipeProcess.runInNewThread();
-				try {
-					Thread.sleep(50);
-				} catch (InterruptedException e) {
-				}
+				UMSUtils.sleep(50);
 				ffAudioPipe[i].deleteLater();
 				p.attachProcess(ffAudio[i]);
 				ffAudio[i].runInNewThread();
 			}
 		}
 
-		try {
-			Thread.sleep(100);
-		} catch (InterruptedException e) {
-		}
+		UMSUtils.sleep(100);
 
 		p.runInNewThread();
 		configuration = prev;

--- a/src/main/java/net/pms/encoders/VLCVideo.java
+++ b/src/main/java/net/pms/encoders/VLCVideo.java
@@ -647,10 +647,7 @@ public class VLCVideo extends Player {
 		pw.attachProcess(pipeProcess);
 
 		// TODO: Why is this here?
-		try {
-			Thread.sleep(150);
-		} catch (InterruptedException e) {
-		}
+		UMSUtils.sleep(150);
 
 		pw.runInNewThread();
 		configuration = prev;

--- a/src/main/java/net/pms/encoders/VideoLanVideoStreaming.java
+++ b/src/main/java/net/pms/encoders/VideoLanVideoStreaming.java
@@ -47,6 +47,7 @@ import net.pms.io.ProcessWrapper;
 import net.pms.io.ProcessWrapperImpl;
 import net.pms.io.SimpleProcessWrapper;
 import net.pms.util.PlayerUtil;
+import net.pms.util.UMSUtils;
 import net.pms.util.Version;
 
 /* XXX this is the old/obsolete VLC web video streaming engine */
@@ -206,10 +207,7 @@ public class VideoLanVideoStreaming extends Player {
 		ProcessWrapperImpl pw = new ProcessWrapperImpl(cmdArray, params);
 		pw.attachProcess(pipeProcess);
 
-		try {
-			Thread.sleep(150);
-		} catch (InterruptedException e) {
-		}
+		UMSUtils.sleep(150);
 
 		pw.runInNewThread();
 		configuration = prev;

--- a/src/main/java/net/pms/io/BufferedOutputFileImpl.java
+++ b/src/main/java/net/pms/io/BufferedOutputFileImpl.java
@@ -30,6 +30,7 @@ import java.util.TimerTask;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.configuration.RendererConfiguration;
+import net.pms.util.UMSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -307,10 +308,7 @@ public class BufferedOutputFileImpl extends OutputStream implements BufferedOutp
 		//LOGGER.trace("write(" + b.length + ", " + off + ", " + len + "), writeCount = " + writeCount + ", readCount = " + (input != null ? input.getReadCount() : "null"));
 
 		while ((input != null && (writeCount - input.getReadCount() > bufferOverflowWarning)) || (input == null && writeCount > bufferOverflowWarning)) {
-			try {
-				Thread.sleep(CHECK_INTERVAL);
-			} catch (InterruptedException e) {
-			}
+			UMSUtils.sleep(CHECK_INTERVAL);
 			input = getCurrentInputStream();
 		}
 
@@ -403,11 +401,8 @@ public class BufferedOutputFileImpl extends OutputStream implements BufferedOutp
 		boolean bb = b % 100000 == 0;
 		WaitBufferedInputStream input = getCurrentInputStream();
 		while (bb && ((input != null && (writeCount - input.getReadCount() > bufferOverflowWarning)) || (input == null && writeCount == bufferOverflowWarning))) {
-			try {
-				Thread.sleep(CHECK_INTERVAL);
-				//LOGGER.trace("BufferedOutputFile Full");
-			} catch (InterruptedException e) {
-			}
+			UMSUtils.sleep(CHECK_INTERVAL);
+			//LOGGER.trace("BufferedOutputFile Full");
 			input = getCurrentInputStream();
 		}
 		int mb = (int) (writeCount++ % maxMemorySize);
@@ -680,10 +675,7 @@ public class BufferedOutputFileImpl extends OutputStream implements BufferedOutp
 
 			c++;
 
-			try {
-				Thread.sleep(CHECK_INTERVAL);
-			} catch (InterruptedException e) {
-			}
+			UMSUtils.sleep(CHECK_INTERVAL);
 		}
 
 		if (attachedThread != null) {
@@ -756,10 +748,7 @@ public class BufferedOutputFileImpl extends OutputStream implements BufferedOutp
 
 			c++;
 
-			try {
-				Thread.sleep(CHECK_INTERVAL);
-			} catch (InterruptedException e) {
-			}
+			UMSUtils.sleep(CHECK_INTERVAL);
 		}
 
 		if (attachedThread != null) {

--- a/src/main/java/net/pms/io/PipeIPCProcess.java
+++ b/src/main/java/net/pms/io/PipeIPCProcess.java
@@ -28,6 +28,7 @@ import net.pms.util.DTSAudioOutputStream;
 import net.pms.util.H264AnnexBInputStream;
 import net.pms.util.IEC61937AudioOutputStream;
 import net.pms.util.PCMAudioOutputStream;
+import net.pms.util.UMSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,10 +165,7 @@ public class PipeIPCProcess extends Thread implements ProcessWrapper {
 
 			// Allow the threads some time to do their work before
 			// starting the main thread
-			try {
-				Thread.sleep(150);
-			} catch (InterruptedException e) {
-			}
+			UMSUtils.sleep(150);
 		}
 
 		start();
@@ -181,10 +179,7 @@ public class PipeIPCProcess extends Thread implements ProcessWrapper {
 
 			// Allow the threads some time to do their work before
 			// running the main thread
-			try {
-				Thread.sleep(150);
-			} catch (InterruptedException e) {
-			}
+			UMSUtils.sleep(150);
 		}
 
 		run();

--- a/src/main/java/net/pms/io/WindowsNamedPipe.java
+++ b/src/main/java/net/pms/io/WindowsNamedPipe.java
@@ -23,6 +23,7 @@ import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.win32.StdCallLibrary;
 import java.io.*;
 import java.util.ArrayList;
+import net.pms.util.UMSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -216,9 +217,7 @@ public class WindowsNamedPipe extends Thread implements ProcessWrapper {
 
 		if (forceReconnect) {
 			while (forced.isAlive()) {
-				try {
-					Thread.sleep(200);
-				} catch (InterruptedException e) { }
+				UMSUtils.sleep(200);
 			}
 
 			LOGGER.debug("Forced reconnection of {} with result: {}", path, b2);

--- a/src/main/java/net/pms/network/SpeedStats.java
+++ b/src/main/java/net/pms/network/SpeedStats.java
@@ -32,6 +32,7 @@ import net.pms.io.BasicSystemUtils;
 import net.pms.io.OutputParams;
 import net.pms.io.ProcessWrapperImpl;
 import net.pms.io.SystemUtils;
+import net.pms.util.UMSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,10 +173,7 @@ public class SpeedStats {
 			SystemUtils sysUtil = BasicSystemUtils.instance;
 			final ProcessWrapperImpl pw = new ProcessWrapperImpl(sysUtil.getPingCommand(addr.getHostAddress(), 5, size), op, true, false);
 			Runnable r = () -> {
-				try {
-					Thread.sleep(3000);
-				} catch (InterruptedException e) {
-				}
+				UMSUtils.sleep(3000);
 				pw.stopProcess();
 			};
 

--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -50,7 +50,6 @@ public class SearchRequestHandler {
 		.compile("(?<property>((\\bdc\\b)|(\\bupnp\\b)):[A-Za-z]+)\\s+(?<op>[A-Za-z=!<>]+)\\s+\"(?<val>.*?)\"", Pattern.CASE_INSENSITIVE);
 
 	private final AtomicInteger updateID = new AtomicInteger(1);
-	private final DbIdResourceLocator dbIdResourceLocator = new DbIdResourceLocator();
 
 	public SearchRequestHandler() {
 	}
@@ -386,7 +385,7 @@ public class SearchRequestHandler {
 												new DbIdTypeAndIdent2(DbIdMediaType.TYPE_MUSICBRAINZ_RECORDID, mbid), "");
 											MusicBrainzAlbum album = new MusicBrainzAlbum(resultSet.getString("MBID_RECORD"),
 												resultSet.getString("album"), resultSet.getString("artist"), resultSet.getInt("media_year"));
-											dbIdResourceLocator.appendAlbumInformation(album, albumFolder);
+											DbIdResourceLocator.appendAlbumInformation(album, albumFolder);
 											filesList.add(albumFolder);
 											foundMbidAlbums.add(mbid);
 										}

--- a/src/main/java/net/pms/network/mediaserver/handlers/api/LikeMusic.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/api/LikeMusic.java
@@ -19,13 +19,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import net.pms.PMS;
 import net.pms.database.MediaDatabase;
+import net.pms.database.MediaTableAudiotracks;
+import net.pms.database.MediaTableMusicBrainzReleaseLike;
 import net.pms.network.mediaserver.handlers.ApiResponseHandler;
 
 public class LikeMusic implements ApiResponseHandler {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LikeMusic.class.getName());
 	public static final String PATH_MATCH = "like";
-	private MediaDatabase db = PMS.get().getMediaDatabase();
 	private final String backupFilename;
 
 	public LikeMusic() {
@@ -35,7 +36,7 @@ public class LikeMusic implements ApiResponseHandler {
 
 	@Override
 	public String handleRequest(String uri, String content, HttpResponse output) {
-		try (Connection connection = db.getConnection()) {
+		try (Connection connection = MediaDatabase.getConnectionIfAvailable()) {
 			if (connection == null) {
 				return null;
 			}
@@ -43,10 +44,10 @@ public class LikeMusic implements ApiResponseHandler {
 			output.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain; charset=UTF-8");
 			output.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
 
-			String sql = null;
+			String sql;
 			switch (uri) {
 				case "likesong":
-					sql = "UPDATE AUDIOTRACKS set LIKESONG = true where MBID_TRACK = ?";
+					sql = "UPDATE " + MediaTableAudiotracks.TABLE_NAME + " SET LIKESONG = true WHERE " + MediaTableAudiotracks.MBID_TRACK + " = ?";
 					try {
 						PreparedStatement ps = connection.prepareStatement(sql);
 						ps.setString(1, content);
@@ -57,7 +58,7 @@ public class LikeMusic implements ApiResponseHandler {
 					}
 					break;
 				case "likealbum":
-					sql = "MERGE INTO MUSIC_BRAINZ_RELEASE_LIKE KEY (MBID_RELEASE) values (?)";
+					sql = "MERGE INTO " + MediaTableMusicBrainzReleaseLike.TABLE_NAME + " KEY (MBID_RELEASE) values (?)";
 					try {
 						PreparedStatement ps = connection.prepareStatement(sql);
 						ps.setString(1, content);
@@ -68,7 +69,7 @@ public class LikeMusic implements ApiResponseHandler {
 					}
 					break;
 				case "dislikesong":
-					sql = "UPDATE AUDIOTRACKS set LIKESONG = false where MBID_TRACK = ?";
+					sql = "UPDATE " + MediaTableAudiotracks.TABLE_NAME + " SET LIKESONG = false WHERE " + MediaTableAudiotracks.MBID_TRACK + " = ?";
 					try {
 						PreparedStatement ps = connection.prepareStatement(sql);
 						ps.setString(1, content);
@@ -79,7 +80,7 @@ public class LikeMusic implements ApiResponseHandler {
 					}
 					break;
 				case "dislikealbum":
-					sql = "DELETE FROM MUSIC_BRAINZ_RELEASE_LIKE where MBID_RELEASE = ?";
+					sql = "DELETE FROM " + MediaTableMusicBrainzReleaseLike.TABLE_NAME + " WHERE " + MediaTableMusicBrainzReleaseLike.MBID_RELEASE + " = ?";
 					try {
 						PreparedStatement ps = connection.prepareStatement(sql);
 						ps.setString(1, content);
@@ -90,10 +91,10 @@ public class LikeMusic implements ApiResponseHandler {
 					}
 					break;
 				case "isalbumliked":
-					sql = "SELECT COUNT(*) FROM MUSIC_BRAINZ_RELEASE_LIKE where MBID_RELEASE = ?";
+					sql = "SELECT COUNT(*) FROM " + MediaTableMusicBrainzReleaseLike.TABLE_NAME + " WHERE " + MediaTableMusicBrainzReleaseLike.MBID_RELEASE + " = ?";
 					return Boolean.toString(isCountGreaterZero(sql, connection, content));
 				case "issongliked":
-					sql = "SELECT COUNT(*) FROM AUDIOTRACKS where MBID_TRACK = ?";
+					sql = "SELECT COUNT(*) FROM " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableAudiotracks.MBID_TRACK + " = ?";
 					return Boolean.toString(isCountGreaterZero(sql, connection, content));
 				case "backupLikedAlbums":
 					backupLikedAlbums();
@@ -128,17 +129,17 @@ public class LikeMusic implements ApiResponseHandler {
 	}
 
 	public void backupLikedAlbums() throws SQLException {
-		try (Connection connection = db.getConnection()) {
-			Script.process(connection, backupFilename, "", "TABLE MUSIC_BRAINZ_RELEASE_LIKE");
+		try (Connection connection = MediaDatabase.getConnectionIfAvailable()) {
+			Script.process(connection, backupFilename, "", "TABLE " + MediaTableMusicBrainzReleaseLike.TABLE_NAME);
 		}
 	}
 
 	public void restoreLikedAlbums() throws SQLException, FileNotFoundException {
 		File backupFile = new File(backupFilename);
 		if (backupFile.exists() && backupFile.isFile()) {
-			try (Connection connection = db.getConnection(); Statement stmt = connection.createStatement()) {
+			try (Connection connection = MediaDatabase.getConnectionIfAvailable(); Statement stmt = connection.createStatement()) {
 				String sql;
-				sql = "DROP TABLE MUSIC_BRAINZ_RELEASE_LIKE";
+				sql = "DROP TABLE " + MediaTableMusicBrainzReleaseLike.TABLE_NAME;
 				stmt.execute(sql);
 				try {
 					RunScript.execute(connection, new FileReader(backupFilename));

--- a/src/main/java/net/pms/network/mediaserver/handlers/api/LikeMusic.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/api/LikeMusic.java
@@ -47,7 +47,7 @@ public class LikeMusic implements ApiResponseHandler {
 			String sql;
 			switch (uri) {
 				case "likesong":
-					sql = "UPDATE " + MediaTableAudiotracks.TABLE_NAME + " SET LIKESONG = true WHERE " + MediaTableAudiotracks.MBID_TRACK + " = ?";
+					sql = "UPDATE " + MediaTableAudiotracks.TABLE_NAME + " SET LIKESONG = true WHERE " + MediaTableAudiotracks.TABLE_COL_MBID_TRACK + " = ?";
 					try {
 						PreparedStatement ps = connection.prepareStatement(sql);
 						ps.setString(1, content);
@@ -69,7 +69,7 @@ public class LikeMusic implements ApiResponseHandler {
 					}
 					break;
 				case "dislikesong":
-					sql = "UPDATE " + MediaTableAudiotracks.TABLE_NAME + " SET LIKESONG = false WHERE " + MediaTableAudiotracks.MBID_TRACK + " = ?";
+					sql = "UPDATE " + MediaTableAudiotracks.TABLE_NAME + " SET LIKESONG = false WHERE " + MediaTableAudiotracks.TABLE_COL_MBID_TRACK + " = ?";
 					try {
 						PreparedStatement ps = connection.prepareStatement(sql);
 						ps.setString(1, content);
@@ -80,7 +80,7 @@ public class LikeMusic implements ApiResponseHandler {
 					}
 					break;
 				case "dislikealbum":
-					sql = "DELETE FROM " + MediaTableMusicBrainzReleaseLike.TABLE_NAME + " WHERE " + MediaTableMusicBrainzReleaseLike.MBID_RELEASE + " = ?";
+					sql = "DELETE FROM " + MediaTableMusicBrainzReleaseLike.TABLE_NAME + " WHERE " + MediaTableMusicBrainzReleaseLike.TABLE_COL_MBID_RELEASE + " = ?";
 					try {
 						PreparedStatement ps = connection.prepareStatement(sql);
 						ps.setString(1, content);
@@ -91,10 +91,10 @@ public class LikeMusic implements ApiResponseHandler {
 					}
 					break;
 				case "isalbumliked":
-					sql = "SELECT COUNT(*) FROM " + MediaTableMusicBrainzReleaseLike.TABLE_NAME + " WHERE " + MediaTableMusicBrainzReleaseLike.MBID_RELEASE + " = ?";
+					sql = "SELECT COUNT(*) FROM " + MediaTableMusicBrainzReleaseLike.TABLE_NAME + " WHERE " + MediaTableMusicBrainzReleaseLike.TABLE_COL_MBID_RELEASE + " = ?";
 					return Boolean.toString(isCountGreaterZero(sql, connection, content));
 				case "issongliked":
-					sql = "SELECT COUNT(*) FROM " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableAudiotracks.MBID_TRACK + " = ?";
+					sql = "SELECT COUNT(*) FROM " + MediaTableAudiotracks.TABLE_NAME + " WHERE " + MediaTableAudiotracks.TABLE_COL_MBID_TRACK + " = ?";
 					return Boolean.toString(isCountGreaterZero(sql, connection, content));
 				case "backupLikedAlbums":
 					backupLikedAlbums();

--- a/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
@@ -118,8 +118,6 @@ public class RequestHandler implements HttpHandler {
 	private static final int BUFFER_SIZE = 8 * 1024;
 	private static final Pattern DIDL_PATTERN = Pattern.compile("<Result>(&lt;DIDL-Lite.*?)</Result>");
 
-	private static final DbIdResourceLocator DB_ID_RESOURCE_LOCATOR = new DbIdResourceLocator();
-
 	private static final String HTTPSERVER_REQUEST_BEGIN =  "================================== HTTPSERVER REQUEST BEGIN =====================================";
 	private static final String HTTPSERVER_REQUEST_END =    "================================== HTTPSERVER REQUEST END =======================================";
 	private static final String HTTPSERVER_RESPONSE_BEGIN = "================================== HTTPSERVER RESPONSE BEGIN ====================================";
@@ -396,7 +394,7 @@ public class RequestHandler implements HttpHandler {
 		// Retrieve the DLNAresource itself.
 		if (id.startsWith(DbIdMediaType.GENERAL_PREFIX)) {
 			try {
-				dlna = DB_ID_RESOURCE_LOCATOR.locateResource(id.substring(0, id.indexOf('/')));
+				dlna = DbIdResourceLocator.locateResource(id.substring(0, id.indexOf('/')));
 			} catch (Exception e) {
 				LOGGER.error("", e);
 			}

--- a/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
+++ b/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
@@ -125,7 +125,6 @@ public class RequestV2 extends HTTPResource {
 
 	private final HttpMethod method;
 	private final SearchRequestHandler searchRequestHandler = new SearchRequestHandler();
-	private final DbIdResourceLocator dbIdResourceLocator = new DbIdResourceLocator();
 
 	private PmsConfiguration configuration = PMS.getConfiguration();
 
@@ -348,7 +347,7 @@ public class RequestV2 extends HTTPResource {
 				// Retrieve the DLNAresource itself.
 				if (id.startsWith(DbIdMediaType.GENERAL_PREFIX)) {
 					try {
-						dlna = dbIdResourceLocator.locateResource(id.substring(0, id.indexOf('/')));
+						dlna = DbIdResourceLocator.locateResource(id.substring(0, id.indexOf('/')));
 					} catch (Exception e) {
 						LOGGER.error("", e);
 					}

--- a/src/main/java/net/pms/network/webinterfaceserver/WebInterfaceServerUtil.java
+++ b/src/main/java/net/pms/network/webinterfaceserver/WebInterfaceServerUtil.java
@@ -17,6 +17,11 @@
  */
 package net.pms.network.webinterfaceserver;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 import com.sun.net.httpserver.Headers;
@@ -29,7 +34,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
-import java.net.URLEncoder;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.util.*;
@@ -39,8 +44,8 @@ import net.pms.configuration.IpFilter;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.configuration.WebRender;
 import net.pms.database.MediaDatabase;
-import net.pms.database.MediaTableFiles;
 import net.pms.database.MediaTableTVSeries;
+import net.pms.database.MediaTableVideoMetadatas;
 import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.Range;
@@ -55,13 +60,13 @@ import net.pms.util.UMSUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("restriction")
 public class WebInterfaceServerUtil {
 	private static final Logger LOGGER = LoggerFactory.getLogger(WebInterfaceServerUtil.class);
+	private static final Gson GSON = new Gson();
 
 	//public static final String MIME_TRANS = MIME_MP4;
 	public static final String MIME_TRANS = HTTPResource.OGG_TYPEMIME;
@@ -316,29 +321,25 @@ public class WebInterfaceServerUtil {
 	 * the codecs within. For example, most browsers support
 	 * MP4 with H.264, but do not support it with H.265 (HEVC)
 	 *
+	 * @param mime
+	 * @return
 	 * @todo refactor to be more specific
 	 */
 	public static boolean directmime(String mime) {
-		if (
-			mime != null &&
-			(
-				mime.equals(HTTPResource.MP4_TYPEMIME) ||
-				mime.equals(HTTPResource.WEBM_TYPEMIME) ||
-				mime.equals(HTTPResource.OGG_TYPEMIME) ||
-				mime.equals(HTTPResource.AUDIO_M4A_TYPEMIME) ||
-				mime.equals(HTTPResource.AUDIO_MP3_TYPEMIME) ||
-				mime.equals(HTTPResource.AUDIO_OGA_TYPEMIME) ||
-				mime.equals(HTTPResource.AUDIO_WAV_TYPEMIME) ||
-				mime.equals(HTTPResource.BMP_TYPEMIME) ||
-				mime.equals(HTTPResource.PNG_TYPEMIME) ||
-				mime.equals(HTTPResource.JPEG_TYPEMIME) ||
-				mime.equals(HTTPResource.GIF_TYPEMIME)
-			)
-		) {
-			return true;
-		}
-
-		return false;
+		return mime != null &&
+		(
+			mime.equals(HTTPResource.MP4_TYPEMIME) ||
+			mime.equals(HTTPResource.WEBM_TYPEMIME) ||
+			mime.equals(HTTPResource.OGG_TYPEMIME) ||
+			mime.equals(HTTPResource.AUDIO_M4A_TYPEMIME) ||
+			mime.equals(HTTPResource.AUDIO_MP3_TYPEMIME) ||
+			mime.equals(HTTPResource.AUDIO_OGA_TYPEMIME) ||
+			mime.equals(HTTPResource.AUDIO_WAV_TYPEMIME) ||
+			mime.equals(HTTPResource.BMP_TYPEMIME) ||
+			mime.equals(HTTPResource.PNG_TYPEMIME) ||
+			mime.equals(HTTPResource.JPEG_TYPEMIME) ||
+			mime.equals(HTTPResource.GIF_TYPEMIME)
+		);
 	}
 
 	public static String userName(HttpExchange t) {
@@ -360,6 +361,84 @@ public class WebInterfaceServerUtil {
 					return pair[1];
 				}
 			}
+		}
+		return null;
+	}
+
+	/**
+	 * @param exchange the HTTP exchange
+	 * @return Array of query parameters
+	 */
+	public static Map<String, String> parseQueryString(HttpExchange exchange) {
+		return parseQueryString(exchange.getRequestURI().getQuery());
+	}
+
+	/**
+	 * @param qs the query string
+	 * @return Array of query parameters
+	 * @see https://stackoverflow.com/a/41610845/2049714
+	 */
+	public static Map<String, String> parseQueryString(String qs) {
+		Map<String, String> result = new HashMap<>();
+		if (qs == null) {
+			return result;
+		}
+
+		int last = 0, next, l = qs.length();
+		while (last < l) {
+			next = qs.indexOf('&', last);
+			if (next == -1) {
+				next = l;
+			}
+
+			if (next > last) {
+				int eqPos = qs.indexOf('=', last);
+				try {
+					if (eqPos < 0 || eqPos > next) {
+						result.put(URLDecoder.decode(qs.substring(last, next), "utf-8"), "");
+					} else {
+						result.put(URLDecoder.decode(qs.substring(last, eqPos), "utf-8"), URLDecoder.decode(qs.substring(eqPos + 1, next), "utf-8"));
+					}
+				} catch (UnsupportedEncodingException e) {
+					throw new RuntimeException(e); // will never happen, utf-8 support is mandatory for java
+				}
+			}
+			last = next + 1;
+		}
+		return result;
+	}
+
+	public static String getPostString(HttpExchange exchange) {
+		try {
+			return IOUtils.toString(exchange.getRequestBody(), StandardCharsets.UTF_8);
+		} catch (IOException ex) {
+			return null;
+		}
+	}
+
+	public static JsonObject getJsonObjectFromPost(HttpExchange exchange) {
+		String reqBody = getPostString(exchange);
+		return jsonObjectFromString(reqBody);
+	}
+
+	private static JsonObject jsonObjectFromString(String str) {
+		try {
+			JsonElement jElem = GSON.fromJson(str, JsonElement.class);
+			if (jElem.isJsonObject()) {
+				return jElem.getAsJsonObject();
+			}
+		} catch (JsonSyntaxException je) {
+		}
+		return null;
+	}
+
+	private static JsonArray jsonArrayFromString(String str) {
+		try {
+			JsonElement jElem = GSON.fromJson(str, JsonElement.class);
+			if (jElem.isJsonArray()) {
+				return jElem.getAsJsonArray();
+			}
+		} catch (JsonSyntaxException je) {
 		}
 		return null;
 	}
@@ -563,6 +642,7 @@ public class WebInterfaceServerUtil {
 		/**
 		 * Register a file as servable.
 		 *
+		 * @param f
 		 * @return its hashcode (for use as a 'filename' in an http path)
 		 */
 		public int add(File f) {
@@ -572,6 +652,8 @@ public class WebInterfaceServerUtil {
 
 		/**
 		 * Retrieve a servable file by its hashcode.
+		 * @param hash
+		 * @return
 		 */
 		public File getFile(String hash) {
 			try {
@@ -597,6 +679,10 @@ public class WebInterfaceServerUtil {
 
 		/**
 		 * Write the given resource as an http response body.
+		 * @param filename
+		 * @param t
+		 * @return
+		 * @throws java.io.IOException
 		 */
 		public boolean write(String filename, HttpExchange t) throws IOException {
 			InputStream stream = getInputStream(filename);
@@ -623,6 +709,8 @@ public class WebInterfaceServerUtil {
 
 		/**
 		 * Retrieve the given mustache template, compiling as necessary.
+		 * @param filename
+		 * @return
 		 */
 		public Template getTemplate(String filename) {
 			Template t = null;
@@ -633,7 +721,7 @@ public class WebInterfaceServerUtil {
 				if (url != null) {
 					t = compile(getInputStream(filename));
 					templates.put(filename, t);
-					PMS.getFileWatcher().add(new FileWatcher.Watch(url.getFile(), recompiler));
+					FileWatcher.add(new FileWatcher.Watch(url.getFile(), recompiler));
 				} else {
 					LOGGER.warn("Couldn't find web template \"{}\"", filename);
 				}
@@ -664,434 +752,151 @@ public class WebInterfaceServerUtil {
 	 * @param language
 	 * @param isTVSeries whether this is a TV series, or an episode/movie
 	 * @param rootFolder the root folder, used for looking up IDs
-	 * @return a JavaScript string to be used by a web browser which includes
+	 * @return a JsonObject to be used by a web browser which includes
 	 *         metadata names and when applicable, associated IDs, or null
 	 *         when there is no metadata
 	 */
-	public static String getAPIMetadataAsJavaScriptVars(DLNAResource resource, String language, boolean isTVSeries, RootFolder rootFolder) {
-		String javascriptVarsScript = "";
+	public static JsonObject getAPIMetadataAsJsonObject(DLNAResource resource, String language, boolean isTVSeries, RootFolder rootFolder) {
+		JsonObject result = getAPIMetadataAsJsonObject(resource, isTVSeries, rootFolder);
+		if (result != null) {
+			result.addProperty("imageBaseURL", APIUtils.getApiImageBaseURL());
+			result.addProperty("actorsTranslation", WebInterfaceServerUtil.getMsgString("Actors", language));
+			result.addProperty("awardsTranslation", WebInterfaceServerUtil.getMsgString("Awards", language));
+			result.addProperty("countryTranslation", WebInterfaceServerUtil.getMsgString("Country", language));
+			result.addProperty("directorTranslation", WebInterfaceServerUtil.getMsgString("Director", language));
+			result.addProperty("genresTranslation", WebInterfaceServerUtil.getMsgString("Genres", language));
+			result.addProperty("ratedTranslation", WebInterfaceServerUtil.getMsgString("Rated", language));
+			result.addProperty("ratingsTranslation", WebInterfaceServerUtil.getMsgString("Ratings", language));
+			result.addProperty("totalSeasonsTranslation", WebInterfaceServerUtil.getMsgString("TotalSeasons", language));
+			result.addProperty("plotTranslation", WebInterfaceServerUtil.getMsgString("Plot", language));
+			result.addProperty("yearStartedTranslation", WebInterfaceServerUtil.getMsgString("YearStarted", language));
+		}
+		return result;
+	}
 
-		try {
-			List<HashMap<String, Object>> resourceMetadataFromDatabase = null;
-
-			Connection connection = null;
-			try {
-				connection = MediaDatabase.getConnectionIfAvailable();
-				if (connection != null) {
-					if (isTVSeries) {
-						String simplifiedTitle = resource.getDisplayName() != null ? FileUtil.getSimplifiedShowName(resource.getDisplayName()) : resource.getName();
-						resourceMetadataFromDatabase = MediaTableTVSeries.getAPIResultsBySimplifiedTitleIncludingExternalTables(connection, simplifiedTitle);
-					} else {
-						resourceMetadataFromDatabase = MediaTableFiles.getAPIResultsByFilenameIncludingExternalTables(connection, resource.getFileName());
-					}
-				}
-			} catch (Exception e) {
-				LOGGER.error("Error while getting metadata for web interface");
-				LOGGER.debug("", e);
-			} finally {
-				MediaDatabase.close(connection);
-			}
-
-			if (resourceMetadataFromDatabase == null) {
-				return null;
-			}
-
-			HashSet<String> actors = new HashSet();
-			String startYear = "";
-			String awards = "";
-			String country = "{}";
-			String director = "{}";
-			HashSet<String> genres = new HashSet();
-			String imdbID = "";
-			String rated = "{}";
-			List<HashMap<String, String>> ratings = new ArrayList<>();
-			String plot = "";
-			String poster = "";
-			Double totalSeasons = null;
-
-			// TMDB metadata added in V11
-			String createdBy = "";
-			String credits = "";
-			String externalIDs = "";
-			String firstAirDate = "";
-			String homepage = "";
-			String images = "[]";
-			Boolean inProduction = null;
-			String languages = "";
-			String lastAirDate = "";
-			String networks = "";
-			Double numberOfEpisodes = null;
-			String numberOfSeasons = "";
-			String originCountry = "";
-			String originalLanguage = "";
-			String originalTitle = "";
-			String productionCompanies = "";
-			String productionCountries = "";
-			String seasons = "";
-			String seriesImages = "[]";
-			String seriesType = "";
-			String spokenLanguages = "";
-			String status = "";
-			String tagline = "";
-
-
-			Boolean hasAPIMetadata = false;
-
-			DLNAResource actorsFolder = null;
-			DLNAResource countryFolder = null;
-			DLNAResource directorFolder = null;
-			DLNAResource genresFolder = null;
-			DLNAResource ratedFolder = null;
-
-			List<DLNAResource> actorsChildren = null;
-			List<DLNAResource> genresChildren = null;
-
-			Iterator<HashMap<String, Object>> i = resourceMetadataFromDatabase.iterator();
-			while (i.hasNext()) {
-				if (genresFolder == null) {
-					// prepare to get IDs of certain metadata resources, to make them clickable
-					List<DLNAResource> rootFolderChildren = rootFolder.getDLNAResources("0", true, 0, 0, rootFolder.getDefaultRenderer(), Messages.getString("MediaLibrary"));
-					UMSUtils.filterResourcesByName(rootFolderChildren, Messages.getString("MediaLibrary"), true, true);
-					if (rootFolderChildren.isEmpty()) {
-						return null;
-					}
-					DLNAResource mediaLibraryFolder = rootFolderChildren.get(0);
-
-					List<DLNAResource> mediaLibraryChildren = mediaLibraryFolder.getDLNAResources(mediaLibraryFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), Messages.getString("Video"));
-					UMSUtils.filterResourcesByName(mediaLibraryChildren, Messages.getString("Video"), true, true);
-					DLNAResource videoFolder = mediaLibraryChildren.get(0);
-
-					boolean isRelatedToTV = isTVSeries || resource.isEpisodeWithinSeasonFolder() || resource.isEpisodeWithinTVSeriesFolder();
-					String folderName = isRelatedToTV ? Messages.getString("TvShows") : Messages.getString("Movies");
-					List<DLNAResource> videoFolderChildren = videoFolder.getDLNAResources(videoFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), folderName);
-					UMSUtils.filterResourcesByName(videoFolderChildren, folderName, true, true);
-					DLNAResource tvShowsOrMoviesFolder = videoFolderChildren.get(0);
-
-					List<DLNAResource> tvShowsOrMoviesChildren = tvShowsOrMoviesFolder.getDLNAResources(tvShowsOrMoviesFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), Messages.getString("FilterByInformation"));
-					UMSUtils.filterResourcesByName(tvShowsOrMoviesChildren, Messages.getString("FilterByInformation"), true, true);
-					DLNAResource filterByInformationFolder = tvShowsOrMoviesChildren.get(0);
-
-					List<DLNAResource> filterByInformationChildren = filterByInformationFolder.getDLNAResources(filterByInformationFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), Messages.getString("Genres"));
-
-					for (int filterByInformationChildrenIterator = 0; filterByInformationChildrenIterator < filterByInformationChildren.size(); filterByInformationChildrenIterator++) {
-						DLNAResource filterByInformationChild = filterByInformationChildren.get(filterByInformationChildrenIterator);
-						if (filterByInformationChild.getDisplayName().equals(Messages.getString("Actors"))) {
-							actorsFolder = filterByInformationChild;
-						} else if (filterByInformationChild.getDisplayName().equals(Messages.getString("Country"))) {
-							countryFolder = filterByInformationChild;
-						} else if (filterByInformationChild.getDisplayName().equals(Messages.getString("Director"))) {
-							directorFolder = filterByInformationChild;
-						} else if (filterByInformationChild.getDisplayName().equals(Messages.getString("Genres"))) {
-							genresFolder = filterByInformationChild;
-						} else if (filterByInformationChild.getDisplayName().equals(Messages.getString("Rated"))) {
-							ratedFolder = filterByInformationChild;
-						}
-					}
-
-					hasAPIMetadata = true;
-				}
-
-				HashMap<String, Object> row = i.next();
-				if (StringUtils.isNotBlank((String) row.get("AWARD"))) {
-					awards = (String) row.get("AWARD");
-				}
-				if (StringUtils.isNotBlank((String) row.get("COUNTRY")) && "{}".equals(country) && countryFolder != null) {
-					String countryValue = (String) row.get("COUNTRY");
-					List<DLNAResource> countriesChildren = countryFolder.getDLNAResources(countryFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), countryValue);
-					UMSUtils.filterResourcesByName(countriesChildren, countryValue, true, true);
-					if (countriesChildren.isEmpty()) {
-						country = "{ }";
-					} else {
-						DLNAResource filteredCountryFolder = countriesChildren.get(0);
-
-						String countryId = filteredCountryFolder.getId();
-						String countryIdForWeb = URLEncoder.encode(countryId, "UTF-8");
-
-						country = "{ id: \"" + countryIdForWeb + "\", name: \"" + StringEscapeUtils.escapeEcmaScript(countryValue) + "\" }";
-					}
-				}
-				if (StringUtils.isNotBlank((String) row.get("DIRECTOR")) && "{}".equals(director) && directorFolder != null) {
-					String directorValue = (String) row.get("DIRECTOR");
-					List<DLNAResource> directorsChildren = directorFolder.getDLNAResources(directorFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), directorValue);
-					UMSUtils.filterResourcesByName(directorsChildren, directorValue, true, true);
-					if (directorsChildren.isEmpty()) {
-						/**
-						* This is usually caused by TV episodes that have a director saved
-						* that is not the director of the TV series. One possible fix for
-						* that is to populate the TV series data with the episode data in
-						* that case, which would mean we need to support multiple directors
-						* as we do for actors and genres.
-						*
-						* For now we stop the code from erroring by ignoring the mismatch.
-						*
-						* @todo do the above fix, and the same fix for other similar folders.
-						*/
-						director = "{ }";
-					} else {
-						DLNAResource filteredDirectorFolder = directorsChildren.get(0);
-
-						String directorId = filteredDirectorFolder.getId();
-						String directorIdForWeb = URLEncoder.encode(directorId, "UTF-8");
-
-						director = "{ id: \"" + directorIdForWeb + "\", name: \"" + StringEscapeUtils.escapeEcmaScript(directorValue) + "\" }";
-					}
-				}
-				if (StringUtils.isNotBlank((String) row.get("IMDBID"))) {
-					imdbID = (String) row.get("IMDBID");
-				}
-				if (StringUtils.isNotBlank((String) row.get("PLOT"))) {
-					plot = (String) row.get("PLOT");
-				}
-				if (StringUtils.isNotBlank((String) row.get("POSTER"))) {
-					poster = (String) row.get("POSTER");
-				}
-				if (StringUtils.isNotBlank((String) row.get("RATING")) && "{}".equals(rated) && ratedFolder != null) {
-					String ratedValue = (String) row.get("RATING");
-					List<DLNAResource> ratedChildren = ratedFolder.getDLNAResources(ratedFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), ratedValue);
-					UMSUtils.filterResourcesByName(ratedChildren, ratedValue, true, true);
-					if (ratedChildren.isEmpty()) {
-						rated = "{ }";
-					} else {
-						DLNAResource filteredRatedFolder = ratedChildren.get(0);
-
-						String ratedId = filteredRatedFolder.getId();
-						String ratedIdForWeb = URLEncoder.encode(ratedId, "UTF-8");
-
-						rated = "{ id: \"" + ratedIdForWeb + "\", name: \"" + StringEscapeUtils.escapeEcmaScript(ratedValue) + "\" }";
-					}
-				}
-				if (StringUtils.isNotBlank((String) row.get("RATINGVALUE")) && StringUtils.isNotBlank((String) row.get("RATINGSOURCE"))) {
-					HashMap<String, String> ratingToInsert = new HashMap();
-					ratingToInsert.put("source", (String) row.get("RATINGSOURCE"));
-					ratingToInsert.put("value", (String) row.get("RATINGVALUE"));
-					if (!ratings.contains(ratingToInsert)) {
-						ratings.add(ratingToInsert);
-					}
-				}
-				if (StringUtils.isNotBlank((String) row.get("STARTYEAR"))) {
-					startYear = (String) row.get("STARTYEAR");
-				}
-				if (row.get("TOTALSEASONS") != null && (Double) row.get("TOTALSEASONS") != 0.0) {
-					totalSeasons = (Double) row.get("TOTALSEASONS");
-				}
-
-				// TMDB metadata added in V11
-				if (StringUtils.isNotBlank((String) row.get("CREATEDBY"))) {
-					createdBy = (String) row.get("CREATEDBY");
-				}
-				if (StringUtils.isNotBlank((String) row.get("CREDITS"))) {
-					credits = (String) row.get("CREDITS");
-				}
-				if (StringUtils.isNotBlank((String) row.get("EXTERNALIDS"))) {
-					externalIDs = (String) row.get("EXTERNALIDS");
-				}
-				if (StringUtils.isNotBlank((String) row.get("FIRSTAIRDATE"))) {
-					firstAirDate = (String) row.get("FIRSTAIRDATE");
-				}
-				if (StringUtils.isNotBlank((String) row.get("HOMEPAGE"))) {
-					homepage = (String) row.get("HOMEPAGE");
-				}
-
-				if (row.get("ISTVEPISODE") != null && (Boolean) row.get("ISTVEPISODE") && StringUtils.isNotBlank((String) row.get("MOVIEORSHOWNAME"))) {
-					connection = null;
-					try {
-						connection = MediaDatabase.getConnectionIfAvailable();
-						if (connection != null) {
-							String simplifiedShowName = FileUtil.getSimplifiedShowName((String) row.get("MOVIEORSHOWNAME"));
-							List<HashMap<String, Object>> optionalSeriesMetadataFromDatabase = MediaTableTVSeries.getAPIResultsBySimplifiedTitleIncludingExternalTables(connection, simplifiedShowName);
-							Iterator<HashMap<String, Object>> seriesIterator = optionalSeriesMetadataFromDatabase.iterator();
-							if (optionalSeriesMetadataFromDatabase != null) {
-								HashMap<String, Object> seriesRow = seriesIterator.next();
-								if (StringUtils.isNotBlank((String) seriesRow.get("IMAGES"))) {
-									seriesImages = (String) seriesRow.get("IMAGES");
-								}
-							}
-						}
-					} catch (Exception e) {
-						LOGGER.error("Error while getting series metadata for web interface");
-						LOGGER.debug("", e);
-					} finally {
-						MediaDatabase.close(connection);
-					}
-				}
-
-				if (StringUtils.isNotBlank((String) row.get("IMAGES"))) {
-					images = (String) row.get("IMAGES");
-				}
-				if (row.get("INPRODUCTION") != null) {
-					inProduction = (Boolean) row.get("INPRODUCTION");
-				}
-				if (StringUtils.isNotBlank((String) row.get("LANGUAGES"))) {
-					languages = (String) row.get("LANGUAGES");
-				}
-				if (StringUtils.isNotBlank((String) row.get("LASTAIRDATE"))) {
-					lastAirDate = (String) row.get("LASTAIRDATE");
-				}
-				if (StringUtils.isNotBlank((String) row.get("NETWORKS"))) {
-					networks = (String) row.get("NETWORKS");
-				}
-				if (row.get("NUMBEROFEPISODES") != null) {
-					numberOfEpisodes = (Double) row.get("NUMBEROFEPISODES");
-				}
-				if (StringUtils.isNotBlank((String) row.get("NUMBEROFSEASONS"))) {
-					numberOfSeasons = (String) row.get("NUMBEROFSEASONS");
-				}
-				if (StringUtils.isNotBlank((String) row.get("ORIGINCOUNTRY"))) {
-					originCountry = (String) row.get("ORIGINCOUNTRY");
-				}
-				if (StringUtils.isNotBlank((String) row.get("ORIGINALLANGUAGE"))) {
-					originalLanguage = (String) row.get("ORIGINALLANGUAGE");
-				}
-				if (StringUtils.isNotBlank((String) row.get("ORIGINALTITLE"))) {
-					originalTitle = (String) row.get("ORIGINALTITLE");
-				}
-				if (StringUtils.isNotBlank((String) row.get("PRODUCTIONCOMPANIES"))) {
-					productionCompanies = (String) row.get("PRODUCTIONCOMPANIES");
-				}
-				if (StringUtils.isNotBlank((String) row.get("PRODUCTIONCOUNTRIES"))) {
-					productionCountries = (String) row.get("PRODUCTIONCOUNTRIES");
-				}
-				if (StringUtils.isNotBlank((String) row.get("SEASONS"))) {
-					seasons = (String) row.get("SEASONS");
-				}
-				if (StringUtils.isNotBlank((String) row.get("SERIESTYPE"))) {
-					seriesType = (String) row.get("SERIESTYPE");
-				}
-				if (StringUtils.isNotBlank((String) row.get("SPOKENLANGUAGES"))) {
-					spokenLanguages = (String) row.get("SPOKENLANGUAGES");
-				}
-				if (StringUtils.isNotBlank((String) row.get("STATUS"))) {
-					status = (String) row.get("STATUS");
-				}
-				if (StringUtils.isNotBlank((String) row.get("TAGLINE"))) {
-					tagline = (String) row.get("TAGLINE");
-				}
-
-				// These are for records that can have multiple results
-				if (StringUtils.isNotBlank((String) row.get("ACTOR")) && actorsFolder != null) {
-					String actor = (String) row.get("ACTOR");
-					String namePartOfJSObject = ", name: \"" + StringEscapeUtils.escapeEcmaScript(actor) + "\"";
-					if (!actors.contains(namePartOfJSObject)) {
-						if (actorsChildren == null) {
-							actorsChildren = actorsFolder.getDLNAResources(actorsFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), actor);
-						}
-						for (int actorsIterator = 0; actorsIterator < actorsChildren.size(); actorsIterator++) {
-							DLNAResource filterByInformationChild = actorsChildren.get(actorsIterator);
-							if (filterByInformationChild.getDisplayName().equals(actor)) {
-								DLNAResource actorFolder = filterByInformationChild;
-
-								String actorId = actorFolder.getId();
-								String actorIdForWeb = URLEncoder.encode(actorId, "UTF-8");
-
-								actors.add("{ id: \"" + actorIdForWeb + "\"" + namePartOfJSObject + " }");
-								break;
-							}
-						}
-					}
-				}
-				if (StringUtils.isNotBlank((String) row.get("GENRE")) && genresFolder != null) {
-					String genre = (String) row.get("GENRE");
-					String namePartOfJSObject = ", name: \"" + StringEscapeUtils.escapeEcmaScript(genre) + "\"";
-					if (!genres.contains(namePartOfJSObject)) {
-						if (genresChildren == null) {
-							genresChildren = genresFolder.getDLNAResources(genresFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), genre);
-						}
-						for (int genresIterator = 0; genresIterator < genresChildren.size(); genresIterator++) {
-							DLNAResource filterByInformationChild = genresChildren.get(genresIterator);
-							if (filterByInformationChild.getDisplayName().equals(genre)) {
-								DLNAResource genreFolder = filterByInformationChild;
-
-								String genreId = genreFolder.getId();
-								String genreIdForWeb = URLEncoder.encode(genreId, "UTF-8");
-
-								genres.add("{ id: \"" + genreIdForWeb + "\"" + namePartOfJSObject + " }");
-								break;
-							}
-						}
-					}
+	/**
+	 * Gets metadata from our database, which may be there from our API, for
+	 * this resource, which could be a TV series, TV episode, or movie.
+	 *
+	 * @param resource
+	 * @param isTVSeries whether this is a TV series, or an episode/movie
+	 * @param rootFolder the root folder, used for looking up IDs
+	 * @return a JsonObject to be used by a web browser which includes
+	 *         metadata names and when applicable, associated IDs, or null
+	 *         when there is no metadata
+	 */
+	public static JsonObject getAPIMetadataAsJsonObject(DLNAResource resource, boolean isTVSeries, RootFolder rootFolder) {
+		JsonObject result = null;
+		try (Connection connection = MediaDatabase.getConnectionIfAvailable()) {
+			if (connection != null) {
+				if (isTVSeries) {
+					String simplifiedTitle = resource.getDisplayName() != null ? FileUtil.getSimplifiedShowName(resource.getDisplayName()) : resource.getName();
+					result = MediaTableTVSeries.getTvSerieMetadataAsJsonObject(connection, simplifiedTitle);
+				} else {
+					result = MediaTableVideoMetadatas.getVideoMetadataAsJsonObject(connection, resource.getFileName());
 				}
 			}
-
-			if (!hasAPIMetadata) {
-				return null;
-			}
-
-			javascriptVarsScript = "";
-			javascriptVarsScript += "var awards = \"" + StringEscapeUtils.escapeEcmaScript(awards) + "\";";
-			javascriptVarsScript += "var awardsTranslation = \"" + WebInterfaceServerUtil.getMsgString("Awards", language) + "\";";
-			javascriptVarsScript += "var country = " + country + ";";
-			javascriptVarsScript += "var countryTranslation = \"" + WebInterfaceServerUtil.getMsgString("Country", language) + "\";";
-			javascriptVarsScript += "var director = " + director + ";";
-			javascriptVarsScript += "var directorTranslation = \"" + WebInterfaceServerUtil.getMsgString("Director", language) + "\";";
-			javascriptVarsScript += "var imdbID = \"" + StringEscapeUtils.escapeEcmaScript(imdbID) + "\";";
-			javascriptVarsScript += "var plot = \"" + StringEscapeUtils.escapeEcmaScript(plot) + "\";";
-			javascriptVarsScript += "var plotTranslation = \"" + WebInterfaceServerUtil.getMsgString("Plot", language) + "\";";
-			javascriptVarsScript += "var poster = \"" + StringEscapeUtils.escapeEcmaScript(poster) + "\";";
-			javascriptVarsScript += "var rated = " + rated + ";";
-			javascriptVarsScript += "var ratedTranslation = \"" + WebInterfaceServerUtil.getMsgString("Rated", language) + "\";";
-			javascriptVarsScript += "var startYear = \"" + StringEscapeUtils.escapeEcmaScript(startYear) + "\";";
-			javascriptVarsScript += "var yearStartedTranslation = \"" + WebInterfaceServerUtil.getMsgString("YearStarted", language) + "\";";
-			javascriptVarsScript += "var totalSeasons = " + totalSeasons + ";";
-			javascriptVarsScript += "var totalSeasonsTranslation = \"" + WebInterfaceServerUtil.getMsgString("TotalSeasons", language) + "\";";
-
-			// TMDB metadata added in V11
-			javascriptVarsScript += "var createdBy = \"" + StringEscapeUtils.escapeEcmaScript(createdBy) + "\";";
-			javascriptVarsScript += "var credits = \"" + StringEscapeUtils.escapeEcmaScript(credits) + "\";";
-			javascriptVarsScript += "var externalIDs = \"" + StringEscapeUtils.escapeEcmaScript(externalIDs) + "\";";
-			javascriptVarsScript += "var firstAirDate = \"" + StringEscapeUtils.escapeEcmaScript(firstAirDate) + "\";";
-			javascriptVarsScript += "var homepage = \"" + StringEscapeUtils.escapeEcmaScript(homepage) + "\";";
-			javascriptVarsScript += "var imageBaseURL = \"" + APIUtils.getApiImageBaseURL() + "\";";
-			javascriptVarsScript += "var images = " + images + ";";
-			javascriptVarsScript += "var inProduction = " + inProduction + ";";
-			javascriptVarsScript += "var languages = \"" + StringEscapeUtils.escapeEcmaScript(languages) + "\";";
-			javascriptVarsScript += "var lastAirDate = \"" + StringEscapeUtils.escapeEcmaScript(lastAirDate) + "\";";
-			javascriptVarsScript += "var networks = \"" + StringEscapeUtils.escapeEcmaScript(networks) + "\";";
-			javascriptVarsScript += "var numberOfEpisodes = " + numberOfEpisodes + ";";
-			javascriptVarsScript += "var numberOfSeasons = \"" + StringEscapeUtils.escapeEcmaScript(numberOfSeasons) + "\";";
-			javascriptVarsScript += "var originCountry = \"" + StringEscapeUtils.escapeEcmaScript(originCountry) + "\";";
-			javascriptVarsScript += "var originalLanguage = \"" + StringEscapeUtils.escapeEcmaScript(originalLanguage) + "\";";
-			javascriptVarsScript += "var originalTitle = \"" + StringEscapeUtils.escapeEcmaScript(originalTitle) + "\";";
-			javascriptVarsScript += "var productionCompanies = \"" + StringEscapeUtils.escapeEcmaScript(productionCompanies) + "\";";
-			javascriptVarsScript += "var productionCountries = \"" + StringEscapeUtils.escapeEcmaScript(productionCountries) + "\";";
-			javascriptVarsScript += "var seasons = \"" + StringEscapeUtils.escapeEcmaScript(seasons) + "\";";
-			javascriptVarsScript += "var seriesImages = " + seriesImages + ";";
-			javascriptVarsScript += "var seriesType = \"" + StringEscapeUtils.escapeEcmaScript(seriesType) + "\";";
-			javascriptVarsScript += "var spokenLanguages = \"" + StringEscapeUtils.escapeEcmaScript(spokenLanguages) + "\";";
-			javascriptVarsScript += "var status = \"" + StringEscapeUtils.escapeEcmaScript(status) + "\";";
-			javascriptVarsScript += "var tagline = \"" + StringEscapeUtils.escapeEcmaScript(tagline) + "\";";
-
-			javascriptVarsScript += "var actorsTranslation = \"" + WebInterfaceServerUtil.getMsgString("Actors", language) + "\";";
-			String actorsArrayJavaScript = "var actors = [";
-			for (String actor : actors) {
-				actorsArrayJavaScript += actor + ",";
-			}
-			actorsArrayJavaScript += "];";
-			javascriptVarsScript += actorsArrayJavaScript;
-
-			javascriptVarsScript += "var genresTranslation = \"" + WebInterfaceServerUtil.getMsgString("Genres", language) + "\";";
-			String genresArrayJavaScript = "var genres = [";
-			for (String genre : genres) {
-				genresArrayJavaScript += genre + ",";
-			}
-			genresArrayJavaScript += "];";
-			javascriptVarsScript += genresArrayJavaScript;
-
-			String ratingsArrayJavaScript = "var ratings = [";
-			javascriptVarsScript += "var ratingsTranslation= \"" + WebInterfaceServerUtil.getMsgString("Ratings", language) + "\";";
-			if (!ratings.isEmpty()) {
-				Iterator<HashMap<String, String>> ratingsIterator = ratings.iterator();
-				while (ratingsIterator.hasNext()) {
-					HashMap<String, String> rating = ratingsIterator.next();
-					ratingsArrayJavaScript += "{ \"source\": \"" + StringEscapeUtils.escapeEcmaScript(rating.get("source")) + "\", \"value\": \"" + StringEscapeUtils.escapeEcmaScript(rating.get("value")) + "\"},";
-				}
-			}
-			ratingsArrayJavaScript += "];";
-			javascriptVarsScript += ratingsArrayJavaScript;
 		} catch (Exception e) {
-			LOGGER.error("Caught exception in getAPIMetadataAsJavaScriptVars: {}", e.getMessage());
-			LOGGER.debug("{}", e);
+			LOGGER.error("Error while getting metadata for web interface");
+			LOGGER.debug("", e);
+		}
+		if (result == null) {
+			return null;
+		}
+		DLNAResource actorsFolder = null;
+		DLNAResource countriesFolder = null;
+		DLNAResource directorsFolder = null;
+		DLNAResource genresFolder = null;
+		DLNAResource ratedFolder = null;
+
+		// prepare to get IDs of certain metadata resources, to make them clickable
+		List<DLNAResource> rootFolderChildren = rootFolder.getDLNAResources("0", true, 0, 0, rootFolder.getDefaultRenderer(), Messages.getString("MediaLibrary"));
+		UMSUtils.filterResourcesByName(rootFolderChildren, Messages.getString("MediaLibrary"), true, true);
+		if (rootFolderChildren.isEmpty()) {
+			return null;
+		}
+		DLNAResource mediaLibraryFolder = rootFolderChildren.get(0);
+		List<DLNAResource> mediaLibraryChildren = mediaLibraryFolder.getDLNAResources(mediaLibraryFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), Messages.getString("Video"));
+		UMSUtils.filterResourcesByName(mediaLibraryChildren, Messages.getString("Video"), true, true);
+		DLNAResource videoFolder = mediaLibraryChildren.get(0);
+
+		boolean isRelatedToTV = isTVSeries || resource.isEpisodeWithinSeasonFolder() || resource.isEpisodeWithinTVSeriesFolder();
+		String folderName = isRelatedToTV ? Messages.getString("TvShows") : Messages.getString("Movies");
+		List<DLNAResource> videoFolderChildren = videoFolder.getDLNAResources(videoFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), folderName);
+		UMSUtils.filterResourcesByName(videoFolderChildren, folderName, true, true);
+		DLNAResource tvShowsOrMoviesFolder = videoFolderChildren.get(0);
+
+		List<DLNAResource> tvShowsOrMoviesChildren = tvShowsOrMoviesFolder.getDLNAResources(tvShowsOrMoviesFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), Messages.getString("FilterByInformation"));
+		UMSUtils.filterResourcesByName(tvShowsOrMoviesChildren, Messages.getString("FilterByInformation"), true, true);
+		DLNAResource filterByInformationFolder = tvShowsOrMoviesChildren.get(0);
+
+		List<DLNAResource> filterByInformationChildren = filterByInformationFolder.getDLNAResources(filterByInformationFolder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), Messages.getString("Genres"));
+
+		for (int filterByInformationChildrenIterator = 0; filterByInformationChildrenIterator < filterByInformationChildren.size(); filterByInformationChildrenIterator++) {
+			DLNAResource filterByInformationChild = filterByInformationChildren.get(filterByInformationChildrenIterator);
+			if (filterByInformationChild.getDisplayName().equals(Messages.getString("Actors"))) {
+				actorsFolder = filterByInformationChild;
+			} else if (filterByInformationChild.getDisplayName().equals(Messages.getString("Country"))) {
+				countriesFolder = filterByInformationChild;
+			} else if (filterByInformationChild.getDisplayName().equals(Messages.getString("Director"))) {
+				directorsFolder = filterByInformationChild;
+			} else if (filterByInformationChild.getDisplayName().equals(Messages.getString("Genres"))) {
+				genresFolder = filterByInformationChild;
+			} else if (filterByInformationChild.getDisplayName().equals(Messages.getString("Rated"))) {
+				ratedFolder = filterByInformationChild;
+			}
 		}
 
-		return javascriptVarsScript;
+		addJsonArrayDlnaIds(result, "actors", actorsFolder, rootFolder);
+		addJsonArrayDlnaIds(result, "countries", countriesFolder, rootFolder);
+		addJsonArrayDlnaIds(result, "directors", directorsFolder, rootFolder);
+		addJsonArrayDlnaIds(result, "genres", genresFolder, rootFolder);
+		addStringDlnaId(result, "rated", ratedFolder, rootFolder);
+
+		return result;
 	}
+
+	private static void addJsonArrayDlnaIds(final JsonObject object, final String memberName, final DLNAResource folder, final RootFolder rootFolder) {
+		if (object.has(memberName)) {
+			JsonElement element = object.remove(memberName);
+			if (element.isJsonArray()) {
+				JsonArray array = element.getAsJsonArray();
+				if (!array.isEmpty() && folder != null) {
+					JsonArray dlnaChilds = new JsonArray();
+					for (JsonElement child : array) {
+						if (child.isJsonPrimitive()) {
+							String value = child.getAsString();
+							List<DLNAResource> folderChildren = folder.getDLNAResources(folder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), value);
+							UMSUtils.filterResourcesByName(folderChildren, value, true, true);
+							if (!folderChildren.isEmpty()) {
+								JsonObject dlnaChild = new JsonObject();
+								dlnaChild.addProperty("id", folderChildren.get(0).getId());
+								dlnaChild.addProperty("name", value);
+								dlnaChilds.add(dlnaChild);
+							}
+						}
+					}
+					object.add(memberName, dlnaChilds);
+				}
+			}
+		}
+	}
+
+	private static void addStringDlnaId(final JsonObject object, final String memberName, final DLNAResource folder, final RootFolder rootFolder) {
+		if (object.has(memberName)) {
+			JsonElement element = object.remove(memberName);
+			if (element.isJsonPrimitive() && folder != null) {
+				String value = element.getAsString();
+				List<DLNAResource> folderChildren = folder.getDLNAResources(folder.getId(), true, 0, 0, rootFolder.getDefaultRenderer(), value);
+				UMSUtils.filterResourcesByName(folderChildren, value, true, true);
+				if (!folderChildren.isEmpty()) {
+					JsonObject dlnaChild = new JsonObject();
+					dlnaChild.addProperty("id", folderChildren.get(0).getId());
+					dlnaChild.addProperty("name", value);
+					object.add(memberName, dlnaChild);
+				}
+			}
+		}
+	}
+
 }

--- a/src/main/java/net/pms/network/webinterfaceserver/WebInterfaceServerUtil.java
+++ b/src/main/java/net/pms/network/webinterfaceserver/WebInterfaceServerUtil.java
@@ -45,7 +45,7 @@ import net.pms.configuration.RendererConfiguration;
 import net.pms.configuration.WebRender;
 import net.pms.database.MediaDatabase;
 import net.pms.database.MediaTableTVSeries;
-import net.pms.database.MediaTableVideoMetadatas;
+import net.pms.database.MediaTableVideoMetadata;
 import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.Range;
@@ -793,7 +793,7 @@ public class WebInterfaceServerUtil {
 					String simplifiedTitle = resource.getDisplayName() != null ? FileUtil.getSimplifiedShowName(resource.getDisplayName()) : resource.getName();
 					result = MediaTableTVSeries.getTvSerieMetadataAsJsonObject(connection, simplifiedTitle);
 				} else {
-					result = MediaTableVideoMetadatas.getVideoMetadataAsJsonObject(connection, resource.getFileName());
+					result = MediaTableVideoMetadata.getVideoMetadataAsJsonObject(connection, resource.getFileName());
 				}
 			}
 		} catch (Exception e) {

--- a/src/main/java/net/pms/network/webinterfaceserver/handlers/BrowseHandler.java
+++ b/src/main/java/net/pms/network/webinterfaceserver/handlers/BrowseHandler.java
@@ -52,7 +52,6 @@ public class BrowseHandler implements HttpHandler {
 	private static final PmsConfiguration CONFIGURATION = PMS.getConfiguration();
 
 	private final WebInterfaceServerHttpServer parent;
-	private final DbIdResourceLocator dbIdResourceLocator = new DbIdResourceLocator();
 
 	public BrowseHandler(WebInterfaceServerHttpServer parent) {
 		this.parent = parent;
@@ -396,7 +395,7 @@ public class BrowseHandler implements HttpHandler {
 			DLNAResource dlna = null;
 			if (id.startsWith(DbIdMediaType.GENERAL_PREFIX)) {
 				try {
-					dlna = dbIdResourceLocator.locateResource(id); // id.substring(0, id.indexOf('/'))
+					dlna = DbIdResourceLocator.locateResource(id); // id.substring(0, id.indexOf('/'))
 				} catch (Exception e) {
 					LOGGER.error("", e);
 				}

--- a/src/main/java/net/pms/network/webinterfaceserver/handlers/BrowseHandler.java
+++ b/src/main/java/net/pms/network/webinterfaceserver/handlers/BrowseHandler.java
@@ -17,6 +17,7 @@
  */
 package net.pms.network.webinterfaceserver.handlers;
 
+import com.google.gson.JsonObject;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -349,10 +350,10 @@ public class BrowseHandler implements HttpHandler {
 					folder.isTVSeries() &&
 					CONFIGURATION.getUseCache()
 				) {
-					String apiMetadataAsJavaScriptVars = WebInterfaceServerUtil.getAPIMetadataAsJavaScriptVars(rootResource, language, true, root);
+					JsonObject apiMetadataAsJavaScriptVars = WebInterfaceServerUtil.getAPIMetadataAsJsonObject(rootResource, language, true, root);
 					if (apiMetadataAsJavaScriptVars != null) {
 						mustacheVars.put("isTVSeriesWithAPIData", true);
-						mustacheVars.put("javascriptVarsScript", apiMetadataAsJavaScriptVars);
+						mustacheVars.put("javascriptVarsScript", "apiMetadata=" + apiMetadataAsJavaScriptVars.toString() + ";");
 					}
 				}
 

--- a/src/main/java/net/pms/network/webinterfaceserver/handlers/PlayHandler.java
+++ b/src/main/java/net/pms/network/webinterfaceserver/handlers/PlayHandler.java
@@ -17,6 +17,7 @@
  */
 package net.pms.network.webinterfaceserver.handlers;
 
+import com.google.gson.JsonObject;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import java.io.File;
@@ -269,10 +270,10 @@ public class PlayHandler implements HttpHandler {
 			mustacheVars.put("javascriptVarsScript", "");
 			if (isVideo) {
 				if (CONFIGURATION.getUseCache()) {
-					String apiMetadataAsJavaScriptVars = WebInterfaceServerUtil.getAPIMetadataAsJavaScriptVars(rootResource, language, false, root);
+					JsonObject apiMetadataAsJavaScriptVars = WebInterfaceServerUtil.getAPIMetadataAsJsonObject(rootResource, language, false, root);
 					if (apiMetadataAsJavaScriptVars != null) {
-						mustacheVars.put("javascriptVarsScript", apiMetadataAsJavaScriptVars);
-						mustacheVars.put("isVideoWithAPIData", true);
+						mustacheVars.put("isTVSeriesWithAPIData", true);
+						mustacheVars.put("javascriptVarsScript", "apiMetadata=" + apiMetadataAsJavaScriptVars.toString() + ";");
 					}
 				}
 				if (rootResource.getMedia() != null && rootResource.getMedia().hasChapters()) {

--- a/src/main/java/net/pms/network/webinterfaceserver/handlers/ThumbHandler.java
+++ b/src/main/java/net/pms/network/webinterfaceserver/handlers/ThumbHandler.java
@@ -45,7 +45,6 @@ public class ThumbHandler implements HttpHandler {
 	private static final PmsConfiguration CONFIGURATION = PMS.getConfiguration();
 
 	private final WebInterfaceServerHttpServer parent;
-	private final DbIdResourceLocator dbIdResourceLocator = new DbIdResourceLocator();
 
 
 	public ThumbHandler(WebInterfaceServerHttpServer parent) {
@@ -77,7 +76,7 @@ public class ThumbHandler implements HttpHandler {
 			DLNAResource r = null;
 			if (id.startsWith(DbIdMediaType.GENERAL_PREFIX)) {
 				try {
-					r = dbIdResourceLocator.locateResource(id); // id.substring(0, id.indexOf('/'))
+					r = DbIdResourceLocator.locateResource(id); // id.substring(0, id.indexOf('/'))
 				} catch (Exception e) {
 					LOGGER.error("", e);
 				}

--- a/src/main/java/net/pms/util/APIUtils.java
+++ b/src/main/java/net/pms/util/APIUtils.java
@@ -93,12 +93,17 @@ public class APIUtils {
 			new OpenSubtitlesBackgroundWorkerThreadFactory() // The ThreadFactory
 	);
 
+	static {
+		Runtime.getRuntime().addShutdownHook(new Thread("Api Utils Executor Shutdown Hook") {
+			@Override
+			public void run() {
+				BACKGROUND_EXECUTOR.shutdownNow();
+			}
+		});
+	}
+
 	private static final UriFileRetriever URI_FILE_RETRIEVER = new UriFileRetriever();
 	private static final Gson GSON = new Gson();
-
-	// Do not instantiate
-	private APIUtils() {
-	}
 
 	/**
 	 * These versions are returned to us from the API server. The versions are

--- a/src/main/java/net/pms/util/APIUtils.java
+++ b/src/main/java/net/pms/util/APIUtils.java
@@ -62,7 +62,7 @@ import net.pms.database.MediaTableVideoMetadataProduction;
 import net.pms.database.MediaTableVideoMetadataRated;
 import net.pms.database.MediaTableVideoMetadataRatings;
 import net.pms.database.MediaTableVideoMetadataReleased;
-import net.pms.database.MediaTableVideoMetadatas;
+import net.pms.database.MediaTableVideoMetadata;
 import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAMediaVideoMetadata;
 import net.pms.dlna.DLNAThumbnail;
@@ -301,7 +301,7 @@ public class APIUtils {
 					return;
 				}
 
-				if (MediaTableVideoMetadatas.doesLatestApiMetadataExist(connection, file.getAbsolutePath(), file.lastModified())) {
+				if (MediaTableVideoMetadata.doesLatestApiMetadataExist(connection, file.getAbsolutePath(), file.lastModified())) {
 					LOGGER.trace("The latest metadata already exists for {}", file.getName());
 					return;
 				}
@@ -501,7 +501,7 @@ public class APIUtils {
 
 				LOGGER.trace("setting metadata for " + file.getName());
 				Long fileId = MediaTableFiles.getFileId(connection, file.getAbsolutePath(), file.lastModified());
-				MediaTableVideoMetadatas.insertOrUpdateVideoMetadata(connection, fileId, media, metadataFromAPI);
+				MediaTableVideoMetadata.insertOrUpdateVideoMetadata(connection, fileId, media, metadataFromAPI);
 
 				if (media.getThumb() != null) {
 					MediaTableThumbnails.setThumbnail(connection, media.getThumb(), file.getAbsolutePath(), -1, false);
@@ -733,7 +733,7 @@ public class APIUtils {
 				titleSimplified.equals(titleSimplifiedFromFilename)
 			) {
 				LOGGER.trace("Converting rows in FILES table with the show name " + titleFromFilename + " to " + title);
-				MediaTableVideoMetadatas.updateMovieOrShowName(connection, titleFromFilename, title);
+				MediaTableVideoMetadata.updateMovieOrShowName(connection, titleFromFilename, title);
 			}
 
 			return title;

--- a/src/main/java/net/pms/util/APIUtils.java
+++ b/src/main/java/net/pms/util/APIUtils.java
@@ -982,4 +982,5 @@ public class APIUtils {
 
 		return posterFromApi;
 	}
+
 }

--- a/src/main/java/net/pms/util/APIUtils.java
+++ b/src/main/java/net/pms/util/APIUtils.java
@@ -47,7 +47,6 @@ import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.database.MediaDatabase;
 import net.pms.database.MediaTableFailedLookups;
-import net.pms.database.MediaTableFiles;
 import net.pms.database.MediaTableMetadata;
 import net.pms.database.MediaTableTVSeries;
 import net.pms.database.MediaTableThumbnails;
@@ -62,6 +61,7 @@ import net.pms.database.MediaTableVideoMetadataProduction;
 import net.pms.database.MediaTableVideoMetadataRated;
 import net.pms.database.MediaTableVideoMetadataRatings;
 import net.pms.database.MediaTableVideoMetadataReleased;
+import net.pms.database.MediaTableVideoMetadatas;
 import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAMediaVideoMetadata;
 import net.pms.dlna.DLNAThumbnail;
@@ -298,7 +298,7 @@ public class APIUtils {
 
 				connection.setAutoCommit(false);
 
-				if (MediaTableFiles.doesLatestApiMetadataExist(connection, file.getAbsolutePath(), file.lastModified())) {
+				if (MediaTableVideoMetadatas.doesLatestApiMetadataExist(connection, file.getAbsolutePath(), file.lastModified())) {
 					LOGGER.trace("The latest metadata already exists for {}", file.getName());
 					return;
 				}
@@ -493,7 +493,7 @@ public class APIUtils {
 				media.setVideoMetadata(videoMetadata);
 
 				LOGGER.trace("setting metadata for " + file.getName());
-				MediaTableFiles.insertVideoMetadata(connection, file.getAbsolutePath(), file.lastModified(), media, metadataFromAPI);
+				MediaTableVideoMetadatas.insertVideoMetadata(connection, file.getAbsolutePath(), file.lastModified(), media, metadataFromAPI);
 
 				if (media.getThumb() != null) {
 					MediaTableThumbnails.setThumbnail(connection, media.getThumb(), file.getAbsolutePath(), -1, false);
@@ -726,7 +726,7 @@ public class APIUtils {
 				titleSimplified.equals(titleSimplifiedFromFilename)
 			) {
 				LOGGER.trace("Converting rows in FILES table with the show name " + titleFromFilename + " to " + title);
-				MediaTableFiles.updateMovieOrShowName(connection, titleFromFilename, title);
+				MediaTableVideoMetadatas.updateMovieOrShowName(connection, titleFromFilename, title);
 			}
 
 			return title;

--- a/src/main/java/net/pms/util/APIUtils.java
+++ b/src/main/java/net/pms/util/APIUtils.java
@@ -21,6 +21,7 @@ import static net.pms.util.FileUtil.indexOf;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import java.io.BufferedReader;
@@ -36,7 +37,6 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -150,7 +150,7 @@ public class APIUtils {
 		Connection connection = null;
 		try {
 			connection = MediaDatabase.getConnectionIfAvailable();
-			HashMap<String, String> jsonData = new HashMap<>();
+			JsonObject jsonData = null;
 
 			if (CONFIGURATION.getExternalNetwork()) {
 				URL domain = new URL("https://api.universalmediaserver.com");
@@ -158,14 +158,17 @@ public class APIUtils {
 				String apiResult = getJson(url);
 
 				try {
-					jsonData = GSON.fromJson(apiResult, jsonData.getClass());
+					JsonElement element = GSON.fromJson(apiResult, JsonElement.class);
+					if (element.isJsonObject()) {
+						jsonData = element.getAsJsonObject();
+					}
 				} catch (JsonSyntaxException e) {
 					LOGGER.debug("API Result was not JSON. Received: {}, full stack: {}", apiResult, e);
 				}
 			}
 
-			if (jsonData == null || jsonData.isEmpty() || jsonData.containsKey("statusCode")) {
-				if (jsonData != null && jsonData.containsKey("statusCode") && "500".equals(jsonData.get("statusCode"))) {
+			if (jsonData == null || !jsonData.has("series") || !jsonData.has("video") || jsonData.has("statusCode")) {
+				if (jsonData != null && jsonData.has("statusCode") && "500".equals(jsonData.get("statusCode").getAsString())) {
 					LOGGER.debug("Got a 500 error while looking for metadata subversions");
 				}
 				LOGGER.trace("Did not get metadata subversions, will attempt to use the database version");
@@ -179,8 +182,8 @@ public class APIUtils {
 				return;
 			}
 
-			apiDataSeriesVersion = jsonData.get("series");
-			apiDataVideoVersion = jsonData.get("video");
+			apiDataSeriesVersion = jsonData.get("series").getAsString();
+			apiDataVideoVersion = jsonData.get("video").getAsString();
 
 			// Persist the values to the database to be used as fallbacks
 			if (connection != null) {
@@ -215,7 +218,7 @@ public class APIUtils {
 		Connection connection = null;
 		try {
 			connection = MediaDatabase.getConnectionIfAvailable();
-			HashMap<String, String> jsonData = new HashMap<>();
+			JsonObject jsonData = null;
 
 			if (CONFIGURATION.getExternalNetwork()) {
 				URL domain = new URL("https://api.universalmediaserver.com");
@@ -223,14 +226,17 @@ public class APIUtils {
 				String apiResult = getJson(url);
 
 				try {
-					jsonData = GSON.fromJson(apiResult, jsonData.getClass());
+					JsonElement element = GSON.fromJson(apiResult, JsonElement.class);
+					if (element.isJsonObject()) {
+						jsonData = element.getAsJsonObject();
+					}
 				} catch (JsonSyntaxException e) {
 					LOGGER.debug("API Result was not JSON. Received: {}, full stack: {}", apiResult, e);
 				}
 			}
 
-			if (jsonData == null || jsonData.isEmpty() || jsonData.containsKey("statusCode")) {
-				if (jsonData != null && jsonData.containsKey("statusCode") && "500".equals(jsonData.get("statusCode"))) {
+			if (jsonData == null || !jsonData.has("imageBaseURL") || jsonData.has("statusCode")) {
+				if (jsonData != null && jsonData.has("statusCode") && "500".equals(jsonData.get("statusCode").getAsString())) {
 					LOGGER.debug("Got a 500 error while looking for imageBaseURL");
 				}
 				LOGGER.trace("Did not get imageBaseURL, will attempt to use the database version");
@@ -243,7 +249,7 @@ public class APIUtils {
 				return;
 			}
 
-			apiImageBaseURL = jsonData.get("imageBaseURL");
+			apiImageBaseURL = jsonData.get("imageBaseURL").getAsString();
 
 			// Persist the values to the database to be used as fallbacks
 			if (connection != null) {
@@ -575,8 +581,7 @@ public class APIUtils {
 	 * @return the title of the series.
 	 */
 	private static String setTVSeriesInfo(final Connection connection, String seriesIMDbIDFromAPI, String titleFromFilename, String startYear, String titleSimplifiedFromFilename, File file, DLNAMediaInfo media) {
-		long tvSeriesDatabaseId;
-		String title;
+		String title = null;
 		String titleSimplified;
 
 		String failedLookupKey = titleSimplifiedFromFilename;
@@ -589,14 +594,13 @@ public class APIUtils {
 		 * in our database yet, and persist it to our database.
 		 */
 		try {
-			HashMap<String, Object> seriesMetadataFromDatabase = null;
 			if (seriesIMDbIDFromAPI != null) {
-				seriesMetadataFromDatabase = MediaTableTVSeries.getByIMDbID(connection, seriesIMDbIDFromAPI);
+				title = MediaTableTVSeries.getTitleByIMDbID(connection, seriesIMDbIDFromAPI);
 			}
 
-			if (seriesMetadataFromDatabase != null) {
-				LOGGER.trace("TV series with API data already found in database {}", seriesMetadataFromDatabase.get("TITLE"));
-				return (String) seriesMetadataFromDatabase.get("TITLE");
+			if (title != null) {
+				LOGGER.trace("TV series with API data already found in database {}", title);
+				return title;
 			}
 
 			/*
@@ -651,7 +655,7 @@ public class APIUtils {
 			 * to insert it or update existing data, so we attempt to find an entry
 			 * based on the title.
 			 */
-			seriesMetadataFromDatabase = MediaTableTVSeries.getByTitle(connection, title);
+			Long tvSeriesId = MediaTableTVSeries.getIdByTitle(connection, title);
 
 			// Restore the startYear appended to the title if it is in the filename
 			if (isNotBlank(startYear)) {
@@ -660,33 +664,32 @@ public class APIUtils {
 				seriesMetadataFromAPI.addProperty("title", titleFromAPI);
 			}
 
-			if (seriesMetadataFromDatabase == null) {
-				LOGGER.trace("No title match, so let's make a new entry for {}", seriesMetadataFromAPI.get("title"));
-				tvSeriesDatabaseId = MediaTableTVSeries.set(connection, seriesMetadataFromAPI, null);
+			if (tvSeriesId == null) {
+				LOGGER.trace("No title match, so let's make a new entry for {}", title);
+				tvSeriesId = MediaTableTVSeries.set(connection, seriesMetadataFromAPI, null);
 			} else {
-				LOGGER.trace("There is an existing entry, so let's fill it in with API data for {}", seriesMetadataFromDatabase.get("TITLE"));
-				tvSeriesDatabaseId = (long) seriesMetadataFromDatabase.get("ID");
+				LOGGER.trace("There is an existing entry, so let's fill it in with API data for {}", title);
 				MediaTableTVSeries.insertAPIMetadata(connection, seriesMetadataFromAPI);
 			}
 
-			if (tvSeriesDatabaseId == -1) {
+			if (tvSeriesId == null) {
 				LOGGER.debug("tvSeriesDatabaseId was not set, something went wrong");
 				return null;
 			}
 
 			// Now we insert the TV series data into the other tables
 			if (seriesMetadataFromAPI.has("actors")) {
-				MediaTableVideoMetadataActors.set(connection, null, seriesMetadataFromAPI.get("actors"), tvSeriesDatabaseId);
+				MediaTableVideoMetadataActors.set(connection, null, seriesMetadataFromAPI.get("actors"), tvSeriesId);
 			}
-			MediaTableVideoMetadataAwards.set(connection, null, getStringOrNull(seriesMetadataFromAPI, "awards"), tvSeriesDatabaseId);
-			MediaTableVideoMetadataCountries.set(connection, null, seriesMetadataFromAPI.get("country"), tvSeriesDatabaseId);
+			MediaTableVideoMetadataAwards.set(connection, null, getStringOrNull(seriesMetadataFromAPI, "awards"), tvSeriesId);
+			MediaTableVideoMetadataCountries.set(connection, null, seriesMetadataFromAPI.get("country"), tvSeriesId);
 			if (seriesMetadataFromAPI.has("directors")) {
-				MediaTableVideoMetadataDirectors.set(connection, null, seriesMetadataFromAPI.get("directors"), tvSeriesDatabaseId);
+				MediaTableVideoMetadataDirectors.set(connection, null, seriesMetadataFromAPI.get("directors"), tvSeriesId);
 			}
 			if (seriesMetadataFromAPI.has("genres")) {
-				MediaTableVideoMetadataGenres.set(connection, null, seriesMetadataFromAPI.get("genres"), tvSeriesDatabaseId);
+				MediaTableVideoMetadataGenres.set(connection, null, seriesMetadataFromAPI.get("genres"), tvSeriesId);
 			}
-			MediaTableVideoMetadataProduction.set(connection, null, getStringOrNull(seriesMetadataFromAPI, "production"), tvSeriesDatabaseId);
+			MediaTableVideoMetadataProduction.set(connection, null, getStringOrNull(seriesMetadataFromAPI, "production"), tvSeriesId);
 
 			String posterFromApi = getPosterUrlFromApiInfo(
 				getStringOrNull(seriesMetadataFromAPI, "poster"),
@@ -695,7 +698,7 @@ public class APIUtils {
 			if (posterFromApi != null) {
 				try {
 					byte[] image = URI_FILE_RETRIEVER.get(posterFromApi);
-					MediaTableThumbnails.setThumbnail(connection, DLNAThumbnail.toThumbnail(image, 640, 480, ScaleType.MAX, ImageFormat.JPEG, false), null, tvSeriesDatabaseId, false);
+					MediaTableThumbnails.setThumbnail(connection, DLNAThumbnail.toThumbnail(image, 640, 480, ScaleType.MAX, ImageFormat.JPEG, false), null, tvSeriesId, false);
 				} catch (EOFException e) {
 					LOGGER.debug(
 						"Error reading \"{}\" thumbnail from API: Unexpected end of stream, probably corrupt or read error.",
@@ -707,20 +710,20 @@ public class APIUtils {
 					LOGGER.error("Error reading \"{}\" thumbnail from API: {}", file.getName(), e.getMessage());
 					LOGGER.trace("", e);
 				}
-				MediaTableVideoMetadataPosters.set(connection, null, posterFromApi, tvSeriesDatabaseId);
+				MediaTableVideoMetadataPosters.set(connection, null, posterFromApi, tvSeriesId);
 			}
 
-			MediaTableVideoMetadataRated.set(connection, null, getStringOrNull(seriesMetadataFromAPI, "rated"), tvSeriesDatabaseId);
+			MediaTableVideoMetadataRated.set(connection, null, getStringOrNull(seriesMetadataFromAPI, "rated"), tvSeriesId);
 			if (seriesMetadataFromAPI.has("rating")  && seriesMetadataFromAPI.get("rating").isJsonPrimitive()) {
 				Double rating = seriesMetadataFromAPI.get("rating").getAsDouble();
 				if (rating != 0) {
-					MediaTableVideoMetadataIMDbRating.set(connection, null, Double.toString(rating), tvSeriesDatabaseId);
+					MediaTableVideoMetadataIMDbRating.set(connection, null, Double.toString(rating), tvSeriesId);
 				}
 			}
 			if (seriesMetadataFromAPI.get("ratings") != null) {
-				MediaTableVideoMetadataRatings.set(connection, null, seriesMetadataFromAPI.get("ratings"), tvSeriesDatabaseId);
+				MediaTableVideoMetadataRatings.set(connection, null, seriesMetadataFromAPI.get("ratings"), tvSeriesId);
 			}
-			MediaTableVideoMetadataReleased.set(connection, null, getStringOrNull(seriesMetadataFromAPI, "released"), tvSeriesDatabaseId);
+			MediaTableVideoMetadataReleased.set(connection, null, getStringOrNull(seriesMetadataFromAPI, "released"), tvSeriesId);
 
 			// Replace any close-but-not-exact titles in the FILES table
 			if (

--- a/src/main/java/net/pms/util/BasicPlayer.java
+++ b/src/main/java/net/pms/util/BasicPlayer.java
@@ -431,10 +431,7 @@ public interface BasicPlayer extends ActionListener {
 					player.addAll(-1, f.getChildren(), -1);
 					// add a short delay here since player.add uses
 					// swing.invokelater
-					try {
-						Thread.sleep(1000);
-					} catch (Exception e) {
-					}
+					UMSUtils.sleep(1000);
 					player.pressPlay(null, null);
 				};
 				new Thread(r).start();

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -36,6 +36,7 @@ import net.pms.configuration.WindowsProgramPaths;
 import net.pms.database.MediaDatabase;
 import net.pms.database.MediaTableFiles;
 import net.pms.dlna.DLNAMediaInfo;
+import net.pms.dlna.DLNAMediaVideoMetadata;
 import net.pms.formats.FormatFactory;
 import net.pms.io.BasicSystemUtils;
 import net.pms.util.FilePermissions.FileFlag;
@@ -755,16 +756,16 @@ public class FileUtil {
 		}
 
 		// Populate the variables from the data if we can, otherwise from the filename
-		if (media != null && getConfiguration().getUseCache() && isNotBlank(media.getMovieOrShowName())) {
-			title = media.getMovieOrShowName();
-
-			year              = isNotBlank(media.getYear())              ? media.getYear()              : "";
-			extraInformation  = isNotBlank(media.getExtraInformation())  ? media.getExtraInformation()  : "";
-			tvSeason          = isNotBlank(media.getTVSeason())          ? media.getTVSeason()          : "";
-			tvEpisodeNumber   = isNotBlank(media.getTVEpisodeNumber())   ? media.getTVEpisodeNumber()   : "";
-			tvEpisodeName     = isNotBlank(media.getTVEpisodeName())     ? media.getTVEpisodeName()     : "";
-			isTVEpisode       = isNotBlank(media.getTVSeason());
-			tvSeriesStartYear = isNotBlank(media.getTVSeriesStartYear()) ? media.getTVSeriesStartYear() : "";
+		if (media != null && getConfiguration().getUseCache() && media.hasVideoMetadata() && isNotBlank(media.getVideoMetadata().getMovieOrShowName())) {
+			DLNAMediaVideoMetadata videoMetadata = media.getVideoMetadata();
+			title             = videoMetadata.getMovieOrShowName();
+			year              = isNotBlank(videoMetadata.getYear())              ? videoMetadata.getYear()              : "";
+			extraInformation  = isNotBlank(videoMetadata.getExtraInformation())  ? videoMetadata.getExtraInformation()  : "";
+			tvSeason          = isNotBlank(videoMetadata.getTVSeason())          ? videoMetadata.getTVSeason()          : "";
+			tvEpisodeNumber   = isNotBlank(videoMetadata.getTVEpisodeNumber())   ? videoMetadata.getTVEpisodeNumber()   : "";
+			tvEpisodeName     = isNotBlank(videoMetadata.getTVEpisodeName())     ? videoMetadata.getTVEpisodeName()     : "";
+			isTVEpisode       = isNotBlank(videoMetadata.getTVSeason());
+			tvSeriesStartYear = isNotBlank(videoMetadata.getTVSeriesStartYear()) ? videoMetadata.getTVSeriesStartYear() : "";
 		} else {
 			String[] metadataFromFilename = getFileNameMetadata(f, absolutePath);
 

--- a/src/main/java/net/pms/util/ProcessUtil.java
+++ b/src/main/java/net/pms/util/ProcessUtil.java
@@ -137,10 +137,7 @@ public class ProcessUtil {
 			if (pid != null) { // Unix only
 				LOGGER.trace("Killing the Unix process: " + pid);
 				Runnable r = () -> {
-					try {
-						Thread.sleep(TERM_TIMEOUT);
-					} catch (InterruptedException e) {
-					}
+					UMSUtils.sleep(TERM_TIMEOUT);
 
 					try {
 						p.exitValue();
@@ -149,12 +146,9 @@ public class ProcessUtil {
 						// kill -14 (ALRM) works (for MEncoder) and is less
 						// dangerous than kill -9 so try that first
 						if (!kill(pid, 14)) {
-							try {
-								// This is a last resort, so let's not be
-								// too eager
-								Thread.sleep(ALRM_TIMEOUT);
-							} catch (InterruptedException ie) {
-							}
+							// This is a last resort, so let's not be
+							// too eager
+							UMSUtils.sleep(ALRM_TIMEOUT);
 
 							kill(pid, 9);
 						}

--- a/src/main/java/net/pms/util/UMSUtils.java
+++ b/src/main/java/net/pms/util/UMSUtils.java
@@ -621,10 +621,7 @@ public class UMSUtils {
 		final ProcessWrapperImpl pw = new ProcessWrapperImpl(
 			new String[] {configuration.getFFmpegPaths().getDefaultPath().toString(), "-hwaccels"}, false, outputParams, true, false);
 		Runnable r = () -> {
-			try {
-				Thread.sleep(10000);
-			} catch (InterruptedException e) {
-			}
+			sleep(10000);
 
 			pw.stopProcess();
 		};


### PR DESCRIPTION
**Database optimizations :**
- Moved video metadata from `FILES` table to `VIDEO_METADATAS`.
- Video metadata is now in the `DLNAMediaVideoMetadata` member in `DLNAMediaInfo`.
- Use `prepareStatments` to speed up the engine.
- Fix `connection.setAutoCommit` changes.
- Use `CLOB` for really large `VARCHAR` (like video metadata jsoned).
- Use static SQL queries.
- Use static `table.columns` members to better handle their usage.
- Fix duplicate rows from api on tv series episod
- Use FileId not Filename on all Metadatas child tables
- Delete cascade Metadatas child tables from `VIDEO_METADATAS` table
- Delete cascade Metadatas child tables from `TV_SERIES` table
- Don't use -1 when NULL on Metadatas child tables

**Code clean on some classes :**
- Set members as static final when never changed.
- Set members as private when not in use externally.
- Set members as final when not changed after class construction.
- Remove old `transcode` and some other functions never used on images.
- Use `Optional.ofNullable` on `Nullable`.
- Use `UMSUtils.sleep` for non catched interruption spleep.
- `DbIdResourceLocator` doesn't have any members => static.