### PR TITLE
fix: RequestV2 missing TextContent (body)

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/nettyserver/RequestHandlerV2.java
+++ b/src/main/java/net/pms/network/mediaserver/nettyserver/RequestHandlerV2.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map.Entry;
@@ -92,7 +93,9 @@ public class RequestHandlerV2 extends SimpleChannelUpstreamHandler {
 
 		HttpMethod method = nettyRequest.getMethod();
 		String uri = getUri(nettyRequest.getUri());
+		String body = nettyRequest.getContent().toString(Charset.forName("UTF-8"));
 		request = new RequestV2(method, uri);
+		request.setTextContent(body);
 
 		if (uri.startsWith("api/")) {
 			writeResponse(ctx, event, request, ia);


### PR DESCRIPTION
Some API request need the POST body, that wasn't set in RequestV2.