### PR TITLE
Analyze all rows, not only first 1000 (default) of a table.

### DIFF
--- a/src/main/java/net/pms/service/LibraryScanner.java
+++ b/src/main/java/net/pms/service/LibraryScanner.java
@@ -62,7 +62,7 @@ public class LibraryScanner {
 	private static void analyzeDb() {
 		PMS.get().getMediaDatabase();
 		try (Statement stmt = MediaDatabase.getConnectionIfAvailable().createStatement()) {
-			stmt.execute("ANALYSE");
+			stmt.execute("ANALYZE SAMPLE_SIZE 0");
 		} catch (SQLException e) {
 			LOGGER.warn("Error analyzing database", e);
 		}


### PR DESCRIPTION
This is a follow up to #3536. Now all rows of a table are analyzed for statistics, not only the first 1000 which is the default, if no sample size is given.