### PR TITLE
Added renderer configs for LG FHD LED-backlit LCD TVs (#5132)

### DIFF
--- a/src/main/external-resources/renderers/LG-L-2022+.conf
+++ b/src/main/external-resources/renderers/LG-L-2022+.conf
@@ -16,8 +16,8 @@ RendererIcon = LG-LB.png
 # ============================================================================
 #
 
-UserAgentSearch = TV.*LG.*\d{2}L[QRT]\d{4}
-UpnpDetailsSearch = TV.*LG.*\d{2}L[QRT]\d{4}
+UserAgentSearch = \d{2}L[QRT]\d{4}
+UpnpDetailsSearch = \d{2}L[QRT]\d{4}
 LoadingPriority = 2
 
 TranscodeVideo = MPEGTS-H264-AC3

--- a/src/main/external-resources/renderers/LG-L-2022+.conf
+++ b/src/main/external-resources/renderers/LG-L-2022+.conf
@@ -1,0 +1,45 @@
+#----------------------------------------------------------------------------
+# Generic profile for LG L (2022+ FHD LED-backlit LCD) TVs.
+# These are similar to previous LG FHD LCD TVs but with HDR support.
+# The following was used to get the model range https://en.tab-tv.com/marking-decoding-tvs-lg-samsung-sony-etc/identifying-the-models-of-lg-tvs/
+# The following was used to see file support http://kr.eguide.lgappstv.com/manual/w22_mr6/global/Apps/w22_mr6_e19/e_eng/etc.html?iFrameLink=w22__etc__videocodec_u_b_e_c_a_t_j__eng.html
+# See DefaultRenderer.conf for descriptions of all the available options.
+#
+
+RendererName = LG LED-backlit LCD TV (2022+)
+RendererIcon = LG-LB.png
+
+# ============================================================================
+# This renderer has sent the following string/s:
+#
+# friendlyName=[LG] webOS TV LQ63006LA, modelNumber=32LQ63006LA
+# ============================================================================
+#
+
+UserAgentSearch = TV.*LG.*\d{2}L[QRT]\d{4}
+UpnpDetailsSearch = TV.*LG.*\d{2}L[QRT]\d{4}
+LoadingPriority = 2
+
+TranscodeVideo = MPEGTS-H264-AC3
+TranscodeAudio = MP3
+MuxNonMod4Resolution = true
+SeekByTime = exclusive
+
+# Supported video formats:
+Supported = f:3gp|3g2    v:h264|mp4                          a:aac-lc                                                   m:video/3gpp
+Supported = f:avi|divx   v:divx|h264|mjpeg|mp4               a:ac3|lpcm|mp3|mpa                                         m:video/avi
+Supported = f:mkv        v:av1|h264|h265|mpeg2|mp4|vp8|vp9   a:aac-lc|he-aac|ac3|dts|mp3|mpa            si:ASS|SUBRIP   m:video/x-matroska
+Supported = f:mp4|mov    v:av1|h264|h265|mp4                 a:aac-lc|eac3|he-aac|ac3|ac4|mp3           si:TX3G         m:video/mp4
+Supported = f:mpegts     v:h264|h265|mpeg2                   a:aac-lc|ac3|ac4|he-aac|ac3|eac3|mp3|mpa                   m:video/mpeg
+Supported = f:mpegps     v:mpeg1|mpeg2                       a:aac-lc|ac3|mp3|mpa                                       m:video/mpeg
+Supported = f:wmv        v:wmv|vc1                           a:wma                                                      m:video/x-ms-wmv
+
+# Supported audio formats:
+Supported = f:flac   m:audio/flac
+Supported = f:mp3    m:audio/mpeg
+Supported = f:oga    m:audio/ogg
+Supported = f:wav    m:audio/wav
+Supported = f:wma    m:audio/x-ms-wma
+
+# Supported subtitles formats:
+SupportedExternalSubtitlesFormats = ASS|SAMI|SUBRIP|TEXT

--- a/src/main/external-resources/renderers/LG-L.conf
+++ b/src/main/external-resources/renderers/LG-L.conf
@@ -1,27 +1,27 @@
 #----------------------------------------------------------------------------
-# Profile for LG LB (2014 FHD LED-backlit LCD) TVs.
+# Generic profile for LG L (FHD LED-backlit LCD) TVs.
+# This provides a fallback for when we don't have a more specific profile.
 # See DefaultRenderer.conf for descriptions of all the available options.
-# A reference for these models is https://www.flatpanelshd.com/article.php?subaction=showfull&id=1396941506
 #
 
-RendererName = LG LCD TV (2014)
+RendererName = LG LED-backlit LCD TV
 RendererIcon = LG-LB.png
 
 # ============================================================================
 # This renderer has sent the following string/s:
 #
-# friendlyName=[TV][LG]42LB5700-ZB
+# friendlyName=[LG] webOS TV LQ63006LA, modelNumber=32LQ63006LA
 # ============================================================================
 #
 
-UserAgentSearch = TV.*LG.*\d{2}LB\d{4}
-UpnpDetailsSearch = TV.*LG.*\d{2}LB\d{4}
-LoadingPriority = 2
+UserAgentSearch = TV.*LG.*\d{2}L[A-Z]\d{4}
+UpnpDetailsSearch = TV.*LG.*\d{2}L[A-Z]\d{4}
+LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = MP3
-TranscodedVideoFileSize = -1
 MuxNonMod4Resolution = true
+SeekByTime = exclusive
 
 # Supported video formats:
 Supported = f:3gp|3g2    v:h264|mp4              a:aac-lc                                m:video/3gpp

--- a/src/main/external-resources/renderers/LG-L.conf
+++ b/src/main/external-resources/renderers/LG-L.conf
@@ -14,8 +14,8 @@ RendererIcon = LG-LB.png
 # ============================================================================
 #
 
-UserAgentSearch = TV.*LG.*\d{2}L[A-Z]\d{4}
-UpnpDetailsSearch = TV.*LG.*\d{2}L[A-Z]\d{4}
+UserAgentSearch = \d{2}L[A-Z]\d{4}
+UpnpDetailsSearch = \d{2}L[A-Z]\d{4}
 LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AC3

--- a/src/main/external-resources/renderers/LG-LA6200.conf
+++ b/src/main/external-resources/renderers/LG-LA6200.conf
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-# Profile for LG LA6200 TVs.
+# Profile for LG LA6200 (2013 FHD LED-backlit LCD) TVs.
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 

--- a/src/main/external-resources/renderers/LG-LA644V.conf
+++ b/src/main/external-resources/renderers/LG-LA644V.conf
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-# Profile for LG LA644V Smart TV.
+# Profile for LG LA644V (2013 FHD LED-backlit LCD) TVs.
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 

--- a/src/main/external-resources/renderers/LG-LM620.conf
+++ b/src/main/external-resources/renderers/LG-LM620.conf
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-# Profile for LG *LM620S/ZE
+# Profile for LG *LM620S/ZE (2019 WXGA LED-backlit LCD) TVs.
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 

--- a/src/main/external-resources/renderers/LG-LM660.conf
+++ b/src/main/external-resources/renderers/LG-LM660.conf
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-# Profile for LG LM660 TVs.
+# Profile for LG LM660 (2012 FHD LED-backlit LCD) TVs.
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 
@@ -17,7 +17,7 @@ RendererIcon = LG-LM660.png
 
 UserAgentSearch = \d{2}LM660
 UpnpDetailsSearch = \d{2}LM660
-LoadingPriority = 1
+LoadingPriority = 2
 
 SeekByTime = true
 

--- a/src/main/external-resources/renderers/LG-LS5700.conf
+++ b/src/main/external-resources/renderers/LG-LS5700.conf
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-# Profile for LG LS5700 TVs.
+# Profile for LG LS5700 (FHD LED-backlit LCD) TVs from 2012.
 # See DefaultRenderer.conf for descriptions of all the available options.
 
 RendererName = LG LS5700
@@ -14,7 +14,7 @@ RendererIcon = lg-la6200.png
 
 UserAgentSearch = \d{2}LS5700
 UpnpDetailsSearch = \d{2}LS5700
-LoadingPriority = 1
+LoadingPriority = 2
 
 SeekByTime = true
 

--- a/src/main/external-resources/renderers/LG-NANO.conf
+++ b/src/main/external-resources/renderers/LG-NANO.conf
@@ -1,0 +1,59 @@
+#----------------------------------------------------------------------------
+# Profile for LG NANO TVs.
+# The short-lived series of TVs started in 2020 and ended in 2022.
+# The technology was superceded by QNED.
+# See DefaultRenderer.conf for descriptions of all the available options.
+#
+
+RendererName = LG NANO TV
+RendererIcon = lg-lb6500.png
+
+# ============================================================================
+# This renderer has sent the following string/s:
+#
+# It is assumed that the NANO756PR sends this:
+# friendlyName=[LG] webOS TV NANO756PR
+# modelNumber=NANO756PR
+#
+# The manual lists the following similar devices:
+#
+# Manual link:
+# http://kr.eguide.lgappstv.com/manual/w21_mr8/global/Apps/w6.0_mr8_e10/e_eng/etc.html?iFrameLink=w60__etc__videocodec_e_c_a_t_j__eng.html
+#
+# Page describing LG OLED model numbers: https://en.tab-tv.com/?page_id=7111
+# ============================================================================
+#
+
+UserAgentSearch = NANO\d{2}
+UpnpDetailsSearch = NANO\d{2}
+
+TranscodeVideo = MPEGTS-H265-AC3
+H264LevelLimit = 5.1
+MaxVideoWidth = 3840
+MaxVideoHeight = 2160
+DefaultVBVBufSize = true
+SeekByTime = exclusive
+ChunkedTransfer = true
+SupportedVideoBitDepths = 8,10,12
+DisableUmsResume = true
+MuxNonMod4Resolution = true
+
+# Supported video formats:
+Supported = f:3gp|3g2   v:h264|mp4                          a:aac-lc                                                                                         m:video/3gpp
+Supported = f:avi       v:divx|h264|mjpeg|mp4               a:aac-lc|ac3|he-aac|mp3|mpa                  gmc:0                                               m:video/avi
+Supported = f:mkv       v:av1|h264|h265|mp4|mpeg2|vp8|vp9   a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|opus           si:ASS|SUBRIP   hdr:hdr10|hlg               m:video/x-matroska
+Supported = f:mov       v:av1|h264|h265|mp4                 a:aac-lc|ac3|ac4|eac3|he-aac|mp3                                                                 m:video/quicktime
+Supported = f:mp4|m4v   v:av1|h264|h265|mp4                 a:aac-lc|ac3|ac4|eac3|he-aac|mp3                     si:TX3G         hdr:dolbyvision|hdr10|hlg   m:video/mp4
+Supported = f:mpegps    v:mpeg1|mpeg2                       a:ac3|lpcm|mpa                                                                                   m:video/mpeg
+Supported = f:mpegts    v:h264|h265|mpeg2                   a:aac-lc|ac3|ac4|eac3|he-aac|lpcm|mp3|mpa                            hdr:dolbyvision|hdr10|hlg   m:video/vnd.dlna.mpeg-tts
+Supported = f:wmv|asf   v:wmv|vc1                           a:wma                                                                                            m:video/x-ms-wmv
+
+# Supported audio formats:
+Supported = f:mp3   m:audio/mpeg
+Supported = f:oga   m:audio/ogg
+Supported = f:wav   m:audio/L16
+Supported = f:wma   m:audio/x-ms-wma
+
+# Supported subtitles formats:
+SupportedExternalSubtitlesFormats = ASS,MICRODVD,SAMI,SUBRIP,TEXT,WEBVTT
+StreamSubsForTranscodedVideo = true

--- a/src/main/external-resources/renderers/LG-TV-2023+.conf
+++ b/src/main/external-resources/renderers/LG-TV-2023+.conf
@@ -24,7 +24,7 @@ RendererIcon = lg-lb6500.png
 # modelName=LG Smart TV
 # modelNumber=UR73003LA
 #
-# The manual lists the following similar devices:
+# The OLED manual lists the following similar devices:
 # OLED48A3AUA
 # OLED48A3PUA
 # OLED55A3AUA
@@ -56,13 +56,16 @@ RendererIcon = lg-lb6500.png
 # Manual link:
 # http://kr.eguide.lgappstv.com/manual/w23_mr2/global/Apps/w23_mr2_us06/u_enga/etc.html?iFrameLink=../../../Contents/etc/videocodec_u_b_e_c_a_t_j/enga/w23__etc__videocodec_u_b_e_c_a_t_j__enga.html
 #
-# Page describing LG OLED model numbers: https://en.tab-tv.com/?page_id=7111
+# This also supports newer QNED TVs, e.g. 65QNED91T6A because that has the same file support as the OLEDs:
+# http://kr.eguide.lgappstv.com/manual/w24_mr2/global/Apps/w24_mr2_eu06/e_eng/etc.html?iFrameLink=w24__etc__videocodec_u_b_e_c_a_t_j__eng.html
+#
+# Page describing LG TV model numbers: https://en.tab-tv.com/?page_id=7111
 # ============================================================================
 #
 
-# Note: The 1-5 part includes a future prediction based on the tab-tv link above. If the naming convention changes it will need to be updated.
-UserAgentSearch = OLED\d{2}[ABCEGRWZ][3-5]|LG*UR\d{4}
-UpnpDetailsSearch = OLED\d{2}[ABCEGRWZ][3-5]|LG*UR\d{4}
+# Note: The 3-5 part includes a future prediction based on the tab-tv link above. If the naming convention changes it will need to be updated.
+UserAgentSearch = OLED\d{2}[ABCEGRWZ][3-5]|LG*UR\d{4}|QNED[89]
+UpnpDetailsSearch = OLED\d{2}[ABCEGRWZ][3-5]|LG*UR\d{4}|QNED[89]
 LoadingPriority = 2
 
 TranscodeVideo = MPEGTS-H265-AC3

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -120,6 +120,8 @@ public class RendererConfigurationTest {
 
 		testUPNPDetails("LG LS5700", "friendlyName=[TV]42LS5700-SB");
 
+		testUPNPDetails("LG NANO TV", "modelNumber=NANO756PR");
+
 		testUPNPDetails(
 			"LG OLED",
 			"modelNumber=OLED65C9PUA",
@@ -147,7 +149,11 @@ public class RendererConfigurationTest {
 // 		This does not match the OLED[0-9]{2} configuration for the LG 2023+ config ...
 //		testUPNPDetails("LG TV 2023+", "modelNumber=UR73003LA");
 
-		testUPNPDetails("LG TV 2023+", "# modelDescription=LG WebOSTV DMRplus OLED65C3AUA");
+		testUPNPDetails(
+			"LG TV 2023+",
+			"# modelDescription=LG WebOSTV DMRplus OLED65C3AUA",
+			"modelNumber=65QNED91T6A"
+		);
 
 		testHeaders    ("LG UB820V", "User-Agent: Linux/3.0.13 UPnP/1.0 LGE_DLNA_SDK/1.6.0 [TV][LG]42UB820V-ZH/04.02.00 DLNADOC/1.50");
 

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -112,6 +112,8 @@ public class RendererConfigurationTest {
 
 		testUPNPDetails("LG EG910V", "modelDescription=webOS TV EG910V");
 
+		testUPNPDetails("LG LED-backlit LCD TV (2022+)", "modelNumber=32LQ63006LA");
+
 		testUPNPDetails("LG LCD TV (2014)", "friendlyName=[TV][LG]42LB5700-ZB");
 
 		testUPNPDetails("LG LM660", "friendlyName=[TV]42LM660S-ZA");


### PR DESCRIPTION
# Description of code changes

Adds support for:
- LG FHD LED-backlit LCD TVs
- LG NANO (LED-backlit with added green layer) TVs
- LG QNED (MiniLED) TVs

Fixes https://github.com/UniversalMediaServer/UniversalMediaServer/issues/5132

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
