### PR TITLE
fix: an incorrect property is used in migrating `ip_filter`

### DIFF
--- a/src/main/java/net/pms/configuration/UmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/UmsConfiguration.java
@@ -740,7 +740,7 @@ public class UmsConfiguration extends BaseConfiguration {
 		//keep ip_filter if it was presents
 		String oldIpFilter = getString("ip_filter", null);
 		if (StringUtils.isNotBlank(oldIpFilter)) {
-			configuration.setProperty(KEY_BLOCK_RENDERERS_BY_DEFAULT, true);
+			configuration.setProperty(KEY_BLOCK_NETWORK_DEVICES_BY_DEFAULT, true);
 			configuration.setProperty(KEY_NETWORK_DEVICES_FILTER, oldIpFilter);
 			configuration.clearProperty("ip_filter");
 		}


### PR DESCRIPTION
## Description
Fix the incorrect property that is used in the process of migrating the old configuration `ip_filter`.

## Motivation
While the original code sets a property called `KEY_BLOCK_RENDERERS_BY_DEFAULT` to `true`, considering that `KEY_NETWORK_DEVICES_FILTER` corresponds with `KEY_BLOCK_NETWORK_DEVICES_BY_DEFAULT`, the configuration that should be enabled is `KEY_BLOCK_NETWORK_DEVICES_BY_DEFAULT`, not `KEY_BLOCK_RENDERERS_BY_DEFAULT`.
