### PR TITLE
fix sse admin account when no auth is enabled

### DIFF
--- a/src/main/java/net/pms/iam/AccountService.java
+++ b/src/main/java/net/pms/iam/AccountService.java
@@ -48,6 +48,9 @@ public class AccountService {
 	}
 
 	public static Account getAccountByUserId(final int userId) {
+		if (userId == Integer.MAX_VALUE) {
+			return FAKE_ADMIN_ACCOUNT;
+		}
 		Account result = new Account();
 		result.setUser(getUserById(userId));
 		return fillGroupAndPermissions(result);


### PR DESCRIPTION
fix sse admin account when no auth is enabled

> Cannot invoke "net.pms.iam.Account.havePermission(int)" because "account" is null

fix #3691
fix #3707