### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,9 +77,9 @@ jobs:
       - name: Run tests
         run: |
           sudo apt-get -y install libmms0
-          wget https://mediaarea.net/download/binary/libzen0/0.4.39/libzen0v5_0.4.39-1_amd64.xUbuntu_20.04.deb
+          wget --no-check-certificate https://mediaarea.net/download/binary/libzen0/0.4.39/libzen0v5_0.4.39-1_amd64.xUbuntu_20.04.deb
           sudo dpkg -i libzen0v5_0.4.39-1_amd64.xUbuntu_20.04.deb
-          wget https://mediaarea.net/download/binary/libmediainfo0/22.09/libmediainfo0v5_22.09-1_amd64.xUbuntu_20.04.deb
+          wget --no-check-certificate https://mediaarea.net/download/binary/libmediainfo0/22.09/libmediainfo0v5_22.09-1_amd64.xUbuntu_20.04.deb
           sudo dpkg -i libmediainfo0v5_22.09-1_amd64.xUbuntu_20.04.deb
           mvn verify -P testing
 
@@ -105,8 +105,8 @@ jobs:
       - name: Run tests
         run: |
           sudo apt-get -y install libmms0
-          wget https://mediaarea.net/download/binary/libzen0/0.4.39/libzen0v5_0.4.39-1_amd64.xUbuntu_22.04.deb
+          wget --no-check-certificate https://mediaarea.net/download/binary/libzen0/0.4.39/libzen0v5_0.4.39-1_amd64.xUbuntu_22.04.deb
           sudo dpkg -i libzen0v5_0.4.39-1_amd64.xUbuntu_22.04.deb
-          wget https://mediaarea.net/download/binary/libmediainfo0/22.09/libmediainfo0v5_22.09-1_amd64.xUbuntu_22.04.deb
+          wget --no-check-certificate https://mediaarea.net/download/binary/libmediainfo0/22.09/libmediainfo0v5_22.09-1_amd64.xUbuntu_22.04.deb
           sudo dpkg -i libmediainfo0v5_22.09-1_amd64.xUbuntu_22.04.deb
           mvn verify -P testing


### PR DESCRIPTION
https://mediaarea.net have a new certificate root not yet known by Ubuntu.
It make the Checks test runs fail on both Ubuntu versions.
```
Issued certificate has expired.
Error: Process completed with exit code 5.
```

I've tried to update root certs without luck (root certs already at the latest version).

As we are confident with https://mediaarea.net, we can just skip the cert check.