### PR TITLE
main fix nsis exe

### DIFF
--- a/src/main/external-resources/windows/nsis-scripts/ums.nsi
+++ b/src/main/external-resources/windows/nsis-scripts/ums.nsi
@@ -48,6 +48,7 @@ Section ""
 	FileClose $1
 	filenotfound:
 
+	SetRegView 64
 	; next check user registry heapmem value.
 	${If} $HEAPMEM == ""  ; no value found
 		ReadRegStr $HEAPMEM HKCU "${REG_KEY_SOFTWARE}" "HeapMem"
@@ -56,6 +57,21 @@ Section ""
 	; next check system registry heapmem value.
 	${If} $HEAPMEM == ""  ; no value found
 		ReadRegStr $HEAPMEM HKLM "${REG_KEY_SOFTWARE}" "HeapMem"
+	${EndIf}
+
+	${If} ${RunningX64}
+		SetRegView 32
+		; next check user registry heapmem value.
+		${If} $HEAPMEM == ""  ; no value found
+			SetRegView 64
+			ReadRegStr $HEAPMEM HKCU "${REG_KEY_SOFTWARE}" "HeapMem"
+		${EndIf}
+
+		; next check system registry heapmem value.
+		${If} $HEAPMEM == ""  ; no value found
+			ReadRegStr $HEAPMEM HKLM "${REG_KEY_SOFTWARE}" "HeapMem"
+		${EndIf}
+		SetRegView 64
 	${EndIf}
 
 	; finally set default heapmem value.


### PR DESCRIPTION
# Description of code changes
fix `HEAPMEM` fall back to `1280 MB` on x64 Windows with current `exe`.

We changed the installer to take care of x64 and use x64 registry key (not `WOW` as before), so the `exe` need to adapt where to find heapmem value.

With `SetRegView 32` (default if no `SetRegView 64`), results are :
x86 `HKLM\Software\xxx` -> `HKLM\Software\xxx`
x64 `HKLM\Software\xxx` -> `HKLM\SOFTWARE\WOW6432Node\xxx`

`SetRegView 64` has no effect on `x86` result, but has for `x64`.
x86 `HKLM\Software\xxx` -> `HKLM\Software\xxx`
x64 `HKLM\Software\xxx` -> `HKLM\Software\xxx`

@SubJunk 
This fix should be merged on main before any new release.
`V15` is not affected as it remove completely the `heapmem` limit
