### PR TITLE
Removes main method from IpFilter

### DIFF
--- a/src/main/java/net/pms/configuration/IpFilter.java
+++ b/src/main/java/net/pms/configuration/IpFilter.java
@@ -293,19 +293,4 @@ public class IpFilter {
 		}
 		return false;
 	}
-
-	private static void eq(String name, Object obj, Object obj2) {
-		if (obj != null && obj.equals(obj2)) {
-			LOGGER.debug("EQ: " + name + '=' + obj);
-		} else {
-			throw new RuntimeException(name + " expected : '" + obj + "' <> actual : '" + obj2 + "'");
-		}
-	}
-
-	public static void main(String[] args) {
-		eq("f1", "192.168.0.1,192.168.0.5", new IpFilter(" 192.168.0.1, 192.168.0.5").getNormalizedFilter());
-		eq("f2", "192.168.0.*,192.1-6.3-.5", new IpFilter(" 192.168.0.*, 192.1-6.3-.5").getNormalizedFilter());
-		eq("f3", "2-3.5,myhost", new IpFilter(" 3-2. 5;myhost").getNormalizedFilter());
-	}
-
 }


### PR DESCRIPTION
It seems like this was added as a test (?) and it gets in the way of building with VS Code