### PR TITLE
Some Samsung TVs (like D6500) don't support EAC3 in MPEG containers so mux it to MPEG-TS

### DIFF
--- a/src/main/external-resources/renderers/Samsung-CD.conf
+++ b/src/main/external-resources/renderers/Samsung-CD.conf
@@ -36,7 +36,7 @@ RendererIcon = samsung-tv.png
 UserAgentSearch = SEC_HHP.*(TV|HT|BD).*[CD]S?\d{3}\d?/
 UpnpDetailsSearch = [CD]S?\d{3}\d? , (Samsung|AllShare)
 
-DefaultVBVBufSize = true
+TranscodeVideo = MPEGTS-H264-AC3
 MuxDTSToMpeg = true
 MaxVideoBitrateMbps = 25
 SubtitleHttpHeader = CaptionInfo.sec
@@ -44,10 +44,13 @@ PrependTrackNumbers = true
 CharMap = / :
 
 # Supported video formats:
-Supported = f:avi|mkv             m:video/avi
-Supported = f:flv                 m:video/mp4
-Supported = f:mov                 m:video/quicktime
-Supported = f:mp4|mpegps|mpegts   m:video/mpeg
+Supported = f:avi       a:ac3|adpcm|dts|lpcm|mp3    m:video/avi
+Supported = f:flv       a:ac3|adpcm|dts|lpcm|mp3    m:video/mp4
+Supported = f:mkv       a:ac3|adpcm|dts|lpcm|mp3    m:video/x-mkv
+Supported = f:mov                                   m:video/quicktime
+Supported = f:mp4       a:aac|adpcm|mp3             m:video/mp4
+Supported = f:mpegps    a:aac|ac3|lpcm              m:video/mpeg
+Supported = f:mpegts    a:aac|ac3|eac3|he-aac|mp3   m:video/mpeg
 
 # Supported audio formats:
 Supported = f:mp3   m:audio/mpeg


### PR DESCRIPTION
Fixes #4039