### PR TITLE
Update H.264 level limit on Samsung C/D Series TVs (fixes #5242)

### DIFF
--- a/src/main/external-resources/renderers/Samsung-CD.conf
+++ b/src/main/external-resources/renderers/Samsung-CD.conf
@@ -24,6 +24,7 @@ RendererIcon = samsung-tv.png
 # User-Agent: SEC_HHP_[TV]PS51D8000/1.0
 # User-Agent: SEC_HHP_BD-C5500/1.0
 # User-Agent: SEC_HHP_[BD]D5300/1.0
+# modelName=UE40D5500
 #
 # Note: if the device name "[TV]PS51D6900" has been edited by the user via the
 # TV menu it will likely be misidentified as E and later series
@@ -42,6 +43,10 @@ MaxVideoBitrateMbps = 25
 SubtitleHttpHeader = CaptionInfo.sec
 PrependTrackNumbers = true
 CharMap = / :
+
+# The manual says the limit is 4.1 but a user says it works
+# https://www.universalmediaserver.com/forum/viewtopic.php?p=49278&sid=5474c1d0905de3e920f1f7926aab4a40#p49278
+H264LevelLimit = 5.1
 
 # Supported video formats:
 Supported = f:avi|mkv             m:video/avi

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -252,6 +252,7 @@ public class RendererConfigurationTest {
 			"User-Agent: DLNADOC/1.50 SEC_HHP_[TV]UE32D5000/1.0",
 			"User-Agent: DLNADOC/1.50 SEC_HHP_[TV]UN55D6050/1.0"
 		);
+		testUPNPDetails("Samsung C/D Series", "modelName=UE40D5500");
 
 		testHeaders(
 			"Samsung E+ Series",

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -252,7 +252,6 @@ public class RendererConfigurationTest {
 			"User-Agent: DLNADOC/1.50 SEC_HHP_[TV]UE32D5000/1.0",
 			"User-Agent: DLNADOC/1.50 SEC_HHP_[TV]UN55D6050/1.0"
 		);
-		testUPNPDetails("Samsung C/D Series", "modelName=UE40D5500");
 
 		testHeaders(
 			"Samsung E+ Series",


### PR DESCRIPTION
# Description of code changes

fixes #5242

# Checklist
- [x] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [x] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [x] Any relevant tests have been written/modified
