### PR TITLE
Attempt to store the last legitimate playback time for a resource

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -3094,8 +3094,15 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	private long lastStartSystemTime;
 
 	/**
-	 * Gets the system time when the resource was last (re)started.
-	 *
+	 * The system time when the resource was last (re)started by a user.
+	 * This is a guess, where we disqualify certain playback requests from
+	 * setting this value based on how close they were to the end, because
+	 * some renderers request the last bytes of a file for processing behind
+	 * the scenes, and that does not count as a real user doing it.
+	 */
+	private long lastStartSystemTimeUser;
+
+	/**
 	 * @return The system time when the resource was last (re)started
 	 */
 	public double getLastStartSystemTime() {
@@ -3109,6 +3116,28 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	 */
 	public void setLastStartSystemTime(long startTime) {
 		lastStartSystemTime = startTime;
+
+		double fileDuration = 0;
+		final RealFile realFile = (RealFile) this;
+		if (realFile.getMedia() != null && (realFile.getMedia().isAudio() || realFile.getMedia().isVideo())) {
+			fileDuration = realFile.getMedia().getDurationInSeconds();
+		}
+
+		/**
+		 * Do not treat this as a legitimate playback attempt if the start
+		 * time was within 2 seconds of the end of the video.
+		 */
+		if (fileDuration < 2.0 || realFile.getLastStartPosition() < (fileDuration - 2.0)) {
+			lastStartSystemTimeUser = startTime;
+		}
+	}
+
+	/**
+	 * @return The system time when the resource was last (re)started
+	 *         by a user.
+	 */
+	public double getLastStartSystemTimeUser() {
+		return lastStartSystemTimeUser;
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/MediaMonitor.java
+++ b/src/main/java/net/pms/dlna/MediaMonitor.java
@@ -220,7 +220,7 @@ public class MediaMonitor extends VirtualFolder {
 		if (realFile.getLastStartPosition() == 0) {
 			elapsed = (double) (System.currentTimeMillis() - realFile.getStartTime()) / 1000;
 		} else {
-			elapsed = (System.currentTimeMillis() - realFile.getLastStartSystemTime()) / 1000;
+			elapsed = (System.currentTimeMillis() - realFile.getLastStartSystemTimeUser()) / 1000;
 			elapsed += realFile.getLastStartPosition();
 		}
 
@@ -231,18 +231,9 @@ public class MediaMonitor extends VirtualFolder {
 			LOGGER.trace("   duration: " + fileDuration);
 			LOGGER.trace("   getLastStartPosition: " + realFile.getLastStartPosition());
 			LOGGER.trace("   getStartTime: " + realFile.getStartTime());
-			LOGGER.trace("   getLastStartSystemTime: " + realFile.getLastStartSystemTime());
+			LOGGER.trace("   getLastStartSystemTimeUser: " + realFile.getLastStartSystemTimeUser());
 			LOGGER.trace("   elapsed: " + elapsed);
 			LOGGER.trace("   minimum play time needed: " + (fileDuration * configuration.getResumeBackFactor()));
-		}
-
-		/**
-		 * Do not treat this as a legitimate playback attempt if the start
-		 * time was within 2 seconds of the end of the video.
-		 */
-		if (fileDuration > 2.0 && realFile.getLastStartPosition() > (fileDuration - 2.0)) {
-			LOGGER.trace("final decision: not legitimate playback");
-			return;
 		}
 
 		/**


### PR DESCRIPTION
which might not be the last playback request from the renderer

Confirmed to fix #3947 