### PR TITLE
Allow LG TVs to receive non-mod4 videos

### DIFF
--- a/src/main/external-resources/renderers/LG-EG910V.conf
+++ b/src/main/external-resources/renderers/LG-EG910V.conf
@@ -17,6 +17,7 @@ H264LevelLimit = 5.1
 DefaultVBVBufSize = true
 SeekByTime = true
 ChunkedTransfer = true
+MuxNonMod4Resolution = true
 
 # Supported video formats (might be off, but works for my media):
 Supported = f:avi|divx    v:divx|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:aac-lc|he-aac|ac3|dts|eac3|lpcm|mp3|wma                 m:video/avi

--- a/src/main/external-resources/renderers/LG-LA6200.conf
+++ b/src/main/external-resources/renderers/LG-LA6200.conf
@@ -17,4 +17,5 @@ LoadingPriority = 0
 TranscodeAudio = MP3
 MaxVideoBitrateMbps = 50
 TranscodedVideoFileSize = -1
+MuxNonMod4Resolution = true
 StreamExtensions = asf,wmv,avi,divx,mp4,m4v,mov,3gp,3g2,mkv,ts,trp,tp,mts,m2ts,vob,mpg,mpeg,mp3,jpg,jpeg,jpe,jps,mpo

--- a/src/main/external-resources/renderers/LG-LA644V.conf
+++ b/src/main/external-resources/renderers/LG-LA644V.conf
@@ -20,4 +20,5 @@ WrapDTSIntoPCM = true
 MuxDTSToMpeg = true
 MaxVideoBitrateMbps = 50
 TranscodedVideoFileSize = -1
+MuxNonMod4Resolution = true
 StreamExtensions = asf,wmv,avi,divx,mp4,m4v,mov,3gp,3g2,mkv,ts,trp,tp,mts,m2ts,vob,mpg,mpeg,mp3,jpg,jpeg,jpe,jps,mpo

--- a/src/main/external-resources/renderers/LG-LB.conf
+++ b/src/main/external-resources/renderers/LG-LB.conf
@@ -20,6 +20,7 @@ LoadingPriority = 1
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3
 TranscodedVideoFileSize = -1
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:3gp|3g2    v:h264|mp4              a:aac-lc                                m:video/3gpp

--- a/src/main/external-resources/renderers/LG-LM620.conf
+++ b/src/main/external-resources/renderers/LG-LM620.conf
@@ -25,6 +25,7 @@ TranscodeAudioTo441kHz = true
 TranscodeFastStart = true
 MimeTypesChanges = video/avi=video/x-divx
 WrapDTSIntoPCM = true
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:mpeg|mpegps|mpegts|mkv   v:mpeg1|mpeg2|mp4|h264   a:lpcm|mpa|wav|aac-lc|ac3                 m:video/mpeg

--- a/src/main/external-resources/renderers/LG-LM660.conf
+++ b/src/main/external-resources/renderers/LG-LM660.conf
@@ -25,6 +25,7 @@ TranscodeVideo = MPEGTS-H264-AAC
 TranscodeFastStart = true
 TranscodedVideoFileSize = -1
 WrapDTSIntoPCM = true
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:avi|divx   v:divx|mjpeg             a:mpa|ac3|mp3                    m:video/x-divx       gmc:0

--- a/src/main/external-resources/renderers/LG-LS5700.conf
+++ b/src/main/external-resources/renderers/LG-LS5700.conf
@@ -22,6 +22,7 @@ TranscodeVideo = MPEGTS-H264-AAC
 TranscodeFastStart = true
 TranscodedVideoFileSize = -1
 WrapDTSIntoPCM = true
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:avi|divx   v:divx|mjpeg             a:mpa|ac3|mp3                  m:video/x-divx       gmc:0

--- a/src/main/external-resources/renderers/LG-OLED-2020+.conf
+++ b/src/main/external-resources/renderers/LG-OLED-2020+.conf
@@ -67,6 +67,7 @@ SeekByTime = true
 ChunkedTransfer = true
 SupportedVideoBitDepths = 8,10,12
 DisableUmsResume = true
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                          a:aac-lc                                                                                         m:video/3gpp

--- a/src/main/external-resources/renderers/LG-OLED.conf
+++ b/src/main/external-resources/renderers/LG-OLED.conf
@@ -56,6 +56,7 @@ SeekByTime = true
 ChunkedTransfer = true
 SupportedVideoBitDepths = 8,10,12
 DisableUmsResume = true
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                          a:aac-lc                                                                 m:video/3gpp

--- a/src/main/external-resources/renderers/LG-TV-2023+.conf
+++ b/src/main/external-resources/renderers/LG-TV-2023+.conf
@@ -74,6 +74,7 @@ SeekByTime = true
 ChunkedTransfer = true
 SupportedVideoBitDepths = 8,10,12
 DisableUmsResume = true
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                          a:aac-lc                                                                                                   m:video/3gpp

--- a/src/main/external-resources/renderers/LG-UB820V.conf
+++ b/src/main/external-resources/renderers/LG-UB820V.conf
@@ -20,6 +20,7 @@ LoadingPriority = 1
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3
 TranscodedVideoFileSize = -1
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:3gp|3g2    v:h264|mp4              a:aac-lc                                m:video/3gpp

--- a/src/main/external-resources/renderers/LG-UH770.conf
+++ b/src/main/external-resources/renderers/LG-UH770.conf
@@ -25,6 +25,7 @@ MaxVideoHeight = 2160
 DefaultVBVBufSize = true
 SeekByTime = true
 ChunkedTransfer = true
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:avi         v:divx|h264|mjpeg|mp4             a:aac-lc|he-aac|ac3|dts|mp3|mpa                    m:video/avi

--- a/src/main/external-resources/renderers/LG-WebOS.conf
+++ b/src/main/external-resources/renderers/LG-WebOS.conf
@@ -35,6 +35,7 @@ H264LevelLimit = 5.1
 DefaultVBVBufSize = true
 SeekByTime = true
 ChunkedTransfer = true
+MuxNonMod4Resolution = true
 
 # Supported video formats:
 Supported = f:avi         v:divx|h264|mjpeg|mp4             a:aac-lc|he-aac|ac3|dts|mp3|mpa                      m:video/avi


### PR DESCRIPTION
I tested this on mine and it is supported

# Description of code changes

...

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
