### PR TITLE
Feature/audio composer

### DIFF
--- a/src/main/java/net/pms/database/MediaTableAudiotracks.java
+++ b/src/main/java/net/pms/database/MediaTableAudiotracks.java
@@ -50,6 +50,8 @@ public class MediaTableAudiotracks extends MediaTable {
 	private static final String COL_MBID_TRACK = "MBID_TRACK";
 	private static final String COL_LIKE_SONG = "LIKESONG";
 	private static final String COL_DISC = "DISC";
+	private static final String COL_COMPOSER = "COMPOSER";
+
 	/**
 	 * COLUMNS with table name
 	 */
@@ -67,6 +69,7 @@ public class MediaTableAudiotracks extends MediaTable {
 
 	private static final int SIZE_LANG = 3;
 	private static final int SIZE_GENRE = 64;
+	private static final int SIZE_COMPOSER = 128;
 	private static final int SIZE_MUXINGMODE = 32;
 	private static final int SIZE_SAMPLEFREQ = 16;
 	private static final int SIZE_CODECA = 32;
@@ -76,7 +79,7 @@ public class MediaTableAudiotracks extends MediaTable {
 	 * definition. Table upgrade SQL must also be added to
 	 * {@link #upgradeTable(Connection, int)}
 	 */
-	private static final int TABLE_VERSION = 9;
+	private static final int TABLE_VERSION = 10;
 
 	/**
 	 * Checks and creates or upgrades the table as needed.
@@ -171,6 +174,14 @@ public class MediaTableAudiotracks extends MediaTable {
 						//PKAUDIO not found, nothing to update.
 					}
 				}
+				case 9 -> {
+					if (!isColumnExist(connection, TABLE_NAME, COL_COMPOSER)) {
+						executeUpdate(connection, "ALTER TABLE " + TABLE_NAME + " ADD " + COL_COMPOSER + " VARCHAR(" + SIZE_COMPOSER + ")");
+						LOGGER.trace("Adding " + COL_COMPOSER + " to table " + TABLE_NAME);
+						executeUpdate(connection, "CREATE INDEX IDX_COMPOSER ON " + TABLE_NAME + " (" + COL_COMPOSER + ");");
+						LOGGER.trace("Indexing column " + COL_COMPOSER + " on table " + TABLE_NAME);
+					}
+				}
 				default -> {
 					throw new IllegalStateException(
 						getMessage(LOG_UPGRADING_TABLE_MISSING, DATABASE_NAME, TABLE_NAME, version, TABLE_VERSION)
@@ -216,6 +227,7 @@ public class MediaTableAudiotracks extends MediaTable {
 			sb.append(", LIKE_SONG         BOOLEAN");
 			sb.append(", RATING            INTEGER");
 			sb.append(", AUDIOTRACK_ID     INTEGER          AUTO_INCREMENT");
+			sb.append(", " + COL_COMPOSER + " VARCHAR(").append(SIZE_COMPOSER).append(')');
 			sb.append(", CONSTRAINT " + TABLE_NAME + "_PK PRIMARY KEY (FILEID, ID)");
 			sb.append(", CONSTRAINT " + TABLE_NAME + "_" + COL_FILEID + "_FK FOREIGN KEY(" + COL_FILEID + ") REFERENCES " + MediaTableFiles.REFERENCE_TABLE_COL_ID + " ON DELETE CASCADE");
 			sb.append(')');
@@ -245,6 +257,9 @@ public class MediaTableAudiotracks extends MediaTable {
 
 			LOGGER.trace("Creating index IDX_AUDIOTRACK_ID");
 			statement.execute("CREATE INDEX IDX_AUDIOTRACK_ID on " + TABLE_NAME + " (AUDIOTRACK_ID)");
+
+			LOGGER.trace("Creating index IDX_COMPOSER");
+			statement.execute("CREATE INDEX IDX_COMPOSER on " + TABLE_NAME + " (" + COL_COMPOSER + ")");
 		}
 	}
 
@@ -254,14 +269,15 @@ public class MediaTableAudiotracks extends MediaTable {
 		}
 
 		String columns = "FILEID, ID, LANG, TITLE, NRAUDIOCHANNELS, SAMPLEFREQ, CODECA, BITSPERSAMPLE, " +
-			"ALBUM, ARTIST, ALBUMARTIST, SONGNAME, GENRE, MEDIA_YEAR, TRACK, DELAY, MUXINGMODE, BITRATE, MBID_RECORD, MBID_TRACK, DISC, RATING";
+			"ALBUM, ARTIST, ALBUMARTIST, SONGNAME, GENRE, MEDIA_YEAR, TRACK, DELAY, MUXINGMODE, BITRATE, MBID_RECORD, MBID_TRACK, DISC, RATING, " +
+			COL_COMPOSER;
 
 		try (
 			PreparedStatement updateStatment = connection.prepareStatement(
 				"SELECT " +
 					"FILEID, ID, MBID_RECORD, MBID_TRACK, LANG, TITLE, NRAUDIOCHANNELS, SAMPLEFREQ, CODECA, " +
 					"BITSPERSAMPLE, ALBUM, ARTIST, ALBUMARTIST, SONGNAME, GENRE, MEDIA_YEAR, TRACK, DISC, " +
-					"DELAY, MUXINGMODE, BITRATE, RATING " +
+					"DELAY, MUXINGMODE, BITRATE, RATING, " + COL_COMPOSER + " " +
 				"FROM " + TABLE_NAME + " " +
 				"WHERE " +
 					"FILEID = ? AND ID = ?",
@@ -308,6 +324,11 @@ public class MediaTableAudiotracks extends MediaTable {
 						rs.updateInt("BITSPERSAMPLE", audioTrack.getBitsperSample());
 						rs.updateString("ALBUM", left(trimToEmpty(audioTrack.getAlbum()), SIZE_MAX));
 						rs.updateString("ARTIST", left(trimToEmpty(audioTrack.getArtist()), SIZE_MAX));
+						if (audioTrack.getComposer() == null) {
+							rs.updateNull(COL_COMPOSER);
+						} else {
+							rs.updateString(COL_COMPOSER, left(trimToEmpty(audioTrack.getComposer()), SIZE_COMPOSER));
+						}
 
 						//Special case for album artist. If it's empty, we want to insert NULL (for quicker retrieval)
 						String albumartist = left(trimToEmpty(audioTrack.getAlbumArtist()), SIZE_MAX);
@@ -387,6 +408,11 @@ public class MediaTableAudiotracks extends MediaTable {
 						} else {
 							insertStatement.setInt(22, audioTrack.getRating());
 						}
+						if (audioTrack.getComposer() == null) {
+							insertStatement.setNull(23, Types.INTEGER);
+						} else {
+							insertStatement.setString(23, audioTrack.getComposer());
+						}
 						insertStatement.executeUpdate();
 					}
 				}
@@ -426,6 +452,7 @@ public class MediaTableAudiotracks extends MediaTable {
 					audio.setAudiotrackId(elements.getInt("AUDIOTRACK_ID"));
 					audio.setMbidRecord(elements.getString("MBID_RECORD"));
 					audio.setMbidTrack(elements.getString("MBID_TRACK"));
+					audio.setComposer(elements.getString(COL_COMPOSER));
 					LOGGER.trace("Adding audio from the database: {}", audio.toString());
 					result.add(audio);
 				}

--- a/src/main/java/net/pms/database/MediaTableAudiotracks.java
+++ b/src/main/java/net/pms/database/MediaTableAudiotracks.java
@@ -272,7 +272,7 @@ public class MediaTableAudiotracks extends MediaTable {
 			statement.execute("CREATE INDEX IDX_COMPOSER on " + TABLE_NAME + " (" + COL_COMPOSER + ")");
 
 			LOGGER.trace("Creating index IDX_CONDUCTOR");
-			statement.execute("CREATE INDEX IDX_COMPOSER on " + TABLE_NAME + " (" + COL_CONDUCTOR + ")");
+			statement.execute("CREATE INDEX IDX_CONDUCTOR on " + TABLE_NAME + " (" + COL_CONDUCTOR + ")");
 		}
 	}
 

--- a/src/main/java/net/pms/database/MediaTableAudiotracks.java
+++ b/src/main/java/net/pms/database/MediaTableAudiotracks.java
@@ -50,8 +50,8 @@ public class MediaTableAudiotracks extends MediaTable {
 	private static final String COL_MBID_TRACK = "MBID_TRACK";
 	private static final String COL_LIKE_SONG = "LIKESONG";
 	private static final String COL_DISC = "DISC";
-	private static final String COL_COMPOSER = "COMPOSER";
-	private static final String COL_CONDUCTOR = "CONDUCTOR";
+	public static final String COL_COMPOSER = "COMPOSER";
+	public static final String COL_CONDUCTOR = "CONDUCTOR";
 
 	/**
 	 * COLUMNS with table name

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -36,6 +36,7 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	private String album;
 	private String artist;
 	private String composer;
+	private String conductor;
 	private String songname;
 	private String genre;
 	private int year;
@@ -538,6 +539,9 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 		if (isNotBlank(getComposer())) {
 			result.append(", Composer: ").append(getComposer());
 		}
+		if (isNotBlank(getConductor())) {
+			result.append(", Conductor: ").append(getConductor());
+		}
 		if (isNotBlank(getAlbum())) {
 			result.append(", Album: ").append(getAlbum());
 		}
@@ -730,6 +734,15 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	}
 
 	/**
+	 * Returns the conductor of the audio track.
+	 *
+	 * @return The conductor name.
+	 */
+	public String getConductor() {
+		return conductor;
+	}
+
+	/**
 	 * Sets the name of the main artist of the album of the audio track.
 	 * This field is often used for the compilation type albums or "featuring..." songs.
 	 *
@@ -765,6 +778,15 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 */
 	public void setComposer(String composer) {
 		this.composer = composer;
+	}
+
+	/**
+	 * Sets the conductor of the audio track.
+	 *
+	 * @param The conductor name to set.
+	 */
+	public void setConductor(String conductor) {
+		this.conductor = conductor;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -35,6 +35,7 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	private String codecA;
 	private String album;
 	private String artist;
+	private String composer;
 	private String songname;
 	private String genre;
 	private int year;
@@ -534,6 +535,9 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 		if (isNotBlank(getArtist())) {
 			result.append(", Artist: ").append(getArtist());
 		}
+		if (isNotBlank(getComposer())) {
+			result.append(", Composer: ").append(getComposer());
+		}
 		if (isNotBlank(getAlbum())) {
 			result.append(", Album: ").append(getAlbum());
 		}
@@ -717,6 +721,15 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	}
 
 	/**
+	 * Returns the composer of the audio track.
+	 *
+	 * @return The composer name.
+	 */
+	public String getComposer() {
+		return composer;
+	}
+
+	/**
 	 * Sets the name of the main artist of the album of the audio track.
 	 * This field is often used for the compilation type albums or "featuring..." songs.
 	 *
@@ -743,6 +756,15 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	 */
 	public void setArtist(String artist) {
 		this.artist = artist;
+	}
+
+	/**
+	 * Sets the composer of the audio track.
+	 *
+	 * @param composer The composer name to set.
+	 */
+	public void setComposer(String composer) {
+		this.composer = composer;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -669,6 +669,7 @@ public class DLNAMediaInfo implements Cloneable {
 
 							audio.setAlbum(extractAudioTagKeyValue(t, FieldKey.ALBUM));
 							audio.setArtist(extractAudioTagKeyValue(t, FieldKey.ARTIST));
+							audio.setComposer(extractAudioTagKeyValue(t, FieldKey.COMPOSER));
 							audio.setSongname(extractAudioTagKeyValue(t, FieldKey.TITLE));
 							audio.setMbidRecord(extractAudioTagKeyValue(t, FieldKey.MUSICBRAINZ_RELEASEID));
 							audio.setMbidTrack(extractAudioTagKeyValue(t, FieldKey.MUSICBRAINZ_TRACK_ID));

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -670,6 +670,7 @@ public class DLNAMediaInfo implements Cloneable {
 							audio.setAlbum(extractAudioTagKeyValue(t, FieldKey.ALBUM));
 							audio.setArtist(extractAudioTagKeyValue(t, FieldKey.ARTIST));
 							audio.setComposer(extractAudioTagKeyValue(t, FieldKey.COMPOSER));
+							audio.setConductor(extractAudioTagKeyValue(t, FieldKey.CONDUCTOR));
 							audio.setSongname(extractAudioTagKeyValue(t, FieldKey.TITLE));
 							audio.setMbidRecord(extractAudioTagKeyValue(t, FieldKey.MUSICBRAINZ_RELEASEID));
 							audio.setMbidTrack(extractAudioTagKeyValue(t, FieldKey.MUSICBRAINZ_TRACK_ID));

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -19,6 +19,7 @@ package net.pms.dlna;
 import static net.pms.util.StringUtil.DURATION_TIME_FORMAT;
 import static net.pms.util.StringUtil.addAttribute;
 import static net.pms.util.StringUtil.addXMLTagAndAttribute;
+import static net.pms.util.StringUtil.addXMLTagAndAttributeWithRole;
 import static net.pms.util.StringUtil.closeTag;
 import static net.pms.util.StringUtil.convertTimeToString;
 import static net.pms.util.StringUtil.encodeXML;
@@ -2291,6 +2292,17 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			if (StringUtils.isNotBlank(firstAudioTrack.getArtist())) {
 				addXMLTagAndAttribute(sb, "upnp:artist", encodeXML(firstAudioTrack.getArtist()));
 				addXMLTagAndAttribute(sb, "dc:creator", encodeXML(firstAudioTrack.getArtist()));
+			}
+
+			if (StringUtils.isNotBlank(firstAudioTrack.getComposer())) {
+				addXMLTagAndAttributeWithRole(sb, "upnp:artist role=\"Composer\"", encodeXML(firstAudioTrack.getComposer()));
+				addXMLTagAndAttributeWithRole(sb, "upnp:author role=\"Composer\"", encodeXML(firstAudioTrack.getComposer()));
+				addXMLTagAndAttribute(sb, "upnp:composer", encodeXML(firstAudioTrack.getComposer()));
+			}
+
+			if (StringUtils.isNotBlank(firstAudioTrack.getConductor())) {
+				addXMLTagAndAttributeWithRole(sb, "upnp:artist role=\"Conductor\"", encodeXML(firstAudioTrack.getConductor()));
+				addXMLTagAndAttribute(sb, "upnp:conductor", encodeXML(firstAudioTrack.getConductor()));
 			}
 
 			if (StringUtils.isNotBlank(firstAudioTrack.getGenre())) {

--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -35,6 +35,7 @@ import org.jupnp.support.model.SortCriterion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import net.pms.database.MediaDatabase;
+import net.pms.database.MediaTableAudiotracks;
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.DbIdMediaType;
 import net.pms.dlna.DbIdResourceLocator;
@@ -335,10 +336,15 @@ public class SearchRequestHandler {
 			// handle title by return type.
 			return getTitlePropertyMapping(requestType);
 		} else if (property.startsWith("upnp:artist")) {
+			// check for @role=composer, @role=conductor or @role=albumartist
 			if (property.contains("albumartist")) {
 				return " A.ALBUMARTIST ";
+			} else if (property.contains("composer")) {
+				return " A." + MediaTableAudiotracks.COL_COMPOSER + " ";
+			} else if (property.contains("conductor")) {
+				return " A." + MediaTableAudiotracks.COL_CONDUCTOR + " ";
 			}
-			// this matches all other like : @role=conductor and @role=composer
+			// no role, just the artist
 			return " A.ARTIST ";
 		} else if ("upnp:genre".equals(property)) {
 			return " A.GENRE ";

--- a/src/main/java/net/pms/parsers/MediaInfoParser.java
+++ b/src/main/java/net/pms/parsers/MediaInfoParser.java
@@ -393,6 +393,8 @@ public class MediaInfoParser {
 					currentAudioTrack.setAlbumArtist(MI.get(general, 0, "Album/Performer"));
 					currentAudioTrack.setArtist(getArtist());
 					currentAudioTrack.setGenre(MI.get(general, 0, "Genre"));
+					currentAudioTrack.setComposer(MI.get(general, 0, "Composer"));
+
 					if (videoTrackCount == 0) {
 						try {
 							AudioFile af;

--- a/src/main/java/net/pms/parsers/MediaInfoParser.java
+++ b/src/main/java/net/pms/parsers/MediaInfoParser.java
@@ -394,6 +394,7 @@ public class MediaInfoParser {
 					currentAudioTrack.setArtist(getArtist());
 					currentAudioTrack.setGenre(MI.get(general, 0, "Genre"));
 					currentAudioTrack.setComposer(MI.get(general, 0, "Composer"));
+					currentAudioTrack.setConductor(MI.get(general, 0, "Conductor"));
 
 					if (videoTrackCount == 0) {
 						try {

--- a/src/main/java/net/pms/util/StringUtil.java
+++ b/src/main/java/net/pms/util/StringUtil.java
@@ -122,6 +122,17 @@ public class StringUtil {
 		sb.append("&gt;");
 	}
 
+	public static void addXMLTagAndAttributeWithRole(StringBuilder sb, String tag, Object value) {
+		String myTagWithoutRole = tag.split(" ")[0];
+		sb.append("&lt;");
+		sb.append(tag);
+		sb.append("&gt;");
+		sb.append(value);
+		sb.append("&lt;/");
+		sb.append(myTagWithoutRole);
+		sb.append("&gt;");
+	}
+
 	/**
 	 * Does double transformations between &<> characters and their XML
 	 * representation with ampersands.

--- a/src/test/java/net/pms/network/mediaserver/handlers/SearchRequestHandlerTest.java
+++ b/src/test/java/net/pms/network/mediaserver/handlers/SearchRequestHandlerTest.java
@@ -59,7 +59,20 @@ public class SearchRequestHandlerTest {
 		String countSQL = h.convertToCountSql(searchCriteria, h.getRequestType(searchCriteria));
 		LOG.info(countSQL);
 		assertTrue(countSQL.matches(
-			"select\\s+count\\s+\\(\\s*DISTINCT\\s+COALESCE\\s*\\(\\s*A.ALBUMARTIST\\s*,\\s*A.ARTIST\\s*\\)\\)\\s+from\\s+AUDIOTRACKS\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.ARTIST\\s*\\)\\s+LIKE\\s+'%tchaikovsky%'"));
+			"select\\s+count\\s+\\(\\s*DISTINCT\\s+COALESCE\\s*\\(\\s*A.ALBUMARTIST\\s*,\\s*A.ARTIST\\s*\\)\\)\\s+from\\s+AUDIOTRACKS\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.COMPOSER\\s*\\)\\s+LIKE\\s+'%tchaikovsky%'"));
+	}
+
+	/**
+	 * Tests SearchCriteria issued by LINN app (iOS) for Composer
+	 */
+	@Test
+	public void testLinnAppConductorSearch() {
+		String searchCriteria = "upnp:class derivedfrom \"object.container.person.musicArtist\" and upnp:artist[@role=\"Conductor\"] contains \"bernstein\"";
+		SearchRequestHandler h = new SearchRequestHandler();
+		String countSQL = h.convertToCountSql(searchCriteria, h.getRequestType(searchCriteria));
+		LOG.info(countSQL);
+		assertTrue(countSQL.matches(
+			"select\\s+count\\s+\\(\\s*DISTINCT\\s+COALESCE\\s*\\(\\s*A.ALBUMARTIST\\s*,\\s*A.ARTIST\\s*\\)\\)\\s+from\\s+AUDIOTRACKS\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.CONDUCTOR\\s*\\)\\s+LIKE\\s+'%bernstein%'"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR helps control points to honor classical music
- reads CONDUCTOR and COMPOSER tags from audio files if available and stores that metadata into the database
- responds to UPnP search requests for conductor and composer roles
- adds DIDL-LITE resource entries for conductor & composer

