### PR TITLE
SearchRequest fixes / improvements

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -315,8 +315,7 @@ public class SearchRequestHandler {
 		if ("=".equals(op)) {
 			sb.append(String.format(" %s = '%s' ", getField(property, requestType), val));
 		} else if ("contains".equals(op)) {
-			sb.append(
-				String.format("LOWER(%s) LIKE '%%%s%%'", getField(property, requestType), escapeH2dbSql(val)));
+			sb.append(String.format("LOWER(%s) LIKE '%%%s%%'", getField(property, requestType), escapeH2dbSql(val)));
 		} else {
 			throw new RuntimeException("unknown or unimplemented operator : " + op);
 		}
@@ -325,28 +324,31 @@ public class SearchRequestHandler {
 
 	private String escapeH2dbSql(String val) {
 		val = val.replaceAll("'", "''");
+		val = val.replaceAll("‘", "''"); // Unicode #2018 is send by iOS (since 11) if "Smart Punctuation" is active
+
 		return val;
 	}
 
-	private String getField(String property, DbIdMediaType requestType) {
-		// handle title by return type.
+	private String getField(String prop, DbIdMediaType requestType) {
+		String property = prop.toLowerCase();
 		if ("dc:title".equalsIgnoreCase(property)) {
+			// handle title by return type.
 			return getTitlePropertyMapping(requestType);
-		} else if (property.toLowerCase().startsWith("upnp:artist")) {
-			if (property.toLowerCase().contains("albumartist")) {
+		} else if (property.startsWith("upnp:artist")) {
+			if (property.contains("albumartist")) {
 				return " A.ALBUMARTIST ";
 			}
 			// this matches all other like : @role=conductor and @role=composer
 			return " A.ARTIST ";
-		} else if ("upnp:genre".equalsIgnoreCase(property)) {
+		} else if ("upnp:genre".equals(property)) {
 			return " A.GENRE ";
-		} else if ("dc:creator".equalsIgnoreCase(property)) {
+		} else if ("dc:creator".equals(property)) {
 			return " A.ALBUMARTIST ";
-		} else if ("upnp:album".equalsIgnoreCase(property)) {
+		} else if ("upnp:album".equals(property)) {
 			return " A.ALBUM ";
-		} else if ("upnp:rating".equalsIgnoreCase(property)) {
+		} else if ("upnp:rating".equals(property)) {
 			return " rating ";
-		} else if ("ums:likedAlbum".equalsIgnoreCase(property)) {
+		} else if ("ums:likedalbum".equals(property)) {
 			return " liked ";
 		}
 

--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -333,7 +333,10 @@ public class SearchRequestHandler {
 		if ("dc:title".equalsIgnoreCase(property)) {
 			return getTitlePropertyMapping(requestType);
 		} else if (property.toLowerCase().startsWith("upnp:artist")) {
-			// we also match @role=conductor and @role=composer
+			if (property.toLowerCase().contains("albumartist")) {
+				return " A.ALBUMARTIST ";
+			}
+			// this matches all other like : @role=conductor and @role=composer
 			return " A.ARTIST ";
 		} else if ("upnp:genre".equalsIgnoreCase(property)) {
 			return " A.GENRE ";

--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -315,7 +315,7 @@ public class SearchRequestHandler {
 		if ("=".equals(op)) {
 			sb.append(String.format(" %s = '%s' ", getField(property, requestType), val));
 		} else if ("contains".equals(op)) {
-			sb.append(String.format("LOWER(%s) LIKE '%%%s%%'", getField(property, requestType), escapeH2dbSql(val)));
+			sb.append(String.format("LOWER(%s) LIKE '%%%s%%'", getField(property, requestType), escapeH2dbSql(val).toLowerCase()));
 		} else {
 			throw new RuntimeException("unknown or unimplemented operator : " + op);
 		}

--- a/src/test/java/net/pms/network/mediaserver/handlers/SearchRequestHandlerTest.java
+++ b/src/test/java/net/pms/network/mediaserver/handlers/SearchRequestHandlerTest.java
@@ -62,6 +62,16 @@ public class SearchRequestHandlerTest {
 			"select\\s+count\\s+\\(\\s*DISTINCT\\s+COALESCE\\s*\\(\\s*A.ALBUMARTIST\\s*,\\s*A.ARTIST\\s*\\)\\)\\s+from\\s+AUDIOTRACKS\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.ARTIST\\s*\\)\\s+LIKE\\s+'%tchaikovsky%'"));
 	}
 
+	@Test
+	public void testAlbumArtistSearch() {
+		String searchCriteria = "upnp:class derivedfrom \"object.container.person.musicArtist\" and upnp:artist[@role=\"AlbumArtist\"] contains \"tchaikovsky\"";
+		SearchRequestHandler h = new SearchRequestHandler();
+		String countSQL = h.convertToCountSql(searchCriteria, h.getRequestType(searchCriteria));
+		LOG.info(countSQL);
+		assertTrue(countSQL.matches(
+			"select\\s+count\\s+\\(\\s*DISTINCT\\s+COALESCE\\s*\\(\\s*A.ALBUMARTIST\\s*,\\s*A.ARTIST\\s*\\)\\)\\s+from\\s+AUDIOTRACKS\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.ALBUMARTIST\\s*\\)\\s+LIKE\\s+'%tchaikovsky%'"));
+	}
+
 	/**
 	 * Tests SearchCriteria issued by LINN app (iOS) for Composer
 	 */


### PR DESCRIPTION
Changes for SearchRequests processing:
 - fixes escaping of `'` char
 - transcoding `‘` to `'`. "Smart Punctuation" in iOS breaks UPNP search if search string contains an apostrophe.
 - support: Handle search requests for upnp:artist `@role` options (fixes Exception of search issued by LINN iOS app for composer).
 - added search support for `composer`. At the moment this is mapped to `Artist`, but should probably be mapped to the composer id3 tag, yet not saved in the ums database.