### PR TITLE
Extended UPnP CreateObject / ImportUri support

### DIFF
--- a/src/main/java/net/pms/database/MediaTableStoreIds.java
+++ b/src/main/java/net/pms/database/MediaTableStoreIds.java
@@ -66,6 +66,7 @@ public class MediaTableStoreIds extends MediaTable {
 	private static final String SQL_GET_ALL_ID = SELECT_ALL + FROM + TABLE_NAME + WHERE + TABLE_COL_ID + EQUAL + PARAMETER;
 	private static final String SQL_GET_ALL_PARENTID_NAME = SELECT_ALL + FROM + TABLE_NAME + WHERE + TABLE_COL_PARENT_ID + EQUAL + PARAMETER + AND + TABLE_COL_NAME + EQUAL + PARAMETER;
 	private static final String SQL_GET_ID_NAME = SELECT + COL_ID + FROM + TABLE_NAME + WHERE + TABLE_COL_NAME + EQUAL + PARAMETER;
+	private static final String SQL_GET_NAME_ID = SELECT + COL_NAME + FROM + TABLE_NAME + WHERE + TABLE_COL_ID + EQUAL + PARAMETER;
 	private static final String SQL_GET_ID_TYPE = SELECT + COL_ID + FROM + TABLE_NAME + WHERE + TABLE_COL_OBJECT_TYPE + EQUAL + PARAMETER;
 	private static final String SQL_GET_ID_NAME_TYPE = SQL_GET_ID_NAME + AND + TABLE_COL_OBJECT_TYPE + EQUAL + PARAMETER;
 	private static final String SQL_GET_ID_NAME_TYPE_PARENTTYPE = SQL_GET_ID_NAME_TYPE + AND + TABLE_COL_PARENT_ID + IN + "(" + SQL_GET_ID_TYPE + ")";
@@ -219,6 +220,24 @@ public class MediaTableStoreIds extends MediaTable {
 			LOGGER.error("Database error in " + TABLE_NAME + " for \"{}\": {}", id, e.getMessage());
 			LOGGER.trace("", e);
 		}
+	}
+
+	public static String getMediaStoreNameForId(Connection connection, String id) {
+		if (connection == null) {
+			return null;
+		}
+		try (PreparedStatement stmt = connection.prepareStatement(SQL_GET_NAME_ID)) {
+			stmt.setLong(1, Long.parseLong(id));
+			try (ResultSet elements = stmt.executeQuery()) {
+				while (elements.next()) {
+					return elements.getString(COL_NAME);
+				}
+			}
+		} catch (SQLException e) {
+			LOGGER.error("Database error in " + TABLE_NAME + " for id \"{}\": {}", id, e.getMessage());
+			LOGGER.trace("", e);
+		}
+		return null;
 	}
 
 	public static List<Long> getMediaStoreIdsForName(Connection connection, String name) {

--- a/src/main/java/net/pms/dlna/DidlHelper.java
+++ b/src/main/java/net/pms/dlna/DidlHelper.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import net.pms.PMS;
 import net.pms.encoders.EncodingFormat;
 import net.pms.formats.Format;
 import net.pms.image.ImageFormat;
@@ -35,6 +36,8 @@ import net.pms.media.audio.metadata.MediaAudioMetadata;
 import net.pms.media.subtitle.MediaSubtitle;
 import net.pms.media.video.MediaVideo;
 import net.pms.media.video.metadata.MediaVideoMetadata;
+import net.pms.network.configuration.NetworkConfiguration;
+import net.pms.network.configuration.NetworkInterfaceAssociation;
 import net.pms.network.mediaserver.HTTPXMLHelper;
 import net.pms.renderers.Renderer;
 import net.pms.store.StoreContainer;
@@ -293,6 +296,14 @@ public class DidlHelper extends DlnaHelper {
 				if (subsAreValidForStreaming && mediaSubtitle != null && renderer.offerSubtitlesByProtocolInfo() && !renderer.useClosedCaption()) {
 					addAttribute(sb, "pv:subtitleFileType", mediaSubtitle.getType().getExtension().toUpperCase());
 					addAttribute(sb, "pv:subtitleFileUri", resource.getSubsURL(mediaSubtitle));
+				}
+				if (item.getRendererMimeType().toLowerCase().startsWith("audio") || item.getRendererMimeType().toLowerCase().startsWith("video")) {
+					NetworkInterfaceAssociation ia = NetworkConfiguration.getNetworkInterfaceAssociationFromConfig();
+					if (ia != null) {
+						int port = PMS.getConfiguration().getMediaServerPort();
+						String hostname = ia.getAddr().getHostAddress();
+						addAttribute(sb, "importUri", String.format("http://%s:%d/import?id=%s", hostname, port, resource.getId()));
+					}
 				}
 
 				if (format != null && format.isVideo() && mediaInfo != null && mediaInfo.isMediaParsed()) {

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
@@ -28,28 +28,6 @@ import java.util.TimerTask;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
-import org.jupnp.binding.annotations.UpnpAction;
-import org.jupnp.binding.annotations.UpnpInputArgument;
-import org.jupnp.binding.annotations.UpnpOutputArgument;
-import org.jupnp.binding.annotations.UpnpService;
-import org.jupnp.binding.annotations.UpnpServiceId;
-import org.jupnp.binding.annotations.UpnpServiceType;
-import org.jupnp.binding.annotations.UpnpStateVariable;
-import org.jupnp.binding.annotations.UpnpStateVariables;
-import org.jupnp.model.profile.RemoteClientInfo;
-import org.jupnp.model.types.ErrorCode;
-import org.jupnp.model.types.UnsignedIntegerFourBytes;
-import org.jupnp.model.types.csv.CSV;
-import org.jupnp.model.types.csv.CSVString;
-import org.jupnp.support.contentdirectory.ContentDirectoryErrorCode;
-import org.jupnp.support.contentdirectory.ContentDirectoryException;
-import org.jupnp.support.model.BrowseFlag;
-import org.jupnp.support.model.BrowseResult;
-import org.jupnp.support.model.SearchResult;
-import org.jupnp.support.model.SortCriterion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
 import net.pms.dlna.DidlHelper;
 import net.pms.network.mediaserver.handlers.SearchRequestHandler;
 import net.pms.network.mediaserver.jupnp.model.meta.UmsRemoteClientInfo;
@@ -74,7 +52,28 @@ import net.pms.store.container.PlaylistFolder;
 import net.pms.store.utils.StoreResourceSorter;
 import net.pms.util.StringUtil;
 import net.pms.util.UMSUtils;
-
+import org.jupnp.binding.annotations.UpnpAction;
+import org.jupnp.binding.annotations.UpnpInputArgument;
+import org.jupnp.binding.annotations.UpnpOutputArgument;
+import org.jupnp.binding.annotations.UpnpService;
+import org.jupnp.binding.annotations.UpnpServiceId;
+import org.jupnp.binding.annotations.UpnpServiceType;
+import org.jupnp.binding.annotations.UpnpStateVariable;
+import org.jupnp.binding.annotations.UpnpStateVariables;
+import org.jupnp.model.profile.RemoteClientInfo;
+import org.jupnp.model.types.ErrorCode;
+import org.jupnp.model.types.UnsignedIntegerFourBytes;
+import org.jupnp.model.types.csv.CSV;
+import org.jupnp.model.types.csv.CSVString;
+import org.jupnp.support.contentdirectory.ContentDirectoryErrorCode;
+import org.jupnp.support.contentdirectory.ContentDirectoryException;
+import org.jupnp.support.model.BrowseFlag;
+import org.jupnp.support.model.BrowseResult;
+import org.jupnp.support.model.SearchResult;
+import org.jupnp.support.model.SortCriterion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
 @UpnpService(
 		serviceId =
@@ -419,13 +418,13 @@ public class UmsContentDirectoryService {
 
 	private void checkInput(Result modelObjectToAdd) {
 		if (modelObjectToAdd.getItems().size() > 1) {
-			LOGGER.warn("more than 1 item ... using first found.");
+			LOGGER.trace("more than 1 item ... using first found.");
 		}
 		if (modelObjectToAdd.getContainers().size() > 1) {
-			LOGGER.warn("more than 1 container ... using first found.");
+			LOGGER.trace("more than 1 container ... using first found.");
 		}
 		if (modelObjectToAdd.getContainers().size() > 0 && modelObjectToAdd.getItems().size() > 0) {
-			LOGGER.warn("found items and container ... using container object ...");
+			LOGGER.trace("found items and container ... using container object ...");
 		}
 	}
 

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/StoreResourceHelper.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/StoreResourceHelper.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import net.pms.PMS;
 import net.pms.dlna.DLNAImageProfile;
 import net.pms.dlna.DLNAImageResElement;
 import net.pms.encoders.EncodingFormat;
@@ -39,6 +40,8 @@ import net.pms.media.audio.metadata.MediaAudioMetadata;
 import net.pms.media.subtitle.MediaSubtitle;
 import net.pms.media.video.MediaVideo;
 import net.pms.media.video.metadata.MediaVideoMetadata;
+import net.pms.network.configuration.NetworkConfiguration;
+import net.pms.network.configuration.NetworkInterfaceAssociation;
 import net.pms.network.mediaserver.jupnp.support.contentdirectory.result.namespace.dc.DC;
 import net.pms.network.mediaserver.jupnp.support.contentdirectory.result.namespace.didl_lite.BaseObject;
 import net.pms.network.mediaserver.jupnp.support.contentdirectory.result.namespace.didl_lite.Desc;
@@ -369,6 +372,14 @@ public class StoreResourceHelper {
 				if (subsAreValidForStreaming && mediaSubtitle != null && renderer.offerSubtitlesByProtocolInfo() && !renderer.useClosedCaption()) {
 					res.getDependentProperties().add(new PV.SubtitleFileType(mediaSubtitle.getType().getExtension().toUpperCase()));
 					res.getDependentProperties().add(new PV.SubtitleFileUri(item.getSubsURL(mediaSubtitle)));
+				}
+				if (item.getRendererMimeType().toLowerCase().startsWith("audio") || item.getRendererMimeType().toLowerCase().startsWith("video")) {
+					NetworkInterfaceAssociation ia = NetworkConfiguration.getNetworkInterfaceAssociationFromConfig();
+					if (ia != null) {
+						int port = PMS.getConfiguration().getMediaServerPort();
+						String hostname = ia.getAddr().getHostAddress();
+						res.getDependentProperties().add(new Res.ImportUri(URI.create(String.format("http://%s:%d/import?id=%s", hostname, port, item.getId()))));
+					}
 				}
 
 				if (format != null && format.isVideo() && mediaInfo != null && mediaInfo.isMediaParsed()) {

--- a/src/main/java/net/pms/network/mediaserver/servlets/MediaServerImportResourceServlet.java
+++ b/src/main/java/net/pms/network/mediaserver/servlets/MediaServerImportResourceServlet.java
@@ -14,6 +14,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import net.pms.network.HttpServletHelper;
+import net.pms.store.MediaScanner;
 import net.pms.store.MediaStoreIds;
 
 @WebServlet(name = "MEDIA SERVER IMPORT RESOURCE", urlPatterns = { "/import" }, displayName = "Media Server Import Resource Servlet")
@@ -51,6 +52,7 @@ public class MediaServerImportResourceServlet extends HttpServletHelper {
 					outFile = new File(filename);
 					IO.copy(inFile, outFile);
 					LOGGER.info("Resource id {} imported/updated at {}", id, outFile.getAbsolutePath());
+					MediaScanner.backgroundScanFileOrFolder(outFile.getParentFile().getAbsolutePath());
 				} else {
 					LOGGER.warn("Store resource with id {} not found. StoreResource will not be updated.", id);
 				}

--- a/src/main/java/net/pms/network/mediaserver/servlets/MediaServerImportResourceServlet.java
+++ b/src/main/java/net/pms/network/mediaserver/servlets/MediaServerImportResourceServlet.java
@@ -13,10 +13,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import net.pms.configuration.RendererConfigurations;
 import net.pms.network.HttpServletHelper;
-import net.pms.renderers.Renderer;
-import net.pms.store.StoreResource;
+import net.pms.store.MediaStoreIds;
 
 @WebServlet(name = "MEDIA SERVER IMPORT RESOURCE", urlPatterns = { "/import" }, displayName = "Media Server Import Resource Servlet")
 public class MediaServerImportResourceServlet extends HttpServletHelper {
@@ -48,11 +46,9 @@ public class MediaServerImportResourceServlet extends HttpServletHelper {
 					LOGGER.error("reported and transmitted file size do not match. StoreResource will not be updated.");
 					return;
 				}
-
-				Renderer renderer = RendererConfigurations.getDefaultRenderer();
-				StoreResource sr = renderer.getMediaStore().getResource(id);
-				if (sr != null) {
-					outFile = new File(sr.getFileName());
+				String filename = MediaStoreIds.getMediaStoreNameForId(id);
+				if (filename != null) {
+					outFile = new File(filename);
 					IO.copy(inFile, outFile);
 					LOGGER.info("Resource id {} imported/updated at {}", id, outFile.getAbsolutePath());
 				} else {

--- a/src/main/java/net/pms/network/mediaserver/servlets/MediaServerImportResourceServlet.java
+++ b/src/main/java/net/pms/network/mediaserver/servlets/MediaServerImportResourceServlet.java
@@ -1,0 +1,72 @@
+package net.pms.network.mediaserver.servlets;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jetty.util.IO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import net.pms.configuration.RendererConfigurations;
+import net.pms.network.HttpServletHelper;
+import net.pms.renderers.Renderer;
+import net.pms.store.StoreResource;
+
+@WebServlet(name = "MEDIA SERVER IMPORT RESOURCE", urlPatterns = { "/import" }, displayName = "Media Server Import Resource Servlet")
+public class MediaServerImportResourceServlet extends HttpServletHelper {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MediaServerImportResourceServlet.class.getName());
+
+	protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		resp.setContentType("text/plain");
+		resp.setCharacterEncoding("utf-8");
+
+		String id = req.getParameter("id");
+
+		if (StringUtils.isBlank(id)) {
+			LOGGER.warn("no StoreResource id submitted. Nothing to update.");
+			return;
+		}
+
+		req.getParts().forEach((part) -> {
+			File inFile = null;
+			File outFile = null;
+			try (InputStream inputStream = part.getInputStream()) {
+				inFile = File.createTempFile("ums", "import");
+				long filesize = part.getSize();
+				LOGGER.info("Updating object with id {}. Expected filesize is {}", id, filesize);
+				IO.copy(part.getInputStream(), new FileOutputStream(inFile));
+				if (Files.size(inFile.toPath()) != filesize) {
+					LOGGER.error("reported and transmitted file size do not match. StoreResource will not be updated.");
+					return;
+				}
+
+				Renderer renderer = RendererConfigurations.getDefaultRenderer();
+				StoreResource sr = renderer.getMediaStore().getResource(id);
+				if (sr != null) {
+					outFile = new File(sr.getFileName());
+					IO.copy(inFile, outFile);
+					LOGGER.info("Resource id {} imported/updated at {}", id, outFile.getAbsolutePath());
+				} else {
+					LOGGER.warn("Store resource with id {} not found. StoreResource will not be updated.", id);
+				}
+			} catch (Throwable x) {
+				LOGGER.error("StoreResource upload error", x);
+			} finally {
+				if (inFile != null && inFile.exists()) {
+					inFile.delete();
+				}
+			}
+		});
+
+		LOGGER.debug("finished updating resource.");
+	}
+}

--- a/src/main/java/net/pms/store/MediaStoreIds.java
+++ b/src/main/java/net/pms/store/MediaStoreIds.java
@@ -114,6 +114,19 @@ public class MediaStoreIds {
 		return ids;
 	}
 
+	public static String getMediaStoreNameForId(String id) {
+		Connection connection = null;
+		try {
+			connection = MediaDatabase.getConnectionIfAvailable();
+			if (connection != null) {
+				return MediaTableStoreIds.getMediaStoreNameForId(connection, id);
+			}
+		} finally {
+			MediaDatabase.close(connection);
+		}
+		return null;
+	}
+
 	public static List<Long> getMediaStoreIdsForName(String name, String objectType) {
 		List<Long> ids = new ArrayList<>();
 		Connection connection = null;

--- a/src/main/java/net/pms/store/item/RealFile.java
+++ b/src/main/java/net/pms/store/item/RealFile.java
@@ -93,7 +93,7 @@ public class RealFile extends StoreItem implements SystemFileResource {
 		if (type == Format.AUDIO || type == Format.VIDEO) {
 			try {
 				if (Files.size(file.toPath()) == UmsContentDirectoryService.EMPTY_FILE_CONTENT.length()) {
-					LOGGER.trace("isUploadResource true");
+					LOGGER.trace("isUploadResource true for {}", file.getAbsolutePath());
 					return true;
 				}
 			} catch (Exception e) {

--- a/src/main/java/net/pms/store/item/RealFile.java
+++ b/src/main/java/net/pms/store/item/RealFile.java
@@ -34,6 +34,7 @@ import net.pms.formats.FormatFactory;
 import net.pms.media.MediaLang;
 import net.pms.media.MediaType;
 import net.pms.media.video.metadata.MediaVideoMetadata;
+import net.pms.network.mediaserver.jupnp.support.contentdirectory.UmsContentDirectoryService;
 import net.pms.parsers.FFmpegParser;
 import net.pms.platform.PlatformUtils;
 import net.pms.renderers.Renderer;
@@ -91,7 +92,7 @@ public class RealFile extends StoreItem implements SystemFileResource {
 	private boolean isUploadResource(File file, int type) {
 		if (type == Format.AUDIO || type == Format.VIDEO) {
 			try {
-				if (Files.size(file.toPath()) == 17) {
+				if (Files.size(file.toPath()) == UmsContentDirectoryService.EMPTY_FILE_CONTENT.length()) {
 					LOGGER.trace("isUploadResource true");
 					return true;
 				}

--- a/src/main/java/net/pms/store/item/RealFile.java
+++ b/src/main/java/net/pms/store/item/RealFile.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Set;
 import net.pms.database.MediaTableCoverArtArchive;
@@ -82,6 +83,25 @@ public class RealFile extends StoreItem implements SystemFileResource {
 		setLastModified(file.lastModified());
 	}
 
+	/**
+	 * Check if this this a new resource.
+	 *
+	 * @return true : File is an empty container. Upload by AV client is still missing. No need to check any formats yet.
+	 */
+	private boolean isUploadResource(File file, int type) {
+		if (type == Format.AUDIO || type == Format.VIDEO) {
+			try {
+				if (Files.size(file.toPath()) == 17) {
+					LOGGER.trace("isUploadResource true");
+					return true;
+				}
+			} catch (Exception e) {
+				LOGGER.error("cannot check file size", e);
+			}
+		}
+		return false;
+	}
+
 	@Override
 	public boolean isValid() {
 		if (file == null || !file.exists() || !file.isFile()) {
@@ -92,6 +112,10 @@ public class RealFile extends StoreItem implements SystemFileResource {
 		if (getType() == Format.SUBTITLE) {
 			// Don't add subtitles as separate resources
 			return false;
+		}
+
+		if (isUploadResource(file, getType())) {
+			return true;
 		}
 
 		boolean valid = getFormat() != null;


### PR DESCRIPTION
This PR adds

extended CDS createObject support 
- `object.container.storageFolder` => creates and adds folders to the CDS
- `object.item` => creates and adds empty objects (for audio or video file type)

import/update CDS objects
- implements UPnP `importUri` attribute for importing / updating CDS content identified by objectID