### PR TITLE
bugfix: avoid NPE in APIUtils.setApiMetadataVersions

### DIFF
--- a/src/main/java/net/pms/util/APIUtils.java
+++ b/src/main/java/net/pms/util/APIUtils.java
@@ -163,7 +163,7 @@ public class APIUtils {
 
 				try {
 					JsonElement element = GSON.fromJson(apiResult, JsonElement.class);
-					if (element.isJsonObject()) {
+					if (element != null && element.isJsonObject()) {
 						jsonData = element.getAsJsonObject();
 					}
 				} catch (JsonSyntaxException e) {


### PR DESCRIPTION
Avoid spamming the logfile with entries like this:
```
INFO  21:10:03.426 [OpenSubtitles background worker 18] Exception in thread "OpenSubtitles background worker 18" java.lang.NullPointerException: Cannot invoke "com.google.gson.JsonElement.isJsonObject()" because "element" is null
INFO  21:10:03.426 [OpenSubtitles background worker 18]         at net.pms.util.APIUtils.setApiMetadataVersions(APIUtils.java:166)
INFO  21:10:03.426 [OpenSubtitles background worker 18]         at net.pms.util.APIUtils.getApiDataVideoVersion(APIUtils.java:131)
INFO  21:10:03.427 [OpenSubtitles background worker 18]         at net.pms.database.MediaTableVideoMetadata.doesLatestApiMetadataExist(MediaTableVideoMetadata.java:581)
INFO  21:10:03.427 [OpenSubtitles background worker 18]         at net.pms.database.MediaTableVideoMetadata.doesLatestApiMetadataExist(MediaTableVideoMetadata.java:574)
INFO  21:10:03.427 [OpenSubtitles background worker 18]         at net.pms.util.APIUtils.lambda$backgroundLookupAndAddMetadata$0(APIUtils.java:304)
INFO  21:10:03.427 [OpenSubtitles background worker 18]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
INFO  21:10:03.427 [OpenSubtitles background worker 18]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
INFO  21:10:03.427 [OpenSubtitles background worker 18]         at java.base/java.lang.Thread.run(Unknown Source)
```

The log-message is also misleading, due to the fact, that the APIUtils use the `OpenSubtitlesBackgroundWorkerThreadFactory` for its `BACKGROUND_EXECUTOR` - but that's a separate issue.