### PR TITLE
main fix #4939

### DIFF
--- a/src/main/java/net/pms/logging/UmsCompressor.java
+++ b/src/main/java/net/pms/logging/UmsCompressor.java
@@ -19,35 +19,39 @@ package net.pms.logging;
 import ch.qos.logback.core.rolling.helper.CompressionMode;
 import ch.qos.logback.core.rolling.helper.Compressor;
 import ch.qos.logback.core.util.FileUtil;
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Enumeration;
+import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
-import java.util.zip.ZipOutputStream;
+import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * <code>UmsCompressor</code> extends {@link Compressor} to allow compressor
- * to compress the rolled log file into a single zip file.
- * Use CompressionMode.ZIP only.
- * Allow only 9999 files.
- * Better to use this with {@link SizeBasedTriggeringPolicy} set to 100MB or more
+ * <code>UmsCompressor</code> extends {@link Compressor} to allow compressor to
+ * compress the rolled log file into a single zip file.
+ *
+ * Use CompressionMode.ZIP only. Allow only 9999 files. Better to use this with
+ * {@link SizeBasedTriggeringPolicy} set to 100MB or more
  */
 public class UmsCompressor extends Compressor {
-	static final int BUFFER_SIZE = 8192;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(UmsCompressor.class);
 
 	/**
 	 * All synchronization in this class is done via the lock object.
 	 */
-	protected final ReentrantLock lock = new ReentrantLock(false);
+	private final ReentrantLock lock = new ReentrantLock(false);
+
 	public UmsCompressor() {
 		super(CompressionMode.ZIP);
 	}
@@ -60,20 +64,14 @@ public class UmsCompressor extends Compressor {
 	 */
 	@Override
 	public void compress(String nameOfFile2Compress, String nameOfCompressedFile, String innerEntryName) {
-		zipCompress(nameOfFile2Compress, nameOfCompressedFile, innerEntryName);
+		nioZipCompress(nameOfFile2Compress, nameOfCompressedFile, innerEntryName);
 	}
 
-	/**
-	 * Same code from Logback, except it will append to zip if zip exist.
-	 * @param nameOfFile2zip
-	 * @param nameOfZippedFile
-	 * @param innerEntryName
-	 */
-	private void zipCompress(String nameOfFile2zip, String nameOfZippedFile, String innerEntryName) {
-		File file2zip = new File(nameOfFile2zip);
+	private void nioZipCompress(String nameOfFile2Compress, String nameOfCompressedFile, String innerEntryName) {
+		File file2zip = new File(nameOfFile2Compress);
 
 		if (!file2zip.exists()) {
-			addWarn("The file to compress named [" + nameOfFile2zip + "] does not exist.");
+			addWarn("The file to compress named [" + nameOfFile2Compress + "] does not exist.");
 			return;
 		}
 
@@ -82,118 +80,55 @@ public class UmsCompressor extends Compressor {
 			return;
 		}
 
-		if (!nameOfZippedFile.endsWith(".zip")) {
-			nameOfZippedFile = nameOfZippedFile + ".zip";
+		if (!nameOfCompressedFile.endsWith(".zip")) {
+			nameOfCompressedFile = nameOfCompressedFile + ".zip";
 		}
 		lock.lock();
 		Instant start = Instant.now();
-		File zippedFile = new File(nameOfZippedFile);
-		File appendZippedFile = new File(nameOfZippedFile + ".tmp");
-		if (appendZippedFile.exists()) {
-			//something went bad on last zipCompress ?
-			FileUtils.deleteQuietly(appendZippedFile);
-		}
-		if (zippedFile.exists()) {
-			//set to append
-			try {
-				if (zippedFile.renameTo(appendZippedFile)) {
-					addInfo("The target compressed file named [" + nameOfZippedFile + "] will be appended.");
-				} else {
-					addWarn("Error occurred while renaming [" + nameOfZippedFile + "]");
-					return;
-				}
-			} catch (SecurityException e) {
-				addWarn("Error occurred while renaming [" + nameOfZippedFile + "]");
-				return;
-			}
-		}
-
-		addInfo("ZIP compressing [" + file2zip + "] as [" + zippedFile + "]");
+		File zippedFile = new File(nameOfCompressedFile);
 		createMissingTargetDirsIfNecessary(zippedFile);
-
-		try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(nameOfZippedFile))) {
-			byte[] inbuf = new byte[BUFFER_SIZE];
-			int n;
-
-			// first, copy contents from existing zip
-			int index = 0;
-			if (appendZippedFile.exists()) {
-				try (ZipFile appendZip = new ZipFile(appendZippedFile)) {
-					Enumeration<? extends ZipEntry> entries = appendZip.entries();
-					while (entries.hasMoreElements()) {
-						ZipEntry zipEntry = entries.nextElement();
-						zos.putNextEntry(zipEntry);
-						if (!zipEntry.isDirectory()) {
-							index++;
-							InputStream zipEntryStream = appendZip.getInputStream(zipEntry);
-							while ((n = zipEntryStream.read(inbuf)) != -1) {
-								zos.write(inbuf, 0, n);
-							}
-						}
-						zos.closeEntry();
-					}
-				}
-				FileUtils.deleteQuietly(appendZippedFile);
+		URI uri = URI.create("jar:" + zippedFile.toURI());
+		addInfo("The target compressed file named [" + nameOfCompressedFile + "] will be appended.");
+		try (FileSystem fs = FileSystems.newFileSystem(uri, Map.of("create", "true"))) {
+			Path e = fs.getRootDirectories().iterator().next();
+			long count;
+			try (Stream<Path> paths = Files.find(e.getRoot(), 1, (path, basicFileAttributes) -> basicFileAttributes.isRegularFile())) {
+				count = paths.count();
 			}
-			//add askef file
-			try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(nameOfFile2zip))) {
-				//try to keep the extension
-				String innerEntryExt = "";
-				if (innerEntryName.contains(".")) {
-					int dotIndex = innerEntryName.lastIndexOf(".");
-					innerEntryExt = innerEntryName.substring(dotIndex);
-					innerEntryName = innerEntryName.substring(0, dotIndex);
-				}
-				//let say we will have no more than 9999 files in the zip
-				innerEntryName += "." + String.format("%04d", index) + innerEntryExt;
-				ZipEntry zipEntry = computeZipEntry(innerEntryName);
-				zos.putNextEntry(zipEntry);
-
-				while ((n = bis.read(inbuf)) != -1) {
-					zos.write(inbuf, 0, n);
-				}
-			}
-
-			if (!file2zip.delete()) {
-				addWarn("Could not delete [" + nameOfFile2zip + "].");
-			}
+			Path source = file2zip.toPath();
+			innerEntryName = getIndexedInnerEntryName(innerEntryName, count);
+			Path pathInZipfile = fs.getPath(innerEntryName);
+			addInfo("ZIP compressing [" + file2zip + "] as [" + innerEntryName + "]");
+			Files.copy(source, pathInZipfile, StandardCopyOption.REPLACE_EXISTING);
 			Instant end = Instant.now();
-			addInfo("Compressing [" + nameOfFile2zip + "] take " + Duration.between(start, end).toString());
+			LOGGER.info("Compressing [" + nameOfFile2Compress + "] take " + Duration.between(start, end).toString());
+			if (!FileUtils.deleteQuietly(file2zip)) {
+				LOGGER.warn("Could not delete [" + nameOfFile2Compress + "].");
+			}
 		} catch (IOException e) {
-			addError("Error occurred while compressing [" + nameOfFile2zip + "] into [" + nameOfZippedFile + "].", e);
+			addError("Error occurred while compressing [" + nameOfFile2Compress + "] into [" + nameOfCompressedFile + "].", e);
 		} finally {
 			lock.unlock();
 		}
 	}
 
-	// http://jira.qos.ch/browse/LBCORE-98
-	// The name of the compressed file as nested within the zip archive
-	//
-	// Case 1: RawFile = null, Pattern = foo-%d.zip
-	// nestedFilename = foo-${current-date}
-	//
-	// Case 2: RawFile = hello.txt, Pattern = = foo-%d.zip
-	// nestedFilename = foo-${current-date}
-	//
-	// in both cases, the strategy consisting of removing the compression
-	// suffix of zip file works reasonably well. The alternative strategy
-	// whereby the nested file name was based on the value of the raw file name
-	// (applicable to case 2 only) has the disadvantage of the nested files
-	// all having the same name, which could make it harder for the user
-	// to unzip the file without collisions
-	ZipEntry computeZipEntry(File zippedFile) {
-		return computeZipEntry(zippedFile.getName());
-	}
-
-	ZipEntry computeZipEntry(String filename) {
-		String nameOfFileNestedWithinArchive = computeFileNameStrWithoutCompSuffix(filename, CompressionMode.ZIP);
-		return new ZipEntry(nameOfFileNestedWithinArchive);
-	}
-
-	void createMissingTargetDirsIfNecessary(File file) {
+	private void createMissingTargetDirsIfNecessary(File file) {
 		boolean result = FileUtil.createMissingParentDirectories(file);
 		if (!result) {
 			addError("Failed to create parent directories for [" + file.getAbsolutePath() + "]");
 		}
 	}
+
+	private static String getIndexedInnerEntryName(String innerEntryName, long index) {
+		String innerEntryExt = "";
+		if (innerEntryName.contains(".")) {
+			int dotIndex = innerEntryName.lastIndexOf(".");
+			innerEntryExt = innerEntryName.substring(dotIndex);
+			innerEntryName = innerEntryName.substring(0, dotIndex);
+		}
+		//let say we will have no more than 9999 files in the zip
+		innerEntryName += "." + String.format("%04d", index) + innerEntryExt;
+		return innerEntryName;
+	}
+
 }


### PR DESCRIPTION
fix  #4939

Before, when a log file is under 100MB, the logging system was : 
- renaming the zip file containing the log files to tmp
- creating a new zipped file
- opening the tmp file, and putting back the files in the new zipped file (streams)
- adding the new file stream to the new zipped file
- deleting the tmp file
- deleting the added log file

This consume a lot of I/O resources (disk/mem) and CPU resources (zip streams decoded/encoded).
This is the way Java `ZipFile` implementation works. You cannot add a file, you need to recreate when you want to add a file.

On my computer tests, more you add files on the zip file, more it take time to process.
First one is 1.2s, after 10 it is 4.5s.

### Fix :
On this PR, UMS use NIO (`ZipFileSystem`) for logging compressor.
`ZipFileSystem` is not as good as `ZipFile` for reading zip files and so on, but is efficient when you only want to add a file in a zip file. Here we don't need to read the zip content/files.

Now, the logging system is :
- opening/creating a zip file
- getting the files count on root (as we only use root of the zip file) for file naming.
- adding the new file to the zip file
- deleting the added log file

On my computer tests, even if the zip file has a lot of file in it, each log file added take about the same time to process (0.5s), even after 10 times. So it should fix #4939.