### PR TITLE
Fix LG OLED transcoding

### DIFF
--- a/src/main/external-resources/renderers/LG-OLED-2020+.conf
+++ b/src/main/external-resources/renderers/LG-OLED-2020+.conf
@@ -58,7 +58,7 @@ UserAgentSearch = OLED\d{2}[ABCEGRWZ][1-2X]
 UpnpDetailsSearch = OLED\d{2}[ABCEGRWZ][1-2X]
 LoadingPriority = 2
 
-TranscodeVideo = MP4-H265-AC3
+TranscodeVideo = MPEGTS-H265-AC3
 H264LevelLimit = 5.1
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160

--- a/src/main/external-resources/renderers/LG-OLED.conf
+++ b/src/main/external-resources/renderers/LG-OLED.conf
@@ -47,7 +47,7 @@ UserAgentSearch = OLED\d{2}[ABCEGRWZ][6-9]
 UpnpDetailsSearch = OLED\d{2}[ABCEGRWZ][6-9]
 LoadingPriority = 2
 
-TranscodeVideo = MP4-H265-AC3
+TranscodeVideo = MPEGTS-H265-AC3
 H264LevelLimit = 5.1
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160

--- a/src/main/external-resources/renderers/LG-TV-2023+.conf
+++ b/src/main/external-resources/renderers/LG-TV-2023+.conf
@@ -65,7 +65,7 @@ UserAgentSearch = OLED\d{2}[ABCEGRWZ][3-5]|LG*UR\d{4}
 UpnpDetailsSearch = OLED\d{2}[ABCEGRWZ][3-5]|LG*UR\d{4}
 LoadingPriority = 2
 
-TranscodeVideo = MP4-H265-AC3
+TranscodeVideo = MPEGTS-H265-AC3
 H264LevelLimit = 5.1
 MaxVideoWidth = 3840
 MaxVideoHeight = 2160


### PR DESCRIPTION
The TVs only support MP4 if "SeekByTime" is "exclusive", and that causes its own problems because seeking does not work, so this is needed until I figure out seeking

# Description of code changes

...

# Checklist
- [x] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [x] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [x] Any relevant tests have been written/modified
