### PR TITLE
Fix "Couldn't parse any supported protocols" error in logs

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -1831,7 +1831,7 @@ public class FFMpegVideo extends Engine {
 				if (result instanceof FFmpegExecutableInfoBuilder fFmpegExecutableInfoBuilder) {
 					List<String> protocols = FFmpegOptions.getSupportedProtocols(executableInfo.getPath());
 					fFmpegExecutableInfoBuilder.protocols(protocols);
-					if (!protocols.isEmpty()) {
+					if (protocols.isEmpty()) {
 						LOGGER.warn("Couldn't parse any supported protocols for \"{}\"", executableInfo.getPath());
 					} else {
 						LOGGER.debug("{} supported protocols: {}", executableInfo.getPath(), protocols);


### PR DESCRIPTION
A user on the [forum](https://www.universalmediaserver.com/forum/viewtopic.php?t=15646) was asking about the error "Couldn't parse any supported protocols for" in the logs. I get that error too.

They think it is due to this line of code and to me it looks like the logic is inverted if I'm reading it right.

This is the first time I tried this so don't know if I have done it right.