### PR TITLE
fixing UMS.launch (running UMS within eclipse)

### DIFF
--- a/UMS.launch
+++ b/UMS.launch
@@ -11,7 +11,7 @@
     </listAttribute>
     <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="net.pms.PMS"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="UniversalMediaServer"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="ums"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx768M -Djava.net.preferIPv4Stack=true -Djava.encoding=UTF-8 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true"/>
 </launchConfiguration>


### PR DESCRIPTION
Eclipse: After importing UMS source as maven project, the new eclipse project is named "ums" ( = artifactId). Adjusted PROJECT_ATTR. With this change UMS can be run from eclipse by launching "UMS.launch".