### PR TITLE
Defaulting to jetty before removing Netty things.

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/MediaServer.java
+++ b/src/main/java/net/pms/network/mediaserver/MediaServer.java
@@ -45,7 +45,7 @@ public class MediaServer {
 		3, "JUPnP (Netty)"
 	);
 
-	public static final int DEFAULT_VERSION = 2;
+	public static final int DEFAULT_VERSION = 1;
 
 	private static boolean isStarted = false;
 	private static ServerStatus status = ServerStatus.STOPPED;

--- a/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
+++ b/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
@@ -34,7 +34,6 @@ import java.util.TimeZone;
 import net.pms.dlna.DLNAImageInputStream;
 import net.pms.dlna.DLNAImageProfile;
 import net.pms.dlna.DLNAThumbnailInputStream;
-import net.pms.dlna.DlnaHelper;
 import net.pms.dlna.protocolinfo.PanasonicDmpProfiles;
 import net.pms.encoders.HlsHelper;
 import net.pms.encoders.ImageEngine;
@@ -51,6 +50,7 @@ import net.pms.media.subtitle.MediaSubtitle;
 import net.pms.network.HTTPResource;
 import net.pms.network.mediaserver.MediaServer;
 import net.pms.network.mediaserver.MediaServerRequest;
+import net.pms.network.mediaserver.jupnp.support.contentdirectory.result.DlnaHelper;
 import net.pms.renderers.ConnectedRenderers;
 import net.pms.renderers.Renderer;
 import net.pms.service.Services;
@@ -398,15 +398,7 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 					} else {
 						inputStream = DLNAImageInputStream.toImageInputStream(imageInputStream, imageProfile, false);
 						if (contentFeatures != null) {
-							if (CONFIGURATION.isUpnpJupnpDidl()) {
-								resp.setHeader("ContentFeatures.DLNA.ORG",
-										net.pms.network.mediaserver.jupnp.support.contentdirectory.result.DlnaHelper.getDlnaImageContentFeatures(item, imageProfile, false)
-								);
-							} else {
-								resp.setHeader("ContentFeatures.DLNA.ORG",
-										DlnaHelper.getDlnaImageContentFeatures(item, imageProfile, false)
-								);
-							}
+							resp.setHeader("ContentFeatures.DLNA.ORG", DlnaHelper.getDlnaImageContentFeatures(item, imageProfile, false));
 						}
 						if (inputStream != null && (range.getStart() > 0 || range.getEnd() > 0)) {
 							if (range.getStart() > 0) {
@@ -572,11 +564,7 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 					range.setEnd(range.getStart() + cLoverride - (cLoverride > 0 ? 1 : 0));
 
 					if (contentFeatures != null) {
-						if (CONFIGURATION.isUpnpJupnpDidl()) {
-							resp.setHeader("ContentFeatures.DLNA.ORG", net.pms.network.mediaserver.jupnp.support.contentdirectory.result.DlnaHelper.getDlnaContentFeatures(item));
-						} else {
-							resp.setHeader("ContentFeatures.DLNA.ORG", DlnaHelper.getDlnaContentFeatures(item));
-						}
+						resp.setHeader("ContentFeatures.DLNA.ORG", DlnaHelper.getDlnaContentFeatures(item));
 					}
 
 					if (samsungMediaInfo != null && item.getMediaInfo().getDurationInSeconds() > 0) {
@@ -679,15 +667,7 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 				filterChain
 		);
 		if (contentFeatures != null) {
-			if (CONFIGURATION.isUpnpJupnpDidl()) {
-				resp.setHeader("ContentFeatures.DLNA.ORG",
-						net.pms.network.mediaserver.jupnp.support.contentdirectory.result.DlnaHelper.getDlnaImageContentFeatures(resource, imageProfile, true)
-				);
-			} else {
-				resp.setHeader("ContentFeatures.DLNA.ORG",
-						DlnaHelper.getDlnaImageContentFeatures(resource, imageProfile, true)
-				);
-			}
+			resp.setHeader("ContentFeatures.DLNA.ORG", DlnaHelper.getDlnaImageContentFeatures(resource, imageProfile, true));
 		}
 		if (inputStream != null && (range.getStart() > 0 || range.getEnd() > 0)) {
 			if (range.getStart() > 0) {


### PR DESCRIPTION
Defaulting to jetty before removing Netty things (#4731).
It default to JUPnP UPnP/DLNA properties builder as well.

If mistake appears, user can still revert by selecting `JUPnP+ (Netty)` as forced engine.