### PR TITLE
mvn frontend error with configured maven proxy settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -964,6 +964,7 @@
 					<nodeDownloadRoot>https://nodejs.org/download/release/</nodeDownloadRoot>
 					<nodeVersion>v20.12.2</nodeVersion>
 					<yarnVersion>v1.22.22</yarnVersion>
+					<yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>					
 					<environmentVariables>
 						<PUBLIC_URL>/</PUBLIC_URL>
 					</environmentVariables>


### PR DESCRIPTION
There is an issue with the maven-frontend-plugin in combination with configured proxy settings in the maven `settings.xml` file. The plugin passes an argument that appearently is not supported by the used yarn 4 installation for the react client. 

Disabling forwarding the proxy setting to the yarn client, solves this issue.