### PR TITLE
main fix nsis exe

### DIFF
--- a/src/main/external-resources/UMS.bat
+++ b/src/main/external-resources/UMS.bat
@@ -6,4 +6,4 @@ echo You can try to reduce the Xmx parameter value if you keep getting "Cannot c
 echo Last word: You must have java installed ! http://www.java.com
 echo ------------------------------------------------
 pause
-start javaw -Xmx768M -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8 -classpath update.jar;ums.jar net.pms.PMS
+start javaw -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8 -classpath update.jar;ums.jar net.pms.PMS

--- a/src/main/external-resources/windows/nsis-scripts/ums.nsi
+++ b/src/main/external-resources/windows/nsis-scripts/ums.nsi
@@ -48,6 +48,7 @@ Section ""
 	FileClose $1
 	filenotfound:
 
+	SetRegView 64
 	; next check user registry heapmem value.
 	${If} $HEAPMEM == ""  ; no value found
 		ReadRegStr $HEAPMEM HKCU "${REG_KEY_SOFTWARE}" "HeapMem"
@@ -56,6 +57,21 @@ Section ""
 	; next check system registry heapmem value.
 	${If} $HEAPMEM == ""  ; no value found
 		ReadRegStr $HEAPMEM HKLM "${REG_KEY_SOFTWARE}" "HeapMem"
+	${EndIf}
+
+	${If} ${RunningX64}
+		SetRegView 32
+		; next check user registry heapmem value.
+		${If} $HEAPMEM == ""  ; no value found
+			SetRegView 64
+			ReadRegStr $HEAPMEM HKCU "${REG_KEY_SOFTWARE}" "HeapMem"
+		${EndIf}
+
+		; next check system registry heapmem value.
+		${If} $HEAPMEM == ""  ; no value found
+			ReadRegStr $HEAPMEM HKLM "${REG_KEY_SOFTWARE}" "HeapMem"
+		${EndIf}
+		SetRegView 64
 	${EndIf}
 
 	; finally set default heapmem value.

--- a/src/main/external-resources/windows/nsis-scripts/ums.nsi
+++ b/src/main/external-resources/windows/nsis-scripts/ums.nsi
@@ -16,7 +16,6 @@ VIAddVersionKey "FileVersion" "${PROJECT_VERSION}"
 VIProductVersion "${PROJECT_VERSION_SHORT}.0"
 
 !define PRODUCT_NAME "${PROJECT_NAME_SHORT}"
-!define REG_KEY_SOFTWARE "SOFTWARE\${PROJECT_NAME}"
 
 ; use javaw.exe to avoid dosbox.
 ; use java.exe to keep stdout/stderr
@@ -29,71 +28,16 @@ AutoCloseWindow true
 ShowInstDetails nevershow
 
 !include "FileFunc.nsh"
-!insertmacro GetFileVersion
 !insertmacro GetParameters
-!include "WordFunc.nsh"
-!insertmacro VersionCompare
-!include "x64.nsh"
-
-Var HEAPMEM
 
 Section ""
 	Pop $R0
 
-	; first check portable heapmem value.
-	ClearErrors
-	FileOpen $1 "$EXEDIR\portable\data\heapmem.conf" r
-	IfErrors filenotfound
-	FileRead $1 $HEAPMEM
-	FileClose $1
-	filenotfound:
-
-	SetRegView 64
-	; next check user registry heapmem value.
-	${If} $HEAPMEM == ""  ; no value found
-		ReadRegStr $HEAPMEM HKCU "${REG_KEY_SOFTWARE}" "HeapMem"
-	${EndIf}
-
-	; next check system registry heapmem value.
-	${If} $HEAPMEM == ""  ; no value found
-		ReadRegStr $HEAPMEM HKLM "${REG_KEY_SOFTWARE}" "HeapMem"
-	${EndIf}
-
-	${If} ${RunningX64}
-		SetRegView 32
-		; next check user registry heapmem value.
-		${If} $HEAPMEM == ""  ; no value found
-			SetRegView 64
-			ReadRegStr $HEAPMEM HKCU "${REG_KEY_SOFTWARE}" "HeapMem"
-		${EndIf}
-
-		; next check system registry heapmem value.
-		${If} $HEAPMEM == ""  ; no value found
-			ReadRegStr $HEAPMEM HKLM "${REG_KEY_SOFTWARE}" "HeapMem"
-		${EndIf}
-		SetRegView 64
-	${EndIf}
-
-	; finally set default heapmem value.
-	${If} $HEAPMEM == ""  ; no value found
-		StrCpy $HEAPMEM "1280"
-	${EndIf}
-
-	; sanitize number.
-	IntOp $HEAPMEM $HEAPMEM + 1
-	IntOp $HEAPMEM $HEAPMEM - 1
-	${If} $HEAPMEM == "0"  ; wrong value found
-		StrCpy $HEAPMEM "1280"
-	${EndIf}
-
-	StrCpy $HEAPMEM "-Xmx$HEAPMEMM"
-
-	; Change for your purpose (-jar etc.)
+	StrCpy $R0 "jre${PROJECT_JRE_VERSION}\bin\${JAVAEXE}"
+	; Change for your purpose (-jar, -Xmx etc.)
 	${GetParameters} $1
 
-	StrCpy $R0 "jre${PROJECT_JRE_VERSION}\bin\${JAVAEXE}"
-
-	StrCpy $0 '"$R0" -classpath update.jar;${PROJECT_JARFILE} $HEAPMEM -Djava.net.preferIPv4Stack=true -Dfile.encoding=${PROJECT_ENCODING} ${PROJECT_MAIN_CLASS} $1'
+	StrCpy $0 '"$R0" -classpath update.jar;${PROJECT_JARFILE} -Djava.net.preferIPv4Stack=true -Dfile.encoding=${PROJECT_ENCODING} ${PROJECT_MAIN_CLASS} $1'
 	SetOutPath $EXEDIR
 	Exec $0
 SectionEnd

--- a/src/main/external-resources/windows/nsis-scripts/update.nsi
+++ b/src/main/external-resources/windows/nsis-scripts/update.nsi
@@ -12,14 +12,19 @@
 !define SERVICE_NAME "UniversalMediaServer"
 !define OLD_SERVICE_NAME "Universal Media Server"
 
+VIAddVersionKey "ProductName" "${PROJECT_NAME}"
+VIAddVersionKey "Comments" ""
+VIAddVersionKey "CompanyName" "${PROJECT_ORGANIZATION_NAME}"
+VIAddVersionKey "LegalTrademarks" ""
+VIAddVersionKey "LegalCopyright" ""
+VIAddVersionKey "FileDescription" "${PROJECT_NAME} Update"
+VIAddVersionKey "FileVersion" "${PROJECT_VERSION}"
+VIProductVersion "${PROJECT_VERSION_SHORT}.0"
+
 ManifestDPIAware true
 RequestExecutionLevel admin
 
 Name "${PROJECT_NAME}"
-InstallDir "$PROGRAMFILES\${PROJECT_NAME}"
-
-; Get install folder from registry for updates
-InstallDirRegKey HKCU "${REG_KEY_SOFTWARE}" ""
 
 SetCompressor /SOLID zlib
 
@@ -34,16 +39,24 @@ SetCompressor /SOLID zlib
 Page Custom LockedListShow LockedListLeave
 !insertmacro MUI_PAGE_INSTFILES
 !insertmacro MUI_PAGE_FINISH
-!insertmacro MUI_UNPAGE_CONFIRM
-!insertmacro MUI_UNPAGE_INSTFILES
 !insertmacro MUI_LANGUAGE "English"
-
-ShowUninstDetails show
 
 Function .onInit
 	SetRegView 64
-	ReadRegStr $0 HKCU "${REG_KEY_SOFTWARE}" "BinaryRevision"
+	SetShellVarContext current
+	ReadRegStr $0 SHCTX "${REG_KEY_SOFTWARE}" ""
 	${If} $0 != "${PROJECT_BINARY_REVISION}"
+		SetShellVarContext all
+		ReadRegStr $0 SHCTX "${REG_KEY_SOFTWARE}" ""
+		${If} $0 != "${PROJECT_BINARY_REVISION}"
+			MessageBox MB_OK|MB_ICONSTOP "Can't update this version, use the full installer" 0 0
+			Abort
+		${EndIf}
+	${EndIf}
+	ReadRegStr $0 SHCTX "${REG_KEY_SOFTWARE}" ""
+	${IfNot} $0 == ""
+		StrCpy $INSTDIR "$0"
+	${Else}
 		MessageBox MB_OK|MB_ICONSTOP "Can't update this version, use the full installer" 0 0
 		Abort
 	${EndIf}
@@ -58,34 +71,11 @@ Function LockedListShow
 		Abort
 	!insertmacro MUI_HEADER_TEXT `UMS must be closed before installation` `Clicking Next will automatically close it and stop the service.`
 	${If} ${RunningX64}
-		File /oname=$PLUGINSDIR\LockedList64.dll `${NSISDIR}\Plugins\x86-unicode\LockedList64.dll`
-		; LockedList old MediaInfo locations
-		LockedList::AddModule "$INSTDIR\MediaInfo64.dll"
-		LockedList::AddModule "$INSTDIR\win32\MediaInfo64.dll"
-	${Else}
-		; LockedList old MediaInfo locations
-		LockedList::AddModule "$INSTDIR\MediaInfo.dll"
-		LockedList::AddModule "$INSTDIR\win32\MediaInfo.dll"
+		File /oname=$PLUGINSDIR\LockedList64.dll "${NSISDIR}\Plugins\x86-unicode\LockedList64.dll"
 	${EndIf}
 	LockedList::AddModule "$INSTDIR\bin\MediaInfo.dll"
-
-	LockedList::Dialog /autonext /autoclosesilent
+	LockedList::Dialog /autonext /autoclosesilent "" ""
 	Pop $R0
-
-	SimpleSC::ServiceIsRunning "${OLD_SERVICE_NAME}"
-	Pop $0 ; returns an errorcode (<>0) otherwise success (0)
-	Pop $1 ; returns 1 (service is running) - returns 0 (service is not running)
-	${If} $1 == 1
-		SimpleSC::StopService "${OLD_SERVICE_NAME}" 1 30
-		Pop $2 ; returns an errorcode (<>0) otherwise success (0)
-		IntCmp $2 0 osuccess 0
-			Push $0
-			SimpleSC::GetErrorMessage
-			Pop $0
-			MessageBox MB_OK|MB_ICONSTOP 'Failed to stop service - Reason: $0' 0 0
-			Abort
-		osuccess:
-	${EndIf}
 
 	SimpleSC::ServiceIsRunning "${SERVICE_NAME}"
 	Pop $0 ; returns an errorcode (<>0) otherwise success (0)
@@ -128,16 +118,14 @@ Section "Program Files"
 	SetOutPath "$INSTDIR"
 	SetOverwrite on
 
+	RMDir /R /REBOOTOK "$INSTDIR\web\react-client\static"
 	File /r "${PROJECT_BASEDIR}\src\main\external-resources\documentation"
 	File /r "${PROJECT_BASEDIR}\src\main\external-resources\renderers"
-
-	RMDir /R /REBOOTOK "$INSTDIR\web\react-client\static"
+	File /r "${PROJECT_BASEDIR}\src\main\external-resources\web"
+	File "${PROJECT_BASEDIR}\src\main\external-resources\UMS.bat"
 
 	File "${PROJECT_BUILD_DIR}\UMS.exe"
-	File "${PROJECT_BASEDIR}\src\main\external-resources\UMS.bat"
-	File /r "${PROJECT_BASEDIR}\src\main\external-resources\web"
 	File "${PROJECT_BUILD_DIR}\ums.jar"
-
 	File "${PROJECT_BASEDIR}\CHANGELOG.md"
 	File "${PROJECT_BASEDIR}\README.md"
 	File "${PROJECT_BASEDIR}\LICENSE.txt"
@@ -148,358 +136,9 @@ Section "Program Files"
 	File "${PROJECT_BASEDIR}\src\main\external-resources\DummyInput.jpg"
 
 	; The user may have set the installation dir as the profile dir, so we can't clobber this
-	SetOutPath "$INSTDIR"
 	SetOverwrite off
 	File "${PROJECT_BASEDIR}\src\main\external-resources\UMS.conf"
 	File "${PROJECT_BASEDIR}\src\main\external-resources\ffmpeg.webfilters"
 
-	; Store install folder
-	WriteRegStr HKCU "${REG_KEY_SOFTWARE}" "" $INSTDIR
-
-	; Create uninstaller
-	WriteUninstaller "$INSTDIR\uninst.exe"
-
-	WriteRegStr HKEY_LOCAL_MACHINE "${REG_KEY_UNINSTALL}" "DisplayName" "${PROJECT_NAME}"
-	WriteRegStr HKEY_LOCAL_MACHINE "${REG_KEY_UNINSTALL}" "DisplayIcon" "$INSTDIR\icon.ico"
-	WriteRegStr HKEY_LOCAL_MACHINE "${REG_KEY_UNINSTALL}" "DisplayVersion" "${PROJECT_VERSION}"
-	WriteRegStr HKEY_LOCAL_MACHINE "${REG_KEY_UNINSTALL}" "Publisher" "${PROJECT_ORGANIZATION_NAME}"
-	WriteRegStr HKEY_LOCAL_MACHINE "${REG_KEY_UNINSTALL}" "URLInfoAbout" "${PROJECT_ORGANIZATION_URL}"
-	WriteRegStr HKEY_LOCAL_MACHINE "${REG_KEY_UNINSTALL}" "UninstallString" '"$INSTDIR\uninst.exe"'
-
-	${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
-	IntFmt $0 "0x%08X" $0
-	WriteRegDWORD HKLM "${REG_KEY_UNINSTALL}" "EstimatedSize" "$0"
-
-	WriteUnInstaller "uninst.exe"
-
-	ReadENVStr $R0 ALLUSERSPROFILE
-	SetOutPath "$R0\UMS"
-
-	CreateDirectory "$R0\UMS\data"
-
-	AccessControl::GrantOnFile "$R0\UMS" "(S-1-5-32-545)" "FullAccess"
-	File "${PROJECT_BASEDIR}\src\main\external-resources\UMS.conf"
-	File "${PROJECT_BASEDIR}\src\main\external-resources\ffmpeg.webfilters"
-
-	; Remove existing firewall rules in case they need updating
-	ExecWait 'netsh advfirewall firewall delete rule name=UMS'
-	ExecWait 'netsh advfirewall firewall delete rule name="UMS Service"'
-
-	; Add firewall rules
-	ExecWait 'netsh advfirewall firewall add rule name="UMS Service" dir=in action=allow program="$INSTDIR\jre${PROJECT_JRE_VERSION}\bin\java.exe" enable=yes profile=public,private'
-	ExecWait 'netsh advfirewall firewall add rule name=UMS dir=in action=allow program="$INSTDIR\jre${PROJECT_JRE_VERSION}\bin\javaw.exe" enable=yes profile=public,private'
-SectionEnd
-
-Section "Uninstall"
-	SetShellVarContext all
-
-	; Current files/folders
-	Delete /REBOOTOK "$INSTDIR\uninst.exe"
-	RMDir /R /REBOOTOK "$INSTDIR\plugins"
-	RMDir /R /REBOOTOK "$INSTDIR\documentation"
-	RMDir /R /REBOOTOK "$INSTDIR\data"
-	RMDir /R /REBOOTOK "$INSTDIR\jre${PROJECT_JRE_VERSION}"
-	RMDir /R /REBOOTOK "$INSTDIR\web"
-	RMDir /R /REBOOTOK "$INSTDIR\bin"
-
-	; Old folders (maybe do this on install/upgrade ?)
-	RMDir /R /REBOOTOK "$INSTDIR\jre17"
-
-	; Current renderer files
-	Delete /REBOOTOK "$INSTDIR\renderers\AnyCast.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Apple-TV-VLC.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Apple-TV-4K-VLC.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Apple-iDevice-AirPlayer.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Apple-iDevice-VLC.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Apple-iDevice-VLC32bit.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Apple-iDevice.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\BlackBerry-PlayBook-KalemSoftMP.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\CambridgeAudio-AzurBD.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\DefaultRenderer.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\DirecTV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\DLink-DSM510.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\FetchTV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Free-Freebox.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\foobar2000-mobile.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Freecom-MusicPal.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Google-Android-Chromecast.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Google-Android.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Google-Android-BubbleUPnP-MXPlayer.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Google-ChromecastUltra.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Hama-IR320.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Hisense-K680.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Kodi.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-BP.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-BP550.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-EG910V.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-LA6200.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-LA644V.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-LB.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-LM620.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-LM660.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-LS5700.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-ST600.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-UB820V.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-UH770.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-WebOS.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Logitech-Squeezebox.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Microsoft-WindowsMediaPlayer.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Microsoft-Xbox360.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Microsoft-XboxOne.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Miracast-M806.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Mirascreen.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Naim-Mu-So.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Netgear-NeoTV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Netgem-N7700.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Nokia-N900.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\OPPO-BDP.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\OPPO-BDP83.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Onkyo-TXNR7xx.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Onkyo-TXNR8xx.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-DMPBDT.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-DMPBDT220.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-DMPBDT360.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-DMR.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-SCBTT.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-Viera.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraAS600E.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraAS650.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraCX680.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraCX700.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraDX.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraE6.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraET60.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraGT50.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraGX800B.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraS60.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraST60.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraTHPU30Z.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraTXL32V10E.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VieraVT60.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Philips-AureaAndNetTV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Philips-PFL.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Philips-PUS.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Philips-PUS-6500Series.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Philips-Streamium.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Pioneer-BDP.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Pioneer-Kuro.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\PopcornHour.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\README.txt"
-	Delete /REBOOTOK "$INSTDIR\renderers\Realtek.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Roku-Roku3-3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Roku-Roku3-5.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Roku-Roku3-6-7.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Roku-DVP10.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Roku-TV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Roku-TV-4K.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Roku-TV8.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-8series.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-9series.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-BDC6800.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-BDH6500.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-C6600.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-CD.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-D6400.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-D7000.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-EH5300.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-EH6070.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-ES6100.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-ES6575.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-ES8000.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-ES8005.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-F5100.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-F5505.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-F5900.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-GalaxyS5.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-GalaxyS7.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-H4500.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-H6203.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-H6400.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-HTE3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-HTF4.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-HU7000.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-HU9000.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-JU6400.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-J55xx.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-J6200.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-JU6400.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-Mobile.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-NotCD.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-PL51E490.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-SMTG7400.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-Soundbar.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-Soundbar-MS750.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-TV-2021-0.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-TV-2021-1.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-TV-2021-2.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-TV-2021-3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-TV-2021-4.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-WiseLink.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-UHD.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-UHD-2019.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-UHD-2019-8K.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sharp-Aquos.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Showtime3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Showtime4.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-Bluray.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-Bluray2013.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-Bluray-UBP-X800M2.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-Bravia4500.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-Bravia5500.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaBX305.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaEX.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaEX620.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaEX725.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaHX.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaHX75.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaNX70x.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaNX800.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaW.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaX.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaXBR.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaXBR-OLED.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-BraviaXD.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-HomeTheatreSystem.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-PlayStation3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-PlayStation4.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-PlayStationVita.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-SMPN100.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-STR5800ES.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-X-Series-TV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-Xperia.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Sony-XperiaZ3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Technisat-S1Plus.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Telefunken-TV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Telstra-Tbox.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Thomson-U3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\VLC-for-desktop.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\VideoWeb-VideoWebTV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Vizio-SmartTV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\WesternDigital-WDTVLive.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\XBMC.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Yamaha-RN500.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Yamaha-RXA1010.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Yamaha-RXA2050.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Yamaha-RXV3900.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Yamaha-RXV500D.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Yamaha-RXV671.conf"
-
-	; Old renderer files (should have already been removed during install/upgrade)
-	Delete /REBOOTOK "$INSTDIR\renderers\AirPlayer.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Android.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\AndroidChromecast.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\BlackBerryPlayBook-KalemSoftMP.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Bravia4500.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Bravia5500.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\BraviaBX305.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\BraviaEX.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\BraviaEX620.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\BraviaHX.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\BraviaW.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\BraviaXBR.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\CambridgeAudioAzur752BD.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\DirecTVHR.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Dlink510.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\DLinkDSM510.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\FreeboxHD.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\FreecomMusicPal.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\iPad-iPhone.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Kuro.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LG-42LA644V.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\LGST600.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\N900.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\NetgearNeoTV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\OnkyoTX-NR717.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\OPPOBDP83.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\OPPOBDP93.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-DMRBWT740.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-SC-BTT.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-TH-P-U30Z.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\PanasonicTX-L32V10E.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Panasonic-VT60.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Philips.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\PhilipsPFL.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\PS3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Roku-Roku3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SamsungAllShare.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SamsungAllShare-CD.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SamsungAllShare-D7000.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SamsungMobile.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-HT-E3.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-SMT-G7400.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Samsung-UE-ES6575.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SamsungWiseLink.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SharpAquos.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SMP-N100.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SonyBluray.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SonyHomeTheatreSystem.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SonySTR-5800ES.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\SonyXperia.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\Streamium.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\TelstraTbox.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\VideoWebTV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\VizioSmartTV.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\WDTVLive.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\WMP.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\XBOX360.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\XboxOne.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\YamahaRXA1010.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\YamahaRXV671.conf"
-	Delete /REBOOTOK "$INSTDIR\renderers\YamahaRXV3900.conf"
-
-	RMDir /REBOOTOK "$INSTDIR\renderers"
-	Delete /REBOOTOK "$INSTDIR\UMS.exe"
-	Delete /REBOOTOK "$INSTDIR\UMS.bat"
-	Delete /REBOOTOK "$INSTDIR\ums.jar"
-
-	; Old MediaInfo files
-	${If} ${RunningX64}
-		Delete /REBOOTOK "$INSTDIR\MediaInfo64.dll"
-	${Else}
-		Delete /REBOOTOK "$INSTDIR\MediaInfo.dll"
-	${EndIf}
-	Delete /REBOOTOK "$INSTDIR\MediaInfo-License.html"
-
-	Delete /REBOOTOK "$INSTDIR\CHANGELOG.md"
-	Delete /REBOOTOK "$INSTDIR\CHANGELOG.txt"
-	Delete /REBOOTOK "$INSTDIR\WEB.conf"
-	Delete /REBOOTOK "$INSTDIR\README.md"
-	Delete /REBOOTOK "$INSTDIR\README.txt"
-	Delete /REBOOTOK "$INSTDIR\LICENSE.txt"
-	Delete /REBOOTOK "$INSTDIR\debug.log"
-	Delete /REBOOTOK "$INSTDIR\debug.log.prev"
-	Delete /REBOOTOK "$INSTDIR\ffmpeg.webfilters"
-	Delete /REBOOTOK "$INSTDIR\logback.xml"
-	Delete /REBOOTOK "$INSTDIR\logback.headless.xml"
-	Delete /REBOOTOK "$INSTDIR\icon.ico"
-	Delete /REBOOTOK "$INSTDIR\DummyInput.ass"
-	Delete /REBOOTOK "$INSTDIR\DummyInput.jpg"
-	Delete /REBOOTOK "$INSTDIR\new-version.exe"
-	Delete /REBOOTOK "$INSTDIR\pms.pid"
-	Delete /REBOOTOK "$INSTDIR\UMS.conf"
-	Delete /REBOOTOK "$INSTDIR\VirtualFolders.conf"
-	RMDir /REBOOTOK "$INSTDIR"
-
-	Delete /REBOOTOK "$DESKTOP\${PROJECT_NAME}.lnk"
-	Delete /REBOOTOK "$SMSTARTUP\${PROJECT_NAME}.lnk"
-	RMDir /REBOOTOK "$SMPROGRAMS\${PROJECT_NAME}"
-	Delete /REBOOTOK "$SMPROGRAMS\${PROJECT_NAME}\${PROJECT_NAME}.lnk"
-	Delete /REBOOTOK "$SMPROGRAMS\${PROJECT_NAME}\${PROJECT_NAME} (Select Profile).lnk"
-	Delete /REBOOTOK "$SMPROGRAMS\${PROJECT_NAME}\Uninstall.lnk"
-
-	DeleteRegKey HKEY_LOCAL_MACHINE "${REG_KEY_UNINSTALL}"
-	DeleteRegKey HKCU "${REG_KEY_SOFTWARE}"
-
-	SimpleSC::ExistsService "${SERVICE_NAME}"
-	Pop $0
-	${If} $0 != 0
-		SimpleSC::StopService "${SERVICE_NAME}" 1 30
-		SimpleSC::RemoveService "${SERVICE_NAME}"
-		DeleteRegKey HKLM "SYSTEM\CurrentControlSet\Services\${SERVICE_NAME}"
-	${EndIf}
-
-	ExecWait 'netsh advfirewall firewall delete rule name=UMS'
-	ExecWait 'netsh advfirewall firewall delete rule name="UMS Service"'
-
+	WriteRegStr SHCTX "${REG_KEY_UNINSTALL}" "DisplayVersion" "${PROJECT_VERSION}"
 SectionEnd

--- a/src/main/external-resources/windows/nsis-scripts/update.nsi
+++ b/src/main/external-resources/windows/nsis-scripts/update.nsi
@@ -41,6 +41,7 @@ Page Custom LockedListShow LockedListLeave
 ShowUninstDetails show
 
 Function .onInit
+	SetRegView 64
 	ReadRegStr $0 HKCU "${REG_KEY_SOFTWARE}" "BinaryRevision"
 	${If} $0 != "${PROJECT_BINARY_REVISION}"
 		MessageBox MB_OK|MB_ICONSTOP "Can't update this version, use the full installer" 0 0


### PR DESCRIPTION
# Description of code changes

- removed `heapmem` from setup file and exe file
- added setup file properties `ProductName`, `CompanyName`, `Version`, etc
- added details about creating the uninstaller instead of leaving the last copied file, which makes the user think it takes a while

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
