### PR TITLE
Fix video quality

### DIFF
--- a/src/main/external-resources/renderers/Sony-PlayStation3.conf
+++ b/src/main/external-resources/renderers/Sony-PlayStation3.conf
@@ -49,7 +49,7 @@ Supported = f:wma                    n:2             m:audio/x-ms-wma
 
 # ============================================================================
 #
-# Taken from: http://manuals.playstation.net/document/en/ps3/current/video/filetypes.html
+# Taken from: https://manuals.playstation.net/document/en/ps3/current/video/filetypes.html
 # Note: Some things on the following list have been experimentally disproven,
 # hence why our settings are sometimes different.
 #
@@ -72,7 +72,7 @@ Supported = f:wma                    n:2             m:audio/x-ms-wma
 #    WMV
 #    - VC-1(WMA Standard V2)
 #
-# Taken from: http://manuals.playstation.net/document/en/ps3/current/music/filetypes.html
+# Taken from: https://manuals.playstation.net/document/en/ps3/current/music/filetypes.html
 #
 #    The following types of files can be played under  (Music).
 #    Memory Stick Audio Format(ATRAC)

--- a/src/main/external-resources/renderers/Sony-PlayStation3.conf
+++ b/src/main/external-resources/renderers/Sony-PlayStation3.conf
@@ -30,8 +30,8 @@ WrapDTSIntoPCM = true
 HalveBitrate = true
 
 # Supported video formats:
-Supported = f:mpegps     v:mpeg1|mpeg2|mp4|h264   a:ac3|lpcm           m:video/mpeg
-Supported = f:mpegts     v:mpeg1|mpeg2|mp4|h264   a:ac3|lpcm|mpa       m:video/mpeg
+Supported = f:mpegps     v:mpeg1|mpeg2            a:aac-lc|ac3|lpcm           m:video/mpeg
+Supported = f:mpegts     v:mpeg1|mpeg2|mp4|h264   a:aac-lc|ac3|lpcm|mpa       m:video/mpeg
 Supported = f:avi|divx   v:mp4|divx|mjpeg         a:mp3|lpcm|mpa|ac3   m:video/x-divx     gmc:0
 Supported = f:mp4        v:mp4|h264               a:ac3                m:video/mp4
 Supported = f:mp4        v:mp4|h264               a:aac-lc             m:video/mp4                n:2

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -37,7 +37,6 @@ import net.pms.media.audio.MediaAudio;
 import net.pms.media.subtitle.MediaSubtitle;
 import net.pms.media.video.MediaVideo.Mode3D;
 import net.pms.parsers.MediaInfoParser;
-import net.pms.platform.PlatformUtils;
 import net.pms.renderers.Renderer;
 import net.pms.store.StoreItem;
 import net.pms.store.StoreResource;
@@ -477,7 +476,7 @@ public class RendererConfiguration extends BaseConfiguration {
 	 * There is a lot of logic necessary to determine that and this is only
 	 * one step in the process.
 	 *
-	 * @param media 
+	 * @param media
 	 * @param encodingFormat the EncodingFormat for transcoding
 	 * @param transcodingContainerOverride override the transcoding container to
 	 *                                     see whether it would be compatible in

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -477,21 +477,29 @@ public class RendererConfiguration extends BaseConfiguration {
 	 * There is a lot of logic necessary to determine that and this is only
 	 * one step in the process.
 	 *
-	 * @param media
+	 * @param media 
+	 * @param encodingFormat the EncodingFormat for transcoding
+	 * @param transcodingContainerOverride override the transcoding container to
+	 *                                     see whether it would be compatible in
+	 *                                     another one
 	 * @return whether this renderer supports the video stream type of this
 	 *         resource inside the container it wants for transcoding.
 	 */
-	public boolean isVideoStreamTypeSupportedInTranscodingContainer(MediaInfo media, EncodingFormat encodingFormat) {
+	public boolean isVideoStreamTypeSupportedInTranscodingContainer(MediaInfo media, EncodingFormat encodingFormat, String transcodingContainerOverride) {
 		if (media.getDefaultVideoTrack() == null) {
 			return true;
 		}
+
 		if (getFormatConfiguration() == null) {
 			return (
 				(encodingFormat.isTranscodeToH264() && media.getDefaultVideoTrack().isH264()) ||
 				(encodingFormat.isTranscodeToH265() && media.getDefaultVideoTrack().isH265())
 			);
 		}
-		return getFormatConfiguration().getMatchedMIMEtype(encodingFormat.getTranscodingContainer(), media.getDefaultVideoTrack().getCodec(), null) != null;
+
+		String transcodingContainer = transcodingContainerOverride != null ? transcodingContainerOverride : encodingFormat.getTranscodingContainer();
+
+		return getFormatConfiguration().getMatchedMIMEtype(transcodingContainer, media.getDefaultVideoTrack().getCodec(), null) != null;
 	}
 
 	/**

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -669,22 +669,6 @@ public class RendererConfiguration extends BaseConfiguration {
 		return getString(KEY_SEEK_BY_TIME, "false").equalsIgnoreCase("exclusive");
 	}
 
-	/**
-	 * @return {boolean} whether the renderer supports H.264 inside MPEG-TS
-	 */
-	public boolean isMuxH264MpegTS() {
-		boolean muxCompatible = getBoolean(KEY_MUX_H264_WITH_MPEGTS, true);
-		if (isUseMediaInfo()) {
-			muxCompatible = getFormatConfiguration().getMatchedMIMEtype(FormatConfiguration.MPEGTS, FormatConfiguration.H264, null) != null;
-		}
-
-		if (!PlatformUtils.INSTANCE.isTsMuxeRCompatible()) {
-			muxCompatible = false;
-		}
-
-		return muxCompatible;
-	}
-
 	public boolean isDTSPlayable() {
 		return isMuxDTSToMpeg() || (isWrapDTSIntoPCM() && isMuxLPCMToMpeg());
 	}

--- a/src/main/java/net/pms/dlna/DlnaHelper.java
+++ b/src/main/java/net/pms/dlna/DlnaHelper.java
@@ -16,6 +16,7 @@
  */
 package net.pms.dlna;
 
+import net.pms.configuration.FormatConfiguration;
 import net.pms.encoders.AviSynthFFmpeg;
 import net.pms.encoders.AviSynthMEncoder;
 import net.pms.encoders.EncodingFormat;
@@ -271,12 +272,14 @@ public class DlnaHelper {
 							 * Note: This is an oversimplified duplicate of the engine logic, that
 							 * should be fixed.
 							 */
-							if (resolvedSubtitle == null &&
-									!item.hasExternalSubtitles() &&
-									mediaInfo != null &&
-									mediaInfo.getDvdtrack() == null &&
-									Engine.isMuxable(mediaInfo.getDefaultVideoTrack(), renderer) &&
-									renderer.isVideoStreamTypeSupportedInTranscodingContainer(mediaInfo, transcodingSettings.getEncodingFormat())) {
+							if (
+								resolvedSubtitle == null &&
+								!item.hasExternalSubtitles() &&
+								mediaInfo != null &&
+								mediaInfo.getDvdtrack() == null &&
+								Engine.isMuxable(mediaInfo.getDefaultVideoTrack(), renderer) &&
+								renderer.isVideoStreamTypeSupportedInTranscodingContainer(mediaInfo, transcodingSettings.getEncodingFormat(), FormatConfiguration.MPEGTS)
+							) {
 								isOutputtingMPEGTS = true;
 							}
 						}

--- a/src/main/java/net/pms/encoders/DCRaw.java
+++ b/src/main/java/net/pms/encoders/DCRaw.java
@@ -331,11 +331,6 @@ public class DCRaw extends ImageEngine {
 	}
 
 	@Override
-	public boolean isEngineCompatible(Renderer renderer) {
-		return true;
-	}
-
-	@Override
 	public @Nullable ExecutableInfo testExecutable(@Nonnull ExecutableInfo executableInfo) {
 		executableInfo = testExecutableFile(executableInfo);
 		if (Boolean.FALSE.equals(executableInfo.getAvailable())) {

--- a/src/main/java/net/pms/encoders/DCRaw.java
+++ b/src/main/java/net/pms/encoders/DCRaw.java
@@ -46,7 +46,6 @@ import net.pms.media.MediaInfo;
 import net.pms.network.HTTPResource;
 import net.pms.parsers.MetadataExtractorParser;
 import net.pms.platform.windows.NTStatus;
-import net.pms.renderers.Renderer;
 import net.pms.store.StoreItem;
 import net.pms.util.ExecutableErrorType;
 import net.pms.util.ExecutableInfo;

--- a/src/main/java/net/pms/encoders/Engine.java
+++ b/src/main/java/net/pms/encoders/Engine.java
@@ -140,8 +140,6 @@ public abstract class Engine {
 
 	public abstract boolean excludeFormat(Format extension);
 
-	public abstract boolean isEngineCompatible(Renderer renderer);
-
 	public abstract ProcessWrapper launchTranscode(
 		StoreItem resource,
 		MediaInfo media,

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -1674,11 +1674,6 @@ public class FFMpegVideo extends Engine {
 	}
 
 	@Override
-	public boolean isEngineCompatible(Renderer renderer) {
-		return true;
-	}
-
-	@Override
 	public ExecutableInfo testExecutable(@Nonnull ExecutableInfo executableInfo) {
 		executableInfo = testExecutableFile(executableInfo);
 		if (Boolean.FALSE.equals(executableInfo.getAvailable())) {

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -1120,9 +1120,7 @@ public class FFMpegVideo extends Engine {
 		}
 
 		if (!override) {
-			if (!canMuxVideoWithFFmpeg) {
-				cmdList.addAll(getVideoBitrateOptions(item, media, params, dtsRemux));
-			}
+			cmdList.addAll(getVideoBitrateOptions(item, media, params, dtsRemux));
 
 			String customFFmpegOptions = renderer.getCustomFFmpegOptions();
 

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -394,6 +394,27 @@ public class FFMpegVideo extends Engine {
 					transcodeOptions.add("copy");
 				}
 			} else {
+				// log the reason for not remuxing audio
+				String logPrepend = "Audio was not remuxed because ";
+				if (params.getAid() == null) {
+					LOGGER.trace(logPrepend + "there is no audio");
+				}
+				if (!configuration.isAudioRemuxAC3() && params.getAid().isAC3()) {
+					LOGGER.trace(logPrepend + "audio is AC-3 and the user setting to remux AC-3 is disabled");
+				}
+				if (!renderer.isAudioStreamTypeSupportedInTranscodingContainer(params.getAid(), encodingFormat)) {
+					LOGGER.trace(logPrepend + "audio stream type {} is not supported inside the container {}", params.getAid().getAudioCodec(), encodingFormat);
+				}
+				if (isAviSynthEngine()) {
+					LOGGER.trace(logPrepend + "this is AviSynth");
+				}
+				if (isSubtitlesAndTimeseek) {
+					LOGGER.trace(logPrepend + "there are subtitles and seeking involved");
+				}
+				if (!ffmpegSupportsRemuxingAudioStreamToTranscodingContainer(params.getAid(), encodingFormat.getTranscodingContainer())) {
+					LOGGER.trace(logPrepend + "FFmpeg does not support remuxing the audio stream {} to the transcoding container {}", params.getAid().getAudioCodec(), encodingFormat.getTranscodingContainer());
+				}
+
 				if (dtsRemux) {
 					// Audio is added in a separate process later
 					transcodeOptions.add("-an");

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -1120,7 +1120,9 @@ public class FFMpegVideo extends Engine {
 		}
 
 		if (!override) {
-			cmdList.addAll(getVideoBitrateOptions(item, media, params, dtsRemux));
+			if (!canMuxVideoWithFFmpeg) {
+				cmdList.addAll(getVideoBitrateOptions(item, media, params, dtsRemux));
+			}
 
 			String customFFmpegOptions = renderer.getCustomFFmpegOptions();
 

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -949,7 +949,7 @@ public class FFMpegVideo extends Engine {
 		boolean canMuxVideoWithFFmpegIfTsMuxerIsNotUsed = false;
 		String prependFfmpegTraceReason = "Not muxing the video stream with FFmpeg because ";
 		if (!(renderer instanceof OutputOverride)) {
-			if (!renderer.isVideoStreamTypeSupportedInTranscodingContainer(media, encodingFormat)) {
+			if (!renderer.isVideoStreamTypeSupportedInTranscodingContainer(media, encodingFormat, null)) {
 				canMuxVideoWithFFmpeg = false;
 				LOGGER.debug(prependFfmpegTraceReason + "the video codec is not the same as the transcoding goal.");
 			} else if (item.isInsideTranscodeFolder()) {
@@ -1008,9 +1008,9 @@ public class FFMpegVideo extends Engine {
 			if (item.isInsideTranscodeFolder()) {
 				deferToTsmuxer = false;
 				LOGGER.debug(prependTraceReason + "the file is being played via a FFmpeg entry in the TRANSCODE folder.");
-			} else if (!renderer.isVideoStreamTypeSupportedInTranscodingContainer(media, encodingFormat)) {
+			} else if (!renderer.isVideoStreamTypeSupportedInTranscodingContainer(media, encodingFormat, FormatConfiguration.MPEGTS)) {
 				deferToTsmuxer = false;
-				LOGGER.debug(prependTraceReason + "the renderer does not support {} inside {}.", defaultVideoTrack.getCodec(), encodingFormat.getTranscodingContainer());
+				LOGGER.debug(prependTraceReason + "the renderer does not support {} inside MPEG-TS.", defaultVideoTrack.getCodec());
 			} else if (params.getSid() != null && !(defaultVideoTrack.getHDRFormatForRenderer() != null && defaultVideoTrack.getHDRFormatForRenderer().equals("dolbyvision"))) {
 				deferToTsmuxer = false;
 				/**

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -489,9 +489,9 @@ public class MEncoderVideo extends Engine {
 		} else if (item.isInsideTranscodeFolder()) {
 			deferToTsmuxer = false;
 			LOGGER.trace(prependTraceReason + "the file is being played via a MEncoder entry in the TRANSCODE folder.");
-		} else if (!renderer.isVideoStreamTypeSupportedInTranscodingContainer(media, encodingFormat)) {
+		} else if (!renderer.isVideoStreamTypeSupportedInTranscodingContainer(media, encodingFormat, FormatConfiguration.MPEGTS)) {
 			deferToTsmuxer = false;
-			LOGGER.debug(prependTraceReason + "the renderer does not support {} inside {}.", defaultVideoTrack.getCodec(), encodingFormat.getTranscodingContainer());
+			LOGGER.debug(prependTraceReason + "the renderer does not support {} inside MPEG-TS.", defaultVideoTrack.getCodec());
 		} else if (params.getSid() != null) {
 			deferToTsmuxer = false;
 			LOGGER.trace(prependTraceReason + "we need to burn subtitles.");

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -2264,11 +2264,6 @@ public class MEncoderVideo extends Engine {
 	}
 
 	@Override
-	public boolean isEngineCompatible(Renderer renderer) {
-		return true;
-	}
-
-	@Override
 	public @Nullable ExecutableInfo testExecutable(@Nonnull ExecutableInfo executableInfo) {
 		executableInfo = testExecutableFile(executableInfo);
 		if (Boolean.FALSE.equals(executableInfo.getAvailable())) {

--- a/src/main/java/net/pms/encoders/TsMuxeRVideo.java
+++ b/src/main/java/net/pms/encoders/TsMuxeRVideo.java
@@ -700,11 +700,6 @@ public class TsMuxeRVideo extends Engine {
 	}
 
 	@Override
-	public boolean isEngineCompatible(Renderer renderer) {
-		return renderer != null && renderer.isMuxH264MpegTS();
-	}
-
-	@Override
 	public boolean isCompatible(StoreItem item) {
 		MediaSubtitle subtitle = item.getMediaSubtitle();
 

--- a/src/main/java/net/pms/encoders/VLCVideo.java
+++ b/src/main/java/net/pms/encoders/VLCVideo.java
@@ -639,11 +639,6 @@ public class VLCVideo extends Engine {
 	}
 
 	@Override
-	public boolean isEngineCompatible(Renderer renderer) {
-		return true;
-	}
-
-	@Override
 	public @Nullable ExecutableInfo testExecutable(@Nonnull ExecutableInfo executableInfo) {
 		executableInfo = testExecutableFile(executableInfo);
 		if (Boolean.FALSE.equals(executableInfo.getAvailable())) {

--- a/src/main/java/net/pms/encoders/VideoLanVideoStreaming.java
+++ b/src/main/java/net/pms/encoders/VideoLanVideoStreaming.java
@@ -36,7 +36,6 @@ import net.pms.io.SimpleProcessWrapper;
 import net.pms.media.MediaInfo;
 import net.pms.network.HTTPResource;
 import net.pms.platform.PlatformUtils;
-import net.pms.renderers.Renderer;
 import net.pms.store.StoreItem;
 import net.pms.util.ExecutableErrorType;
 import net.pms.util.ExecutableInfo;

--- a/src/main/java/net/pms/encoders/VideoLanVideoStreaming.java
+++ b/src/main/java/net/pms/encoders/VideoLanVideoStreaming.java
@@ -217,11 +217,6 @@ public class VideoLanVideoStreaming extends Engine {
 	}
 
 	@Override
-	public boolean isEngineCompatible(Renderer renderer) {
-		return true;
-	}
-
-	@Override
 	public @Nullable ExecutableInfo testExecutable(@Nonnull ExecutableInfo executableInfo) {
 		executableInfo = testExecutableFile(executableInfo);
 		if (Boolean.FALSE.equals(executableInfo.getAvailable())) {

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/DlnaHelper.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/DlnaHelper.java
@@ -16,6 +16,7 @@
  */
 package net.pms.network.mediaserver.jupnp.support.contentdirectory.result;
 
+import net.pms.configuration.FormatConfiguration;
 import net.pms.dlna.DLNAImageProfile;
 import net.pms.encoders.AviSynthFFmpeg;
 import net.pms.encoders.AviSynthMEncoder;
@@ -324,12 +325,14 @@ public class DlnaHelper {
 						 * Note: This is an oversimplified duplicate of the engine logic, that
 						 * should be fixed.
 						 */
-						if (resolvedSubtitle == null &&
-								!item.hasExternalSubtitles() &&
-								mediaInfo != null &&
-								mediaInfo.getDvdtrack() == null &&
-								Engine.isMuxable(mediaInfo.getDefaultVideoTrack(), renderer) &&
-								renderer.isVideoStreamTypeSupportedInTranscodingContainer(mediaInfo, encodingFormat)) {
+						if (
+							resolvedSubtitle == null &&
+							!item.hasExternalSubtitles() &&
+							mediaInfo != null &&
+							mediaInfo.getDvdtrack() == null &&
+							Engine.isMuxable(mediaInfo.getDefaultVideoTrack(), renderer) &&
+							renderer.isVideoStreamTypeSupportedInTranscodingContainer(mediaInfo, encodingFormat, FormatConfiguration.MPEGTS)
+						) {
 							isOutputtingMPEGTS = true;
 						}
 					}

--- a/src/main/java/net/pms/store/MediaInfoStore.java
+++ b/src/main/java/net/pms/store/MediaInfoStore.java
@@ -118,7 +118,7 @@ public class MediaInfoStore {
 			if (mediaInfo != null) {
 				return mediaInfo;
 			}
-			LOGGER.trace("Store do not yet contains MediaInfo for {}", filename);
+			LOGGER.trace("Store does not yet contain MediaInfo for {}", filename);
 			Connection connection = null;
 			InputFile input = new InputFile();
 			input.setFile(file);
@@ -206,7 +206,7 @@ public class MediaInfoStore {
 			if (mediaInfo != null) {
 				return mediaInfo;
 			}
-			LOGGER.trace("Store do not yet contains MediaInfo for {}", url);
+			LOGGER.trace("Store does not yet contain MediaInfo for {}", url);
 			try (Connection connection = MediaDatabase.getConnectionIfAvailable()) {
 				mediaInfo = MediaTableFiles.getMediaInfo(connection, url, 0);
 				if (mediaInfo == null) {


### PR DESCRIPTION
# Description of code changes

Users have reported a big regression in video quality recently on the forum
https://www.universalmediaserver.com/forum/viewtopic.php?p=48784
https://www.universalmediaserver.com/forum/viewtopic.php?p=48788

The problem is mostly that the PS3 config says it supports H.264 inside MPEG-PS, but when I tested it this was not true. There were other bugs that intersected to cause this problem, which is that when there is a video stream that is compatible with PS3, UMS was incorrectly transcoding the stream, but also not applying the video quality parameters, so the transcoding happened with the default FFmpeg quality for MPEG-2 video which isn't very good

I fixed other bugs along the way:
- [x] Changed PS3 config to support AAC-LC inside MPEG-PS and MPEG-TS, I have tested it with 2 and 5.1 channel AAC-LC
- [x] Fixed the checks in MEncoder and FFmpeg engines to defer to tsMuxeR - they were checking compatibility in MPEG-PS but it should be MPEG-TS
- [x] Fixed support for remuxing supported video streams when the goal is MPEG-2 video
- [x] Logging and formatting improvements

# Checklist
- [x] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [x] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
