### PR TITLE
fix HTTP 400 bad uri

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/jetty/ee10/JettyServletContainer.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/jetty/ee10/JettyServletContainer.java
@@ -24,6 +24,7 @@ import net.pms.network.mediaserver.servlets.MediaServerServlet;
 import net.pms.network.mediaserver.servlets.NextcpApiServlet;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
@@ -69,7 +70,9 @@ public class JettyServletContainer implements JakartaServletContainerAdapter {
 
 	@Override
 	public synchronized int addConnector(String host, int port) throws IOException {
-		ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(), new HTTP2CServerConnectionFactory());
+		HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory();
+		httpConnectionFactory.getHttpConfiguration().setUriCompliance(UriCompliance.LEGACY);
+		ServerConnector connector = new ServerConnector(server, httpConnectionFactory, new HTTP2CServerConnectionFactory());
 		connector.setHost(host);
 		connector.setPort(port);
 		//let some time for pausing from media renderer (2 hours)


### PR DESCRIPTION
UMS generates some URI's which are not processed by Jetty like `/ums/thumbnail/419b4fa5-c752-f1f0-0000-000005b0528a/77463/JPEG_SM_Rhye%2FLewisOfMan.jpg` because they are ambiguous. This PR activates Jetty LEGACY support, so thumbs are transferred ... 

Alternatively, the URI has to be unambiguous (not realized in this PR).