### PR TITLE
docker: setting correct ums profile path parameter

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ EXPOSE 9001 5002 1044
 ENV JVM_OPTS=-Xmx512M
 
 CMD java $JVM_OPTS -XX:+UnlockExperimentalVMOptions \
-	-DUMS_PROFILE=/profile -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -Djna.nosys=true \
+	-Dums.profile.path=/profile -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -Djna.nosys=true \
 	-cp ums.jar net.pms.PMS
 
 COPY . /usr/src/ums


### PR DESCRIPTION
The UMS profile path variable wasn't set correctly. Configuration provided in "/profile" is now used if available.