### PR TITLE
main fix 5203

### DIFF
--- a/src/main/java/net/pms/encoders/AviSynthFFmpeg.java
+++ b/src/main/java/net/pms/encoders/AviSynthFFmpeg.java
@@ -333,7 +333,7 @@ public class AviSynthFFmpeg extends FFMpegVideo {
 
 			File f = new File(filename);
 			if (f.exists()) {
-				filename = ProcessUtil.getShortFileNameIfWideChars(filename);
+				filename = ProcessUtil.getSystemPathName(filename);
 			}
 
 			String movieLine       		= "";
@@ -450,7 +450,7 @@ public class AviSynthFFmpeg extends FFMpegVideo {
 					if (subTrack.getType() == SubtitleType.VOBSUB) {
 						function = "VobSub";
 					}
-					subLine = function + "(\"" + ProcessUtil.getShortFileNameIfWideChars(subTrack.getExternalFile()) + "\")";
+					subLine = function + "(\"" + ProcessUtil.getSystemPathName(subTrack.getExternalFile()) + "\")";
 				} else {
 					LOGGER.error("External subtitles file \"{}\" is unavailable", subTrack.getName());
 				}

--- a/src/main/java/net/pms/encoders/AviSynthMEncoder.java
+++ b/src/main/java/net/pms/encoders/AviSynthMEncoder.java
@@ -109,7 +109,7 @@ public class AviSynthMEncoder extends MEncoderVideo {
 
 			File f = new File(fileName);
 			if (f.exists()) {
-				fileName = ProcessUtil.getShortFileNameIfWideChars(fileName);
+				fileName = ProcessUtil.getSystemPathName(fileName);
 			}
 
 			String movieLine       = "DirectShowSource(\"" + fileName + "\"" + directShowFPS + convertfps + ")" + assumeFPS;
@@ -164,7 +164,7 @@ public class AviSynthMEncoder extends MEncoderVideo {
 					if (subTrack.getType() == SubtitleType.VOBSUB) {
 						function = "VobSub";
 					}
-					subLine = function + "(\"" + ProcessUtil.getShortFileNameIfWideChars(subTrack.getExternalFile()) + "\")";
+					subLine = function + "(\"" + ProcessUtil.getSystemPathName(subTrack.getExternalFile()) + "\")";
 				} else {
 					LOGGER.error("External subtitles file \"{}\" is unavailable", subTrack.getName());
 				}

--- a/src/main/java/net/pms/encoders/FFMpegVideo.java
+++ b/src/main/java/net/pms/encoders/FFMpegVideo.java
@@ -928,7 +928,7 @@ public class FFMpegVideo extends Engine {
 		cmdList.add("-i");
 		if (avisynth && !filename.toLowerCase().endsWith(".iso") && this instanceof AviSynthFFmpeg aviSynthFFmpeg) {
 			AviSynthScriptGenerationResult aviSynthScriptGenerationResult = aviSynthFFmpeg.getAVSScript(filename, params, frameRateRatio, frameRateNumber, media);
-			cmdList.add(ProcessUtil.getShortFileNameIfWideChars(aviSynthScriptGenerationResult.getAvsFile().getAbsolutePath()));
+			cmdList.add(ProcessUtil.getSystemPathName(aviSynthScriptGenerationResult.getAvsFile().getAbsolutePath()));
 			isConvertedTo3d = aviSynthScriptGenerationResult.isConvertedTo3d();
 		} else {
 			if (params.getStdIn() != null) {

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -444,9 +444,9 @@ public class MEncoderVideo extends Engine {
 					// convert UTF-16 -> UTF-8
 					File convertedSubtitles = new File(configuration.getTempFolder(), "utf8_" + params.getSid().getExternalFile().getName());
 					FileUtil.convertFileFromUtf16ToUtf8(params.getSid().getExternalFile(), convertedSubtitles);
-					externalSubtitlesFileName = ProcessUtil.getShortFileNameIfWideChars(convertedSubtitles.getAbsolutePath());
+					externalSubtitlesFileName = ProcessUtil.getSystemPathName(convertedSubtitles.getAbsolutePath());
 				} else {
-					externalSubtitlesFileName = ProcessUtil.getShortFileNameIfWideChars(params.getSid().getExternalFile());
+					externalSubtitlesFileName = ProcessUtil.getSystemPathName(params.getSid().getExternalFile());
 				}
 			} else {
 				LOGGER.error("External subtitles file \"{}\" is unavailable", params.getSid().getName());
@@ -1221,7 +1221,7 @@ public class MEncoderVideo extends Engine {
 		// Input filename
 		if (avisynth && !filename.toLowerCase().endsWith(".iso")) {
 			File avsFile = AviSynthMEncoder.getAVSScript(filename, params.getSid(), params.getFromFrame(), params.getToFrame(), frameRateRatio, frameRateNumber, configuration);
-			cmdList.add(ProcessUtil.getShortFileNameIfWideChars(avsFile.getAbsolutePath()));
+			cmdList.add(ProcessUtil.getSystemPathName(avsFile.getAbsolutePath()));
 		} else {
 			if (params.getStdIn() != null) {
 				cmdList.add("-");

--- a/src/main/java/net/pms/encoders/VLCVideo.java
+++ b/src/main/java/net/pms/encoders/VLCVideo.java
@@ -530,13 +530,13 @@ public class VLCVideo extends Engine {
 							// Convert UTF-16 -> UTF-8
 							File convertedSubtitles = new File(CONFIGURATION.getTempFolder(), "utf8_" + params.getSid().getName());
 							FileUtil.convertFileFromUtf16ToUtf8(params.getSid().getExternalFile(), convertedSubtitles);
-							externalSubtitlesFileName = ProcessUtil.getShortFileNameIfWideChars(convertedSubtitles.getAbsolutePath());
+							externalSubtitlesFileName = ProcessUtil.getSystemPathName(convertedSubtitles.getAbsolutePath());
 						} catch (IOException e) {
 							LOGGER.debug("Error converting file from UTF-16 to UTF-8", e);
-							externalSubtitlesFileName = ProcessUtil.getShortFileNameIfWideChars(params.getSid().getExternalFile());
+							externalSubtitlesFileName = ProcessUtil.getSystemPathName(params.getSid().getExternalFile());
 						}
 					} else {
-						externalSubtitlesFileName = ProcessUtil.getShortFileNameIfWideChars(params.getSid().getExternalFile());
+						externalSubtitlesFileName = ProcessUtil.getSystemPathName(params.getSid().getExternalFile());
 					}
 
 					if (externalSubtitlesFileName != null) {

--- a/src/main/java/net/pms/parsers/FFmpegParser.java
+++ b/src/main/java/net/pms/parsers/FFmpegParser.java
@@ -138,7 +138,7 @@ public class FFmpegParser {
 
 		String input;
 		if (inputFile.getFile() != null) {
-			input = ProcessUtil.getShortFileNameIfWideChars(inputFile.getFile().getAbsolutePath());
+			input = ProcessUtil.getSystemPathName(inputFile.getFile().getAbsolutePath());
 		} else {
 			input = "-";
 		}
@@ -227,7 +227,7 @@ public class FFmpegParser {
 		args.add("-i");
 
 		if (inputFile.getFile() != null) {
-			args.add(ProcessUtil.getShortFileNameIfWideChars(inputFile.getFile().getAbsolutePath()));
+			args.add(ProcessUtil.getSystemPathName(inputFile.getFile().getAbsolutePath()));
 		} else {
 			args.add("-");
 		}

--- a/src/main/java/net/pms/parsers/MPlayerParser.java
+++ b/src/main/java/net/pms/parsers/MPlayerParser.java
@@ -99,7 +99,7 @@ public class MPlayerParser {
 			"-vo",
 			"null",
 			"-dvd-device",
-			ProcessUtil.getShortFileNameIfWideChars(file.getAbsolutePath()),
+			ProcessUtil.getSystemPathName(file.getAbsolutePath()),
 			"dvd://"
 		};
 		OutputParams params = new OutputParams(CONFIGURATION);
@@ -170,7 +170,7 @@ public class MPlayerParser {
 				"-vo",
 				"jpeg:outdir=mplayer_thumbs:subdirs=\"" + frameName + "\"",
 				"-dvd-device",
-				ProcessUtil.getShortFileNameIfWideChars(file.getAbsolutePath()),
+				ProcessUtil.getSystemPathName(file.getAbsolutePath()),
 				"dvd://" + title
 			};
 		} else {
@@ -187,7 +187,7 @@ public class MPlayerParser {
 				"-vo",
 				"null",
 				"-dvd-device",
-				ProcessUtil.getShortFileNameIfWideChars(file.getAbsolutePath()),
+				ProcessUtil.getSystemPathName(file.getAbsolutePath()),
 				"dvd://" + title
 			};
 		}
@@ -236,7 +236,7 @@ public class MPlayerParser {
 		args[3] = "-quiet";
 
 		if (file != null) {
-			args[4] = ProcessUtil.getShortFileNameIfWideChars(file.getAbsolutePath());
+			args[4] = ProcessUtil.getSystemPathName(file.getAbsolutePath());
 		} else {
 			args[4] = "-";
 		}

--- a/src/main/java/net/pms/parsers/mediainfo/MediaInfoHelper.java
+++ b/src/main/java/net/pms/parsers/mediainfo/MediaInfoHelper.java
@@ -19,6 +19,7 @@ package net.pms.parsers.mediainfo;
 import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.WString;
+import net.pms.util.ProcessUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,7 +86,8 @@ public class MediaInfoHelper implements AutoCloseable {
 	 * @return 1 if file was opened, 0 if file was not not opened
 	 */
 	public int openFile(String fileName) {
-		return MediaInfoLibrary.INSTANCE.Open(handle, new WString(fileName));
+		String path = ProcessUtil.getSystemPathName(fileName);
+		return MediaInfoLibrary.INSTANCE.Open(handle, new WString(path));
 	}
 
 	/**

--- a/src/main/java/net/pms/platform/IPlatformUtils.java
+++ b/src/main/java/net/pms/platform/IPlatformUtils.java
@@ -39,7 +39,7 @@ public interface IPlatformUtils {
 
 	public abstract File getKLiteFiltersDir();
 
-	public abstract String getShortPathNameW(String longPathName);
+	public abstract String getSystemPathName(String longPathName);
 
 	public abstract String getDiskLabel(File f);
 

--- a/src/main/java/net/pms/platform/PlatformUtils.java
+++ b/src/main/java/net/pms/platform/PlatformUtils.java
@@ -96,7 +96,7 @@ public class PlatformUtils implements IPlatformUtils {
 	}
 
 	@Override
-	public String getShortPathNameW(String longPathName) {
+	public String getSystemPathName(String longPathName) {
 		return longPathName;
 	}
 

--- a/src/main/java/net/pms/platform/windows/WindowsUtils.java
+++ b/src/main/java/net/pms/platform/windows/WindowsUtils.java
@@ -109,6 +109,10 @@ public class WindowsUtils extends PlatformUtils {
 		if (path != null) {
 			File file = new File(path);
 			String resolved = file.getAbsolutePath();
+			/*
+			 * On Windows the maximum short path is 260 minus 1 (NUL) -> 259 char.
+			 * But for directories it is 260 minus 12 (8.3 file) minus 1 (NUL) to allow for the creation of a file in the directory -> 247.
+			 */
 			if (resolved.length() > 247) {
 				if (resolved.length() > 32000) {
 					LOGGER.warn("Cannot access file with path exceeding 32000 characters");

--- a/src/main/java/net/pms/platform/windows/WindowsUtils.java
+++ b/src/main/java/net/pms/platform/windows/WindowsUtils.java
@@ -17,7 +17,6 @@
 package net.pms.platform.windows;
 
 import com.sun.jna.Native;
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.Shell32Util;
 import com.sun.jna.platform.win32.VerRsrc;
@@ -30,11 +29,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
-import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -108,37 +105,21 @@ public class WindowsUtils extends PlatformUtils {
 	}
 
 	@Override
-	public String getShortPathNameW(String longPathName) {
-		if (longPathName == null) {
-			return null;
-		}
-		boolean unicodeChars;
-		try {
-			byte[] b1 = longPathName.getBytes(StandardCharsets.UTF_8);
-			byte[] b2 = longPathName.getBytes("cp1252");
-			unicodeChars = b1.length != b2.length;
-		} catch (UnsupportedEncodingException e) {
-			return longPathName;
-		}
-
-		if (unicodeChars) {
-			try {
-				WString pathname = new WString(longPathName);
-
-				char[] test = new char[2 + pathname.length() * 2];
-				int r = Kernel32.INSTANCE.GetShortPathNameW(pathname, test, test.length);
-				if (r > 0) {
-					String result = Native.toString(test);
-					LOGGER.trace("Using short path name of \"{}\": \"{}\"", pathname, result);
-					return result;
+	public String getSystemPathName(String path) {
+		if (path != null) {
+			File file = new File(path);
+			String resolved = file.getAbsolutePath();
+			if (resolved.length() > 247) {
+				if (resolved.length() > 32000) {
+					LOGGER.warn("Cannot access file with path exceeding 32000 characters");
+				} else if (resolved.startsWith("\\\\")) {
+					return "\\\\?\\UNC" + resolved.substring(1, resolved.length());
+				} else {
+					return "\\\\?\\" + resolved;
 				}
-				return longPathName;
-
-			} catch (Exception e) {
-				return longPathName;
 			}
 		}
-		return longPathName;
+		return path;
 	}
 
 	private static String getWindowsDirectory() {

--- a/src/main/java/net/pms/store/container/PlaylistFolder.java
+++ b/src/main/java/net/pms/store/container/PlaylistFolder.java
@@ -87,7 +87,7 @@ public final class PlaylistFolder extends StoreContainer {
 
 	@Override
 	public String getSystemName() {
-		return isweb ? uri : ProcessUtil.getShortFileNameIfWideChars(uri);
+		return isweb ? uri : ProcessUtil.getSystemPathName(uri);
 	}
 
 	@Override

--- a/src/main/java/net/pms/store/container/RealFolder.java
+++ b/src/main/java/net/pms/store/container/RealFolder.java
@@ -64,7 +64,7 @@ public class RealFolder extends VirtualFolder implements SystemFileResource {
 
 	@Override
 	public String getSystemName() {
-		return ProcessUtil.getShortFileNameIfWideChars(directory.getAbsolutePath());
+		return ProcessUtil.getSystemPathName(directory.getAbsolutePath());
 	}
 
 	@Override

--- a/src/main/java/net/pms/store/item/RealFile.java
+++ b/src/main/java/net/pms/store/item/RealFile.java
@@ -207,7 +207,7 @@ public class RealFile extends StoreItem implements SystemFileResource {
 	 */
 	@Override
 	public String getFileName() {
-		return ProcessUtil.getShortFileNameIfWideChars(getFile().getAbsolutePath());
+		return ProcessUtil.getSystemPathName(getFile().getAbsolutePath());
 	}
 
 	@Override

--- a/src/main/java/net/pms/util/ProcessUtil.java
+++ b/src/main/java/net/pms/util/ProcessUtil.java
@@ -96,30 +96,26 @@ public class ProcessUtil {
 	}
 
 	/**
-	 * Converts the path of the specified {@link File} to the equivalent MS-DOS
-	 * style 8.3 path using the Windows API function {@code GetShortPathNameW()}
-	 * if the path contains Unicode characters.
+	 * Converts the path of the specified {@link File} to the a system path.
 	 *
 	 * @param file the {@link File} whose path to convert.
 	 * @return The resulting non-Unicode file path.
 	 */
-	public static String getShortFileNameIfWideChars(File file) {
+	public static String getSystemPathName(File file) {
 		if (file == null) {
 			return null;
 		}
-		return getShortFileNameIfWideChars(file.getPath());
+		return ProcessUtil.getSystemPathName(file.getPath());
 	}
 
 	/**
-	 * Converts the specified file path to the equivalent MS-DOS style 8.3 path
-	 * using the Windows API function {@code GetShortPathNameW()} if the path
-	 * contains Unicode characters.
+	 * Converts the specified file path to the equivalent system path.
 	 *
 	 * @param name the file path to convert.
 	 * @return The resulting non-Unicode file path.
 	 */
-	public static String getShortFileNameIfWideChars(String name) {
-		return PlatformUtils.INSTANCE.getShortPathNameW(name);
+	public static String getSystemPathName(String name) {
+		return PlatformUtils.INSTANCE.getSystemPathName(name);
 	}
 
 	// Run cmd and return combined stdout/stderr


### PR DESCRIPTION
fix #5203

# Description of code changes
use of Win32 file prefixing and conventions
refactoring `getShortFileNameIfWideChars` to `getSystemPathName`
refactoring `getShortPathNameW` to `getSystemPathName`
