### PR TITLE
fixed recursive delete of files -> containerFiles -> files and so on

### DIFF
--- a/src/main/java/net/pms/database/MediaTableContainerFiles.java
+++ b/src/main/java/net/pms/database/MediaTableContainerFiles.java
@@ -184,10 +184,6 @@ public class MediaTableContainerFiles extends MediaTable {
 		} catch (Exception e) {
 			LOGGER.error("Cannot delete entry {}", entryId, e);
 		}
-		//clean MediaTableFiles if not more related to a container
-		if (Boolean.FALSE.equals(MediaTableContainerFiles.isInContainer(connection, entryId))) {
-			MediaTableFiles.removeEntry(connection, entryId);
-		}
 	}
 
 	public static void addContainerEntry(final Long containerId, final Long entryId) {


### PR DESCRIPTION
There is a delete loop, ending in a StackOverflowError ... 

`deleteEntry` is only called from `MediaTableFiles `. 