### PR TITLE
Main fix #4919

### DIFF
--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -657,25 +657,61 @@ public class RendererConfiguration extends BaseConfiguration {
 		return file;
 	}
 
+	private String getTranscodeSeekBy() {
+		return getString(KEY_SEEK_BY_TIME, "false");
+	}
+
 	/**
-	 * Returns true if SeekByTime is set to "true" or "exclusive", false otherwise.
-	 * Default value is false.
+	 * Returns true if SeekByTime is set to "false", false otherwise. Default
+	 * value is true.
 	 *
-	 * @return true if the renderer supports seek-by-time, false otherwise.
+	 * @return true if the renderer supports seek-by-byte exclusively, false
+	 * otherwise.
 	 */
-	public boolean isSeekByTime() {
-		return isSeekByTimeExclusive() || getString(KEY_SEEK_BY_TIME, "false").equalsIgnoreCase("true");
+	public boolean isTranscodeSeekByByteExclusive() {
+		return getTranscodeSeekBy().equalsIgnoreCase("false");
+	}
+
+	/**
+	 * Returns true if SeekByTime is set to "true", false otherwise. Default
+	 * value is false.
+	 *
+	 * @return true if the renderer supports seek-by-byte and seek-by-time,
+	 * false otherwise.
+	 */
+	public boolean isTranscodeSeekByBoth() {
+		return getTranscodeSeekBy().equalsIgnoreCase("true");
 	}
 
 	/**
 	 * Returns true if SeekByTime is set to "exclusive", false otherwise.
 	 * Default value is false.
 	 *
-	 * @return true if the renderer supports seek-by-time exclusively
-	 * (i.e. not in conjunction with seek-by-byte), false otherwise.
+	 * @return true if the renderer supports seek-by-time exclusively (i.e. not
+	 * in conjunction with seek-by-byte), false otherwise.
 	 */
-	public boolean isSeekByTimeExclusive() {
-		return getString(KEY_SEEK_BY_TIME, "false").equalsIgnoreCase("exclusive");
+	public boolean isTranscodeSeekByTimeExclusive() {
+		return getTranscodeSeekBy().equalsIgnoreCase("exclusive");
+	}
+
+	/**
+	 * Returns true if SeekByTime is set to "false" or "true", false otherwise.
+	 * Default value is true.
+	 *
+	 * @return true if the renderer supports seek-by-byte, false otherwise.
+	 */
+	public boolean isTranscodeSeekByByte() {
+		return isTranscodeSeekByByteExclusive() || isTranscodeSeekByBoth();
+	}
+
+	/**
+	 * Returns true if SeekByTime is set to "exclusive" or "true", false
+	 * otherwise. Default value is false.
+	 *
+	 * @return true if the renderer supports seek-by-time, false otherwise.
+	 */
+	public boolean isTranscodeSeekByTime() {
+		return isTranscodeSeekByTimeExclusive() || isTranscodeSeekByBoth();
 	}
 
 	public boolean isDTSPlayable() {

--- a/src/main/java/net/pms/dlna/DlnaHelper.java
+++ b/src/main/java/net/pms/dlna/DlnaHelper.java
@@ -129,7 +129,7 @@ public class DlnaHelper {
 		String dlnaOrgOpFlags = "01"; // seek by byte (exclusive)
 		final Renderer renderer = item.getDefaultRenderer();
 
-		if (renderer.isSeekByTime() && item.isTranscoded() && item.getTranscodingSettings().getEngine().isTimeSeekable()) {
+		if (renderer.isTranscodeSeekByTime() && item.isTranscoded() && item.getTranscodingSettings().getEngine().isTimeSeekable()) {
 			/**
 			 * Some renderers - e.g. the PS3 and Panasonic TVs - behave
 			 * erratically when transcoding if we keep the default seek-by-byte
@@ -156,7 +156,7 @@ public class DlnaHelper {
 			 *
 			 * SeekByTime = both
 			 */
-			if (renderer.isSeekByTimeExclusive()) {
+			if (renderer.isTranscodeSeekByTimeExclusive()) {
 				dlnaOrgOpFlags = "10"; // seek by time (exclusive)
 			} else {
 				dlnaOrgOpFlags = "11"; // seek by both

--- a/src/main/java/net/pms/io/BufferedOutputFileImpl.java
+++ b/src/main/java/net/pms/io/BufferedOutputFileImpl.java
@@ -720,6 +720,16 @@ public class BufferedOutputFileImpl extends OutputStream implements BufferedOutp
 		} else {
 			length = len - cut;
 			System.arraycopy(buffer, mb, buf, off, length);
+			try {
+				System.arraycopy(buffer, mb, buf, off, length);
+			} catch (ArrayIndexOutOfBoundsException e) {
+				LOGGER.trace("Something went wrong with the buffer, error: " + e);
+				LOGGER.trace("buffer: " + Arrays.toString(buffer));
+				LOGGER.trace("mb: " + mb);
+				LOGGER.trace("buf: " + Arrays.toString(buf));
+				LOGGER.trace("off: " + off);
+				LOGGER.trace("len - cut: " + length);
+			}
 			return length;
 		}
 	}

--- a/src/main/java/net/pms/network/HttpServletHelper.java
+++ b/src/main/java/net/pms/network/HttpServletHelper.java
@@ -267,7 +267,7 @@ public abstract class HttpServletHelper extends HttpServlet {
 				}
 			}
 			LOGGER.trace("Sending stream finished after: " + sendBytes + " bytes.");
-		} catch (IOException e) {
+		} catch (IOException | IndexOutOfBoundsException e) {
 			String reason = e.getMessage();
 			if (reason == null && e.getCause() != null) {
 				reason = e.getCause().getMessage();

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/DlnaHelper.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/DlnaHelper.java
@@ -169,7 +169,7 @@ public class DlnaHelper {
 		dlnaOrgOp.setHttpRangeHeaderAccepted(true); // seek by byte (exclusive)
 		final Renderer renderer = item.getDefaultRenderer();
 
-		if (renderer.isSeekByTime() && item.isTranscoded() && item.isTimeSeekable()) {
+		if (renderer.isTranscodeSeekByTime() && item.isTranscoded() && item.isTimeSeekable()) {
 			/**
 			 * Some renderers - e.g. the PS3 and Panasonic TVs - behave
 			 * erratically when transcoding if we keep the default seek-by-byte
@@ -197,7 +197,7 @@ public class DlnaHelper {
 			 * SeekByTime = both
 			 */
 			dlnaOrgOp.setHttpTimeSeekRangeHeaderAccepted(true);
-			if (renderer.isSeekByTimeExclusive()) {
+			if (renderer.isTranscodeSeekByTimeExclusive()) {
 				// seek by time (exclusive)
 				dlnaOrgOp.setHttpRangeHeaderAccepted(false);
 			}

--- a/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
+++ b/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
@@ -582,7 +582,9 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 						resp.setHeader("MediaInfo.sec", "SEC_Duration=" + (long) (item.getMediaInfo().getDurationInSeconds() * 1000));
 					}
 
-					resp.setHeader("Accept-Ranges", "bytes");
+					if (!item.isTranscoded() || renderer.isTranscodeSeekByByte()) {
+						resp.setHeader("Accept-Ranges", "bytes");
+					}
 					if (GET.equals(req.getMethod().toUpperCase())) {
 						resp.setHeader("Connection", "keep-alive");
 					}

--- a/src/main/java/net/pms/network/webguiserver/servlets/PlayerApiServlet.java
+++ b/src/main/java/net/pms/network/webguiserver/servlets/PlayerApiServlet.java
@@ -1165,7 +1165,7 @@ public class PlayerApiServlet extends GuiHttpServlet {
 				LOGGER.debug("Sending {} with mime type {} to {}", item, mimeType, renderer);
 				InputStream in = item.getInputStream(range);
 				long len = item.length();
-				boolean isTranscoding = len == StoreResource.TRANS_SIZE;
+				boolean isTranscoding = item.isTranscoded();
 				resp.setContentType(mimeType);
 				resp.setHeader("Server", MediaServer.getServerName());
 				resp.setHeader("Connection", "keep-alive");


### PR DESCRIPTION
Main fix #4919

- handle IndexOutOfBoundsException to run `complete` on the servlet context.

- do not advertise `Accept-Ranges` if renderer do not support seek by byte on transcoded media