### PR TITLE
Shared Configurations

### DIFF
--- a/react-client/src/components/SharedContent/SharedContent.tsx
+++ b/react-client/src/components/SharedContent/SharedContent.tsx
@@ -44,6 +44,9 @@ export default function SharedContent() {
     if (sse.userConfiguration === null) {
       return;
     }
+    if (sse.userConfiguration['shared_content']) {
+      configuration['shared_content'] = undefined;
+    }
     const userConfig = _.merge({}, configuration, sse.userConfiguration);
     sse.setUserConfiguration(null);
     setConfiguration(userConfig);

--- a/src/main/java/net/pms/configuration/sharedcontent/SharedContentConfiguration.java
+++ b/src/main/java/net/pms/configuration/sharedcontent/SharedContentConfiguration.java
@@ -123,9 +123,11 @@ public class SharedContentConfiguration {
 	}
 
 	public static void updateSharedContent(SharedContentArray values, boolean save) {
+		LOGGER.debug("New shared content configuration sent.");
 		boolean updated = false;
 		synchronized (SHARED_CONTENT_ARRAY) {
 			if (!values.equals(SHARED_CONTENT_ARRAY)) {
+				LOGGER.debug("Updating shared content configuration");
 				SHARED_CONTENT_ARRAY.clear();
 				//check viability
 				for (SharedContent sharedContent : values) {
@@ -145,6 +147,8 @@ public class SharedContentConfiguration {
 					PMS.get().resetRenderersRoot();
 				}
 				updated = true;
+			} else {
+				LOGGER.debug("Current shared content configuration is already up to date.");
 			}
 		}
 		if (updated) {
@@ -227,11 +231,13 @@ public class SharedContentConfiguration {
 
 	private static synchronized SharedContentArray readConfiguration() {
 		Path sharedConfFilePath = Paths.get(CONFIGURATION.getSharedConfPath());
+		LOGGER.debug("Reading shared content configuration file: " + sharedConfFilePath);
 		try {
 			if (Files.exists(sharedConfFilePath)) {
 				String json = Files.readString(sharedConfFilePath, StandardCharsets.UTF_8);
 				return GSON.fromJson(json, SharedContentArray.class);
 			}
+			LOGGER.trace("Shared content configuration file missing: " + sharedConfFilePath);
 		} catch (IOException | JsonSyntaxException ex) {
 			LOGGER.info("Error in shared content configuration file : " + ex.getMessage());
 			LOGGER.debug(null, ex);
@@ -257,16 +263,18 @@ public class SharedContentConfiguration {
 	private static synchronized void writeConfiguration() {
 		try {
 			isWritingConfiguration = true;
-			Path webConfFilePath = Paths.get(CONFIGURATION.getSharedConfPath());
-			Files.writeString(webConfFilePath, GSON.toJson(SHARED_CONTENT_ARRAY), StandardCharsets.UTF_8);
+			Path sharedConfFilePath = Paths.get(CONFIGURATION.getSharedConfPath());
+			LOGGER.debug("Writing shared content configuration file: " + sharedConfFilePath);
+			Files.writeString(sharedConfFilePath, GSON.toJson(SHARED_CONTENT_ARRAY), StandardCharsets.UTF_8);
 		} catch (IOException e) {
-			LOGGER.debug("An error occurred while writing the web config file: {}", e);
+			LOGGER.debug("An error occurred while writing the shared content configuration file: {}", e);
 		}
 		isWritingConfiguration = false;
 	}
 
 	private static synchronized void reloadConfiguration() {
 		if (!isWritingConfiguration) {
+			LOGGER.debug("Reloading shared content configuration file");
 			updateSharedContent(readConfiguration(), false);
 		}
 	}

--- a/src/main/java/net/pms/configuration/sharedcontent/SharedContentConfiguration.java
+++ b/src/main/java/net/pms/configuration/sharedcontent/SharedContentConfiguration.java
@@ -51,10 +51,11 @@ public class SharedContentConfiguration {
 	private static final SharedContentArray SHARED_CONTENT_ARRAY = new SharedContentArray();
 
 	// Automatic reloading
-	public static final FileWatcher.Listener RELOAD_WATCHER = (String filename, String event, FileWatcher.Watch watch, boolean isDir) -> updateSharedContent(readConfiguration(), false);
+	private static boolean isWritingConfiguration = false;
+	public static final FileWatcher.Listener RELOAD_WATCHER = (String filename, String event, FileWatcher.Watch watch, boolean isDir) -> reloadConfiguration();
 
 	static {
-		updateSharedContent(readAllConfigurations(), false);
+		readAllConfigurations();
 		FileWatcher.add(new FileWatcher.Watch(CONFIGURATION.getSharedConfPath(), RELOAD_WATCHER));
 	}
 
@@ -184,7 +185,7 @@ public class SharedContentConfiguration {
 	}
 
 	/**
-	 * Get Shared contents configuration.
+	 * Set Shared contents configuration.
 	 * First, parse shared contents configs file (default to SHARED.conf).
 	 * If not exists, try to update from old shared contents configs files (WEB.conf, VirtualFolders.conf and UMS.conf)
 	 * If no results, default to the default media folders on your computer.
@@ -199,30 +200,29 @@ public class SharedContentConfiguration {
 	 *    - /user/Videos
 	 *  On Linux:
 	 *    - /user
-	 *
-	 * @return the SharedContentArray.
 	 */
-	private static synchronized SharedContentArray readAllConfigurations() {
+	private static synchronized void readAllConfigurations() {
 		Path sharedConfFilePath = Paths.get(CONFIGURATION.getSharedConfPath());
 		try {
 			if (Files.exists(sharedConfFilePath)) {
+				LOGGER.info("Getting shared content from configuration file : " + sharedConfFilePath);
 				String json = Files.readString(sharedConfFilePath, StandardCharsets.UTF_8);
-				return GSON.fromJson(json, SharedContentArray.class);
+				updateSharedContent(GSON.fromJson(json, SharedContentArray.class), false);
 			} else {
 				//import old settings
+				LOGGER.info("Importing old shared content configuration files");
 				SharedContentArray oldConfig = OldConfigurationImporter.getOldConfigurations();
 				if (oldConfig.isEmpty()) {
 					//no shared conf files, set to default media folders
 					oldConfig = defaultConfiguration();
 				}
 				updateSharedContent(oldConfig, true);
-				return oldConfig;
 			}
 		} catch (IOException | JsonSyntaxException ex) {
 			LOGGER.info("Error in shared content configuration file : " + ex.getMessage());
 			LOGGER.debug(null, ex);
+			updateSharedContent(new SharedContentArray(), false);
 		}
-		return new SharedContentArray();
 	}
 
 	private static synchronized SharedContentArray readConfiguration() {
@@ -256,10 +256,18 @@ public class SharedContentConfiguration {
 
 	private static synchronized void writeConfiguration() {
 		try {
+			isWritingConfiguration = true;
 			Path webConfFilePath = Paths.get(CONFIGURATION.getSharedConfPath());
 			Files.writeString(webConfFilePath, GSON.toJson(SHARED_CONTENT_ARRAY), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			LOGGER.debug("An error occurred while writing the web config file: {}", e);
+		}
+		isWritingConfiguration = false;
+	}
+
+	private static synchronized void reloadConfiguration() {
+		if (!isWritingConfiguration) {
+			updateSharedContent(readConfiguration(), false);
 		}
 	}
 


### PR DESCRIPTION
don't reload when writing file.
`readAllConfigurations` better handle when it need to save.