### PR TITLE
Fix playing and seeking transcoded videos on older Samsung UHD TVs

### DIFF
--- a/src/main/external-resources/renderers/Samsung-UHD.conf
+++ b/src/main/external-resources/renderers/Samsung-UHD.conf
@@ -32,9 +32,13 @@ LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeFastStart = true
-SeekByTime = true
+# https://github.com/UniversalMediaServer/UniversalMediaServer/issues/4272
+SeekByTime = exclusive
 UseClosedCaption = true
 SubtitleHttpHeader = CaptionInfo.sec
+
+# https://github.com/UniversalMediaServer/UniversalMediaServer/issues/4272
+ChunkedTransfer = true
 
 MaxVideoWidth = 4096
 MaxVideoHeight = 2160


### PR DESCRIPTION
This should fix #4272 

As discussed there, I'm changing the base `Samsung-UHD.conf`
