### PR TITLE
Made Samsung UDH 2019+ config default for unrecognized Samsung TVs

### DIFF
--- a/src/main/external-resources/renderers/Samsung-NotCD.conf
+++ b/src/main/external-resources/renderers/Samsung-NotCD.conf
@@ -18,15 +18,11 @@ RendererIcon = samsung-tv.png
 # UN55ES6100     SEC_HHP_[TV]UN55ES6100/1.0 DLNADOC/1.50
 # UE37ES5500     SEC_HHP_[TV]UE37ES5500/1.0 DLNADOC/1.50
 #
-# Note: for maximum compatibility the regex is defined negatively as anything
-# not matching a C/D series UA (see SamsungAllShare-CD.conf). The positive
-# definition would be:
-# UserAgentSearch = SEC_HHP.*(TV|HT|BD).*([E-Z]S?\d{4}|Samsung.*\d{2})/
 # ============================================================================
 #
 
-UserAgentSearch = SEC_HHP(?!.*[CD]S?\d{3}\d?/)
-UpnpDetailsSearch = (?!.*[CD]S?\d{3}\d?) , (Samsung|AllShare)
+UserAgentSearch = SEC_HHP.*(TV|HT|BD).*([E-Z]S?\d{4}|Samsung.*\d{2})/
+UpnpDetailsSearch = (UE|UN)\d{2}(ES|H)\d{4}
 
 DefaultVBVBufSize = true
 MuxDTSToMpeg = true

--- a/src/main/external-resources/renderers/Samsung-UHD-2019.conf
+++ b/src/main/external-resources/renderers/Samsung-UHD-2019.conf
@@ -15,7 +15,6 @@ RendererIcon = samsung-tv.png
 # modelName=QN75Q90RAFXZA
 # modelName=QE55QN95AATXXU
 # modelName=TQ43Q68CAUXXC
-# modelName=UE43RU7179UXZG
 # friendlyName=Samsung Q68CA 43, manufacturer=Samsung Electronics, modelName=TQ43Q68CAUXXC, modelNumber=AllShare1.0, modelDescription=Samsung TV DMR, manufacturerURL=http://www.samsung.com/sec, modelURL=http://www.samsung.com/sec
 # modelName=QA65QE1DASXNZ
 # modelName=UA65DU8000SXNZ
@@ -35,9 +34,9 @@ RendererIcon = samsung-tv.png
 # we will rely on modelName and modelDescription
 #
 
-UserAgentSearch = (QN|UA|UE|GQ|QE|TQ|QA)\d{2}(Q|QN|RU|LS|QE|AU|BU|CU|DU|S)\d[\dBCD]
-UpnpDetailsSearch = (QN|UA|UE|GQ|QE|TQ|QA)\d{2}(Q|QN|RU|LS|QE|AU|BU|CU|DU|S)\d[\dBCD]
-LoadingPriority = 2
+UserAgentSearch = (QN|UA|UE|GQ|QE|TQ|QA)\d{2}(Q|QN|RU|LS|QE|AU|BU|CU|DU|S)\d[\dBCD]|Samsung TV
+UpnpDetailsSearch = (QN|UA|UE|GQ|QE|TQ|QA)\d{2}(Q|QN|RU|LS|QE|AU|BU|CU|DU|S)\d[\dBCD]|Samsung TV
+LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeFastStart = true

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -251,7 +251,11 @@ public class RendererConfigurationTest {
 		testHeaders("Samsung ES8000", "User-Agent: SEC_HHP_[TV]UE46ES8000/1.0 DLNADOC/1.50");
 
 		testHeaders("Samsung LED UHD", "USER-AGENT: DLNADOC/1.50 SEC_HHP_[TV] UE88KS9810/1.0 UPnP/1.0");
-		testUPNPDetails("Samsung LED UHD", "modelName=UE88KS9810");
+		testUPNPDetails(
+			"Samsung LED UHD",
+			"modelName=UE88KS9810", 
+			"modelName=UE43RU7179UXZG"
+		);
 
 		testHeaders("Samsung SMT-G7400", "User-Agent: Linux/2.6.35 UPnP/1.0 NDS_MHF DLNADOC/1.50");
 
@@ -266,7 +270,6 @@ public class RendererConfigurationTest {
 
 		testUPNPDetails(
 			"Samsung QLED 4K 2019+",
-			"modelName=UE43RU7179UXZG",
 			"modelName=QN49Q70RAFXZA",
 			"modelName=QN75Q90RAFXZA",
 			"modelName=GQ43LS03TAUXZG",


### PR DESCRIPTION
# Description of code changes

...

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
