### PR TITLE
Stop treating LG video thumbnail requests as play/stop events

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -3076,7 +3076,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 								} else {
 									res = res.clone();
 								}
-					
+
 								root.stopPlaying(res);
 							}
 						}

--- a/src/main/java/net/pms/dlna/MediaMonitor.java
+++ b/src/main/java/net/pms/dlna/MediaMonitor.java
@@ -169,6 +169,18 @@ public class MediaMonitor extends VirtualFolder {
 		return true;
 	}
 
+	/**
+	 * Performs certain actions after a video or audio file is stopped, if the file is
+	 * within a monitored directory.
+	 * These actions include:
+	 * - If the file is fully played:
+	 *   - Marking the file as fully played in the database
+	 *   - Updating the systemUpdateID to indicate to the client there is updated content
+	 * - If the file is not fully played:
+	 *   - Update the last played date for the file in the database
+	 *
+	 * @param resource
+	 */
 	public void stopped(DLNAResource resource) {
 		if (!(resource instanceof RealFile)) {
 			return;

--- a/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
@@ -670,7 +670,7 @@ public class RequestHandler implements HttpHandler {
 				} else {
 					// Notify plugins that the DLNAresource is about to start playing
 					startStopListenerDelegate = new StartStopListenerDelegate(exchange.getRemoteAddress().getAddress().getHostAddress());
-					startStopListenerDelegate.start(dlna);
+					startStopListenerDelegate.start(dlna, false);
 
 					// Try to determine the content type of the file
 					String rendererMimeType = renderer.getMimeType(dlna);
@@ -749,7 +749,7 @@ public class RequestHandler implements HttpHandler {
 			sendResponse(exchange, renderer, status, inputStream, cLoverride, (range.getStart() != DLNAMediaInfo.ENDFILE_POS));
 		} finally {
 			if (startStopListenerDelegate != null) {
-				startStopListenerDelegate.stop();
+				startStopListenerDelegate.stop(false);
 			}
 		}
 	}

--- a/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/NettyStreamServer.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/NettyStreamServer.java
@@ -222,7 +222,7 @@ public class NettyStreamServer implements StreamServer<UmsStreamServerConfigurat
 					StartStopListenerDelegate startStopListenerDelegate = (StartStopListenerDelegate) ctx.getAttachment();
 					if (startStopListenerDelegate != null) {
 						LOGGER.debug("Premature end, stopping...");
-						startStopListenerDelegate.stop();
+						startStopListenerDelegate.stop(false);
 					}
 				} else if (!cause.getClass().equals(ClosedChannelException.class)) {
 					LOGGER.debug("Caught exception: {}", cause.getMessage());

--- a/src/main/java/net/pms/renderers/devices/WebGuiRenderer.java
+++ b/src/main/java/net/pms/renderers/devices/WebGuiRenderer.java
@@ -242,7 +242,7 @@ public class WebGuiRenderer extends Renderer {
 			startStop = new StartStopListenerDelegate(getAddress().getHostAddress());
 		}
 		startStop.setRenderer(this);
-		startStop.start(getPlayingRes());
+		startStop.start(getPlayingRes(), false);
 	}
 
 	public void stop() {
@@ -252,7 +252,7 @@ public class WebGuiRenderer extends Renderer {
 		if (getPlayingRes() != null) {
 			LOGGER.trace("WebGuiRender stop for " + getPlayingRes().getDisplayName());
 		}
-		startStop.stop();
+		startStop.stop(false);
 		startStop = null;
 	}
 

--- a/src/main/java/net/pms/renderers/devices/WebRender.java
+++ b/src/main/java/net/pms/renderers/devices/WebRender.java
@@ -607,7 +607,7 @@ public class WebRender extends Renderer implements OutputOverride {
 			startStop = new StartStopListenerDelegate(ip);
 		}
 		startStop.setRenderer(this);
-		startStop.start(getPlayingRes());
+		startStop.start(getPlayingRes(), false);
 	}
 
 	public void stop() {
@@ -617,8 +617,7 @@ public class WebRender extends Renderer implements OutputOverride {
 		if (getPlayingRes() != null) {
 			LOGGER.trace("WebRender stop for " + getPlayingRes().getDisplayName());
 		}
-		startStop.stop();
+		startStop.stop(false);
 		startStop = null;
 	}
-
 }

--- a/src/main/java/net/pms/service/StartStopListenerDelegate.java
+++ b/src/main/java/net/pms/service/StartStopListenerDelegate.java
@@ -41,15 +41,20 @@ public class StartStopListenerDelegate {
 		return renderer;
 	}
 
-	// technically, these don't need to be synchronized as there should be
-	// one thread per request/response, but it doesn't hurt to enforce the contract
-	public synchronized void start(DLNAResource dlna) {
+	/**
+	 * Note: technically, these don't need to be synchronized as there should be
+	 * one thread per request/response, but it doesn't hurt to enforce the contract.
+	 *
+	 * @param dlna the resource to start playing
+	 * @param isThumbnailRequest whether this is a thumbnail request
+	 */
+	public synchronized void start(DLNAResource dlna, Boolean isThumbnailRequest) {
 		assert this.dlna == null;
 		this.dlna = dlna;
 		Format ext = dlna.getFormat();
 		// only trigger the start/stop events for audio and video
 		if (!started && ext != null && (ext.isVideo() || ext.isAudio())) {
-			dlna.startPlaying(rendererId, renderer);
+			dlna.startPlaying(rendererId, renderer, isThumbnailRequest);
 			started = true;
 			Services.sleepManager().startPlaying();
 		} else {
@@ -57,9 +62,9 @@ public class StartStopListenerDelegate {
 		}
 	}
 
-	public synchronized void stop() {
+	public synchronized void stop(Boolean isThumbnailRequest) {
 		if (started && !stopped) {
-			dlna.stopPlaying(rendererId, renderer);
+			dlna.stopPlaying(rendererId, renderer, isThumbnailRequest);
 			stopped = true;
 			Services.sleepManager().stopPlaying();
 		}


### PR DESCRIPTION
LG TVs send play requests in their Media Player app to get dynamic thumbnails on hover, which causes all kinds of problems, like marking the video as fully played if the thumbnail requested is near the end of the video. Here we detect the unique user-agent of those requests and treat them differently.

Note: I didn't make it an option in the renderer configs because I want it to be future-proof too, even when we don't have a config yet