### PR TITLE
Feature / cds update object album art

### DIFF
--- a/src/main/java/net/pms/external/radiobrowser/RadioBrowser4j.java
+++ b/src/main/java/net/pms/external/radiobrowser/RadioBrowser4j.java
@@ -31,8 +31,6 @@ import net.pms.PMS;
 import net.pms.configuration.UmsConfiguration;
 import net.pms.database.MediaDatabase;
 import net.pms.database.MediaTableFiles;
-import net.pms.dlna.DLNAThumbnail;
-import net.pms.external.JavaHttpClient;
 import net.pms.formats.Format;
 import net.pms.formats.FormatFactory;
 import net.pms.media.MediaInfo;
@@ -128,15 +126,7 @@ public class RadioBrowser4j {
 					mediaInfo.getAudioMetadata().setGenre(genre);
 				}
 				if (StringUtils.isNotBlank(station.getFavicon()) && !ThumbnailSource.RADIOBROWSER.equals(mediaInfo.getThumbnailSource())) {
-					DLNAThumbnail thumbnail = JavaHttpClient.getThumbnail(station.getFavicon());
-					if (thumbnail != null) {
-						Long fileId = MediaTableFiles.getFileId(url);
-						if (fileId != null) {
-							Long thumbnailId = ThumbnailStore.getId(thumbnail, fileId, ThumbnailSource.RADIOBROWSER);
-							mediaInfo.setThumbnailId(thumbnailId);
-							mediaInfo.setThumbnailSource(ThumbnailSource.RADIOBROWSER);
-						}
-					}
+					ThumbnailStore.updateThumbnailByURI(station.getFavicon(), url, ThumbnailSource.RADIOBROWSER);
 				}
 				return true;
 			} catch (Exception e) {

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/updateobject/AlbumArtUriHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/updateobject/AlbumArtUriHandler.java
@@ -1,0 +1,45 @@
+package net.pms.network.mediaserver.jupnp.support.contentdirectory.updateobject;
+
+import org.jupnp.support.contentdirectory.ContentDirectoryException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.NodeList;
+import net.pms.store.StoreResource;
+import net.pms.store.ThumbnailSource;
+import net.pms.store.ThumbnailStore;
+
+/**
+ * Updates the Thumbnail AlbumArtURI of a resource.
+ */
+public class AlbumArtUriHandler extends BaseUpdateObjectHandler {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AlbumArtUriHandler.class.getName());
+
+	public AlbumArtUriHandler(StoreResource objectResource, NodeList currentTagValue, NodeList newTagValue) {
+		super(objectResource, currentTagValue, newTagValue);
+	}
+
+	@Override
+	public void handle() throws ContentDirectoryException {
+		LOGGER.debug("UpdateObject : AlbumArtURI ... ");
+		try {
+			String currentValue = getNodeTextValue(getCurrentTagValue(), 0);
+			String newValue = getNodeTextValue(getNewTagValue(), 0);
+
+			if (!isModelValueEqual(currentValue)) {
+				throw new ContentDirectoryException(702, "UpdateObject() failed because upnp:albumArtURI value listed in " +
+					"the CurrentTagValue argument do not match the current state of the ContentDirectory service. " +
+					"The specified data is likely out of date.");
+			}
+
+			ThumbnailStore.updateThumbnailByURI(newValue, getObjectResource().getFileName(), ThumbnailSource.USER);
+		} catch (Exception e) {
+			LOGGER.debug("UpdateObject : failed", e);
+		}
+	}
+
+	private boolean isModelValueEqual(String currentValue) {
+		// check URL
+		return true;
+	}
+}

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/updateobject/AlbumArtUriHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/updateobject/AlbumArtUriHandler.java
@@ -7,6 +7,8 @@ import org.w3c.dom.NodeList;
 import net.pms.store.StoreResource;
 import net.pms.store.ThumbnailSource;
 import net.pms.store.ThumbnailStore;
+import net.pms.store.container.PlaylistFolder;
+import net.pms.store.item.WebStream;
 
 /**
  * Updates the Thumbnail AlbumArtURI of a resource.
@@ -31,15 +33,17 @@ public class AlbumArtUriHandler extends BaseUpdateObjectHandler {
 					"the CurrentTagValue argument do not match the current state of the ContentDirectory service. " +
 					"The specified data is likely out of date.");
 			}
-
 			ThumbnailStore.updateThumbnailByURI(newValue, getObjectResource().getFileName(), ThumbnailSource.USER);
+			if (getObjectResource() instanceof WebStream ws && getObjectResource().getParent() instanceof PlaylistFolder pls) {
+				// This entry is a webResource from a Playlist. We can try to update the album art uri
+				pls.updateAlbumArtUriDirective(ws.getUrl(), newValue);
+			}
 		} catch (Exception e) {
 			LOGGER.debug("UpdateObject : failed", e);
 		}
 	}
 
 	private boolean isModelValueEqual(String currentValue) {
-		// check URL
 		return true;
 	}
 }

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/updateobject/UpdateObjectFactory.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/updateobject/UpdateObjectFactory.java
@@ -41,6 +41,10 @@ public class UpdateObjectFactory {
 			return new UpnpRatingHandler(objectResource, currentTagNode, newTagNode);
 		}
 
+		if ("upnp:albumArtURI".equalsIgnoreCase(getNodeName(currentTagNode)) || "upnp:albumArtURI".equalsIgnoreCase(getNodeName(newTagNode))) {
+			return new AlbumArtUriHandler(objectResource, currentTagNode, newTagNode);
+		}
+
 		LOGGER.warn("NO handler found for tag pair values : '{}' AND '{}'", currentTagValue, newTagValue);
 		return null;
 	}

--- a/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
+++ b/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
@@ -714,7 +714,7 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 			resp.setHeader("etag", updateId);
 		}
 
-		InputStream inputStream;
+		InputStream inputStream = null;
 
 		if (req.getHeader("transfermode.dlna.org") != null) {
 			resp.setHeader("TransferMode.DLNA.ORG", req.getHeader("transfermode.dlna.org"));
@@ -744,11 +744,14 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 			filterChain = new BufferedImageFilterChain(FullyPlayed.getOverlayFilter());
 		}
 		filterChain = resource.addFlagFilters(filterChain);
-		inputStream = thumbInputStream.transcode(
-				imageProfile,
-				renderer.isThumbnailPadding(),
-				filterChain
-		);
+
+		if (thumbInputStream != null) {
+			inputStream = thumbInputStream.transcode(
+					imageProfile,
+					renderer.isThumbnailPadding(),
+					filterChain
+			);
+		}
 		if (contentFeatures != null) {
 			resp.setHeader("ContentFeatures.DLNA.ORG", DlnaHelper.getDlnaImageContentFeatures(resource, imageProfile, true));
 		}

--- a/src/main/java/net/pms/parsers/WebStreamParser.java
+++ b/src/main/java/net/pms/parsers/WebStreamParser.java
@@ -150,12 +150,8 @@ public class WebStreamParser {
 			if (f != null) {
 				type = f.getType();
 				if (type == Format.PLAYLIST && !url.endsWith(ext)) {
-					// If the filename continues past the "extension" (i.e. has
-					// a query string) it's
-					// likely not a nested playlist but a media item, for
-					// instance Twitch TV media urls:
-					// 'http://video10.iad02.hls.twitch.tv/.../index-live.m3u8?token=id=235...'
-					type = defaultType;
+					// This can be a HLS stream, or some other content. Must analyze the URL headers ...
+					type = 0;
 				}
 				LOGGER.debug("Stream content type set to {} for {}", Format.getStringType(type), url);
 			} else {
@@ -177,6 +173,9 @@ public class WebStreamParser {
 				return Format.VIDEO;
 			} else if (contentType.startsWith("image")) {
 				return Format.IMAGE;
+			} else if (contentType.startsWith("application/vnd.apple.mpegurl")) {
+				// HLS playlist
+				return Format.PLAYLIST;
 			} else {
 				LOGGER.trace("web server has no content type set ...");
 				return currentType;

--- a/src/main/java/net/pms/store/ThumbnailSource.java
+++ b/src/main/java/net/pms/store/ThumbnailSource.java
@@ -26,7 +26,8 @@ public enum ThumbnailSource {
 	MUSICBRAINZ,
 	WEBSTREAM,
 	RADIOBROWSER,
-	EMBEDDED;
+	EMBEDDED,
+	USER;
 
 	public static ThumbnailSource valueOfName(String value) {
 		try {

--- a/src/main/java/net/pms/store/ThumbnailSource.java
+++ b/src/main/java/net/pms/store/ThumbnailSource.java
@@ -27,6 +27,7 @@ public enum ThumbnailSource {
 	WEBSTREAM,
 	RADIOBROWSER,
 	EMBEDDED,
+	PLAYLIST,
 	USER;
 
 	public static ThumbnailSource valueOfName(String value) {

--- a/src/main/java/net/pms/store/item/WebStream.java
+++ b/src/main/java/net/pms/store/item/WebStream.java
@@ -30,6 +30,9 @@ import net.pms.network.HTTPResourceAuthenticator;
 import net.pms.renderers.Renderer;
 import net.pms.store.MediaInfoStore;
 import net.pms.store.StoreItem;
+import net.pms.store.ThumbnailSource;
+import net.pms.store.ThumbnailStore;
+import net.pms.store.container.PlaylistFolder;
 import net.pms.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -178,9 +181,12 @@ public class WebStream extends StoreItem {
 		if (getMediaInfo() == null || !getMediaInfo().isMediaParsed()) {
 			setMediaInfo(MediaInfoStore.getWebStreamMediaInfo(url, getSpecificType()));
 		}
-		if (directives != null && directives.containsKey("RADIOBROWSERUUID")) {
+		if (directives != null && directives.containsKey(PlaylistFolder.DIRECTIVE_RADIOBROWSERUUID)) {
 			// Attempt to enhance the metadata via RADIOBROWSER API.
-			RadioBrowser4j.backgroundLookupAndAddMetadata(url, directives.get("RADIOBROWSERUUID"), mediaInfo);
+			RadioBrowser4j.backgroundLookupAndAddMetadata(url, directives.get(PlaylistFolder.DIRECTIVE_RADIOBROWSERUUID), mediaInfo);
+		}
+		if (directives != null && directives.containsKey(PlaylistFolder.DIRECTIVE_ALBUMART_URI)) {
+			ThumbnailStore.updateThumbnailByURI(directives.get(PlaylistFolder.DIRECTIVE_ALBUMART_URI), getFileName(), ThumbnailSource.PLAYLIST);
 		}
 	}
 

--- a/src/main/java/net/pms/store/item/WebVideoStream.java
+++ b/src/main/java/net/pms/store/item/WebVideoStream.java
@@ -27,7 +27,7 @@ public class WebVideoStream extends WebStream {
 	}
 
 	public WebVideoStream(Renderer renderer, String fluxName, String url, String thumbURL, Map<String, String> directives) {
-		super(renderer, fluxName, url, thumbURL, Format.VIDEO, null);
+		super(renderer, fluxName, url, thumbURL, Format.VIDEO, directives);
 	}
 
 }


### PR DESCRIPTION
- adds the ability to update `upnp:albumArtURI` over the `ContentDirectory.UpdateObject` service.
- Playlist will read `#EXTIMG:` directive for handling album art of a WebResouce

This is especially useful for playlists containing external web streams without cover art information. If the playlist is a `m3u` playlist, the `#EXTIMG:` directive will be updated, so the albumArt image will survive a database rebuild.