### PR TITLE
main fix head content length

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
+++ b/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
@@ -271,6 +271,9 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 			OutputStream os = new BufferedOutputStream(resp.getOutputStream(), BUFFER_SIZE);
 			copyStreamAsync(inputStream, os, async);
 		} else {
+			if (HEAD.equalsIgnoreCase(req.getMethod()) && contentLength < 1) {
+				resp.flushBuffer();
+			}
 			try {
 				inputStream.close();
 			} catch (IOException ioe) {


### PR DESCRIPTION
fix jetty head content length when their should not be any content-length.

if content length was not set, servlet was advising content length = 0.
Some renderer think then that it is no content.
flush will send header before servlet try to force advising a content length.