### PR TITLE
Fix playback of divx and xvid videos on LG TVs

### DIFF
--- a/src/main/external-resources/renderers/LG-WebOS.conf
+++ b/src/main/external-resources/renderers/LG-WebOS.conf
@@ -38,7 +38,7 @@ ChunkedTransfer = true
 MuxNonMod4Resolution = true
 
 # Supported video formats:
-Supported = f:avi         v:divx|h264|mjpeg|mp4             a:aac-lc|he-aac|ac3|dts|mp3|mpa                      m:video/avi
+Supported = f:avi         v:h264|mjpeg|mp4             a:aac-lc|he-aac|ac3|dts|mp3|mpa                      m:video/avi
 Supported = f:mkv         v:h264|h265|mp4|mpeg2|vp8|vp9     a:aac-lc|he-aac|ac3|dts|mp3|mpa|vorbis               m:video/x-matroska
 Supported = f:mov         v:h264|h265|mp4                   a:aac-lc|he-aac                                      m:video/quicktime
 Supported = f:mp4|m4v     v:h264|mp4                        a:aac-lc|he-aac                            si:TX3G   m:video/mp4


### PR DESCRIPTION
This commit adds support for videos with DivX and XviD codec on LG TVs based on WebOS. Tested on "[LG] webOS TV UR73003LA".