### PR TITLE
Put back react stylistic eslint

### DIFF
--- a/react-client/eslint.config.js
+++ b/react-client/eslint.config.js
@@ -1,49 +1,53 @@
-import tseslint from 'typescript-eslint';
-import reactPlugin from 'eslint-plugin-react';
-import hooksPlugin from 'eslint-plugin-react-hooks';
-import refreshPlugin from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint'
+import reactPlugin from 'eslint-plugin-react'
+import hooksPlugin from 'eslint-plugin-react-hooks'
+import refreshPlugin from 'eslint-plugin-react-refresh'
+import stylisticPlugin from '@stylistic/eslint-plugin'
 
 export default tseslint.config(
-        {
-          ignores: [
-            '.yarn/**',
-            'node/**',
-            'node_modules/**'
-          ]
-        },
-        {
-          files: ['**/*.js', '**/*.mjs', '**/*.cjs', '**/*.ts', '**/*.tsx'],
-          languageOptions: {
-            parser: tseslint.parser,
-            parserOptions: {
-              sourceType: 'module',
-              ecmaVersion: 2021
-            }
-          },
-          plugins: {
-            '@typescript-eslint': tseslint.plugin,
-            'react': reactPlugin,
-            'react-hooks': hooksPlugin,
-            'react-refresh': refreshPlugin
-          },
-          rules: {
-            ...tseslint.plugin.configs['eslint-recommended'].rules,
-            ...tseslint.plugin.configs.recommended.rules,
-            '@typescript-eslint/no-empty-function': 'off',
-            '@typescript-eslint/no-unused-vars': 'off',
-            '@typescript-eslint/no-explicit-any': 'off',
-            ...reactPlugin.configs['jsx-runtime'].rules,
-            ...hooksPlugin.configs.recommended.rules,
-            'react-hooks/exhaustive-deps': 'off',
-            'react-refresh/only-export-components': [
-              'warn',
-              {allowConstantExport: true}
-            ]
-          },
-          settings: {
-            react: {
-              version: 'detect'
-            }
-          }
-        }
+  {
+    ignores: [
+      '.yarn/**',
+      'node/**',
+      'node_modules/**',
+    ],
+  },
+  {
+    files: ['**/*.js', '**/*.mjs', '**/*.cjs', '**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        sourceType: 'module',
+        ecmaVersion: 2021,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+      'react': reactPlugin,
+      'react-hooks': hooksPlugin,
+      'react-refresh': refreshPlugin,
+      '@stylistic': stylisticPlugin,
+    },
+    rules: {
+      ...tseslint.plugin.configs['eslint-recommended'].rules,
+      ...tseslint.plugin.configs.recommended.rules,
+      '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      ...reactPlugin.configs['jsx-runtime'].rules,
+      ...hooksPlugin.configs.recommended.rules,
+      'react-hooks/exhaustive-deps': 'off',
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+      /* uncomment to check recommended stylistic rules */
+      //...stylisticPlugin.configs.recommended.rules,
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+  },
 )

--- a/react-client/package.json
+++ b/react-client/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.49.0",
+    "@stylistic/eslint-plugin": "4.1.0",
     "@types/lodash": "4.17.15",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",

--- a/react-client/playwright.config.ts
+++ b/react-client/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test'
 
 /**
  * Read environment variables from file.
@@ -83,4 +83,4 @@ export default defineConfig({
       timeout: 480000,
     },
   ],
-});
+})

--- a/react-client/tests/ServerSettings.spec.ts
+++ b/react-client/tests/ServerSettings.spec.ts
@@ -1,23 +1,23 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@playwright/test'
 
 test('should be able to navigate to Server Settings', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/')
 
-  await page.getByText('Main menu').click();
-  await page.getByText('Server Settings').click();
+  await page.getByText('Main menu').click()
+  await page.getByText('Server Settings').click()
 
-  await expect(page).toHaveURL(/.*settings/);
+  await expect(page).toHaveURL(/.*settings/)
 
-  //await expect(page).toHaveScreenshot();
-});
+  // await expect(page).toHaveScreenshot();
+})
 
 test('should be able to see the advanced settings', async ({ page }) => {
-  await page.goto('/settings');
+  await page.goto('/settings')
 
-  await page.getByText('Application').click();
-  await page.getByText('Show advanced settings').click();
+  await page.getByText('Application').click()
+  await page.getByText('Show advanced settings').click()
 
-  await expect(page.getByText('Renderers Settings')).toBeInViewport();
+  await expect(page.getByText('Renderers Settings')).toBeInViewport()
 
-  //await expect(page).toHaveScreenshot();
-});
+  // await expect(page).toHaveScreenshot();
+})

--- a/react-client/tests/SharedContent.spec.ts
+++ b/react-client/tests/SharedContent.spec.ts
@@ -1,31 +1,31 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@playwright/test'
 
 test('should be able to navigate to Shared Content', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/')
 
-  await page.getByText('Main menu').click();
-  await page.getByText('Shared Content').click();
+  await page.getByText('Main menu').click()
+  await page.getByText('Shared Content').click()
 
-  await expect(page).toHaveURL(/.*shared/);
+  await expect(page).toHaveURL(/.*shared/)
 
-  //await expect(page).toHaveScreenshot();
-});
+  // await expect(page).toHaveScreenshot();
+})
 
 test('should be able to add a YouTube channel as a video feed', async ({ page }) => {
-  await page.goto('/shared');
+  await page.goto('/shared')
 
-  await page.getByText('Add new shared content').click();
+  await page.getByText('Add new shared content').click()
 
-  //await expect(page).toHaveScreenshot();
+  // await expect(page).toHaveScreenshot();
 
-  await page.getByLabel('Type').first().click();
-  await page.getByText('Video feed').click();
+  await page.getByLabel('Type').first().click()
+  await page.getByText('Video feed').click()
 
-  await page.getByLabel('Source/URL').fill('https://www.youtube.com/@kurzgesagt');
+  await page.getByLabel('Source/URL').fill('https://www.youtube.com/@kurzgesagt')
 
-  await page.getByText('Add', { exact: true }).click();
+  await page.getByText('Add', { exact: true }).click()
 
-  await expect(page.getByText('Kurzgesagt – In a Nutshell')).toBeVisible();
+  await expect(page.getByText('Kurzgesagt – In a Nutshell')).toBeVisible()
 
-  //await expect(page).toHaveScreenshot();
-});
+  // await expect(page).toHaveScreenshot();
+})

--- a/react-client/tests/global.setup.ts
+++ b/react-client/tests/global.setup.ts
@@ -1,12 +1,12 @@
-import { test as setup } from '@playwright/test';
+import { test as setup } from '@playwright/test'
 
 setup('global setup', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/')
 
   // todo: fix the need for this initial delay/reload
-  await page.waitForTimeout(1000);
-  await page.reload();
+  await page.waitForTimeout(1000)
+  await page.reload()
 
-  await page.getByText('Disable authentication').click();
-  await page.getByText('Confirm').click();
-});
+  await page.getByText('Disable authentication').click()
+  await page.getByText('Confirm').click()
+})

--- a/react-client/vite.config.ts
+++ b/react-client/vite.config.ts
@@ -5,7 +5,7 @@ import livePreview from 'vite-live-preview'
 export default defineConfig({
   plugins: [
     react(),
-    livePreview()
+    livePreview(),
   ],
   build: {
     outDir: '../src/main/external-resources/web/react-client',
@@ -15,7 +15,7 @@ export default defineConfig({
     chunkSizeWarningLimit: 2000,
     rollupOptions: {
       output: {
-          hashCharacters: 'hex'
+        hashCharacters: 'hex',
       },
       onwarn(warning, defaultHandler) {
         if (warning.code === 'SOURCEMAP_ERROR') {
@@ -32,6 +32,6 @@ export default defineConfig({
     open: '/',
     proxy: {
       '/v1': 'http://localhost:9001',
-    }
-  }
+    },
+  },
 })

--- a/react-client/yarn.lock
+++ b/react-client/yarn.lock
@@ -943,6 +943,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stylistic/eslint-plugin@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@stylistic/eslint-plugin@npm:4.1.0"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^8.23.0"
+    eslint-visitor-keys: "npm:^4.2.0"
+    espree: "npm:^10.3.0"
+    estraverse: "npm:^5.3.0"
+    picomatch: "npm:^4.0.2"
+  peerDependencies:
+    eslint: ">=9.0.0"
+  checksum: 10c0/edf1c14243017ca6b524bec0c3969be45b81e20498a98714290cdb24c3f2c111ad600b352ac254e41f081af2c84ee1895e0dbc63f96e71d96481f3e552e69ea9
+  languageName: node
+  linkType: hard
+
 "@tabler/icons-react@npm:^3.26.0":
   version: 3.26.0
   resolution: "@tabler/icons-react@npm:3.26.0"
@@ -1154,6 +1169,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.25.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.25.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.25.0"
+    "@typescript-eslint/visitor-keys": "npm:8.25.0"
+  checksum: 10c0/0a53a07873bdb569be38053ec006009cc8ba6b12c538b6df0935afd18e431cb17da1eb15b0c9cd267ac211c47aaa44fbc8d7ff3b7b44ff711621ff305fa3b355
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:8.18.1":
   version: 8.18.1
   resolution: "@typescript-eslint/type-utils@npm:8.18.1"
@@ -1176,6 +1201,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:8.25.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/types@npm:8.25.0"
+  checksum: 10c0/b39addbee4be4d66e3089c2d01f9f1d69cedc13bff20e4fa9ed0ca5a0e7591d7c6e41ab3763c8c35404f971bc0fbf9f7867dbc2832740e5b63ee0049d60289f5
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:8.18.1":
   version: 8.18.1
   resolution: "@typescript-eslint/typescript-estree@npm:8.18.1"
@@ -1194,6 +1226,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:8.25.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.25.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.25.0"
+    "@typescript-eslint/visitor-keys": "npm:8.25.0"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.0.1"
+  peerDependencies:
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: 10c0/fc9de1c4f6ab81fb80b632dedef84d1ecf4c0abdc5f5246698deb6d86d5c6b5d582ef8a44fdef445bf7fbfa6658db516fe875c9d7c984bf4802e3a508b061856
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:8.18.1":
   version: 8.18.1
   resolution: "@typescript-eslint/utils@npm:8.18.1"
@@ -1209,6 +1259,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^8.23.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/utils@npm:8.25.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.25.0"
+    "@typescript-eslint/types": "npm:8.25.0"
+    "@typescript-eslint/typescript-estree": "npm:8.25.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: 10c0/cd15c4919f02899fd3975049a0a051a1455332a108c085a3e90ae9872e2cddac7f20a9a2c616f1366fca84274649e836ad6a437c9c5ead0bdabf5a123d12403f
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:8.18.1":
   version: 8.18.1
   resolution: "@typescript-eslint/visitor-keys@npm:8.18.1"
@@ -1216,6 +1281,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.18.1"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/68651ae1825dbd660ea39b4e1d1618f6ad0026fa3a04aecec296750977cab316564e3e2ace8edbebf1ae86bd17d86acc98cac7b6e9aad4e1c666bd26f18706ad
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.25.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.25.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.25.0"
+    eslint-visitor-keys: "npm:^4.2.0"
+  checksum: 10c0/7eb84c5899a25b1eb89d3c3f4be3ff18171f934669c57e2530b6dfa5fdd6eaae60629f3c89d06f4c8075fd1c701de76c0b9194e2922895c661ab6091e48f7db9
   languageName: node
   linkType: hard
 
@@ -4279,6 +4354,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "picomatch@npm:4.0.2"
+  checksum: 10c0/7c51f3ad2bb42c776f49ebf964c644958158be30d0a510efd5a395e8d49cb5acfed5b82c0c5b365523ce18e6ab85013c9ebe574f60305892ec3fa8eee8304ccc
+  languageName: node
+  linkType: hard
+
 "pkcs7@npm:^1.0.4":
   version: 1.0.4
   resolution: "pkcs7@npm:1.0.4"
@@ -5246,6 +5328,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-api-utils@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "ts-api-utils@npm:2.0.1"
+  peerDependencies:
+    typescript: ">=4.8.4"
+  checksum: 10c0/23fd56a958b332cac00150a652e4c84730df30571bd2faa1ba6d7b511356d1a61656621492bb6c7f15dd6e18847a1408357a0e406671d358115369a17f5bfedd
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.0.0, tslib@npm:^2.1.0":
   version: 2.6.3
   resolution: "tslib@npm:2.6.3"
@@ -5420,6 +5511,7 @@ __metadata:
     "@mantine/notifications": "npm:7.16.3"
     "@microsoft/fetch-event-source": "npm:2.0.1"
     "@playwright/test": "npm:1.49.0"
+    "@stylistic/eslint-plugin": "npm:4.1.0"
     "@tabler/icons-react": "npm:^3.26.0"
     "@types/lodash": "npm:4.17.15"
     "@types/react": "npm:18.3.12"


### PR DESCRIPTION
# Description of code changes
`stylistic ESLint` was removed from `ESLint core` and migrated to `@stylistic/eslint-plugin`

- Added `@stylistic/eslint-plugin` dev dependencies.
- set stylistic ESLint rules to `stylistic.configs.recommended` (ESLint default)
- commented for now as there is 3685 errors and work in progress on files.
(that will change a lot of files and mess up with other PR)
- I'll do the fix on another PR when most of react files are changed for #5204

# Checklist
- [x] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [x] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [x] Any relevant tests have been written/modified
