### PR TITLE
star rating / update GlobalRepo cached object

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/handlers/api/starrating/RequestVO.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/api/starrating/RequestVO.java
@@ -20,10 +20,12 @@ public class RequestVO {
 
 	private final String trackID;
 	private final int stars;
+	private final Integer globalID;
 
-	public RequestVO(String trackID, int stars) {
+	public RequestVO(String trackID, Integer globalID, int stars) {
 		this.trackID = trackID;
 		this.stars = stars;
+		this.globalID = globalID;
 	}
 
 	public String getTrackID() {
@@ -32,6 +34,10 @@ public class RequestVO {
 
 	public int getStars() {
 		return stars;
+	}
+
+	public Integer getGlobalID() {
+		return this.globalID;
 	}
 
 	public boolean isStarsValid() {

--- a/src/main/java/net/pms/network/mediaserver/handlers/api/starrating/RequestVO.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/api/starrating/RequestVO.java
@@ -20,9 +20,9 @@ public class RequestVO {
 
 	private final String trackID;
 	private final int stars;
-	private final Integer globalID;
+	private final String globalID;
 
-	public RequestVO(String trackID, Integer globalID, int stars) {
+	public RequestVO(String trackID, String globalID, int stars) {
 		this.trackID = trackID;
 		this.stars = stars;
 		this.globalID = globalID;
@@ -36,7 +36,7 @@ public class RequestVO {
 		return stars;
 	}
 
-	public Integer getGlobalID() {
+	public String getGlobalID() {
 		return this.globalID;
 	}
 

--- a/src/main/java/net/pms/network/mediaserver/handlers/api/starrating/StarRating.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/api/starrating/StarRating.java
@@ -188,7 +188,7 @@ public class StarRating implements ApiResponseHandler {
 		if (contentArray.length < 3) {
 			throw new RuntimeException("illegal API call : expected 3 parameters");
 		}
-		RequestVO request = new RequestVO(contentArray[0], Integer.parseInt(contentArray[2]), Integer.parseInt(contentArray[1]));
+		RequestVO request = new RequestVO(contentArray[0], contentArray[2], Integer.parseInt(contentArray[1]));
 		if (!request.isStarsValid()) {
 			throw new NumberFormatException("Rating value must be between 0 and 5 (including).");
 		}


### PR DESCRIPTION
Bugfix: updates star rating value in the GlobalRepo cache to make updated rating information visible to consecutive reads of media file (DLNAResource).

At the moment the updated rating value is only visible after that object got invalidated in the GlobalRepo cache or UMS was restarted.