### PR TITLE
main fix tmdb api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -671,7 +671,7 @@
 		<dependency>
 			<groupId>com.universalmediaserver</groupId>
 			<artifactId>tmdbapi</artifactId>
-			<version>0.3</version>
+			<version>1.0.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
@SubJunk [tmdb-api repo](https://github.com/UniversalMediaServer/tmdb-api/tree/main) need to be published for this PR to pass.

- update TMDb schemas to 24/09/2024.
- fix uri bug.
- updated deps.
