### PR TITLE
Remove Content-Length header for chunked response

### DIFF
--- a/src/main/java/net/pms/network/webguiserver/servlets/PlayerApiServlet.java
+++ b/src/main/java/net/pms/network/webguiserver/servlets/PlayerApiServlet.java
@@ -819,10 +819,8 @@ public class PlayerApiServlet extends GuiHttpServlet {
 			if (in != null && in.available() != len) {
 				resp.setHeader("Content-Range", "bytes " + range.getStart() + "-" + in.available() + "/" + len);
 				resp.setStatus(206);
-				resp.setContentLength(in.available());
 			} else {
 				resp.setStatus(200);
-				resp.setContentLength(0);
 			}
 			if (LOGGER.isTraceEnabled()) {
 				WebGuiServletHelper.logHttpServletResponse(req, resp, null, in);
@@ -921,10 +919,8 @@ public class PlayerApiServlet extends GuiHttpServlet {
 			if (in != null && in.available() != len) {
 				resp.setHeader("Content-Range", "bytes " + range.getStart() + "-" + in.available() + "/" + len);
 				resp.setStatus(206);
-				resp.setContentLength(in.available());
 			} else {
 				resp.setStatus(200);
-				resp.setContentLength(0);
 			}
 			if (LOGGER.isTraceEnabled()) {
 				WebGuiServletHelper.logHttpServletResponse(req, resp, null, in);


### PR DESCRIPTION
Including both Content-Length and Tranfer-Encoding: chunked is an HTTP protocol violation and breaks proxies.