### PR TITLE
Scan Playlists at startup

### DIFF
--- a/src/main/java/net/pms/dlna/PlaylistFolder.java
+++ b/src/main/java/net/pms/dlna/PlaylistFolder.java
@@ -63,6 +63,11 @@ public final class PlaylistFolder extends DLNAResource {
 	}
 
 	@Override
+	public boolean allowScan() {
+		return true;
+	}
+
+	@Override
 	public InputStream getInputStream() throws IOException {
 		return null;
 	}

--- a/src/main/java/net/pms/dlna/RootFolder.java
+++ b/src/main/java/net/pms/dlna/RootFolder.java
@@ -306,7 +306,7 @@ public class RootFolder extends DLNAResource {
 					if (child.isDiscovered()) {
 						child.refreshChildren();
 					} else {
-						if (child instanceof DVDISOFile || child instanceof DVDISOTitle) { // ugly hack
+						if (child instanceof DVDISOFile || child instanceof DVDISOTitle || child instanceof PlaylistFolder) { // ugly hack
 							child.syncResolve();
 						}
 						child.discoverChildren();


### PR DESCRIPTION
Issue: 
- Playlists are not being scanned by the LibraryScanner and therefore not added to the internal FILES table at startup.
- Playlists are added to the database only when the parent folder of a playlists is being navigated by the user.

This PR adds playlists at scan time.