### PR TITLE
Fixed broken language parsing for locale-specific variants

### DIFF
--- a/src/main/java/net/pms/util/Iso639.java
+++ b/src/main/java/net/pms/util/Iso639.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.pms.PMS;
 import net.pms.media.MediaLang;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -61,6 +63,9 @@ public final class Iso639 {
 	private static final List<String> CODES;
 
 	private static final Map<String, String> COMMON_MISSPELLINGS;
+
+	private static final String LANGUAGE_REGEX = "(\\w{2,3})\\s\\(\\w{2,3}\\)";
+	private static final Pattern LANGUAGE_REGEX_PATTERN = Pattern.compile(LANGUAGE_REGEX);
 
 	static {
 		// Make sure everything is initialized before it is retrieved.
@@ -128,7 +133,15 @@ public final class Iso639 {
 			return null;
 		}
 
-		code = code.trim().toLowerCase(Locale.ROOT);
+		code = code.trim();
+
+		Matcher matcher = LANGUAGE_REGEX_PATTERN.matcher(code);
+		if (matcher.find()) {
+			code = matcher.group(1);
+		} else {
+			code = code.toLowerCase(Locale.ROOT);
+		}
+
 		if (LOCAL_ALIAS.equals(code)) {
 			code = normalize(code);
 			if (isBlank(code)) {

--- a/src/main/java/net/pms/util/Iso639.java
+++ b/src/main/java/net/pms/util/Iso639.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.pms.PMS;
 import net.pms.media.MediaLang;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -63,9 +61,6 @@ public final class Iso639 {
 	private static final List<String> CODES;
 
 	private static final Map<String, String> COMMON_MISSPELLINGS;
-
-	private static final String LANGUAGE_REGEX = "(\\w{2,3})\\s\\(\\w{2,3}\\)";
-	private static final Pattern LANGUAGE_REGEX_PATTERN = Pattern.compile(LANGUAGE_REGEX);
 
 	static {
 		// Make sure everything is initialized before it is retrieved.
@@ -133,15 +128,7 @@ public final class Iso639 {
 			return null;
 		}
 
-		code = code.trim();
-
-		Matcher matcher = LANGUAGE_REGEX_PATTERN.matcher(code);
-		if (matcher.find()) {
-			code = matcher.group(1);
-		} else {
-			code = code.toLowerCase(Locale.ROOT);
-		}
-
+		code = code.trim().toLowerCase(Locale.ROOT);
 		if (LOCAL_ALIAS.equals(code)) {
 			code = normalize(code);
 			if (isBlank(code)) {

--- a/src/test/java/net/pms/dlna/MediaInfoTest.java
+++ b/src/test/java/net/pms/dlna/MediaInfoTest.java
@@ -176,7 +176,7 @@ public class MediaInfoTest {
 			getTestFileMediaInfo("video-h264-heaac.mp4")
 		);
 		assertEquals(
-			"Container: MKV, Size: 6356992, Overall Bitrate: 7121, Video Tracks: 1, Video Codec: h264, Duration: 1:59:01.690, Video Resolution: 1280 x 544, Display Aspect Ratio: 2.35:1, Scan Type: Progressive, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Frame Rate Mode Raw: CFR, Reference Frame Count: 1, AVC Level: 5.1, AVC Profile: main, Audio Tracks: 1 [Audio Codec: Enhanced AC-3, Bitrate: 1536000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 6270615, Overall Bitrate: 8339970, Video Tracks: 1, Video Codec: h264, Duration: 0:00:06.015, Video Resolution: 1280 x 544, Display Aspect Ratio: 2.35:1, Scan Type: Progressive, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Frame Rate Mode Raw: CFR, Reference Frame Count: 1, AVC Level: 5.1, AVC Profile: main, Audio Tracks: 1 [Id: 0, Language Code: fre, Audio Codec: Enhanced AC-3, Bitrate: 1536000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h264-eac3.mkv")
 		);
 		assertEquals(


### PR DESCRIPTION
This fixes parsing when the language comes from MediaInfo as "en (US)" or "fr (CA)"