### PR TITLE
V14 - Localize video metadata

### DIFF
--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -92,7 +92,10 @@ import net.pms.renderers.Renderer;
 import net.pms.renderers.RendererFilter;
 import net.pms.renderers.RendererUser;
 import net.pms.service.Services;
+import net.pms.store.MediaInfoStore;
 import net.pms.store.MediaScanner;
+import net.pms.store.MediaStatusStore;
+import net.pms.store.ThumbnailStore;
 import net.pms.store.container.CodeEnter;
 import net.pms.util.CodeDb;
 import net.pms.util.CredMgr;
@@ -498,8 +501,8 @@ public class PMS {
 					GuiManager.setReloadable(true);
 				} else if (UmsConfiguration.NEED_WEB_PLAYER_SERVER_RELOAD_FLAGS.contains(event.getPropertyName())) {
 					resetWebPlayerServer();
-				} else if (UmsConfiguration.NEED_MEDIA_LIBRARY_RELOAD_FLAGS.contains(event.getPropertyName())) {
-					resetMediaLibrary();
+				} else if (UmsConfiguration.LANGUAGE_CHANGED.contains(event.getPropertyName())) {
+					resetLanguage();
 				} else if (UmsConfiguration.NEED_RENDERERS_MEDIA_STORE_RELOAD_FLAGS.contains(event.getPropertyName())) {
 					resetRenderersMediaStore();
 				}
@@ -692,11 +695,13 @@ public class PMS {
 	}
 
 	/**
-	 * Reset the media library.
+	 * Reset the media store cache language.
 	 * The trigger is configuration change.
 	 */
-	public void resetMediaLibrary() {
-		resetRenderersMediaStore();
+	public void resetLanguage() {
+		ThumbnailStore.resetLanguage();
+		MediaStatusStore.clear();
+		MediaInfoStore.clear();
 	}
 
 	/**

--- a/src/main/java/net/pms/configuration/UmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/UmsConfiguration.java
@@ -557,14 +557,10 @@ public class UmsConfiguration extends BaseConfiguration {
 	);
 
 	/**
-	 * The set of keys defining when the media library has to reset due to a
-	 * configuration change.
-	 *
-	 * It will need a media store reload as renderers build from it.
+	 * The set of keys defining when the server language was changed.
 	 */
-	public static final Set<String> NEED_MEDIA_LIBRARY_RELOAD_FLAGS = Set.of(
-		KEY_FULLY_PLAYED_ACTION,
-		KEY_SHOW_RECENTLY_PLAYED_FOLDER
+	public static final Set<String> LANGUAGE_CHANGED = Set.of(
+		KEY_LANGUAGE
 	);
 
 	/**
@@ -578,11 +574,13 @@ public class UmsConfiguration extends BaseConfiguration {
 		KEY_DISABLE_TRANSCODE_FOR_EXTENSIONS,
 		KEY_DISABLE_TRANSCODING,
 		KEY_FORCE_TRANSCODE_FOR_EXTENSIONS,
+		KEY_FULLY_PLAYED_ACTION,
 		KEY_HIDE_EMPTY_FOLDERS,
 		KEY_OPEN_ARCHIVES,
 		KEY_PRETTIFY_FILENAMES,
 		KEY_SHOW_LIVE_SUBTITLES_FOLDER,
 		KEY_SHOW_MEDIA_LIBRARY_FOLDER,
+		KEY_SHOW_RECENTLY_PLAYED_FOLDER,
 		KEY_SHOW_SERVER_SETTINGS_FOLDER,
 		KEY_SHOW_TRANSCODE_FOLDER,
 		KEY_SORT_METHOD
@@ -1929,28 +1927,6 @@ public class UmsConfiguration extends BaseConfiguration {
 	}
 
 	/**
-	 * Returns the number of seconds from the start of a video file (the seek
-	 * position) where the thumbnail image for the movie should be extracted
-	 * from. Default is 4 seconds.
-	 *
-	 * @return The seek position in seconds.
-	 */
-	public int getThumbnailSeekPos() {
-		return getInt(KEY_THUMBNAIL_SEEK_POS, 4);
-	}
-
-	/**
-	 * Sets the number of seconds from the start of a video file (the seek
-	 * position) where the thumbnail image for the movie should be extracted
-	 * from.
-	 *
-	 * @param value The seek position in seconds.
-	 */
-	public void setThumbnailSeekPos(int value) {
-		configuration.setProperty(KEY_THUMBNAIL_SEEK_POS, value);
-	}
-
-	/**
 	 * Returns whether the user wants ASS/SSA subtitle support. Default is
 	 * true.
 	 *
@@ -2515,6 +2491,28 @@ public class UmsConfiguration extends BaseConfiguration {
 	 */
 	public void setThumbnailGenerationEnabled(boolean value) {
 		configuration.setProperty(KEY_THUMBNAIL_GENERATION_ENABLED, value);
+	}
+
+	/**
+	 * Returns the number of seconds from the start of a video file (the seek
+	 * position) where the thumbnail image for the movie should be extracted
+	 * from. Default is 4 seconds.
+	 *
+	 * @return The seek position in seconds.
+	 */
+	public int getThumbnailSeekPos() {
+		return getInt(KEY_THUMBNAIL_SEEK_POS, 4);
+	}
+
+	/**
+	 * Sets the number of seconds from the start of a video file (the seek
+	 * position) where the thumbnail image for the movie should be extracted
+	 * from.
+	 *
+	 * @param value The seek position in seconds.
+	 */
+	public void setThumbnailSeekPos(int value) {
+		configuration.setProperty(KEY_THUMBNAIL_SEEK_POS, value);
 	}
 
 	/**

--- a/src/main/java/net/pms/database/MediaTableThumbnails.java
+++ b/src/main/java/net/pms/database/MediaTableThumbnails.java
@@ -246,6 +246,9 @@ public final class MediaTableThumbnails extends MediaTable {
 	 * @param id the ID to remove
 	 */
 	public static void removeById(final Connection connection, final Long id) {
+		if (id == null) {
+			return;
+		}
 		try (PreparedStatement statement = connection.prepareStatement(SQL_DELETE_ID)) {
 			statement.setLong(1, id);
 			int rows = statement.executeUpdate();
@@ -261,7 +264,7 @@ public final class MediaTableThumbnails extends MediaTable {
 	 *
 	 * @param connection
 	 */
-	protected static void cleanup(final Connection connection) {
+	public static void cleanup(final Connection connection) {
 		try (PreparedStatement statement = connection.prepareStatement(SQL_CLEANUP)) {
 			int rows = statement.executeUpdate();
 			LOGGER.trace("Removed {} entries in \"{}\"", rows, TABLE_NAME);

--- a/src/main/java/net/pms/database/MediaTableVideoMetadata.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadata.java
@@ -462,6 +462,32 @@ public class MediaTableVideoMetadata extends MediaTable {
 						metadata.setTmdbId(rs.getLong(COL_TMDBID));
 						metadata.setTmdbTvId(rs.getLong(COL_TMDBTVID));
 						metadata.setVotes(rs.getString(COL_VOTES));
+						String lang = CONFIGURATION.getLanguageRawString();
+						if (lang != null && !"en-us".equalsIgnoreCase(lang)) {
+							if (metadata.isTVEpisode()) {
+								String season = rs.getString(COL_TVSEASON);
+								String episode = rs.getString(COL_TVEPISODENUMBER);
+								VideoMetadataLocalized loc = MediaTableVideoMetadataLocalized.getVideoMetadataLocalized(connection, fileId, false, lang, metadata.getIMDbID(), "tv_episode", metadata.getTmdbTvId(), season, episode);
+								if (loc != null) {
+									loc.localizeMediaVideoMetadata(metadata);
+									//store tmdbTvID if it was not before
+									if (metadata.getTmdbTvId() == 0 && loc.getTmdbID() != null) {
+										updateTmdbId(connection, fileId, loc.getTmdbID(), true);
+										metadata.setTmdbTvId(loc.getTmdbID());
+									}
+								}
+							} else {
+								VideoMetadataLocalized loc = MediaTableVideoMetadataLocalized.getVideoMetadataLocalized(connection, fileId, false, lang, metadata.getIMDbID(), "movie", metadata.getTmdbId(), null, null);
+								if (loc != null) {
+									loc.localizeMediaVideoMetadata(metadata);
+									//store tmdbID if it was not before
+									if (metadata.getTmdbId() == 0 && loc.getTmdbID() != null) {
+										updateTmdbId(connection, fileId, loc.getTmdbID(), false);
+										metadata.setTmdbId(loc.getTmdbID());
+									}
+								}
+							}
+						}
 						return metadata;
 					}
 				}

--- a/src/main/java/net/pms/database/MediaTableVideoMetadataLocalized.java
+++ b/src/main/java/net/pms/database/MediaTableVideoMetadataLocalized.java
@@ -245,4 +245,5 @@ public final class MediaTableVideoMetadataLocalized extends MediaTable {
 		set(connection, id, fromTvSeries, result, language);
 		return result;
 	}
+
 }

--- a/src/main/java/net/pms/dlna/DidlHelper.java
+++ b/src/main/java/net/pms/dlna/DidlHelper.java
@@ -590,8 +590,8 @@ public class DidlHelper extends DlnaHelper {
 		ImageInfo thumbnailImageInf = null;
 		if (resource.getThumbnailImageInfo() != null) {
 			thumbnailImageInf = resource.getThumbnailImageInfo();
-		} else if (mediaInfo != null && mediaInfo.getThumb() != null && mediaInfo.getThumb().getImageInfo() != null) {
-			thumbnailImageInf = mediaInfo.getThumb().getImageInfo();
+		} else if (mediaInfo != null && mediaInfo.getThumbnail() != null && mediaInfo.getThumbnail().getImageInfo() != null) {
+			thumbnailImageInf = mediaInfo.getThumbnail().getImageInfo();
 		}
 
 		// Only include GIF elements if the source is a GIF and it's supported
@@ -750,8 +750,8 @@ public class DidlHelper extends DlnaHelper {
 			ImageInfo imageInfo = null;
 			if (resource.getThumbnailImageInfo() != null) {
 				imageInfo = resource.getThumbnailImageInfo();
-			} else if (mediaInfo != null && mediaInfo.getThumb() != null && mediaInfo.getThumb().getImageInfo() != null) {
-				imageInfo = mediaInfo.getThumb().getImageInfo();
+			} else if (mediaInfo != null && mediaInfo.getThumbnail() != null && mediaInfo.getThumbnail().getImageInfo() != null) {
+				imageInfo = mediaInfo.getThumbnail().getImageInfo();
 			}
 
 			// Only include GIF elements if the source is a GIF and it's

--- a/src/main/java/net/pms/dlna/DlnaHelper.java
+++ b/src/main/java/net/pms/dlna/DlnaHelper.java
@@ -64,8 +64,8 @@ public class DlnaHelper {
 		ImageInfo thumbnailImageInf = null;
 		if (resource.getThumbnailImageInfo() != null) {
 			thumbnailImageInf = resource.getThumbnailImageInfo();
-		} else if (mediaInfo != null && mediaInfo.getThumb() != null && mediaInfo.getThumb().getImageInfo() != null) {
-			thumbnailImageInf = mediaInfo.getThumb().getImageInfo();
+		} else if (mediaInfo != null && mediaInfo.getThumbnail() != null && mediaInfo.getThumbnail().getImageInfo() != null) {
+			thumbnailImageInf = mediaInfo.getThumbnail().getImageInfo();
 		}
 		ImageInfo imageInfo = null;
 		if (thumbnailRequest) {

--- a/src/main/java/net/pms/media/MediaInfo.java
+++ b/src/main/java/net/pms/media/MediaInfo.java
@@ -36,6 +36,7 @@ import net.pms.media.chapter.MediaChapter;
 import net.pms.media.subtitle.MediaSubtitle;
 import net.pms.media.video.MediaVideo;
 import net.pms.media.video.metadata.MediaVideoMetadata;
+import net.pms.store.ThumbnailSource;
 import net.pms.store.ThumbnailStore;
 import net.pms.util.StringUtil;
 import net.pms.util.UMSUtils;
@@ -67,6 +68,7 @@ public class MediaInfo implements Cloneable {
 	private String aspectRatioDvdIso;
 
 	private Long thumbnailId = null;
+	private ThumbnailSource thumbnailSource = ThumbnailSource.UNKNOWN;
 
 	private MediaVideoMetadata videoMetadata;
 	private MediaAudioMetadata audioMetadata;
@@ -340,31 +342,43 @@ public class MediaInfo implements Cloneable {
 	}
 
 	/**
-	 * @return the thumb
+	 * @return the thumbnail
 	 * @since 1.50.0
 	 */
-	public DLNAThumbnail getThumb() {
+	public DLNAThumbnail getThumbnail() {
 		return ThumbnailStore.getThumbnail(thumbnailId);
 	}
 
-	public Long getThumbId() {
+	public Long getThumbnailId() {
 		return thumbnailId;
 	}
 
-	public void setThumbId(Long thumbnailId) {
+	public void setThumbnailId(Long thumbnailId) {
 		this.thumbnailId = thumbnailId;
 	}
 
+	public ThumbnailSource getThumbnailSource() {
+		return thumbnailSource;
+	}
+
+	public void setThumbnailSource(ThumbnailSource value) {
+		this.thumbnailSource = value;
+	}
+
+	public void setThumbnailSource(String value) {
+		this.thumbnailSource = ThumbnailSource.valueOfName(value);
+	}
+
 	/**
-	 * @return the thumbready
+	 * @return the thumbnail is ready
 	 * @since 1.50.0
 	 */
-	public boolean isThumbready() {
-		return getThumb() != null;
+	public boolean isThumbnailReady() {
+		return getThumbnail() != null;
 	}
 
 	public DLNAThumbnailInputStream getThumbnailInputStream() {
-		DLNAThumbnail thumb = getThumb();
+		DLNAThumbnail thumb = getThumbnail();
 		return thumb != null ? new DLNAThumbnailInputStream(thumb) : null;
 	}
 
@@ -834,8 +848,8 @@ public class MediaInfo implements Cloneable {
 			}
 		}
 
-		if (getThumb() != null) {
-			result.append(", ").append(getThumb());
+		if (getThumbnail() != null) {
+			result.append(", ").append(getThumbnail());
 		}
 
 		if (getMimeType() != null) {

--- a/src/main/java/net/pms/media/video/metadata/TvSeriesMetadata.java
+++ b/src/main/java/net/pms/media/video/metadata/TvSeriesMetadata.java
@@ -18,6 +18,7 @@ package net.pms.media.video.metadata;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import net.pms.store.ThumbnailSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +76,16 @@ public class TvSeriesMetadata {
 	private String apiVersion;
 	private String votes;
 	private Long thumbnailId;
+	private ThumbnailSource thumbnailSource = ThumbnailSource.UNKNOWN;
+	private Long tvSeriesId;
+
+	public Long getTvSeriesId() {
+		return tvSeriesId;
+	}
+
+	public void setTvSeriesId(Long value) {
+		tvSeriesId = value;
+	}
 
 	public ApiStringArray getActors() {
 		return actors;
@@ -526,6 +537,18 @@ public class TvSeriesMetadata {
 
 	public void setThumbnailId(Long value) {
 		this.thumbnailId = value;
+	}
+
+	public ThumbnailSource getThumbnailSource() {
+		return thumbnailSource;
+	}
+
+	public void setThumbnailSource(ThumbnailSource value) {
+		this.thumbnailSource = value;
+	}
+
+	public void setThumbnailSource(String value) {
+		this.thumbnailSource = ThumbnailSource.valueOfName(value);
 	}
 
 	public String getVotes() {

--- a/src/main/java/net/pms/media/video/metadata/VideoMetadataLocalized.java
+++ b/src/main/java/net/pms/media/video/metadata/VideoMetadataLocalized.java
@@ -97,4 +97,41 @@ public class VideoMetadataLocalized {
 			jsonObject.addProperty("title", title);
 		}
 	}
+
+	public void localizeMediaVideoMetadata(final MediaVideoMetadata mediaVideoMetadata) {
+		if (StringUtils.isNotBlank(homepage)) {
+			mediaVideoMetadata.setHomepage(homepage);
+		}
+		if (StringUtils.isNotBlank(overview)) {
+			mediaVideoMetadata.setOverview(overview);
+		}
+		if (StringUtils.isNotBlank(poster)) {
+			mediaVideoMetadata.setPoster(poster);
+		}
+		if (StringUtils.isNotBlank(tagline)) {
+			mediaVideoMetadata.setTagline(tagline);
+		}
+		if (StringUtils.isNotBlank(title)) {
+			mediaVideoMetadata.setOriginalTitle(title);
+		}
+	}
+
+	public void localizeTvSeriesMetadata(final TvSeriesMetadata tvSeriesMetadata) {
+		if (StringUtils.isNotBlank(homepage)) {
+			tvSeriesMetadata.setHomepage(homepage);
+		}
+		if (StringUtils.isNotBlank(overview)) {
+			tvSeriesMetadata.setOverview(overview);
+		}
+		if (StringUtils.isNotBlank(poster)) {
+			tvSeriesMetadata.setPoster(poster);
+		}
+		if (StringUtils.isNotBlank(tagline)) {
+			tvSeriesMetadata.setTagline(tagline);
+		}
+		if (StringUtils.isNotBlank(title)) {
+			tvSeriesMetadata.setTitle(title);
+		}
+	}
+
 }

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/DlnaHelper.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/DlnaHelper.java
@@ -65,8 +65,8 @@ public class DlnaHelper {
 		ImageInfo thumbnailImageInf = null;
 		if (resource.getThumbnailImageInfo() != null) {
 			thumbnailImageInf = resource.getThumbnailImageInfo();
-		} else if (mediaInfo != null && mediaInfo.getThumb() != null && mediaInfo.getThumb().getImageInfo() != null) {
-			thumbnailImageInf = mediaInfo.getThumb().getImageInfo();
+		} else if (mediaInfo != null && mediaInfo.getThumbnail() != null && mediaInfo.getThumbnail().getImageInfo() != null) {
+			thumbnailImageInf = mediaInfo.getThumbnail().getImageInfo();
 		}
 		ImageInfo imageInfo = null;
 		if (thumbnailRequest) {

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/StoreResourceHelper.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/StoreResourceHelper.java
@@ -600,8 +600,8 @@ public class StoreResourceHelper {
 		ImageInfo thumbnailImageInf = null;
 		if (resource.getThumbnailImageInfo() != null) {
 			thumbnailImageInf = resource.getThumbnailImageInfo();
-		} else if (mediaInfo != null && mediaInfo.getThumb() != null && mediaInfo.getThumb().getImageInfo() != null) {
-			thumbnailImageInf = mediaInfo.getThumb().getImageInfo();
+		} else if (mediaInfo != null && mediaInfo.getThumbnail() != null && mediaInfo.getThumbnail().getImageInfo() != null) {
+			thumbnailImageInf = mediaInfo.getThumbnail().getImageInfo();
 		}
 
 		// Only include GIF elements if the source is a GIF and it's supported
@@ -736,8 +736,8 @@ public class StoreResourceHelper {
 			ImageInfo imageInfo = null;
 			if (resource.getThumbnailImageInfo() != null) {
 				imageInfo = resource.getThumbnailImageInfo();
-			} else if (mediaInfo != null && mediaInfo.getThumb() != null && mediaInfo.getThumb().getImageInfo() != null) {
-				imageInfo = mediaInfo.getThumb().getImageInfo();
+			} else if (mediaInfo != null && mediaInfo.getThumbnail() != null && mediaInfo.getThumbnail().getImageInfo() != null) {
+				imageInfo = mediaInfo.getThumbnail().getImageInfo();
 			}
 
 			// Only include GIF elements if the source is a GIF and it's

--- a/src/main/java/net/pms/parsers/FFmpegParser.java
+++ b/src/main/java/net/pms/parsers/FFmpegParser.java
@@ -40,6 +40,7 @@ import net.pms.media.audio.MediaAudio;
 import net.pms.media.chapter.MediaChapter;
 import net.pms.media.subtitle.MediaSubtitle;
 import net.pms.media.video.MediaVideo;
+import net.pms.store.ThumbnailSource;
 import net.pms.util.InputFile;
 import net.pms.util.MpegUtil;
 import net.pms.util.ProcessUtil;
@@ -167,10 +168,6 @@ public class FFmpegParser {
 		media.setParsing(false);
 	}
 
-	public static DLNAThumbnail getThumbnail(MediaInfo media, InputFile inputFile) {
-		return getThumbnail(media, inputFile, null);
-	}
-
 	public static DLNAThumbnail getThumbnail(MediaInfo media, InputFile inputFile, Double seekPosition) {
 		/*
 		 * Note: The text output from FFmpeg is used by renderers that do
@@ -184,7 +181,7 @@ public class FFmpegParser {
 		}
 		ArrayList<String> args = new ArrayList<>();
 		args.add(engine);
-		DLNAThumbnail result = null;
+		DLNAThumbnail thumbnail = null;
 		args.add("-ss");
 		double thumbnailSeekPos = seekPosition != null ? seekPosition : CONFIGURATION.getThumbnailSeekPos();
 		thumbnailSeekPos = Math.min(thumbnailSeekPos, media.getDurationInSeconds());
@@ -233,7 +230,10 @@ public class FFmpegParser {
 			byte[] bytes = pw.getOutputByteArray().toByteArray();
 			if (bytes != null && bytes.length > 0) {
 				try {
-					result = DLNAThumbnail.toThumbnail(bytes);
+					thumbnail = DLNAThumbnail.toThumbnail(bytes);
+					if (thumbnail != null) {
+						media.setThumbnailSource(ThumbnailSource.FFMPEG_SEEK);
+					}
 				} catch (IOException e) {
 					LOGGER.debug("Error while decoding thumbnail: " + e.getMessage());
 					LOGGER.trace("", e);
@@ -241,7 +241,7 @@ public class FFmpegParser {
 			}
 		}
 		media.setParsing(false);
-		return result;
+		return thumbnail;
 	}
 
 	/**

--- a/src/main/java/net/pms/parsers/MPlayerParser.java
+++ b/src/main/java/net/pms/parsers/MPlayerParser.java
@@ -40,6 +40,7 @@ import net.pms.media.MediaLang;
 import net.pms.media.audio.MediaAudio;
 import net.pms.media.subtitle.MediaSubtitle;
 import net.pms.media.video.MediaVideo;
+import net.pms.store.ThumbnailSource;
 import net.pms.store.ThumbnailStore;
 import net.pms.util.InputFile;
 import net.pms.util.Iso639;
@@ -200,16 +201,16 @@ public class MPlayerParser {
 			LOGGER.info("Error parsing information from the file: " + file);
 		} else {
 			if (generateThumbnails) {
-				Long thumbId = ThumbnailStore.getId(MPlayerParser.getThumbnail(frameName));
-				media.setThumbId(thumbId);
+				DLNAThumbnail thumbnail = MPlayerParser.getThumbnail(frameName);
+				if (thumbnail != null) {
+					Long thumbId = ThumbnailStore.getId(thumbnail);
+					media.setThumbnailId(thumbId);
+					media.setThumbnailSource(ThumbnailSource.MPLAYER_SEEK);
+				}
 			}
 			parseDvdTitleInfo(media, pw.getOtherResults(), title);
 		}
 		media.setParsing(false);
-	}
-
-	public static DLNAThumbnail getThumbnail(MediaInfo media, InputFile inputFile) {
-		return getThumbnail(media, inputFile, null);
 	}
 
 	public static DLNAThumbnail getThumbnail(MediaInfo media, InputFile inputFile, Double seekPosition) {
@@ -270,7 +271,11 @@ public class MPlayerParser {
 			LOGGER.info("Error parsing information from the file: " + file);
 			return null;
 		}
-		return MPlayerParser.getThumbnail(frameName);
+		DLNAThumbnail thumbnail = MPlayerParser.getThumbnail(frameName);
+		if (thumbnail != null) {
+			media.setThumbnailSource(ThumbnailSource.MPLAYER_SEEK);
+		}
+		return thumbnail;
 	}
 
 	private static DLNAThumbnail getThumbnail(String frameName) {

--- a/src/main/java/net/pms/parsers/MediaInfoParser.java
+++ b/src/main/java/net/pms/parsers/MediaInfoParser.java
@@ -52,6 +52,7 @@ import net.pms.parsers.mediainfo.StreamKind;
 import net.pms.parsers.mediainfo.StreamMenu;
 import net.pms.parsers.mediainfo.StreamSubtitle;
 import net.pms.parsers.mediainfo.StreamVideo;
+import net.pms.store.ThumbnailSource;
 import net.pms.store.ThumbnailStore;
 import net.pms.util.FileUtil;
 import net.pms.util.Iso639;
@@ -171,15 +172,19 @@ public class MediaInfoParser {
 			value = StreamContainer.getCoverData(MI, 0);
 			if (!value.isEmpty()) {
 				try {
-					Long thumbId = ThumbnailStore.getId(DLNAThumbnail.toThumbnail(
+					DLNAThumbnail thumbnail = DLNAThumbnail.toThumbnail(
 						new Base64().decode(value.getBytes(StandardCharsets.US_ASCII)),
 						640,
 						480,
 						ScaleType.MAX,
 						ImageFormat.SOURCE,
 						false
-					));
-					media.setThumbId(thumbId);
+					);
+					if (thumbnail != null) {
+						Long thumbId = ThumbnailStore.getId(thumbnail);
+						media.setThumbnailId(thumbId);
+						media.setThumbnailSource(ThumbnailSource.EMBEDDED);
+					}
 				} catch (EOFException e) {
 					LOGGER.debug(
 						"Error reading \"{}\" thumbnail from MediaInfo: Unexpected end of stream, probably corrupt or read error.",

--- a/src/main/java/net/pms/parsers/RealAudioParser.java
+++ b/src/main/java/net/pms/parsers/RealAudioParser.java
@@ -34,6 +34,7 @@ import net.pms.image.ImagesUtil;
 import net.pms.media.MediaInfo;
 import net.pms.media.audio.MediaAudio;
 import net.pms.media.audio.metadata.MediaAudioMetadata;
+import net.pms.store.ThumbnailSource;
 import net.pms.store.ThumbnailStore;
 import net.pms.util.CoverSupplier;
 import net.pms.util.InputFile;
@@ -266,15 +267,19 @@ public class RealAudioParser {
 				tag.setArtist(audioMetadata.getArtist());
 			}
 			try {
-				Long thumbId = ThumbnailStore.getId(DLNAThumbnail.toThumbnail(
+				DLNAThumbnail thumbnail = DLNAThumbnail.toThumbnail(
 					CoverUtil.get().getThumbnail(tag),
 					640,
 					480,
 					ImagesUtil.ScaleType.MAX,
 					ImageFormat.SOURCE,
 					false
-				));
-				mediaInfo.setThumbId(thumbId);
+				);
+				if (thumbnail != null) {
+					Long thumbId = ThumbnailStore.getId(thumbnail);
+					mediaInfo.setThumbnailId(thumbId);
+					mediaInfo.setThumbnailSource(ThumbnailSource.MUSICBRAINZ);
+				}
 			} catch (IOException e) {
 				LOGGER.error(
 					"An error occurred while generating thumbnail for RealAudio source: [\"{}\", \"{}\"]",

--- a/src/main/java/net/pms/store/MediaInfoStore.java
+++ b/src/main/java/net/pms/store/MediaInfoStore.java
@@ -176,7 +176,7 @@ public class MediaInfoStore {
 
 		// If the in-memory mediaInfo has not already been populated with filename metadata, we attempt it
 		try {
-			if (!mediaInfo.hasVideoMetadata()) {
+			if (mediaInfo.isVideo() && !mediaInfo.hasVideoMetadata()) {
 				MediaVideoMetadata videoMetadata = new MediaVideoMetadata();
 				String[] metadataFromFilename = FileUtil.getFileNameMetadata(file.getName(), absolutePath);
 				String titleFromFilename = metadataFromFilename[0];

--- a/src/main/java/net/pms/store/MediaStatusStore.java
+++ b/src/main/java/net/pms/store/MediaStatusStore.java
@@ -21,8 +21,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import net.pms.Messages;
-import net.pms.PMS;
-import net.pms.configuration.UmsConfiguration;
 import net.pms.database.MediaDatabase;
 import net.pms.database.MediaTableFiles;
 import net.pms.database.MediaTableFilesStatus;
@@ -31,7 +29,6 @@ import net.pms.media.MediaStatus;
 
 public class MediaStatusStore {
 
-	private static final UmsConfiguration CONFIGURATION = PMS.getConfiguration();
 	private static final Map<Integer, Map<String, MediaStatus>> STORE = new HashMap<>();
 
 	private MediaStatusStore() {

--- a/src/main/java/net/pms/store/StoreContainer.java
+++ b/src/main/java/net/pms/store/StoreContainer.java
@@ -255,7 +255,8 @@ public class StoreContainer extends StoreResource {
 					}
 
 					if (resumeRes != null && resumeRes.getMediaInfo() != null) {
-						resumeRes.getMediaInfo().setThumbId(null);
+						resumeRes.getMediaInfo().setThumbnailId(null);
+						resumeRes.getMediaInfo().setThumbnailSource(ThumbnailSource.UNKNOWN);
 						resumeRes.getMediaInfo().setMimeType(HTTPResource.VIDEO_TRANSCODE);
 					}
 

--- a/src/main/java/net/pms/store/ThumbnailSource.java
+++ b/src/main/java/net/pms/store/ThumbnailSource.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package net.pms.store;
+
+public enum ThumbnailSource {
+
+	UNKNOWN,
+	MPLAYER_SEEK,
+	FFMPEG_SEEK,
+	TMDB,
+	TMDB_LOC,
+	MUSICBRAINZ,
+	EMBEDDED;
+
+	public static ThumbnailSource valueOfName(String value) {
+		try {
+			return valueOf(ThumbnailSource.class, value);
+		} catch (IllegalArgumentException | NullPointerException e) {
+			//bad string
+		}
+		return UNKNOWN;
+	}
+
+}

--- a/src/main/java/net/pms/store/ThumbnailStore.java
+++ b/src/main/java/net/pms/store/ThumbnailStore.java
@@ -59,7 +59,7 @@ public class ThumbnailStore {
 		}
 	}
 
-	public static Long getId(DLNAThumbnail thumbnail, Integer fileId) {
+	public static Long getId(DLNAThumbnail thumbnail, Integer fileId, ThumbnailSource thumbnailSource) {
 		if (thumbnail == null) {
 			return null;
 		}
@@ -73,7 +73,7 @@ public class ThumbnailStore {
 					if (id != null) {
 						STORE.put(id, new WeakReference<>(thumbnail));
 						if (fileId != null) {
-							MediaTableFiles.updateThumbnailId(connection, fileId, id);
+							MediaTableFiles.updateThumbnailId(connection, fileId, id, thumbnailSource.toString());
 						}
 					}
 				}
@@ -84,7 +84,7 @@ public class ThumbnailStore {
 		}
 	}
 
-	public static Long getIdForTvSerie(DLNAThumbnail thumbnail, long tvSeriesId) {
+	public static Long getIdForTvSerie(DLNAThumbnail thumbnail, long tvSeriesId, ThumbnailSource thumbnailSource) {
 		if (thumbnail == null) {
 			return null;
 		}
@@ -96,7 +96,7 @@ public class ThumbnailStore {
 				id = MediaTableThumbnails.setThumbnail(connection, thumbnail, false);
 				if (id != null) {
 					STORE.put(id, new WeakReference<>(thumbnail));
-					MediaTableTVSeries.updateThumbnailId(connection, tvSeriesId, id);
+					MediaTableTVSeries.updateThumbnailId(connection, tvSeriesId, id, thumbnailSource.toString());
 				}
 			}
 		} finally {
@@ -145,6 +145,24 @@ public class ThumbnailStore {
 	public static DLNAThumbnailInputStream getThumbnailInputStream(Long id) {
 		DLNAThumbnail thumbnail = getThumbnail(id);
 		return thumbnail != null ? new DLNAThumbnailInputStream(thumbnail) : null;
+	}
+
+	public static void resetLanguage() {
+		synchronized (STORE) {
+			STORE.clear();
+			tempId = Long.MAX_VALUE;
+			Connection connection = null;
+			try {
+				connection = MediaDatabase.getConnectionIfAvailable();
+				if (connection != null) {
+					MediaTableFiles.resetLocalizedThumbnail(connection);
+					MediaTableTVSeries.resetLocalizedThumbnail(connection);
+					MediaTableThumbnails.cleanup(connection);
+				}
+			} finally {
+				MediaDatabase.close(connection);
+			}
+		}
 	}
 
 }

--- a/src/main/java/net/pms/store/container/RealFolder.java
+++ b/src/main/java/net/pms/store/container/RealFolder.java
@@ -74,7 +74,7 @@ public class RealFolder extends VirtualFolder implements SystemFileResource {
 		try {
 			if (cachedThumbnail != null) {
 				result = DLNAThumbnailInputStream.toThumbnailInputStream(new FileInputStream(cachedThumbnail));
-			} else if (getMediaInfo() != null && getMediaInfo().getThumb() != null) {
+			} else if (getMediaInfo() != null && getMediaInfo().getThumbnail() != null) {
 				result = getMediaInfo().getThumbnailInputStream();
 			}
 		} catch (IOException e) {

--- a/src/main/java/net/pms/store/item/DVDISOTitle.java
+++ b/src/main/java/net/pms/store/item/DVDISOTitle.java
@@ -138,7 +138,7 @@ public class DVDISOTitle extends StoreItem {
 
 		if (cachedThumbnail != null) {
 			return DLNAThumbnailInputStream.toThumbnailInputStream(new FileInputStream(cachedThumbnail));
-		} else if (getMediaInfo() != null && getMediaInfo().getThumb() != null) {
+		} else if (getMediaInfo() != null && getMediaInfo().getThumbnail() != null) {
 			return getMediaInfo().getThumbnailInputStream();
 		} else {
 			return getGenericThumbnailInputStream(null);

--- a/src/main/java/net/pms/store/item/RarredEntry.java
+++ b/src/main/java/net/pms/store/item/RarredEntry.java
@@ -153,7 +153,7 @@ public class RarredEntry extends StoreItem implements IPushOutput {
 
 	@Override
 	public DLNAThumbnailInputStream getThumbnailInputStream() throws IOException {
-		if (getMediaInfo() != null && getMediaInfo().getThumb() != null) {
+		if (getMediaInfo() != null && getMediaInfo().getThumbnail() != null) {
 			return getMediaInfo().getThumbnailInputStream();
 		} else {
 			return super.getThumbnailInputStream();

--- a/src/main/java/net/pms/store/item/RealFile.java
+++ b/src/main/java/net/pms/store/item/RealFile.java
@@ -242,12 +242,12 @@ public class RealFile extends StoreItem {
 			}
 		}
 
-		boolean hasAlreadyEmbeddedCoverArt = getType() == Format.AUDIO && getMediaInfo() != null && getMediaInfo().getThumb() != null;
+		boolean hasAlreadyEmbeddedCoverArt = getType() == Format.AUDIO && getMediaInfo() != null && getMediaInfo().getThumbnail() != null;
 		DLNAThumbnailInputStream result = null;
 		try {
 			if (cachedThumbnail != null && !hasAlreadyEmbeddedCoverArt) {
 				result = DLNAThumbnailInputStream.toThumbnailInputStream(new FileInputStream(cachedThumbnail));
-			} else if (getMediaInfo() != null && getMediaInfo().getThumb() != null) {
+			} else if (getMediaInfo() != null && getMediaInfo().getThumbnail() != null) {
 				result = getMediaInfo().getThumbnailInputStream();
 			}
 		} catch (IOException e) {

--- a/src/main/java/net/pms/store/item/SevenZipEntry.java
+++ b/src/main/java/net/pms/store/item/SevenZipEntry.java
@@ -171,7 +171,7 @@ public class SevenZipEntry extends StoreItem implements IPushOutput {
 
 	@Override
 	public DLNAThumbnailInputStream getThumbnailInputStream() throws IOException {
-		if (getMediaInfo() != null && getMediaInfo().getThumb() != null) {
+		if (getMediaInfo() != null && getMediaInfo().getThumbnail() != null) {
 			return getMediaInfo().getThumbnailInputStream();
 		} else {
 			return super.getThumbnailInputStream();

--- a/src/main/java/net/pms/store/item/ZippedEntry.java
+++ b/src/main/java/net/pms/store/item/ZippedEntry.java
@@ -145,7 +145,7 @@ public class ZippedEntry extends StoreItem implements IPushOutput {
 
 	@Override
 	public DLNAThumbnailInputStream getThumbnailInputStream() throws IOException {
-		if (getMediaInfo() != null && getMediaInfo().getThumb() != null) {
+		if (getMediaInfo() != null && getMediaInfo().getThumbnail() != null) {
 			return getMediaInfo().getThumbnailInputStream();
 		} else {
 			return super.getThumbnailInputStream();


### PR DESCRIPTION
Save thumbnail source.
Localize video metadata for server language (non web gui).
Localize default video thumbnails for server language (non web gui). Store thumbnail source.
fix duplicate background api request.

It will check for thumbnail loc on first mediainfo request (may delay get).
As v14 reset all mediaInfo, it should not be a problem.