### PR TITLE
Bugfix/thumbnail fix

### DIFF
--- a/src/main/java/net/pms/parsers/MediaInfoParser.java
+++ b/src/main/java/net/pms/parsers/MediaInfoParser.java
@@ -185,10 +185,10 @@ public class MediaInfoParser {
 			// set cover
 			value = StreamContainer.getCoverData(mediaInfoHelper, 0);
 			if (!value.isEmpty()) {
+				String[] thumbs = value.split(" / ");
 				try {
-					value = value.trim();
 					DLNAThumbnail thumbnail = DLNAThumbnail.toThumbnail(
-						Base64.getDecoder().decode(value),
+						Base64.getDecoder().decode(thumbs[0]),
 						640,
 						480,
 						ScaleType.MAX,

--- a/src/main/java/net/pms/parsers/MediaInfoParser.java
+++ b/src/main/java/net/pms/parsers/MediaInfoParser.java
@@ -187,6 +187,7 @@ public class MediaInfoParser {
 			if (!value.isEmpty()) {
 				String[] thumbs = value.split(" / ");
 				try {
+					thumbs[0] = thumbs[0].trim();
 					DLNAThumbnail thumbnail = DLNAThumbnail.toThumbnail(
 						Base64.getDecoder().decode(thumbs[0]),
 						640,


### PR DESCRIPTION
This PR fixes #4659. In case MediaInfo delivers more than 1 cover art, they must be separated.