### PR TITLE
Implements UPnP log levels

### DIFF
--- a/react-client/src/components/Settings/GeneralSettings.tsx
+++ b/react-client/src/components/Settings/GeneralSettings.tsx
@@ -147,17 +147,19 @@ export default function GeneralSettings(
                 {...form.getInputProps('upnp_enable', { type: 'checkbox' })}
               />
               {advancedSettings &&
-                <Checkbox
+                <Select
                   disabled={!canModify}
-                  label={i18n.get('JUPnPDIDLLite')}
-                  {...form.getInputProps('upnp_jupnp_didl', { type: 'checkbox' })}
+                  size='xs'
+                  label={i18n.get('LogLevelColon')}
+                  data={getI18nSelectData(selectionSettings.upnpLoglevels)}
+                  {...form.getInputProps('upnp_log_level')}
                 />
               }
               {advancedSettings &&
                 <Checkbox
                   disabled={!canModify}
-                  label={i18n.get('DebugUpnpService')}
-                  {...form.getInputProps('upnp_debug', { type: 'checkbox' })}
+                  label={i18n.get('JUPnPDIDLLite')}
+                  {...form.getInputProps('upnp_jupnp_didl', { type: 'checkbox' })}
                 />
               }
               <Checkbox

--- a/react-client/src/components/Settings/Settings.tsx
+++ b/react-client/src/components/Settings/Settings.tsx
@@ -48,6 +48,7 @@ export default function Settings() {
     audioCoverSuppliers: [] as mantineSelectData[],
     enabledRendererNames: [] as mantineSelectData[],
     ffmpegLoglevels: [],
+    upnpLoglevels: [] as mantineSelectData[],
     fullyPlayedActions: [] as mantineSelectData[],
     gpuAccelerationMethod: [],
     networkInterfaces: [],

--- a/src/main/java/net/pms/configuration/UmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/UmsConfiguration.java
@@ -425,9 +425,9 @@ public class UmsConfiguration extends BaseConfiguration {
 	private static final String KEY_TRANSCODE_KEEP_FIRST_CONNECTION = "transcode_keep_first_connection";
 	private static final String KEY_TSMUXER_FORCEFPS = "tsmuxer_forcefps";
 	private static final String KEY_UPNP_ALIVE_DELAY = "upnp_alive_delay";
-	public static final String KEY_UPNP_DEBUG = "upnp_debug";
 	private static final String KEY_UPNP_ENABLED = "upnp_enable";
 	private static final String KEY_UPNP_JUPNP_DIDL = "upnp_jupnp_didl";
+	public static final String KEY_UPNP_LOG_LEVEL = "upnp_log_level";
 	private static final String KEY_UPNP_PORT = "upnp_port";
 	private static final String KEY_USE_EMBEDDED_SUBTITLES_STYLE = "use_embedded_subtitles_style";
 	private static final String KEY_USE_IMDB_INFO = "use_imdb_info";
@@ -3713,11 +3713,7 @@ public class UmsConfiguration extends BaseConfiguration {
 		}
 		return SubtitlesInfoLevel.BASIC; // Default
 	}
-	public static synchronized JsonArray getFfmpegLoglevels() {
-		String[] values = FFmpegLogLevels.getLabels();
-		String[] labels = FFmpegLogLevels.getLabels();
-		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
-	}
+
 	/**
 	 * Sets if subtitles information should be added to video names.
 	 *
@@ -3725,104 +3721,6 @@ public class UmsConfiguration extends BaseConfiguration {
 	 */
 	public void setSubtitlesInfoLevel(SubtitlesInfoLevel value) {
 		configuration.setProperty(KEY_SUBS_INFO_LEVEL, value == null ? "" : value.toString());
-	}
-
-	/**
-	 * @return available subtitles info levels as a JSON array
-	 */
-	public static synchronized JsonArray getSubtitlesInfoLevelsAsJsonArray() {
-		String[] values = new String[] {
-			SubtitlesInfoLevel.NONE.toString(),
-			SubtitlesInfoLevel.BASIC.toString(),
-			SubtitlesInfoLevel.FULL.toString()
-		};
-		String[] labels = new String[] {
-			"i18n@None",
-			"i18n@Basic",
-			"i18n@Full"
-		};
-		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
-	}
-
-	/**
-	 * @return available fully played actions as a JSON array
-	 */
-	public static synchronized JsonArray getFullyPlayedActionsAsJsonArray() {
-		String[] values = new String[]{
-			String.valueOf(FullyPlayedAction.NO_ACTION.getValue()),
-			String.valueOf(FullyPlayedAction.MARK.getValue()),
-			String.valueOf(FullyPlayedAction.HIDE_MEDIA.getValue()),
-			String.valueOf(FullyPlayedAction.MOVE_FOLDER.getValue()),
-			String.valueOf(FullyPlayedAction.MOVE_FOLDER_AND_MARK.getValue()),
-			String.valueOf(FullyPlayedAction.MOVE_TRASH.getValue())
-		};
-		String[] labels = new String[]{
-			"i18n@DoNothing",
-			"i18n@MarkMedia",
-			"i18n@HideMedia",
-			"i18n@MoveFileToDifferentFolder",
-			"i18n@MoveFileDifferentFolderMark",
-			"i18n@MoveFileRecycleTrashBin"
-		};
-		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
-	}
-
-	public static synchronized JsonArray getSubtitlesCodepageArray() {
-		String[] values = new String[]{
-			"", "cp874", "cp932", "cp936", "cp949", "cp950", "cp1250",
-			"cp1251", "cp1252", "cp1253", "cp1254", "cp1255", "cp1256",
-			"cp1257", "cp1258", "ISO-2022-CN", "ISO-2022-JP", "ISO-2022-KR",
-			"ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4",
-			"ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8",
-			"ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13",
-			"ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "Big5", "EUC-JP",
-			"EUC-KR", "GB18030", "IBM420", "IBM424", "KOI8-R", "Shift_JIS", "TIS-620"
-		};
-		String[] labels = new String[]{
-			"i18n@AutoDetect",
-			"i18n@CharacterSet.874",
-			"i18n@CharacterSet.932",
-			"i18n@CharacterSet.936",
-			"i18n@CharacterSet.949",
-			"i18n@CharacterSet.950",
-			"i18n@CharacterSet.1250",
-			"i18n@CharacterSet.1251",
-			"i18n@CharacterSet.1252",
-			"i18n@CharacterSet.1253",
-			"i18n@CharacterSet.1254",
-			"i18n@CharacterSet.1255",
-			"i18n@CharacterSet.1256",
-			"i18n@CharacterSet.1257",
-			"i18n@CharacterSet.1258",
-			"i18n@CharacterSet.2022-CN",
-			"i18n@CharacterSet.2022-JP",
-			"i18n@CharacterSet.2022-KR",
-			"i18n@CharacterSet.8859-1",
-			"i18n@CharacterSet.8859-2",
-			"i18n@CharacterSet.8859-3",
-			"i18n@CharacterSet.8859-4",
-			"i18n@CharacterSet.8859-5",
-			"i18n@CharacterSet.8859-6",
-			"i18n@CharacterSet.8859-7",
-			"i18n@CharacterSet.8859-8",
-			"i18n@CharacterSet.8859-9",
-			"i18n@CharacterSet.8859-10",
-			"i18n@CharacterSet.8859-11",
-			"i18n@CharacterSet.8859-13",
-			"i18n@CharacterSet.8859-14",
-			"i18n@CharacterSet.8859-15",
-			"i18n@CharacterSet.8859-16",
-			"i18n@CharacterSet.Big5",
-			"i18n@CharacterSet.EUC-JP",
-			"i18n@CharacterSet.EUC-KR",
-			"i18n@CharacterSet.GB18030",
-			"i18n@CharacterSet.IBM420",
-			"i18n@CharacterSet.IBM424",
-			"i18n@CharacterSet.KOI8-R",
-			"i18n@CharacterSet.ShiftJIS",
-			"i18n@CharacterSet.TIS-620"
-		};
-		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
 	}
 
 	public boolean isHideExtensions() {
@@ -5343,8 +5241,24 @@ public class UmsConfiguration extends BaseConfiguration {
 		return getBoolean(KEY_UPNP_ENABLED, true);
 	}
 
-	public boolean isUpnpDebug() {
-		return getBoolean(KEY_UPNP_DEBUG, false);
+	private int getUpnpDebugLevel() {
+		return getInt(KEY_UPNP_LOG_LEVEL, 1);
+	}
+
+	public boolean isUpnpDebugOff() {
+		return getUpnpDebugLevel() < 1;
+	}
+
+	public boolean isUpnpDebugMediaServer() {
+		return getUpnpDebugLevel() > 0;
+	}
+
+	public boolean isUpnpDebugBasic() {
+		return getUpnpDebugLevel() > 1;
+	}
+
+	public boolean isUpnpDebugFull() {
+		return getUpnpDebugLevel() > 2;
 	}
 
 	public boolean isUpnpJupnpDidl() {
@@ -5503,6 +5417,116 @@ public class UmsConfiguration extends BaseConfiguration {
 			"i18n@NoSorting"
 		};
 
+		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
+	}
+
+	public static synchronized JsonArray getFfmpegLoglevels() {
+		String[] values = FFmpegLogLevels.getLabels();
+		String[] labels = FFmpegLogLevels.getLabels();
+		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
+	}
+
+	/**
+	 * @return available subtitles info levels as a JSON array
+	 */
+	public static synchronized JsonArray getSubtitlesInfoLevelsAsJsonArray() {
+		String[] values = new String[] {
+			SubtitlesInfoLevel.NONE.toString(),
+			SubtitlesInfoLevel.BASIC.toString(),
+			SubtitlesInfoLevel.FULL.toString()
+		};
+		String[] labels = new String[] {
+			"i18n@None",
+			"i18n@Basic",
+			"i18n@Full"
+		};
+		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
+	}
+
+	public static synchronized JsonArray getUpnpLoglevels() {
+		String[] values = new String[]{"0", "1", "2", "3"};
+		String[] labels = new String[]{"i18n@None", "i18n@MediaServerOnly", "i18n@Basic", "i18n@Full"};
+		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
+	}
+
+	/**
+	 * @return available fully played actions as a JSON array
+	 */
+	public static synchronized JsonArray getFullyPlayedActionsAsJsonArray() {
+		String[] values = new String[]{
+			String.valueOf(FullyPlayedAction.NO_ACTION.getValue()),
+			String.valueOf(FullyPlayedAction.MARK.getValue()),
+			String.valueOf(FullyPlayedAction.HIDE_MEDIA.getValue()),
+			String.valueOf(FullyPlayedAction.MOVE_FOLDER.getValue()),
+			String.valueOf(FullyPlayedAction.MOVE_FOLDER_AND_MARK.getValue()),
+			String.valueOf(FullyPlayedAction.MOVE_TRASH.getValue())
+		};
+		String[] labels = new String[]{
+			"i18n@DoNothing",
+			"i18n@MarkMedia",
+			"i18n@HideMedia",
+			"i18n@MoveFileToDifferentFolder",
+			"i18n@MoveFileDifferentFolderMark",
+			"i18n@MoveFileRecycleTrashBin"
+		};
+		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
+	}
+
+	public static synchronized JsonArray getSubtitlesCodepageArray() {
+		String[] values = new String[]{
+			"", "cp874", "cp932", "cp936", "cp949", "cp950", "cp1250",
+			"cp1251", "cp1252", "cp1253", "cp1254", "cp1255", "cp1256",
+			"cp1257", "cp1258", "ISO-2022-CN", "ISO-2022-JP", "ISO-2022-KR",
+			"ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4",
+			"ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8",
+			"ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13",
+			"ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "Big5", "EUC-JP",
+			"EUC-KR", "GB18030", "IBM420", "IBM424", "KOI8-R", "Shift_JIS", "TIS-620"
+		};
+		String[] labels = new String[]{
+			"i18n@AutoDetect",
+			"i18n@CharacterSet.874",
+			"i18n@CharacterSet.932",
+			"i18n@CharacterSet.936",
+			"i18n@CharacterSet.949",
+			"i18n@CharacterSet.950",
+			"i18n@CharacterSet.1250",
+			"i18n@CharacterSet.1251",
+			"i18n@CharacterSet.1252",
+			"i18n@CharacterSet.1253",
+			"i18n@CharacterSet.1254",
+			"i18n@CharacterSet.1255",
+			"i18n@CharacterSet.1256",
+			"i18n@CharacterSet.1257",
+			"i18n@CharacterSet.1258",
+			"i18n@CharacterSet.2022-CN",
+			"i18n@CharacterSet.2022-JP",
+			"i18n@CharacterSet.2022-KR",
+			"i18n@CharacterSet.8859-1",
+			"i18n@CharacterSet.8859-2",
+			"i18n@CharacterSet.8859-3",
+			"i18n@CharacterSet.8859-4",
+			"i18n@CharacterSet.8859-5",
+			"i18n@CharacterSet.8859-6",
+			"i18n@CharacterSet.8859-7",
+			"i18n@CharacterSet.8859-8",
+			"i18n@CharacterSet.8859-9",
+			"i18n@CharacterSet.8859-10",
+			"i18n@CharacterSet.8859-11",
+			"i18n@CharacterSet.8859-13",
+			"i18n@CharacterSet.8859-14",
+			"i18n@CharacterSet.8859-15",
+			"i18n@CharacterSet.8859-16",
+			"i18n@CharacterSet.Big5",
+			"i18n@CharacterSet.EUC-JP",
+			"i18n@CharacterSet.EUC-KR",
+			"i18n@CharacterSet.GB18030",
+			"i18n@CharacterSet.IBM420",
+			"i18n@CharacterSet.IBM424",
+			"i18n@CharacterSet.KOI8-R",
+			"i18n@CharacterSet.ShiftJIS",
+			"i18n@CharacterSet.TIS-620"
+		};
 		return UMSUtils.getArraysAsJsonArrayOfObjects(values, labels, null);
 	}
 
@@ -5686,9 +5710,9 @@ public class UmsConfiguration extends BaseConfiguration {
 		jObj.addProperty(KEY_ASS_SHADOW, 1);
 		jObj.addProperty(KEY_THUMBNAIL_SEEK_POS, 4);
 		jObj.addProperty(KEY_TMDB_API_KEY, "");
-		jObj.addProperty(KEY_UPNP_DEBUG, false);
 		jObj.addProperty(KEY_UPNP_ENABLED, true);
 		jObj.addProperty(KEY_UPNP_JUPNP_DIDL, false);
+		jObj.addProperty(KEY_UPNP_LOG_LEVEL, "1");
 		jObj.addProperty(KEY_USE_EMBEDDED_SUBTITLES_STYLE, true);
 		jObj.addProperty(KEY_USE_IMDB_INFO, true);
 		jObj.addProperty(KEY_USE_TMDB_INFO, true);

--- a/src/main/java/net/pms/network/mediaserver/MediaServer.java
+++ b/src/main/java/net/pms/network/mediaserver/MediaServer.java
@@ -91,7 +91,7 @@ public class MediaServer {
 			if (CONFIGURATION.isUpnpEnabled()) {
 				if (upnpService == null) {
 					LOGGER.debug("Starting UPnP (JUPnP) services.");
-					upnpService = new UmsUpnpService(true);
+					upnpService = new UmsUpnpService();
 					upnpService.startup();
 				}
 				try {

--- a/src/main/java/net/pms/network/mediaserver/jupnp/UmsUpnpService.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/UmsUpnpService.java
@@ -16,19 +16,11 @@
  */
 package net.pms.network.mediaserver.jupnp;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.LoggerContext;
-import net.pms.PMS;
-import net.pms.configuration.UmsConfiguration;
 import net.pms.network.mediaserver.jupnp.model.meta.UmsLocalDevice;
 import net.pms.network.mediaserver.jupnp.registry.UmsRegistryListener;
-import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.jupnp.UpnpServiceImpl;
 import org.jupnp.protocol.ProtocolFactory;
 import org.jupnp.registry.Registry;
-import org.jupnp.util.SpecificationViolationReporter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * HTTPMU/HTTPU only implementation. Use it's own ssdp upnp server if
@@ -38,41 +30,10 @@ import org.slf4j.LoggerFactory;
  */
 public class UmsUpnpService extends UpnpServiceImpl {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(UmsUpnpService.class);
-	private static final UmsConfiguration CONFIGURATION = PMS.getConfiguration();
-
 	private final UmsLocalDevice mediaServerDevice = UmsLocalDevice.createMediaServerDevice();
 
-	public UmsUpnpService(boolean serveContentDirectory) {
-		super(new UmsUpnpServiceConfiguration(serveContentDirectory));
-		CONFIGURATION.addConfigurationListener((ConfigurationEvent event) -> {
-			if (!event.isBeforeUpdate() &&
-				UmsConfiguration.KEY_UPNP_DEBUG.equals(event.getPropertyName())) {
-				resetLoggingMode();
-			}
-		});
-		resetLoggingMode();
-	}
-
-	private static void resetLoggingMode() {
-		if (!CONFIGURATION.isUpnpDebug()) {
-			//don't log org.jupnp by default to reflext Cling not log to UMS.
-			LOGGER.debug("Upnp set in silent log mode");
-			LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-			ch.qos.logback.classic.Logger rootLogger = loggerContext.getLogger("org.jupnp");
-			rootLogger.setLevel(Level.OFF);
-			rootLogger = loggerContext.getLogger("org.jupnp.support");
-			rootLogger.setLevel(Level.OFF);
-			SpecificationViolationReporter.disableReporting();
-		} else {
-			LOGGER.debug("Upnp set in debug log mode");
-			LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-			ch.qos.logback.classic.Logger rootLogger = loggerContext.getLogger("org.jupnp");
-			rootLogger.setLevel(Level.ALL);
-			rootLogger = loggerContext.getLogger("org.jupnp.support");
-			rootLogger.setLevel(Level.ALL);
-			SpecificationViolationReporter.enableReporting();
-		}
+	public UmsUpnpService() {
+		super(new UmsUpnpServiceConfiguration());
 	}
 
 	@Override

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
@@ -392,10 +392,10 @@ public class UmsContentDirectoryService {
 				checkInput(modelObjectToAdd);
 
 				StoreResource resource = null;
-				if (modelObjectToAdd.getItems().isEmpty()) {
+				if (!modelObjectToAdd.getItems().isEmpty()) {
 					resource = createItemResource(storeContainer, modelObjectToAdd.getItems().get(0), resource);
 				}
-				if (modelObjectToAdd.getContainers().isEmpty()) {
+				if (!modelObjectToAdd.getContainers().isEmpty()) {
 					resource = createContainerResource(storeContainer, modelObjectToAdd.getContainers().get(0), resource);
 				}
 				if (resource != null) {
@@ -423,7 +423,7 @@ public class UmsContentDirectoryService {
 		if (modelObjectToAdd.getContainers().size() > 1) {
 			LOGGER.trace("more than 1 container ... using first found.");
 		}
-		if (modelObjectToAdd.getContainers().isEmpty() && modelObjectToAdd.getItems().isEmpty()) {
+		if (!modelObjectToAdd.getContainers().isEmpty() && !modelObjectToAdd.getItems().isEmpty()) {
 			LOGGER.trace("found items and container ... using container object ...");
 		}
 	}

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/Generator.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/Generator.java
@@ -38,6 +38,7 @@ import org.jupnp.model.XMLUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Attr;
+import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -178,12 +179,18 @@ public class Generator {
 			Class<?> namespace,
 			String namespaceURI) {
 		for (Property<?> property : object.getProperties().getPropertiesInstanceOf(namespace)) {
-			Element element = descriptor.createElementNS(namespaceURI, property.getQualifiedName());
-			String pre = descriptor.lookupPrefix(namespaceURI);
-			element.setPrefix(pre);
-			appendAttributes(descriptor, element, property);
-			element.setTextContent(property.toString());
-			parent.appendChild(element);
+			String qualifiedName = property.getQualifiedName();
+			try {
+				Element element = descriptor.createElementNS(namespaceURI, qualifiedName);
+				String pre = descriptor.lookupPrefix(namespaceURI);
+				element.setPrefix(pre);
+				appendAttributes(descriptor, element, property);
+				element.setTextContent(property.toString());
+				parent.appendChild(element);
+			} catch (DOMException e) {
+				LOGGER.warn("Property '{}' throw an exception: {}", qualifiedName, e.getMessage());
+				LOGGER.trace("", e);
+			}
 		}
 	}
 

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/namespace/upnp/UPNP.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/namespace/upnp/UPNP.java
@@ -666,11 +666,11 @@ public class UPNP {
 		}
 
 		public Genre(String value) {
-			super(value, null);
+			super(value, "genre");
 		}
 
 		public Genre(String value, String id, String extended) {
-			super(value, null);
+			super(value, "genre");
 			setId(id);
 			setExtended(extended);
 		}

--- a/src/main/java/net/pms/network/webguiserver/servlets/SettingsApiServlet.java
+++ b/src/main/java/net/pms/network/webguiserver/servlets/SettingsApiServlet.java
@@ -58,6 +58,7 @@ public class SettingsApiServlet extends GuiHttpServlet {
 	private static final JsonObject WEB_SETTINGS_WITH_DEFAULTS = UmsConfiguration.getWebSettingsWithDefaults();
 	private static final JsonArray AUDIO_COVER_SUPPLIERS = UmsConfiguration.getAudioCoverSuppliersAsJsonArray();
 	private static final JsonArray FFMPEG_LOGLEVEL = UmsConfiguration.getFfmpegLoglevels();
+	private static final JsonArray UPNP_LOGLEVEL = UmsConfiguration.getUpnpLoglevels();
 	private static final JsonArray FULLY_PLAYED_ACTIONS = UmsConfiguration.getFullyPlayedActionsAsJsonArray();
 	private static final JsonArray SORT_METHODS = UmsConfiguration.getSortMethodsAsJsonArray();
 	private static final JsonArray SUBTITLES_CODEPAGES = UmsConfiguration.getSubtitlesCodepageArray();
@@ -75,7 +76,7 @@ public class SettingsApiServlet extends GuiHttpServlet {
 			"web_gui_port",
 			"web_player_port"
 	);
-	private static final List<String> SELECT_KEYS = List.of("server_engine", "audio_thumbnails_method", "sort_method", "ffmpeg_avisynth_output_format_index_3d", "ffmpeg_avisynth_conversion_algorithm_index_2d_to_3d", "ffmpeg_avisynth_horizontal_resize_resolution");
+	private static final List<String> SELECT_KEYS = List.of("server_engine", "audio_thumbnails_method", "sort_method", "ffmpeg_avisynth_output_format_index_3d", "ffmpeg_avisynth_conversion_algorithm_index_2d_to_3d", "ffmpeg_avisynth_horizontal_resize_resolution", UmsConfiguration.KEY_UPNP_LOG_LEVEL);
 	private static final List<String> ARRAY_KEYS = List.of("folders", "folders_monitored");
 
 	@Override
@@ -104,6 +105,7 @@ public class SettingsApiServlet extends GuiHttpServlet {
 				jsonResponse.add("subtitlesCodepages", SUBTITLES_CODEPAGES);
 				jsonResponse.add("subtitlesDepth", SUBTITLES_DEPTH);
 				jsonResponse.add("ffmpegLoglevels", FFMPEG_LOGLEVEL);
+				jsonResponse.add("upnpLoglevels", UPNP_LOGLEVEL);
 				jsonResponse.add("fullyPlayedActions", FULLY_PLAYED_ACTIONS);
 				jsonResponse.add("networkInterfaces", NetworkConfiguration.getNetworkInterfacesAsJsonArray());
 				jsonResponse.add("allRendererNames", RendererConfigurations.getAllRendererNamesAsJsonArray());

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -495,6 +495,7 @@ MDNSChromecastService=mDNS Chromecast service
 MediaLibrary=Media Library
 MediaLibraryFolderWillAvailable=<html><strong>Default:</strong> Enabled<br><strong>Notes:</strong> If enabled, the Media Library folder will be available, which lets you dynamically filter and sort your media by things like played status, genre, rating, etc.</html>
 MediaServer=Media server
+MediaServerOnly=MediaServer only
 MediaServerIpAddress=<html><strong>Media Server</strong> IP address<br>Click to copy to clipboard</html>
 MediumQualityHdWifi=Medium quality (HD Wi-Fi)
 MemoryUsage=Memory Usage:


### PR DESCRIPTION
- Implements UPnP log levels (avoid spamming / big log file) for readability.
It is quite similar that what we get before upgrading to JUPnP (old cling).
It is a real time setting, so we can still log debug in real time the datagrams/io UPnP.

- Log contentdirectory DOMException, fix UPnP genre.

