### PR TITLE
Transcode if any audio is unsupported

### DIFF
--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -721,8 +721,21 @@ public class FormatConfiguration {
 				renderer
 			);
 			finalMimeType = mimeType;
-			if (mimeType != null) { // if at least one audio track is compatible, the file can be streamed.
-				return finalMimeType;
+
+			/**
+			 * If at least one audio track is not compatible, the file must be transcoded.
+			 *
+			 * Explanation: This was different in the past (see link below).
+			 * The reason it needs to be like this is because some files have the audio tracks
+			 * matching the Blu-rays, which is often a DTS variant main track, with other tracks
+			 * like commentary in Dolby Digital (AC-3), and for a media player that does not
+			 * support DTS that could result in the file being streamed with only the commentary
+			 * track playable, which is really annoying.
+			 *
+			 * @see https://github.com/UniversalMediaServer/UniversalMediaServer/pull/2089/files#diff-3926da02948039b178d111df20a3d7ac43794b5941f24285d300f1c09cb33759R680
+			 */
+			if (mimeType == null) {
+				return null;
 			}
 		}
 

--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -647,7 +647,8 @@ public class FormatConfiguration {
 		}
 		if (media.getDefaultAudioTrack() == null) {
 			// no sound
-			return getMatchedMIMEtype(media.getContainer(),
+			return getMatchedMIMEtype(
+				media.getContainer(),
 				media.getDefaultVideoTrack() != null ? media.getDefaultVideoTrack().getCodec() : null,
 				null,
 				0,
@@ -678,7 +679,8 @@ public class FormatConfiguration {
 			* track needs to be checked.
 			*/
 			MediaAudio audio = media.getDefaultAudioTrack();
-			return getMatchedMIMEtype(media.getContainer(),
+			return getMatchedMIMEtype(
+				media.getContainer(),
 				media.getDefaultVideoTrack() != null ? media.getDefaultVideoTrack().getCodec() : null,
 				audio.getCodec(),
 				audio.getNumberOfChannels(),
@@ -700,7 +702,8 @@ public class FormatConfiguration {
 		String finalMimeType = null;
 
 		for (MediaAudio audio : media.getAudioTracks()) {
-			String mimeType = getMatchedMIMEtype(media.getContainer(),
+			String mimeType = getMatchedMIMEtype(
+				media.getContainer(),
 				media.getDefaultVideoTrack() != null ? media.getDefaultVideoTrack().getCodec() : null,
 				audio.getCodec(),
 				audio.getNumberOfChannels(),

--- a/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
+++ b/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
@@ -480,11 +480,13 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 				if (!isVideoThumbnailRequest && format != null && format.isVideo()) {
 					MediaType mediaType = item.getMediaInfo() == null ? null : item.getMediaInfo().getMediaType();
 					if (mediaType == MediaType.VIDEO) {
-						if (item.getMediaInfo() != null &&
-								item.getMediaSubtitle() != null &&
-								item.getMediaSubtitle().isExternal() &&
-								!CONFIGURATION.isDisableSubtitles() &&
-								renderer.isExternalSubtitlesFormatSupported(item.getMediaSubtitle(), item)) {
+						if (
+							item.getMediaInfo() != null &&
+							item.getMediaSubtitle() != null &&
+							item.getMediaSubtitle().isExternal() &&
+							!CONFIGURATION.isDisableSubtitles() &&
+							renderer.isExternalSubtitlesFormatSupported(item.getMediaSubtitle(), item)
+						) {
 							String subtitleHttpHeader = renderer.getSubtitleHttpHeader();
 							if (StringUtils.isNotBlank(subtitleHttpHeader) && (!item.isTranscoded() || renderer.streamSubsForTranscodedVideo())) {
 								// Device allows a custom subtitle HTTP header; construct it


### PR DESCRIPTION
# Description of code changes

If at least one audio track is not compatible, the file must be transcoded.

The reason it needs to be like this is because some files have the audio tracks matching the Blu-rays, which is often a DTS variant main track, with other tracks like commentary in Dolby Digital (AC-3), and for a media player that does not support DTS that could result in the file being streamed with only the commentary track playable, which is really annoying.

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
