### PR TITLE
Ensure resolution is divisible by 2 after scaling

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -145,6 +145,7 @@ public class FFMpegVideo extends Engine {
 				scalePadFilterChain.add(String.format("scale=%1$d:%2$d", renderer.getMaxVideoWidth(), renderer.getMaxVideoHeight()));
 			} else {
 				scalePadFilterChain.add(String.format("scale=iw*min(%1$d/iw\\,%2$d/ih):ih*min(%1$d/iw\\,%2$d/ih)", renderer.getMaxVideoWidth(), renderer.getMaxVideoHeight()));
+				scalePadFilterChain.add(String.format("pad=ceil(iw/2)*2:ceil(ih/2)*2:(ow-iw)/2:(oh-ih)/2"));  // ensure height and width are divisible by 2
 
 				if (keepAR) {
 					scalePadFilterChain.add(String.format("pad=%1$d:%2$d:(%1$d-iw)/2:(%2$d-ih)/2", renderer.getMaxVideoWidth(), renderer.getMaxVideoHeight()));

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -145,7 +145,7 @@ public class FFMpegVideo extends Engine {
 				scalePadFilterChain.add(String.format("scale=%1$d:%2$d", renderer.getMaxVideoWidth(), renderer.getMaxVideoHeight()));
 			} else {
 				scalePadFilterChain.add(String.format("scale=iw*min(%1$d/iw\\,%2$d/ih):ih*min(%1$d/iw\\,%2$d/ih)", renderer.getMaxVideoWidth(), renderer.getMaxVideoHeight()));
-				scalePadFilterChain.add(String.format("pad=ceil(iw/2)*2:ceil(ih/2)*2:(ow-iw)/2:(oh-ih)/2"));  // ensure height and width are divisible by 2
+				scalePadFilterChain.add(String.format("pad=ceil(iw/4)*4:ceil(ih/4)*4:(ow-iw)/2:(oh-ih)/2"));  // ensure height and width are divisible by 4
 
 				if (keepAR) {
 					scalePadFilterChain.add(String.format("pad=%1$d:%2$d:(%1$d-iw)/2:(%2$d-ih)/2", renderer.getMaxVideoWidth(), renderer.getMaxVideoHeight()));


### PR DESCRIPTION
I had an issue where some video files would not play with the renderer's max resolution set to 640x480. It turned out that the `scale` filter had calculated an output resolution with an odd number of pixels for the height, which caused libx264 to crash.

This PR adds a black 1-pixel pad in either axis if needed, with the output centered. This makes the resolution divisible by 2 along both axes. It only applies to one usage of the `scale` filter because the others either get their output resolutions from the renderer's max resolution (instead of calculating some oddball res), or already have even-number padding implemented (using `convertToModX`). So, now all cases should be accounted for.

One bit of inconsistency is that multiples of 2 are enforced, instead of multiples of 4 as in the existing code with `convertToModX`. If multiples of 4 are required for some reason, then this should be edited to make it so.