### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
           sudo dpkg -i libzen0v5_0.4.40-1_amd64.xUbuntu_20.04.deb
           wget --no-check-certificate https://mediaarea.net/download/binary/libmediainfo0/22.12/libmediainfo0v5_22.12-1_amd64.xUbuntu_20.04.deb
           sudo dpkg -i libmediainfo0v5_22.12-1_amd64.xUbuntu_20.04.deb
-          mvn verify -P testing
+          mvn verify -P testing -DdisableXmlReport=true
 
   linux-jammy:
     if: |
@@ -121,4 +121,4 @@ jobs:
           sudo dpkg -i libzen0v5_0.4.40-1_amd64.xUbuntu_22.04.deb
           wget --no-check-certificate https://mediaarea.net/download/binary/libmediainfo0/22.12/libmediainfo0v5_22.12-1_amd64.xUbuntu_22.04.deb
           sudo dpkg -i libmediainfo0v5_22.12-1_amd64.xUbuntu_22.04.deb
-          mvn verify -P testing
+          mvn verify -P testing -DdisableXmlReport=true


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.