### PR TITLE
show Playlists title without extension

### DIFF
--- a/src/main/java/net/pms/store/container/PlaylistFolder.java
+++ b/src/main/java/net/pms/store/container/PlaylistFolder.java
@@ -324,6 +324,10 @@ public final class PlaylistFolder extends StoreContainer {
 
 	@Override
 	public String getDisplayName(boolean withSuffix) {
-		return super.getDisplayNameBase().substring(0, super.getDisplayNameBase().lastIndexOf("."));
+		String displayName = super.getDisplayNameBase();
+		if (displayName.contains(".")) {
+			displayName = displayName.substring(0, displayName.lastIndexOf("."));
+		}
+		return displayName;
 	}
 }

--- a/src/main/java/net/pms/store/container/PlaylistFolder.java
+++ b/src/main/java/net/pms/store/container/PlaylistFolder.java
@@ -322,4 +322,8 @@ public final class PlaylistFolder extends StoreContainer {
 		return null;
 	}
 
+	@Override
+	public String getDisplayName(boolean withSuffix) {
+		return super.getDisplayNameBase().substring(0, super.getDisplayNameBase().lastIndexOf("."));
+	}
 }


### PR DESCRIPTION
dc.title has now only the filename set, not the extension. 