### PR TITLE
Improved video quality when transcoding to H.265

### DIFF
--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -475,7 +475,7 @@ public class FFMpegVideo extends Engine {
 						} else if (selectedTranscodeAccelerationMethod.startsWith("libx265")) {
 							if (!customFFmpegOptions.contains("-preset")) {
 								transcodeOptions.add("-preset");
-								transcodeOptions.add("ultrafast");
+								transcodeOptions.add("superfast");
 							}
 						}
 
@@ -705,7 +705,7 @@ public class FFMpegVideo extends Engine {
 					x264CRF = "16";
 
 					// Lower quality for 720p+ content
-					if (media.getWidth() > 720) {
+					if (media.getWidth() > 720 && !params.getMediaRenderer().isTranscodeToH265()) {
 						x264CRF = "19";
 					}
 				}

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -967,7 +967,7 @@ public class MEncoderVideo extends Engine {
 						x264CRF = "16";
 
 						// Lower quality for 720p+ content
-						if (defaultVideoTrack.getWidth() > 720) {
+						if (defaultVideoTrack.getWidth() > 720 && !params.getMediaRenderer().isTranscodeToH265()) {
 							x264CRF = "19";
 						}
 					}

--- a/src/main/java/net/pms/encoders/VLCVideo.java
+++ b/src/main/java/net/pms/encoders/VLCVideo.java
@@ -415,7 +415,7 @@ public class VLCVideo extends Engine {
 				x264CRF = "16";
 
 				// Lower CRF for 720p+ content
-				if (media.getWidth() > 720) {
+				if (media.getWidth() > 720 && !params.getMediaRenderer().isTranscodeToH265()) {
 					x264CRF = "19";
 				}
 			}


### PR DESCRIPTION
# Description of code changes

I noticed some compression artefacts while watching a video, and this fixed them

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
