### PR TITLE
Fix running via VS Code

### DIFF
--- a/src/main/java/net/pms/io/SimpleProcessWrapper.java
+++ b/src/main/java/net/pms/io/SimpleProcessWrapper.java
@@ -261,7 +261,6 @@ public class SimpleProcessWrapper<C extends ProcessWrapperConsumer<R, T>, R exte
 	 * @throws InterruptedException If interrupted while waiting for the
 	 *             {@link Process} to finish.
 	 */
-	@Nonnull
 	public static void runProcessNullOutput(
 		long timeout,
 		@Nonnull TimeUnit timeUnit,
@@ -284,7 +283,6 @@ public class SimpleProcessWrapper<C extends ProcessWrapperConsumer<R, T>, R exte
 	 * @throws InterruptedException If interrupted while waiting for the
 	 *             {@link Process} to finish.
 	 */
-	@Nonnull
 	public static void runProcessNullOutput(
 		long timeoutMS,
 		long terminateTimeoutMS,
@@ -307,7 +305,6 @@ public class SimpleProcessWrapper<C extends ProcessWrapperConsumer<R, T>, R exte
 	 * @throws InterruptedException If interrupted while waiting for the
 	 *             {@link Process} to finish.
 	 */
-	@Nonnull
 	public static void runProcessNullOutput(
 		@Nonnull List<String> command,
 		long timeout,
@@ -330,7 +327,6 @@ public class SimpleProcessWrapper<C extends ProcessWrapperConsumer<R, T>, R exte
 	 * @throws InterruptedException If interrupted while waiting for the
 	 *             {@link Process} to finish.
 	 */
-	@Nonnull
 	public static void runProcessNullOutput(
 		@Nonnull List<String> command,
 		long timeoutMS,

--- a/src/main/java/net/pms/io/ThreadedProcessWrapper.java
+++ b/src/main/java/net/pms/io/ThreadedProcessWrapper.java
@@ -256,7 +256,6 @@ public class ThreadedProcessWrapper<C extends ProcessWrapperConsumer<R, T>, R ex
 	 *            termination attempt before a new attempt is made.
 	 * @param command the command(s) used to create the {@link Process}.
 	 */
-	@Nonnull
 	public static void runProcessNullOutput(
 		long timeout,
 		@Nonnull TimeUnit timeUnit,
@@ -277,7 +276,6 @@ public class ThreadedProcessWrapper<C extends ProcessWrapperConsumer<R, T>, R ex
 	 *            termination attempt before a new attempt is made.
 	 * @param command the command(s) used to create the {@link Process}.
 	 */
-	@Nonnull
 	public static void runProcessNullOutput(
 		long timeoutMS,
 		long terminateTimeoutMS,
@@ -298,7 +296,6 @@ public class ThreadedProcessWrapper<C extends ProcessWrapperConsumer<R, T>, R ex
 	 * @param terminateTimeoutMS the timeout in milliseconds for each
 	 *            termination attempt before a new attempt is made.
 	 */
-	@Nonnull
 	public static void runProcessNullOutput(
 		@Nonnull List<String> command,
 		long timeout,
@@ -319,7 +316,6 @@ public class ThreadedProcessWrapper<C extends ProcessWrapperConsumer<R, T>, R ex
 	 * @param terminateTimeoutMS the timeout in milliseconds for each
 	 *            termination attempt before a new attempt is made.
 	 */
-	@Nonnull
 	public static void runProcessNullOutput(
 		@Nonnull List<String> command,
 		long timeoutMS,


### PR DESCRIPTION
This fixes the following error I get when running via VS Code:

```
Exception in thread "main" java.lang.Error: Unresolved compilation problem:
        The nullness annotation @Nonnull is not applicable for the primitive type void

        at net.pms.io.ThreadedProcessWrapper.runProcessNullOutput(ThreadedProcessWrapper.java:259)
        at net.pms.PMS.init(PMS.java:534)
        at net.pms.PMS.createInstance(PMS.java:867)
        at net.pms.PMS.main(PMS.java:1021)
```