### PR TITLE
search response issues / DIDL envelope / XML unescaping

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -168,7 +168,8 @@ public class SearchRequestHandler {
 			dlnaItems.append(uf.getDidlString(renderer));
 		}
 
-		return new BrowseResult(dlnaItems.toString(), numberReturned, totalMatches, updateID.getAndIncrement());
+		StringBuilder response = buildEnvelope(numberReturned, totalMatches, updateID.getAndIncrement(), dlnaItems);
+		return new BrowseResult(response.toString(), numberReturned, totalMatches, updateID.getAndIncrement());
 	}
 
 	/**

--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jupnp.support.model.BrowseResult;
 import org.jupnp.support.model.SortCriterion;
@@ -168,8 +169,9 @@ public class SearchRequestHandler {
 			dlnaItems.append(uf.getDidlString(renderer));
 		}
 
+		// Info: The engine using this method seems not to unescape to proper XML
 		StringBuilder response = buildEnvelope(numberReturned, totalMatches, updateID.getAndIncrement(), dlnaItems);
-		return new BrowseResult(response.toString(), numberReturned, totalMatches, updateID.getAndIncrement());
+		return new BrowseResult(StringEscapeUtils.unescapeXml(response.toString()), numberReturned, totalMatches, updateID.getAndIncrement());
 	}
 
 	/**


### PR DESCRIPTION
With commit 6c77075  a new search method was introduced returning a `BrowseResult` object, I believe for an alternative http engine. I noticed two things:
- the DIDL envelope was missing in the `result`. 
- (maybe, not checked) the new engine doesn't unescape the `result` to proper xml. At least the escaped XML is received by a client.
I fixed both issues for getting the search implementation to work again