### PR TITLE
Fix detection of Dolby Vision hvc1 variant

### DIFF
--- a/src/main/java/net/pms/parsers/MediaInfoParser.java
+++ b/src/main/java/net/pms/parsers/MediaInfoParser.java
@@ -886,7 +886,8 @@ public class MediaInfoParser {
 			format = FormatConfiguration.QCELP;
 		} else if (
 			value.matches("(?i)(dv)|(cdv.?)|(dc25)|(dcap)|(dvc.?)|(dvs.?)|(dvrs)|(dv25)|(dv50)|(dvan)|(dvh.?)|(dvis)|(dvl.?)|(dvnm)|(dvp.?)|(mdvf)|(pdvc)|(r411)|(r420)|(sdcc)|(sl25)|(sl50)|(sldv)") &&
-			!value.contains("dvhe")
+			!value.contains("dvhe") &&
+			!value.contains("dvh1")
 		) {
 			format = FormatConfiguration.DV;
 		} else if (value.contains("mpeg video")) {


### PR DESCRIPTION
This stops it being detected as the unfortunately-named DV codec