### PR TITLE
Access-Control-Allow-Origin set to "*"

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -1808,6 +1808,14 @@ audio_likes_visible_root =
 # Default: ""
 managed_playlist_folder =
 
+# Access-Control-Allow-Origin response header
+# -------------------------------------------
+# Sets the Access-Control-Allow-Origin response header indicating whether the 
+# http server response (images, etc.) can be shared with requesting code from the 
+# given origin. By default, no Access-Control-Allow-Origin is set. 
+# Default: ""
+access-control-allow-origin =
+
 # ---< Other settings saved by UMS >------------------------------------------
 alternativeffmpegpath = 
 gui_log_search_case_sensitive = 

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -106,6 +106,7 @@ public class PmsConfiguration extends RendererConfiguration {
 	protected static final int MENCODER_MAX_THREADS = 8;
 
 	protected static final String KEY_3D_SUBTITLES_DEPTH = "3d_subtitles_depth";
+	protected static final String KEY_ACCESS_CONTROL_ALLOW_ORIGIN = "access-control-allow-origin";
 	protected static final String KEY_ALIVE_DELAY = "ALIVE_delay";
 	protected static final String KEY_ALTERNATE_SUBTITLES_FOLDER = "alternate_subtitles_folder";
 	protected static final String KEY_ALTERNATE_THUMB_FOLDER = "alternate_thumb_folder";
@@ -5073,6 +5074,10 @@ public class PmsConfiguration extends RendererConfiguration {
 	 */
 	public void setHasRunOnce() {
 		configuration.setProperty(WAS_YOUTUBE_DL_ENABLED_ONCE, true);
+	}
+
+	public String getAccessControlAllowOrigin() {
+		return getString(KEY_ACCESS_CONTROL_ALLOW_ORIGIN, "");
 	}
 
 	/**

--- a/src/main/java/net/pms/network/mediaserver/nettyserver/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/mediaserver/nettyserver/RequestHandlerV2.java
@@ -416,6 +416,7 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 				HttpResponseStatus.OK
 			);
 		}
+		response.headers().add("Access-Control-Allow-Origin", "*");
 
 		StartStopListenerDelegate startStopListenerDelegate = new StartStopListenerDelegate(ia.getHostAddress());
 		// Attach it to the context so it can be invoked if connection is reset unexpectedly

--- a/src/main/java/net/pms/network/mediaserver/nettyserver/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/mediaserver/nettyserver/RequestHandlerV2.java
@@ -416,7 +416,10 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 				HttpResponseStatus.OK
 			);
 		}
-		response.headers().add("Access-Control-Allow-Origin", "*");
+
+		if (StringUtil.hasValue(PMS.getConfiguration().getAccessControlAllowOrigin())) {
+			response.headers().add("Access-Control-Allow-Origin", PMS.getConfiguration().getAccessControlAllowOrigin());
+		}
 
 		StartStopListenerDelegate startStopListenerDelegate = new StartStopListenerDelegate(ia.getHostAddress());
 		// Attach it to the context so it can be invoked if connection is reset unexpectedly


### PR DESCRIPTION
Hey guys. I'd like to add this policy for manipulating thumbnail images delivered by UMS in JavaScript. I need to crop images that are delivered as rectangle to squares. Without this policy the browser will not allow to do that.