### PR TITLE
Append season names to season folders #2

### DIFF
--- a/src/main/java/net/pms/store/container/MediaLibraryFolder.java
+++ b/src/main/java/net/pms/store/container/MediaLibraryFolder.java
@@ -604,12 +604,15 @@ public class MediaLibraryFolder extends MediaLibraryAbstract {
 						}
 					}
 					boolean isExpectedTVSeries = expectedOutput == TVSERIES || expectedOutput == TVSERIES_NOSORT || expectedOutput == TVSERIES_WITH_FILTERS;
+					boolean isExpectedTVSeason = expectedOutput == EPISODES;
 					boolean isExpectedMovieFolder = expectedOutput == MOVIE_FOLDERS;
 					if (isExpectedTVSeries) {
 						Long tvSeriesId = getMediaLibraryTvSeriesId(virtualFolderName);
 						if (tvSeriesId != null) {
 							newVirtualFoldersResources.add(new MediaLibraryTvSeries(renderer, tvSeriesId, sqls2, expectedOutputs2));
 						}
+					} else if (isExpectedTVSeason) {
+						newVirtualFoldersResources.add(new MediaLibraryTvSeason(renderer, i18nName, virtualFolderName, sqls2, expectedOutputs2));
 					} else if (isExpectedMovieFolder) {
 						String filename = getMediaLibraryMovieFilename(virtualFolderName);
 						if (filename != null) {

--- a/src/main/java/net/pms/store/container/MediaLibraryTvSeason.java
+++ b/src/main/java/net/pms/store/container/MediaLibraryTvSeason.java
@@ -33,7 +33,6 @@ public class MediaLibraryTvSeason extends MediaLibraryFolder {
 	public MediaLibraryTvSeason(Renderer renderer, String i18nName, String tvSeason, String[] sql, int[] expectedOutput) {
 		super(renderer, i18nName, sql, expectedOutput, tvSeason);
 		this.tvSeasonId = getInteger(tvSeason);
-		this.isSortable = false;
 	}
 
 	@Override

--- a/src/main/java/net/pms/store/container/MediaLibraryTvSeason.java
+++ b/src/main/java/net/pms/store/container/MediaLibraryTvSeason.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package net.pms.store.container;
+
+import net.pms.media.video.metadata.ApiSeason;
+import net.pms.media.video.metadata.TvSeriesMetadata;
+import net.pms.renderers.Renderer;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @author SurfaceS
+ */
+public class MediaLibraryTvSeason extends MediaLibraryFolder {
+
+	private final Integer tvSeasonId;
+	private TvSeriesMetadata tvSeriesMetadata;
+	private String seasonName = "";
+
+	public MediaLibraryTvSeason(Renderer renderer, String i18nName, String tvSeason, String[] sql, int[] expectedOutput) {
+		super(renderer, i18nName, sql, expectedOutput, tvSeason);
+		this.tvSeasonId = getInteger(tvSeason);
+		this.isSortable = false;
+	}
+
+	@Override
+	public String getName() {
+		return super.getName().concat(getSeasonName());
+	}
+
+	/**
+	 * Returns the localized display name.
+	 *
+	 * @return The localized display name.
+	 */
+	@Override
+	public String getLocalizedDisplayName(String lang) {
+		return super.getLocalizedDisplayName(lang).concat(getSeasonName());
+	}
+
+	private TvSeriesMetadata getTvSeriesMetadata() {
+		if (tvSeriesMetadata == null && tvSeasonId != null && getParent() instanceof MediaLibraryTvSeries mediaLibraryTvSeries) {
+			tvSeriesMetadata = mediaLibraryTvSeries.getTvSeriesMetadata();
+		}
+		return tvSeriesMetadata;
+	}
+
+	/**
+	 * Get the season name.
+	 *
+	 * Will be possible to localize it when/if we store localized data.
+	 *
+	 * @return the season name or empty string.
+	 */
+	private synchronized String getSeasonName() {
+		if (seasonName.isEmpty() && getTvSeriesMetadata() != null && tvSeriesMetadata.getSeasons() != null && tvSeasonId != null) {
+			for (ApiSeason season : tvSeriesMetadata.getSeasons()) {
+				if (season.getSeasonNumber() == tvSeasonId) {
+					if (!StringUtils.isBlank(season.getName()) &&
+							!season.getName().equalsIgnoreCase("Season " + season.getSeasonNumber())) {
+						seasonName = ": " + season.getName();
+					}
+					break;
+				}
+			}
+		}
+		return seasonName;
+	}
+
+	private static Integer getInteger(String value) {
+		try {
+			return Integer.valueOf(value);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
@SubJunk 
ref to #4819
I personally will go like that as :
It mess less the MediaLibraryFolder.
It take the series metadata already fetched from parent.
It may be easily localized if a day we store localized names.