### PR TITLE
Fix various documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It is powered by [FFmpeg][27], [MediaInfo][28], [OpenSubtitles][25], [Crowdin][2
 * [Website][1]
 * [Forum][9]
 * [Source code][10]
-* [Offical Releases][11]
+* [Official Releases][11]
 * [Issue tracker][12]
 * [Knowledge Base][13]
 * [Wiki][14]

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -347,7 +347,7 @@ public class PMS {
 		dbgPack = new DbgPacker();
 		tfm = new TempFileMgr();
 
-		// Start this here to let the converison work
+		// Start this here to let the conversion work
 		tfm.schedule();
 
 	}
@@ -1256,7 +1256,7 @@ public class PMS {
 		}
 
 		// check first and last, update since taskkill changed
-		// also check 2nd last since we migh have ", POSSIBLY UNSTABLE" in there
+		// also check 2nd last since we might have ", POSSIBLY UNSTABLE" in there
 		boolean ums = tmp[tmp.length - 1].contains("universal media server") ||
 						tmp[tmp.length - 2].contains("universal media server");
 		return tmp[0].equals("javaw.exe") && ums;

--- a/src/main/java/net/pms/configuration/ConfigurationReader.java
+++ b/src/main/java/net/pms/configuration/ConfigurationReader.java
@@ -82,7 +82,7 @@ public class ConfigurationReader {
 		if (ObjectUtils.notEqual(oldValue, value)) {
 			logMap.put(key, value);
 
-			// Do an independant lookup to determine if the value's source was the device conf,
+			// Do an independent lookup to determine if the value's source was the device conf,
 			// and if so log it as a device override by explicitly identifying the source.
 			String src = (dConf != null && value != null && value.equals(dConf.getProperty(key))) ? dTag : "";
 			if (initialised) {

--- a/src/main/java/net/pms/configuration/UmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/UmsConfiguration.java
@@ -571,7 +571,7 @@ public class UmsConfiguration extends BaseConfiguration {
 	);
 
 	/**
-	 * The set of keys defining when the renderers has to rebuid their root folder
+	 * The set of keys defining when the renderers has to rebuild their root folder
 	 * due to a configuration change.
 	 */
 	public static final Set<String> NEED_RENDERERS_ROOT_RELOAD_FLAGS = Set.of(
@@ -2316,7 +2316,7 @@ public class UmsConfiguration extends BaseConfiguration {
 	 * Set to true if MEncoder should use the deinterlace filter, false
 	 * otherwise.
 	 *
-	 * @param value Set ot true if the deinterlace filter should be used.
+	 * @param value Set to true if the deinterlace filter should be used.
 	 */
 	public void setMencoderYadif(boolean value) {
 		configuration.setProperty(KEY_MENCODER_YADIF, value);

--- a/src/main/java/net/pms/configuration/old/MapFileConfiguration.java
+++ b/src/main/java/net/pms/configuration/old/MapFileConfiguration.java
@@ -84,7 +84,7 @@ public class MapFileConfiguration {
 			try {
 				conf = FileUtils.readFileToString(file, StandardCharsets.US_ASCII);
 			} catch (IOException e) {
-				LOGGER.warn("Unexpected exeption while reading \"{}\": {}", file.getAbsolutePath(), e.getMessage());
+				LOGGER.warn("Unexpected exception while reading \"{}\": {}", file.getAbsolutePath(), e.getMessage());
 				LOGGER.debug("", e);
 				return null;
 			}

--- a/src/main/java/net/pms/database/DatabaseEmbedded.java
+++ b/src/main/java/net/pms/database/DatabaseEmbedded.java
@@ -285,7 +285,7 @@ public class DatabaseEmbedded {
 						} catch (IOException ex) {
 						}
 					} else {
-						LOGGER.info("Database updated succefully");
+						LOGGER.info("Database updated successfully");
 					}
 				}
 			}

--- a/src/main/java/net/pms/database/DatabaseHelper.java
+++ b/src/main/java/net/pms/database/DatabaseHelper.java
@@ -338,7 +338,7 @@ public abstract class DatabaseHelper {
 	}
 
 	/**
-	 * Drops (deletes) the named table and its constaints. Use with caution, there is no undo.
+	 * Drops (deletes) the named table and its constraints. Use with caution, there is no undo.
 	 *
 	 * @param connection the {@link Connection} to use
 	 * @param tableName the name of the table to delete

--- a/src/main/java/net/pms/database/MediaDatabase.java
+++ b/src/main/java/net/pms/database/MediaDatabase.java
@@ -32,7 +32,7 @@ public class MediaDatabase extends Database {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MediaDatabase.class);
 	public static final String DATABASE_NAME = "medias";
 	/**
-	 * Pointer to the instanciated MediaDatabase.
+	 * Pointer to the instantiated MediaDatabase.
 	 */
 	private static MediaDatabase instance = null;
 	private static boolean tablesChecked = false;
@@ -213,7 +213,7 @@ public class MediaDatabase extends Database {
 	/**
 	 * Check the MediaDatabase instance availability.
 	 *
-	 * @return {@code true } if the MediaDatabase is instanciated and opened
+	 * @return {@code true } if the MediaDatabase is instantiated and opened
 	 * , <code>false</code> otherwise
 	 */
 	public static boolean isAvailable() {

--- a/src/main/java/net/pms/database/MediaTableFailedLookups.java
+++ b/src/main/java/net/pms/database/MediaTableFailedLookups.java
@@ -159,7 +159,7 @@ public final class MediaTableFailedLookups extends MediaTable {
 	}
 
 	/**
-	 * @param connection the db conncection
+	 * @param connection the db connection
 	 * @param fullPathToFile
 	 * @param isVideo whether this is a video, otherwise it's a TV series
 	 * @return whether a lookup for this file has failed recently

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -455,7 +455,7 @@ public class MediaTableFiles extends MediaTable {
 				MediaDatabase.dropTable(connection, TABLE_NAME);
 				createTable(connection);
 				MediaTableTablesVersions.setTableVersion(connection, TABLE_NAME, TABLE_VERSION);
-				//put back constaints
+				//put back constraints
 				executeUpdate(connection, ALTER_TABLE + IF_EXISTS + MediaTableAudiotracks.TABLE_NAME + ADD + CONSTRAINT + IF_NOT_EXISTS + MediaTableAudiotracks.TABLE_NAME + CONSTRAINT_SEPARATOR + MediaTableAudiotracks.COL_FILEID + FK_MARKER + FOREIGN_KEY + "(" + MediaTableAudiotracks.COL_FILEID + ")" + REFERENCES + TABLE_NAME + "(" + COL_ID + ")" + ON_DELETE_CASCADE);
 				executeUpdate(connection, ALTER_TABLE + IF_EXISTS + MediaTableSubtracks.TABLE_NAME + ADD + CONSTRAINT + IF_NOT_EXISTS + MediaTableSubtracks.TABLE_NAME + CONSTRAINT_SEPARATOR + MediaTableSubtracks.COL_FILEID + FK_MARKER + FOREIGN_KEY + "(" + MediaTableSubtracks.COL_FILEID + ")" + REFERENCES + TABLE_NAME + "(" + COL_ID + ")" + ON_DELETE_CASCADE);
 				executeUpdate(connection, ALTER_TABLE + IF_EXISTS + MediaTableChapters.TABLE_NAME + ADD + CONSTRAINT + IF_NOT_EXISTS + MediaTableChapters.TABLE_NAME + CONSTRAINT_SEPARATOR + MediaTableChapters.COL_FILEID + FK_MARKER + FOREIGN_KEY + "(" + MediaTableChapters.COL_FILEID + ")" + REFERENCES + TABLE_NAME + "(" + COL_ID + ")" + ON_DELETE_CASCADE);

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -884,7 +884,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			/*
 			 * Transcode if: 1) transcoding is forced by configuration, or 2)
 			 * transcoding is not prevented by configuration and is needed due
-			 * to subtitles or some other renderer incompatbility
+			 * to subtitles or some other renderer incompatibility
 			 */
 			if (forceTranscode || (isIncompatible && !isSkipTranscode())) {
 				if (parserV2) {
@@ -2095,7 +2095,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 						}
 					}
 				} else if (media != null && mime.equals(MPEGTS_TYPEMIME)) {
-					// patters - on Sony BDP m2ts clips aren't listed without this
+					// patterns - on Sony BDP m2ts clips aren't listed without this
 					if ((engine == null && media.isH264()) || (engine != null && renderer.isTranscodeToH264())) {
 						dlnaOrgPnFlags = "DLNA.ORG_PN=" + getMpegTsH264OrgPN(localizationValue, media, renderer, engine == null);
 					} else if ((engine == null && media.isMpeg2()) || (engine != null && renderer.isTranscodeToMPEG2())) {
@@ -4529,7 +4529,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	/**
 	 * Set to true if transcoding should be skipped for this resource.
 	 *
-	 * @param skipTranscode Set to true if trancoding should be skipped, false
+	 * @param skipTranscode Set to true if transcoding should be skipped, false
 	 *            otherwise.
 	 * @since 1.50
 	 */

--- a/src/main/java/net/pms/dlna/DVDISOTitle.java
+++ b/src/main/java/net/pms/dlna/DVDISOTitle.java
@@ -322,7 +322,7 @@ public class DVDISOTitle extends DLNAResource {
 	// Ditlew
 	@Override
 	public long length(Renderer renderer) {
-		// WDTV Live at least, needs a realistic size for stop/resume to works proberly. 2030879 = ((15000 + 256) * 1024 / 8 * 1.04) : 1.04 = overhead
+		// WDTV Live at least, needs a realistic size for stop/resume to work properly. 2030879 = ((15000 + 256) * 1024 / 8 * 1.04) : 1.04 = overhead
 		int cbrVideoBitrate = getDefaultRenderer().getCBRVideoBitrate();
 		return (cbrVideoBitrate > 0) ? (long) (((cbrVideoBitrate + 256) * 1024 / (double) 8 * 1.04) * getMedia().getDurationInSeconds()) : length();
 	}

--- a/src/main/java/net/pms/dlna/FileSearch.java
+++ b/src/main/java/net/pms/dlna/FileSearch.java
@@ -38,7 +38,7 @@ public class FileSearch implements SearchObj {
 		for (RealFile res : folders) {
 			String name = res.getName().toLowerCase();
 			if (name.contains(searchString)) {
-				// easy case file contians search string, add it and be gone
+				// easy case file contains search string, add it and be gone
 				searcher.addChild(res.clone());
 				continue;
 			}

--- a/src/main/java/net/pms/encoders/HlsHelper.java
+++ b/src/main/java/net/pms/encoders/HlsHelper.java
@@ -131,7 +131,7 @@ public class HlsHelper {
 			List<HlsAudioConfiguration> audioGroups = new ArrayList<>();
 			MediaAudio mediaAudioDefault = null;
 			if (!mediaVideo.getAudioTracksList().isEmpty()) {
-				//try to find the prefered language
+				//try to find the preferred language
 				mediaAudioDefault = null;
 				StringTokenizer st = new StringTokenizer(CONFIGURATION.getAudioLanguages(), ",");
 				while (st.hasMoreTokens() && mediaAudioDefault == null) {

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -1036,7 +1036,7 @@ public class MEncoderVideo extends Engine {
 			// Use ASS flag (and therefore ASS font styles) for all subtitled files except vobsub, PGS (Blu-ray Disc) and DVD
 			boolean applyAssStyling = params.getSid().getType() != SubtitleType.VOBSUB &&
 				params.getSid().getType() != SubtitleType.PGS &&
-				configuration.isMencoderAss() &&   // GUI: enable subtitles formating
+				configuration.isMencoderAss() &&   // GUI: enable subtitles formatting
 				!foundNoassParam &&                // GUI: codec specific options
 				!isDVD;
 

--- a/src/main/java/net/pms/image/PNGInfo.java
+++ b/src/main/java/net/pms/image/PNGInfo.java
@@ -241,7 +241,7 @@ public class PNGInfo extends ImageInfo {
 					((PNGParseInfo) parsedInfo).colorType ==  PngColorType.TRUE_COLOR_WITH_ALPHA
 				) {
 					throw new ParseException(String.format(
-						"PNG parsing failed with illegal combination of %s color type and tRNS transparancy chunk",
+						"PNG parsing failed with illegal combination of %s color type and tRNS transparency chunk",
 						((PNGParseInfo) parsedInfo).colorType
 					));
 				}

--- a/src/main/java/net/pms/logging/UmsCompressor.java
+++ b/src/main/java/net/pms/logging/UmsCompressor.java
@@ -137,7 +137,7 @@ public class UmsCompressor extends Compressor {
 			}
 			//add askef file
 			try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(nameOfFile2zip))) {
-				//try to keep the extention
+				//try to keep the extension
 				String innerEntryExt = "";
 				if (innerEntryName.contains(".")) {
 					int dotIndex = innerEntryName.lastIndexOf(".");
@@ -169,7 +169,7 @@ public class UmsCompressor extends Compressor {
 	// http://jira.qos.ch/browse/LBCORE-98
 	// The name of the compressed file as nested within the zip archive
 	//
-	// Case 1: RawFile = null, Patern = foo-%d.zip
+	// Case 1: RawFile = null, Pattern = foo-%d.zip
 	// nestedFilename = foo-${current-date}
 	//
 	// Case 2: RawFile = hello.txt, Pattern = = foo-%d.zip

--- a/src/main/java/net/pms/network/HTTPResource.java
+++ b/src/main/java/net/pms/network/HTTPResource.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implements any item that can be transfered through the HTTP pipes.
+ * Implements any item that can be transferred through the HTTP pipes.
  * In the PMS case, this item represents media files.
  * @see DLNAResource
  */

--- a/src/main/java/net/pms/network/httpserverservletcontainer/HttpServerServletContainer.java
+++ b/src/main/java/net/pms/network/httpserverservletcontainer/HttpServerServletContainer.java
@@ -71,7 +71,7 @@ public class HttpServerServletContainer {
 					httpContext.setHandler(handler);
 				}
 			} catch (NoSuchMethodException | InstantiationException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-				throw new ServletException("Servlet failed to instanciate.", ex);
+				throw new ServletException("Servlet failed to instantiate.", ex);
 			}
 		} else {
 			throw new ServletException("Servlet does not include any pattern.");

--- a/src/main/java/net/pms/network/mediaserver/handlers/api/starrating/StarRating.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/api/starrating/StarRating.java
@@ -292,7 +292,7 @@ public class StarRating implements ApiResponseHandler {
 		} else if (tag instanceof AbstractID3v2Tag || tag instanceof ID3v11Tag) {
 			num = convertStarsToID3(stars);
 		} else {
-			// Dont't know ... maybe we use vorbis tags by default
+			// Don't know ... maybe we use vorbis tags by default
 			num = convertStarsToVorbis(stars);
 		}
 
@@ -345,7 +345,7 @@ public class StarRating implements ApiResponseHandler {
 				} else if (tag instanceof AbstractID3v2Tag || tag instanceof ID3v11Tag) {
 					return convertID3ToStars(num);
 				} else {
-					// Dont't know ... maybe we use vorbis tags by default
+					// Don't know ... maybe we use vorbis tags by default
 					return convertVorbisToStars(num);
 				}
 			}

--- a/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/javahttpserver/RequestHandler.java
@@ -897,7 +897,7 @@ public class RequestHandler implements HttpHandler {
 		SamsungBookmark payload = getPayload(SamsungBookmark.class, requestBody);
 		if (payload.getPosSecond() == 0) {
 			// Sometimes when Samsung device is starting to play the video
-			// it sends X_SetBookmark message immediatelly with the position=0.
+			// it sends X_SetBookmark message immediately with the position=0.
 			// No need to update database in such case.
 			LOGGER.debug("Skipping \"set bookmark\". Position=0");
 		} else {

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
@@ -601,7 +601,7 @@ public class UmsContentDirectoryService {
 
 		if (posSecond == 0) {
 			// Sometimes when Samsung device is starting to play the video
-			// it sends X_SetBookmark message immediatelly with the position=0.
+			// it sends X_SetBookmark message immediately with the position=0.
 			// No need to update database in such case.
 			LOGGER.debug("Skipping \"set bookmark\". Position=0");
 		} else {

--- a/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/JdkHttpServerUpnpStream.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/JdkHttpServerUpnpStream.java
@@ -158,7 +158,7 @@ public class JdkHttpServerUpnpStream extends UpnpStream {
 			// TODO: We should only send an error if the problem was on our side
 			// You don't have to catch Throwable unless, like we do here in unit tests,
 			// you might run into Errors as well (assertions).
-			LOGGER.trace("Exception occured during UPnP stream processing: {}", t);
+			LOGGER.trace("Exception occurred during UPnP stream processing: {}", t);
 			if (LOGGER.isTraceEnabled()) {
 				LOGGER.trace("Cause: {}", Exceptions.unwrap(t), Exceptions.unwrap(t));
 			}

--- a/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/NettyUpnpStream.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/NettyUpnpStream.java
@@ -202,7 +202,7 @@ public class NettyUpnpStream extends UpnpStream {
 			// TODO: We should only send an error if the problem was on our side
 			// You don't have to catch Throwable unless, like we do here in unit tests,
 			// you might run into Errors as well (assertions).
-			LOGGER.debug("Exception occured during UPnP stream processing: {}", t);
+			LOGGER.debug("Exception occurred during UPnP stream processing: {}", t);
 			if (LOGGER.isTraceEnabled()) {
 				LOGGER.trace("Cause: {}", Exceptions.unwrap(t));
 			}

--- a/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/UmsDatagramProcessor.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/UmsDatagramProcessor.java
@@ -48,7 +48,7 @@ public class UmsDatagramProcessor extends DatagramProcessorImpl {
 	private static final String SERVER_HTTP_TOKEN = new ServerClientTokens("UMS", PMS.getVersion()).getHttpToken();
 
 	/**
-	 * Overrided as JUPnP logger show null char from the datagram data buffer.
+	 * Overridden as JUPnP logger show null char from the datagram data buffer.
 	 * Check on JUPnP update if it's corrected, then remove the overriding method.
 	 * @param receivedOnAddress
 	 * @param datagram
@@ -84,7 +84,7 @@ public class UmsDatagramProcessor extends DatagramProcessorImpl {
 	}
 
 	/**
-	 * Overrided as there is no simple way to change the product/version for datagrams message.
+	 * Overridden as there is no simple way to change the product/version for datagrams message.
 	 *
 	 * @param message
 	 * @return

--- a/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
+++ b/src/main/java/net/pms/network/mediaserver/nettyserver/RequestV2.java
@@ -1264,7 +1264,7 @@ public class RequestV2 extends HTTPResource {
 		SamsungBookmark payload = this.getPayload(SamsungBookmark.class);
 		if (payload.getPosSecond() == 0) {
 			// Sometimes when Samsung device is starting to play the video
-			// it sends X_SetBookmark message immediatelly with the position=0.
+			// it sends X_SetBookmark message immediately with the position=0.
 			// No need to update database in such case.
 			LOGGER.debug("Skipping \"set bookmark\". Position=0");
 		} else {

--- a/src/main/java/net/pms/network/webguiserver/servlets/PlayerApiServlet.java
+++ b/src/main/java/net/pms/network/webguiserver/servlets/PlayerApiServlet.java
@@ -767,7 +767,7 @@ public class PlayerApiServlet extends GuiHttpServlet {
 			res = renderer.getRootFolder().getDLNAResources(id, false, 0, 0, renderer);
 			if (res.size() != 1) {
 				// another error
-				LOGGER.debug("media unkonwn");
+				LOGGER.debug("media unknown");
 				return false;
 			}
 			DLNAResource dlna = res.get(0);
@@ -821,7 +821,7 @@ public class PlayerApiServlet extends GuiHttpServlet {
 			res = renderer.getRootFolder().getDLNAResources(id, false, 0, 0, renderer);
 			if (res.size() != 1) {
 				// another error
-				LOGGER.debug("media unkonwn");
+				LOGGER.debug("media unknown");
 				return false;
 			}
 			DLNAResource dlna = res.get(0);
@@ -852,7 +852,7 @@ public class PlayerApiServlet extends GuiHttpServlet {
 			res = renderer.getRootFolder().getDLNAResources(id, false, 0, 0, renderer);
 			if (res.size() != 1) {
 				// another error
-				LOGGER.debug("media unkonwn");
+				LOGGER.debug("media unknown");
 				return false;
 			}
 			DLNAResource dlna = res.get(0);
@@ -936,7 +936,7 @@ public class PlayerApiServlet extends GuiHttpServlet {
 		DLNAResource resource = renderer.getRootFolder().getDLNAResource(resourceId, renderer);
 		if (resource == null) {
 			// another error
-			LOGGER.debug("media unkonwn");
+			LOGGER.debug("media unknown");
 			return false;
 		}
 		MediaSubtitle sid = null;

--- a/src/main/java/net/pms/newgui/GuiUtil.java
+++ b/src/main/java/net/pms/newgui/GuiUtil.java
@@ -285,7 +285,7 @@ public final class GuiUtil {
 		}
 	}
 
-	// A progressbar ui with labled subregions, a progress-sensitive main label, and tickmarks
+	// A progressbar ui with labeled subregions, a progress-sensitive main label, and tickmarks
 	public static class SegmentedProgressBarUI extends javax.swing.plaf.basic.BasicProgressBarUI {
 		Color fg;
 		Color bg;
@@ -549,7 +549,7 @@ public final class GuiUtil {
 		*/
 		private Dimension layoutSize(Container target, boolean preferred) {
 		synchronized (target.getTreeLock()) {
-			//  Each row must fit with the width allocated to the containter.
+			//  Each row must fit with the width allocated to the container.
 			//  When the container width = 0, the preferred width of the container
 			//  has not yet been calculated so lets ask for the maximum.
 
@@ -605,7 +605,7 @@ public final class GuiUtil {
 
 			//	When using a scroll pane or the DecoratedLookAndFeel we need to
 			//  make sure the preferred size is less than the size of the
-			//  target containter so shrinking the container size works
+			//  target container so shrinking the container size works
 			//  correctly. Removing the horizontal gap is an easy way to do this.
 
 			Container scrollPane = SwingUtilities.getAncestorOfClass(JScrollPane.class, target);

--- a/src/main/java/net/pms/newgui/RestrictedFileSystemView.java
+++ b/src/main/java/net/pms/newgui/RestrictedFileSystemView.java
@@ -152,7 +152,7 @@ public class RestrictedFileSystemView extends FileSystemView {
 	}
 
 	/**
-	 * @param folder a <code>File</code> object repesenting a directory
+	 * @param folder a <code>File</code> object representing a directory
 	 * @param file a <code>File</code> object
 	 * @return <code>true</code> if <code>folder</code> is a directory and contains
 	 * <code>file</code>.
@@ -167,7 +167,7 @@ public class RestrictedFileSystemView extends FileSystemView {
 	}
 
 	/**
-	 * @param parent a <code>File</code> object repesenting a directory
+	 * @param parent a <code>File</code> object representing a directory
 	 * @param fileName a name of a file or folder which exists in <code>parent</code>
 	 * @return a File object. This is normally constructed with <code>new
 	 * File(parent, fileName)</code>.

--- a/src/main/java/net/pms/newgui/SmartScroller.java
+++ b/src/main/java/net/pms/newgui/SmartScroller.java
@@ -39,7 +39,7 @@ import javax.swing.text.*;
  * then adjust the viewport to the relative position it was at before the data
  * was added
  *
- * Similiar logic would apply for horizontal scrolling.
+ * Similar logic would apply for horizontal scrolling.
  *
  * Source: http://www.camick.com/java/source/SmartScroller.java
  */

--- a/src/main/java/net/pms/newgui/components/TristateCheckBox.java
+++ b/src/main/java/net/pms/newgui/components/TristateCheckBox.java
@@ -25,7 +25,7 @@ import javax.swing.plaf.ActionMapUIResource;
  * Maintenance tip - There were some tricks to getting this code
  * working:
  *
- * 1. You have to overwite addMouseListener() to do nothing
+ * 1. You have to overwrite addMouseListener() to do nothing
  * 2. You have to add a mouse event on mousePressed by calling
  * super.addMouseListener()
  * 3. You have to replace the UIActionMap for the keyboard event

--- a/src/main/java/net/pms/platform/windows/NTStatus.java
+++ b/src/main/java/net/pms/platform/windows/NTStatus.java
@@ -6391,11 +6391,11 @@ public enum NTStatus {
 	STATUS_SXS_SECTION_NOT_FOUND(0xC0150001L, "The requested section is not present in the activation context."),
 
 	/**
-	 * Windows was unble to process the application binding information. Refer
+	 * Windows was unable to process the application binding information. Refer
 	 * to the system event log for further information.
 	 */
 	STATUS_SXS_CANT_GEN_ACTCTX(0xC0150002L,
-		"Windows was unble to process the application binding information. Refer to the system event log for further information."),
+		"Windows was unable to process the application binding information. Refer to the system event log for further information."),
 
 	/** The application binding data format is invalid. */
 	STATUS_SXS_INVALID_ACTCTXDATA_FORMAT(0xC0150003L, "The application binding data format is invalid."),

--- a/src/main/java/net/pms/renderers/devices/players/MinimalPlayer.java
+++ b/src/main/java/net/pms/renderers/devices/players/MinimalPlayer.java
@@ -23,7 +23,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import net.pms.renderers.Renderer;
 
 /**
- * An empty implementation with some basic funtionalities defined.
+ * An empty implementation with some basic functionalities defined.
  */
 public abstract class MinimalPlayer implements BasicPlayer {
 	protected Renderer renderer;

--- a/src/main/java/net/pms/util/AudioUtils.java
+++ b/src/main/java/net/pms/util/AudioUtils.java
@@ -109,7 +109,7 @@ public final class AudioUtils {
 			// (as of r34814 / SB28)
 
 			// as of MEncoder r34814 '-af pan' do nothing (LFE is missing from right channel)
-			// same thing for AC3 transcoding. Thats why we should always use 5.1 output on PS3MS configuration
+			// same thing for AC3 transcoding. That's why we should always use 5.1 output on PS3MS configuration
 			// and leave stereo downmixing to PS3!
 			// mixer for 5.1 => 2.0 mixer = "pan=2:1:0:0:1:0:1:0.707:0.707:1:0:1:1";
 

--- a/src/main/java/net/pms/util/CoverArtArchiveUtil.java
+++ b/src/main/java/net/pms/util/CoverArtArchiveUtil.java
@@ -360,7 +360,7 @@ public class CoverArtArchiveUtil extends CoverUtil {
 
 		while (!owner && !Thread.currentThread().isInterrupted()) {
 
-			// Find if any other tread is currently searching the same tag
+			// Find if any other thread is currently searching the same tag
 			synchronized (TAG_LATCHES_LOCK) {
 				for (CoverArtArchiveTagLatch latch : TAG_LATCHES) {
 					if (latch.info.equals(tagInfo)) {
@@ -427,7 +427,7 @@ public class CoverArtArchiveUtil extends CoverUtil {
 
 		while (!owner && !Thread.currentThread().isInterrupted()) {
 
-			// Find if any other tread is currently searching the same MBID
+			// Find if any other thread is currently searching the same MBID
 			synchronized (COVER_LATCHES_LOCK) {
 				for (CoverArtArchiveCoverLatch latch : COVER_LATCHES) {
 					if (latch.mBID.equals(mBID)) {
@@ -446,7 +446,7 @@ public class CoverArtArchiveUtil extends CoverUtil {
 			// Check for timeout here instead of in the while loop make logging
 			// it easier.
 			if (!owner && System.currentTimeMillis() - startTime > WAIT_TIMEOUT_MS) {
-				LOGGER.debug("A Cover Art Achive search timed out while waiting it's turn");
+				LOGGER.debug("A Cover Art Archive search timed out while waiting it's turn");
 				return null;
 			}
 

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -134,7 +134,7 @@ public class FileUtil {
 	 * @since 1.90.0
 	 */
 	// this is called from a static initialiser, where errors aren't clearly reported,
-	// so do everything possible to return a valid reponse, even if the parameters aren't sane
+	// so do everything possible to return a valid response, even if the parameters aren't sane
 	public static FileLocation getFileLocation(
 		String customPath,
 		String defaultDirectory,
@@ -1677,7 +1677,7 @@ public class FileUtil {
 				return Charset.forName(match.getName());
 			}
 			LOGGER.debug(
-				"Detected charset \"{}\" in file \"{}\", but cannot use it because it's not supported by the Java Virual Machine",
+				"Detected charset \"{}\" in file \"{}\", but cannot use it because it's not supported by the Java Virtual Machine",
 				match.getName(),
 				file.getAbsolutePath()
 			);
@@ -1778,7 +1778,7 @@ public class FileUtil {
 				return match.getName().toUpperCase(Locale.ROOT);
 			}
 			LOGGER.debug(
-				"Detected charset \"{}\" in file \"{}\", but cannot use it because it's not supported by the Java Virual Machine",
+				"Detected charset \"{}\" in file \"{}\", but cannot use it because it's not supported by the Java Virtual Machine",
 				match.getName(),
 				file.getAbsolutePath()
 			);

--- a/src/main/java/net/pms/util/ImdbUtil.java
+++ b/src/main/java/net/pms/util/ImdbUtil.java
@@ -144,7 +144,7 @@ public class ImdbUtil {
 					}
 				} catch (IOException e) {
 					LOGGER.error(
-						"An error occured when trying to scan for nfo files belonging to \"{}\": {}",
+						"An error occurred when trying to scan for nfo files belonging to \"{}\": {}",
 						file,
 						e.getMessage()
 					);

--- a/src/main/java/net/pms/util/NaturalComparator.java
+++ b/src/main/java/net/pms/util/NaturalComparator.java
@@ -124,7 +124,7 @@ public final class NaturalComparator {
 	 * comparing contained numbers based on their numeric values.</p>
 	 * <p>This is probably the best default comparison to use.</p> <p>If you
 	 * know that the texts to be compared are in a certain language that
-	 * differs from the default locale's langage, then get a collator for
+	 * differs from the default locale's language, then get a collator for
 	 * the desired locale
 	 * ({@link java.text.Collator#getInstance(java.util.Locale)}) and pass
 	 * it to {@link #compareNatural(java.text.Collator, String, String)}</p>
@@ -305,7 +305,7 @@ public final class NaturalComparator {
 			} else {
 				// Compare words
 				if (collator != null) {
-					// To use the collator the whole subwords have to be compared - character-by-character comparision
+					// To use the collator the whole subwords have to be compared - character-by-character comparison
 					// is not possible. So find the two subwords first
 					int aw = sIndex;
 					int bw = tIndex;

--- a/src/main/java/net/pms/util/SubtitleUtils.java
+++ b/src/main/java/net/pms/util/SubtitleUtils.java
@@ -452,7 +452,7 @@ public class SubtitleUtils {
 				FilenameUtils.getBaseName(fileName) + "." + outputSubtitleType.getExtension()
 			);
 		} catch (IOException e1) {
-			LOGGER.debug("Subtitles conversion finished wih error: " + e1);
+			LOGGER.debug("Subtitles conversion finished with error: " + e1);
 			return null;
 		}
 		cmdList.add(tempSubsFile.getAbsolutePath());
@@ -468,7 +468,7 @@ public class SubtitleUtils {
 			// Avoid creating a pipe for this process and messing up with buffer progress bar
 			pw.stopProcess();
 		} catch (InterruptedException e) {
-			LOGGER.debug("Subtitles conversion finished wih error: " + e);
+			LOGGER.debug("Subtitles conversion finished with error: " + e);
 			Thread.currentThread().interrupt();
 			return null;
 		}

--- a/src/main/java/net/pms/util/ZeroCopyConsumerWithCallback.java
+++ b/src/main/java/net/pms/util/ZeroCopyConsumerWithCallback.java
@@ -142,7 +142,7 @@ public abstract class ZeroCopyConsumerWithCallback<T> extends AbstractAsyncRespo
 	 *
 	 * @param response original response head.
 	 * @param file file containing response content.
-	 * @param contentType the cotnent type.
+	 * @param contentType the content type.
 	 * @return result of the response processing
 	 */
 	protected abstract T process(

--- a/src/test/java/net/pms/network/webguiserver/servlets/PlayerApiServletTest.java
+++ b/src/test/java/net/pms/network/webguiserver/servlets/PlayerApiServletTest.java
@@ -72,7 +72,7 @@ public class PlayerApiServletTest {
 					"100");
 			assertEquals(null, jLibraryVideos);
 		} catch (Exception ex) {
-			LOGGER.error("Exception occured : ", ex.getMessage());
+			LOGGER.error("Exception occurred : ", ex.getMessage());
 		}
 	}
 
@@ -97,7 +97,7 @@ public class PlayerApiServletTest {
 					"100");
 			assertEquals(null, jLibraryVideos);
 		} catch (Exception ex) {
-			LOGGER.error("Exception occured : " + ex);
+			LOGGER.error("Exception occurred : " + ex);
 		}
 	}
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "./CHANGELOG.md,./src/main/resources/i18n,./react-client,./src/main/external-resources,./target/classes/resources/i18n,./src/main/java/net/pms/util/Iso639.java" -L abitrate,als,bu,caf,childrens,childs,datas,medias,reencode,serie,setts,vie`