### PR TITLE
Let audio files populate into "Audiotracks" table.

### DIFF
--- a/src/main/java/net/pms/database/MediaTableAudiotracks.java
+++ b/src/main/java/net/pms/database/MediaTableAudiotracks.java
@@ -238,10 +238,6 @@ public class MediaTableAudiotracks extends MediaTable {
 			updateStatment.executeUpdate();
 		}
 
-		if (trackCount == 0) {
-			return;
-		}
-
 		try (
 			PreparedStatement updateStatment = connection.prepareStatement(SQL_GET_ALL_FILEID_ID, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
 		) {


### PR DESCRIPTION
This fixes #4029. 
If you populate only audio files. 

By looking at the table `AUDIOTRACKS` all `ID` values are 0. I think this might not be intentional.