### PR TITLE
newgui documentation typo fix

### DIFF
--- a/src/test/java/net/pms/newgui/LanguageSelectionTest.java
+++ b/src/test/java/net/pms/newgui/LanguageSelectionTest.java
@@ -31,7 +31,7 @@ public class LanguageSelectionTest {
 
 	@BeforeEach
 	public void setUp() throws ConfigurationException {
-		// Silence all log messages from the UMS code that is being tested
+		// Silence all log messages from the UMS code that are being tested
 		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
 		context.getLogger(Logger.ROOT_LOGGER_NAME).setLevel(Level.OFF);
 	}

--- a/src/test/java/net/pms/newgui/ViewLevelTest.java
+++ b/src/test/java/net/pms/newgui/ViewLevelTest.java
@@ -29,7 +29,7 @@ public class ViewLevelTest {
 
 	@BeforeEach
 	public void setUp() throws ConfigurationException {
-		// Silence all log messages from the UMS code that is being tested
+		// Silence all log messages from the UMS code that are being tested
 		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
 		context.getLogger(Logger.ROOT_LOGGER_NAME).setLevel(Level.OFF);
 	}

--- a/src/test/java/net/pms/newgui/components/SpinnerIntModelTest.java
+++ b/src/test/java/net/pms/newgui/components/SpinnerIntModelTest.java
@@ -30,7 +30,7 @@ public class SpinnerIntModelTest {
 
 	@BeforeEach
 	public void setUp() throws ConfigurationException {
-		// Silence all log messages from the UMS code that is being tested
+		// Silence all log messages from the UMS code that are being tested
 		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
 		context.getLogger(Logger.ROOT_LOGGER_NAME).setLevel(Level.OFF);
 	}

--- a/src/test/java/net/pms/newgui/components/TextAreaFIFOTest.java
+++ b/src/test/java/net/pms/newgui/components/TextAreaFIFOTest.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 public class TextAreaFIFOTest {
 	@BeforeEach
 	public void setUp() throws ConfigurationException, InterruptedException {
-		// Silence all log messages from the UMS code that is being tested
+		// Silence all log messages from the UMS code that are being tested
 		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
 		context.getLogger(Logger.ROOT_LOGGER_NAME).setLevel(Level.OFF);
 	}


### PR DESCRIPTION
fixed a copy-pasted grammar error in the documentation under the src/test/java\net\pms/newgui folder