### PR TITLE
transcoding issue WebStream / check if renderer support native stream

### DIFF
--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -795,6 +795,23 @@ public class FormatConfiguration {
 		);
 	}
 
+
+	/**
+	 * Checks if renderer supports a specific mime type.
+	 * @param mimeType
+	 * @return
+	 */
+	public boolean supportsMimeType(String mimeType) {
+		for (SupportSpec supportSpec : supportSpecs) {
+			if (supportSpec.mimeType.equalsIgnoreCase(mimeType)) {
+				LOGGER.debug("renderer supports mime type {}", mimeType);
+				return true;
+			}
+		}
+		LOGGER.debug("renderer doesn't support mime type {}", mimeType);
+		return false;
+	}
+
 	public String getMatchedMIMEtype(
 		String container,
 		String videoCodec,

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -378,9 +378,7 @@ public class RendererConfiguration extends BaseConfiguration {
 			configuration.addProperty(KEY_SUPPORTED, "f:.+");
 		}
 
-		if (isUseMediaInfo()) {
-			formatConfiguration = new FormatConfiguration(configuration.getList(KEY_SUPPORTED));
-		}
+		formatConfiguration = new FormatConfiguration(configuration.getList(KEY_SUPPORTED));
 	}
 
 	public void reset() {

--- a/src/main/java/net/pms/store/StoreContainer.java
+++ b/src/main/java/net/pms/store/StoreContainer.java
@@ -119,6 +119,7 @@ public class StoreContainer extends StoreResource {
 		}
 
 		if (child instanceof StoreItem storeItem) {
+			child.resolve();
 			addChildItem(storeItem, isNew, isAddGlobally);
 		} else if (child instanceof StoreContainer storeContainer) {
 			addChildContainer(storeContainer, isNew, isAddGlobally);

--- a/src/main/java/net/pms/store/StoreItem.java
+++ b/src/main/java/net/pms/store/StoreItem.java
@@ -63,6 +63,7 @@ import net.pms.store.container.ChapterFileTranscodeVirtualFolder;
 import net.pms.store.item.DVDISOTitle;
 import net.pms.store.item.RealFile;
 import net.pms.store.item.VirtualVideoAction;
+import net.pms.store.item.WebStream;
 import net.pms.util.ByteRange;
 import net.pms.util.FileUtil;
 import net.pms.util.IPushOutput;
@@ -440,6 +441,20 @@ public abstract class StoreItem extends StoreResource {
 		if (renderer.getUmsConfiguration().isDisableTranscoding()) {
 			LOGGER.debug("Final verdict: \"{}\" will be streamed since transcoding is disabled", getName());
 			return null;
+		}
+
+		// WebStreams should be checked against the mime-type of the stream
+		if (this instanceof WebStream ws) {
+			if (getMediaInfo() != null && renderer.getFormatConfiguration() != null) {
+				if (StringUtils.isAllBlank(getMediaInfo().getMimeType())) {
+					LOGGER.warn("cannot read MIME-TYPE of stream {} ...", ws.getUrl());
+				}
+				LOGGER.debug("checking if renderer supports MIME-TYPE {}", getMediaInfo().getMimeType());
+				if (renderer.getFormatConfiguration().supportsMimeType(getMediaInfo().getMimeType())) {
+					LOGGER.debug("MIME-TYPE is supported. No transcoding.", getMediaInfo().getMimeType());
+					return null;
+				}
+			}
 		}
 
 		// Use device-specific conf, if any


### PR DESCRIPTION
WebStreams should only be transcoded, if the renderer doesn't support the streams mime-type. 

This PR checks if the renderer configuration has a "supports line" for the streams mime-type. In that case no transcoding is being done.