### PR TITLE
Fix startup crash

### DIFF
--- a/src/main/java/net/pms/util/APIUtils.java
+++ b/src/main/java/net/pms/util/APIUtils.java
@@ -229,7 +229,7 @@ public class APIUtils {
 
 				try {
 					JsonElement element = GSON.fromJson(apiResult, JsonElement.class);
-					if (element.isJsonObject()) {
+					if (element != null && element.isJsonObject()) {
 						jsonData = element.getAsJsonObject();
 					}
 				} catch (JsonSyntaxException e) {


### PR DESCRIPTION
Error was
```
java.lang.NullPointerException: Cannot invoke "com.google.gson.JsonElement.isJsonObject()" because "element" is null
 at net.pms.util.APIUtils.setApiImageBaseURL(APIUtils.java:232)
 at net.pms.PMS.init(PMS.java:631)
 at net.pms.PMS.createInstance(PMS.java:867)
 at net.pms.PMS.main(PMS.java:1021)
```