### PR TITLE
v15 - added media info to the web player

### DIFF
--- a/react-client/src/components/Player/MediaInfoAudiotrack.tsx
+++ b/react-client/src/components/Player/MediaInfoAudiotrack.tsx
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+import { Box, Button, Collapse, Group } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+
+import { I18nInterface } from '../../services/i18n-service'
+import { AudioTrackInfo } from '../../services/player-service'
+import MediaInfoBooleanValue from './MediaInfoBooleanValue'
+import MediaInfoNumberValue from './MediaInfoNumberValue'
+import MediaInfoStringValue from './MediaInfoStringValue'
+
+export default function MediaInfoAudiotrack({ i18n, audioTrack }: { i18n: I18nInterface, audioTrack: AudioTrackInfo }) {
+  const [opened, { toggle }] = useDisclosure(false)
+
+  const Title = ({ i18n, audioTrack }: { i18n: I18nInterface, audioTrack: AudioTrackInfo }) => {
+    return i18n.get('AudioStream') + ' #' + audioTrack.id
+  }
+
+  return audioTrack && (
+    <Box>
+      <Group>
+        <Button variant="default" size="compact-xs" onClick={toggle}><Title i18n={i18n} audioTrack={audioTrack} /></Button>
+      </Group>
+
+      <Collapse in={opened}>
+        <MediaInfoBooleanValue i18n={i18n} value={audioTrack.default} title={i18n.get('Default')} />
+        <MediaInfoBooleanValue i18n={i18n} value={audioTrack.forced} title={i18n.get('Forced')} />
+        <MediaInfoStringValue value={audioTrack.title} title={i18n.get('Title')} />
+        <MediaInfoStringValue value={audioTrack.lang} title={i18n.get('Language')} />
+        <MediaInfoNumberValue value={audioTrack.stream} title="File Stream" />
+        <MediaInfoStringValue value={audioTrack.codec} title="Codec" />
+        <MediaInfoNumberValue value={audioTrack.bitrate} title="BitRate" />
+        <MediaInfoNumberValue value={audioTrack.bitdepth} title="BitDepth" />
+        <MediaInfoNumberValue value={audioTrack.channel} title="Number Of Channels" />
+        <MediaInfoNumberValue value={audioTrack.samplerate} title="SampleRate" />
+        <MediaInfoStringValue value={audioTrack.muxing} title="Muxing" />
+      </Collapse>
+    </Box>
+  )
+}

--- a/react-client/src/components/Player/MediaInfoBooleanValue.tsx
+++ b/react-client/src/components/Player/MediaInfoBooleanValue.tsx
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+import { Group, Text } from '@mantine/core'
+
+import { I18nInterface } from '../../services/i18n-service'
+
+export default function MediaInfoBooleanValue({ i18n, value, title }: { i18n: I18nInterface, value?: boolean, title: string }) {
+  return typeof value === 'boolean' && (
+    <Group>
+      <Text size="xs" fw={500} c="dimmed">{title}</Text>
+      <Text size="xs">{value ? i18n.get('Yes') : i18n.get('No')}</Text>
+    </Group>
+  )
+}

--- a/react-client/src/components/Player/MediaInfoImage.tsx
+++ b/react-client/src/components/Player/MediaInfoImage.tsx
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+import { Box, Button, Collapse, Group } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+
+import { I18nInterface } from '../../services/i18n-service'
+import { ImageInfo } from '../../services/player-service'
+import MediaInfoNumberValue from './MediaInfoNumberValue'
+import MediaInfoStringValue from './MediaInfoStringValue'
+
+export default function MediaInfoImage({ i18n, image, title }: { i18n: I18nInterface, image?: ImageInfo, title: string }) {
+  const [opened, { toggle }] = useDisclosure(false)
+
+  return image && (
+    <Box>
+      <Group>
+        <Button variant="default" size="compact-xs" onClick={toggle}>{title}</Button>
+      </Group>
+
+      <Collapse in={opened}>
+        <MediaInfoStringValue value={image.format} title={i18n.get('Format')} />
+        <MediaInfoStringValue value={image.resolution} title={i18n.get('Resolution')} />
+        <MediaInfoNumberValue value={image.size} title={i18n.get('Size')} />
+        <MediaInfoNumberValue value={image.bitDepth} title="BitDepth" />
+      </Collapse>
+    </Box>
+  )
+}

--- a/react-client/src/components/Player/MediaInfoModal.tsx
+++ b/react-client/src/components/Player/MediaInfoModal.tsx
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+import { Button, Group, Modal, ScrollArea } from '@mantine/core'
+import { IconDeviceSpeaker, IconFileInfo, IconMovie } from '@tabler/icons-react'
+import axios, { AxiosError } from 'axios'
+import { useEffect, useState } from 'react'
+
+import { I18nInterface } from '../../services/i18n-service'
+import { playerApiUrl } from '../../utils'
+import { showError } from '../../utils/notifications'
+import { BaseMediaInfo } from '../../services/player-service'
+import MediaInfoNumberValue from './MediaInfoNumberValue'
+import MediaInfoPanel from './MediaInfoPanel'
+import MediaInfoStringValue from './MediaInfoStringValue'
+
+export default function MediaInfoModal({
+  i18n,
+  uuid,
+  id,
+}: {
+  i18n: I18nInterface
+  uuid: string
+  id: string
+}) {
+  const [isLoading, setLoading] = useState(true)
+  const [opened, setOpened] = useState(false)
+  const [mediaInfo, setMediaInfo] = useState<BaseMediaInfo | null>(null)
+
+  const getMediaInfo = () => {
+    setLoading(true)
+    axios.post(playerApiUrl + 'getMediaInfo', { uuid: uuid, id: id })
+      .then(function (response: any) {
+        setMediaInfo(response.data)
+        setOpened(true)
+      })
+      .catch(function (error: AxiosError) {
+        if (!error.response && error.request) {
+          i18n.showServerUnreachable()
+        }
+        else {
+          showError({
+            id: 'data-loading',
+            title: i18n.get('Error'),
+            message: 'Your edit data was not received from the server.',
+          })
+        }
+      })
+      .then(function () {
+        setLoading(false)
+      })
+  }
+
+  const getTitle = () => {
+    if (mediaInfo && mediaInfo.mediaInfo && mediaInfo.mediaInfo.mediaType) {
+      switch (mediaInfo.mediaInfo.mediaType) {
+        case 'video':
+          return (
+            <Group>
+              <IconMovie />
+              {i18n.get('MediaInfo')}
+            </Group>
+          )
+        case 'audio':
+          return (
+            <Group>
+              <IconDeviceSpeaker />
+              {i18n.get('MediaInfo')}
+            </Group>
+          )
+      }
+    }
+    return i18n.get('MediaInfo')
+  }
+
+  useEffect(() => {
+    if (opened) {
+      getMediaInfo()
+    }
+  }, [opened])
+
+  return (
+    <>
+      <Modal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        title={getTitle()}
+        scrollAreaComponent={ScrollArea.Autosize}
+        size="lg"
+      >
+        <MediaInfoStringValue value={mediaInfo?.filename} title={i18n.get('File')} />
+        <MediaInfoNumberValue value={mediaInfo?.size} title={i18n.get('Size')} />
+        <MediaInfoPanel i18n={i18n} mediaInfo={mediaInfo?.mediaInfo} />
+        <Button
+          fullWidth
+          mt="md"
+          loading={isLoading}
+          size="compact-md"
+          onClick={() => {
+            setOpened(false)
+          }}
+        >
+          {i18n.get('Close')}
+        </Button>
+      </Modal>
+      <Button
+        variant="default"
+        size="compact-md"
+        onClick={() => {
+          setOpened(true)
+        }}
+      >
+        <IconFileInfo size={14} />
+      </Button>
+    </>
+  )
+}

--- a/react-client/src/components/Player/MediaInfoNumberValue.tsx
+++ b/react-client/src/components/Player/MediaInfoNumberValue.tsx
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+import { Group, Text } from '@mantine/core'
+
+export default function MediaInfoNumberValue({ value, title }: { value?: number, title: string }) {
+  return typeof value === 'number' && (
+    <Group>
+      <Text size="xs" fw={500} c="dimmed">{title}</Text>
+      <Text size="xs">{value}</Text>
+    </Group>
+  )
+}

--- a/react-client/src/components/Player/MediaInfoPanel.tsx
+++ b/react-client/src/components/Player/MediaInfoPanel.tsx
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+import { Stack } from '@mantine/core'
+
+import { I18nInterface } from '../../services/i18n-service'
+import { MediaInfo } from '../../services/player-service'
+import MediaInfoAudiotrack from './MediaInfoAudiotrack'
+import MediaInfoStringValue from './MediaInfoStringValue'
+import MediaInfoSubtitles from './MediaInfoSubtitles'
+import MediaInfoVideotrack from './MediaInfoVideotrack'
+import MediaInfoImage from './MediaInfoImage'
+
+export default function MediaInfoPanel({ i18n, mediaInfo }: { i18n: I18nInterface, mediaInfo?: MediaInfo }) {
+  return mediaInfo && (
+    <Stack>
+      <MediaInfoStringValue value={mediaInfo.container} title={i18n.get('Format')} />
+      {mediaInfo.videotracks && mediaInfo.videotracks.map((videoTrack, index) =>
+        <MediaInfoVideotrack key={index} i18n={i18n} videoTrack={videoTrack} />,
+      )}
+      {mediaInfo.audiotracks && mediaInfo.audiotracks.map((audioTrack, index) =>
+        <MediaInfoAudiotrack key={index} i18n={i18n} audioTrack={audioTrack} />,
+      )}
+      {mediaInfo.subtitlestracks && mediaInfo.subtitlestracks.map((subtitles, index) =>
+        <MediaInfoSubtitles key={index} i18n={i18n} subtitles={subtitles} />,
+      )}
+      <MediaInfoImage i18n={i18n} image={mediaInfo.image} title={i18n.get('Image')} />
+      <MediaInfoImage i18n={i18n} image={mediaInfo.thumbnail} title={i18n.get('Thumbnail')} />
+    </Stack>
+  )
+}

--- a/react-client/src/components/Player/MediaInfoStringValue.tsx
+++ b/react-client/src/components/Player/MediaInfoStringValue.tsx
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+import { Group, Text } from '@mantine/core'
+
+export default function MediaInfoStringValue({ value, title }: { value?: string, title: string }) {
+  return value && (
+    <Group>
+      <Text size="xs" fw={500} c="dimmed">{title}</Text>
+      <Text size="xs">{value}</Text>
+    </Group>
+  )
+}

--- a/react-client/src/components/Player/MediaInfoSubtitles.tsx
+++ b/react-client/src/components/Player/MediaInfoSubtitles.tsx
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+import { Box, Button, Collapse, Group } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+
+import { I18nInterface } from '../../services/i18n-service'
+import { SubtitlesInfo } from '../../services/player-service'
+import MediaInfoBooleanValue from './MediaInfoBooleanValue'
+import MediaInfoNumberValue from './MediaInfoNumberValue'
+import MediaInfoStringValue from './MediaInfoStringValue'
+
+export default function MediaInfoSubtitles({ i18n, subtitles }: { i18n: I18nInterface, subtitles: SubtitlesInfo }) {
+  const [opened, { toggle }] = useDisclosure(false)
+
+  const Title = ({ i18n, subtitles }: { i18n: I18nInterface, subtitles: SubtitlesInfo }) => {
+    return subtitles.embedded
+      ? i18n.get('Subtitles') + ' #' + subtitles.id
+      : i18n.get('Subtitles') + ' #' + subtitles.externalFile
+  }
+
+  return subtitles && (
+    <Box>
+      <Group>
+        <Button variant="default" size="compact-xs" onClick={toggle}><Title i18n={i18n} subtitles={subtitles} /></Button>
+      </Group>
+
+      <Collapse in={opened}>
+        <MediaInfoBooleanValue i18n={i18n} value={subtitles.embedded} title={i18n.get('Embedded')} />
+        <MediaInfoBooleanValue i18n={i18n} value={subtitles.default} title={i18n.get('Default')} />
+        <MediaInfoBooleanValue i18n={i18n} value={subtitles.forced} title={i18n.get('Forced')} />
+        <MediaInfoStringValue value={subtitles.title} title={i18n.get('Title')} />
+        <MediaInfoStringValue value={subtitles.lang} title={i18n.get('Language')} />
+        <MediaInfoNumberValue value={subtitles.stream} title="File Stream" />
+        <MediaInfoStringValue value={subtitles.type} title="Type" />
+        <MediaInfoStringValue value={subtitles.externalFile} title="External File" />
+        <MediaInfoStringValue value={subtitles.subsCharacterSet} title="Character Set" />
+        <MediaInfoStringValue value={subtitles.convertedFile} title="Converted File" />
+      </Collapse>
+    </Box>
+  )
+}

--- a/react-client/src/components/Player/MediaInfoVideotrack.tsx
+++ b/react-client/src/components/Player/MediaInfoVideotrack.tsx
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Universal Media Server, based on PS3 Media Server.
+ *
+ * This program is a free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2 of the License only.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+import { Box, Button, Collapse, Group } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+
+import { I18nInterface } from '../../services/i18n-service'
+import { VideoTrackInfo } from '../../services/player-service'
+import MediaInfoNumberValue from './MediaInfoNumberValue'
+import MediaInfoStringValue from './MediaInfoStringValue'
+import MediaInfoBooleanValue from './MediaInfoBooleanValue'
+
+export default function MediaInfoVideotrack({ i18n, videoTrack }: { i18n: I18nInterface, videoTrack: VideoTrackInfo }) {
+  const [opened, { toggle }] = useDisclosure(false)
+
+  const Title = ({ i18n, videoTrack }: { i18n: I18nInterface, videoTrack: VideoTrackInfo }) => {
+    return i18n.get('VideoStream') + ' #' + videoTrack.id
+  }
+
+  return videoTrack && (
+    <Box>
+      <Group>
+        <Button variant="default" size="compact-xs" onClick={toggle}><Title i18n={i18n} videoTrack={videoTrack} /></Button>
+      </Group>
+
+      <Collapse in={opened}>
+        <MediaInfoStringValue value={videoTrack.title} title={i18n.get('Title')} />
+        <MediaInfoStringValue value={videoTrack.lang} title={i18n.get('Language')} />
+        <MediaInfoBooleanValue i18n={i18n} value={videoTrack.default} title={i18n.get('Default')} />
+        <MediaInfoBooleanValue i18n={i18n} value={videoTrack.forced} title={i18n.get('Forced')} />
+        <MediaInfoStringValue value={videoTrack.resolution} title="Resolution" />
+        <MediaInfoStringValue value={videoTrack.duration} title="Duration" />
+        <MediaInfoStringValue value={videoTrack.codec} title={i18n.get('Codec')} />
+        <MediaInfoStringValue value={videoTrack.formatProfile} title="Format Profile" />
+        <MediaInfoStringValue value={videoTrack.formatLevel} title="Format Level" />
+        <MediaInfoStringValue value={videoTrack.formatTier} title="Format Tier" />
+        <MediaInfoNumberValue value={videoTrack.stream} title="File Stream" />
+        <MediaInfoNumberValue value={videoTrack.bitDepth} title="Bit Depth" />
+        <MediaInfoStringValue value={videoTrack.displayaspectratio} title="Display Aspect ratio" />
+        <MediaInfoNumberValue value={videoTrack.pixelaspectratio} title="Pixel Aspect ratio" />
+        <MediaInfoStringValue value={videoTrack.scantype} title="Scan type" />
+        <MediaInfoStringValue value={videoTrack.scanOrder} title="Scan order" />
+        <MediaInfoNumberValue value={videoTrack.framerate} title="Framerate" />
+        <MediaInfoStringValue value={videoTrack.framerateMode} title="Framerate mode" />
+        <MediaInfoStringValue value={videoTrack.framerateModeRaw} title="Framerate mode raw" />
+        <MediaInfoStringValue value={videoTrack.muxingMode} title="Muxing mode" />
+        <MediaInfoStringValue value={videoTrack.matrixCoefficients} title="Matrix Coefficients" />
+        <MediaInfoNumberValue value={videoTrack.referenceFrameCount} title="Reference Frame Count" />
+        <MediaInfoStringValue value={videoTrack.hdrFormat} title="HDR Format" />
+        <MediaInfoStringValue value={videoTrack.hdrFormatRenderer} title="HDR Format (renderer)" />
+        <MediaInfoStringValue value={videoTrack.hdrFormatCompatibility} title="HDR Compatibility Format" />
+        <MediaInfoStringValue value={videoTrack.hdrFormatCompatibilityRenderer} title="HDR Compatibility Format (renderer)" />
+      </Collapse>
+    </Box>
+  )
+}

--- a/react-client/src/components/Player/MediaPanelMenu.tsx
+++ b/react-client/src/components/Player/MediaPanelMenu.tsx
@@ -23,6 +23,7 @@ import { PlayerEventInterface } from '../../services/player-server-event-service
 import { BaseBrowse, PlayMedia, VideoMedia } from '../../services/player-service'
 import { playerApiUrl } from '../../utils'
 import MediaEditButton from './MediaEditButton'
+import MediaInfoModal from './MediaInfoModal'
 import VideoMetadataEditModal from './VideoMetadataEditModal'
 
 export default function MediaPanelMenu({ i18n, sse, data, refreshPage, setLoading }: { i18n: I18nInterface, sse: PlayerEventInterface, data: BaseBrowse, refreshPage: () => void, setLoading: (loading: boolean) => void }) {
@@ -31,6 +32,7 @@ export default function MediaPanelMenu({ i18n, sse, data, refreshPage, setLoadin
   const videoMedia = playMedia && playMedia.mediaType === 'video' ? playMedia as VideoMedia : undefined
   const isVideoMetadataEditable = (data.goal === 'browse' && data.metadata?.isEditable) || (videoMedia && videoMedia.metadata?.isEditable)
   const fullyplayed = (playMedia && playMedia.fullyplayed != null) ? playMedia.fullyplayed : data.fullyplayed
+  const hasMediaInfo = (playMedia && playMedia.hasMediaInfo)
   const hasFullyplayedValue = fullyplayed != null
   const hasEditMenu = isVideoMetadataEditable || hasFullyplayedValue
 
@@ -38,6 +40,8 @@ export default function MediaPanelMenu({ i18n, sse, data, refreshPage, setLoadin
     ? (
         <Button.Group>
           <Button variant="default" size="compact-md" leftSection={<IconPlayerPlay size={14} />} onClick={() => sse.askPlayId(data.medias[0].id)}>{i18n.get('Play')}</Button>
+          {hasMediaInfo
+            && <MediaInfoModal i18n={i18n} uuid={sse.uuid} id={sse.reqId} />}
           {isVideoMetadataEditable
             && <VideoMetadataEditModal i18n={i18n} uuid={sse.uuid} id={sse.reqId} start={showVideoMetadataEdit} started={() => setShowVideoMetadataEdit(false)} callback={() => refreshPage()} />}
           {hasEditMenu

--- a/react-client/src/providers/session-provider.tsx
+++ b/react-client/src/providers/session-provider.tsx
@@ -282,6 +282,20 @@ const SessionProvider = ({ children, i18n }: { children?: ReactNode, i18n: I18nI
     refresh()
   }
 
+  const tokenIsValid = () => {
+    if (!token) {
+      return false
+    }
+    const now = Math.floor(new Date().getTime() / 1000) + 300
+    try {
+      const decoded = jwtDecode<JwtPayload>(token)
+      return (decoded.exp && decoded.exp > now)
+    }
+    catch (e) {
+      return false
+    }
+  }
+
   const refreshLocalUsers = () => {
     const localUsersTemp = [] as LocalUser[]
     const renew = Math.floor(new Date().getTime() / 1000) + 300
@@ -369,7 +383,12 @@ const SessionProvider = ({ children, i18n }: { children?: ReactNode, i18n: I18nI
     if (initialized) {
       return
     }
-    axios.defaults.headers.common['Authorization'] = token ? 'Bearer ' + token : undefined
+    if (tokenIsValid()) {
+      axios.defaults.headers.common['Authorization'] = token ? 'Bearer ' + token : undefined
+    }
+    else {
+      clearToken()
+    }
     axios.interceptors.response.use(function (response) {
       return response
     }, function (error) {

--- a/react-client/src/services/player-service.tsx
+++ b/react-client/src/services/player-service.tsx
@@ -33,6 +33,7 @@ export interface PlayMedia extends BaseMedia {
   isDynamicPls: boolean
   mediaType: string
   surroundMedias: SurroundMedias
+  hasMediaInfo?: boolean
 }
 
 export interface VideoMedia extends PlayMedia {
@@ -146,6 +147,95 @@ export interface VideoMetadataImage {
 
 export interface ImageMedia extends PlayMedia {
   delay?: number
+}
+
+export interface BaseMediaInfo {
+  filename?: string
+  size?: number
+  mediaInfo?: MediaInfo
+}
+
+export interface MediaInfo {
+  size: number
+  container?: string
+  mediaType?: string
+  title?: string
+  bitrate?: number
+  framerate?: number
+  duration?: string
+  videotracks?: VideoTrackInfo[]
+  audiotracks?: AudioTrackInfo[]
+  subtitlestracks?: SubtitlesInfo[]
+  images?: number
+  image?: ImageInfo
+  thumbnail?: ImageInfo
+  mimetype?: string
+}
+
+export interface VideoTrackInfo {
+  id: number
+  default: boolean
+  forced: boolean
+  codec: string
+  stream: number
+  bitDepth: number
+  resolution: string
+  title?: string
+  lang?: string
+  formatProfile?: string
+  formatLevel?: string
+  formatTier?: string
+  duration?: string
+  displayaspectratio?: string
+  pixelaspectratio?: number
+  scantype?: string
+  scanOrder?: string
+  framerate?: number
+  framerateMode?: string
+  framerateModeRaw?: string
+  muxingMode?: string
+  matrixCoefficients?: string
+  referenceFrameCount?: number
+  hdrFormat?: string
+  hdrFormatRenderer?: string
+  hdrFormatCompatibility?: string
+  hdrFormatCompatibilityRenderer?: string
+}
+
+export interface AudioTrackInfo {
+  id: number
+  default: boolean
+  forced: boolean
+  codec: string
+  stream: number
+  bitrate: number
+  bitdepth: number
+  channel: number
+  samplerate: number
+  muxing: string
+  title?: string
+  lang?: string
+}
+
+export interface SubtitlesInfo {
+  id?: number
+  default?: boolean
+  forced?: boolean
+  embedded: boolean
+  stream?: number
+  title?: string
+  lang: string
+  type: string
+  externalFile?: string
+  subsCharacterSet?: string
+  convertedFile?: string
+}
+
+export interface ImageInfo {
+  resolution: string
+  format?: string
+  size?: number
+  bitDepth?: number
 }
 
 export function getMediaIcon(media: BaseMedia, i18n: I18nInterface, size: string | number, icon?: Icon) {

--- a/src/main/java/net/pms/image/ImageInfo.java
+++ b/src/main/java/net/pms/image/ImageInfo.java
@@ -17,6 +17,7 @@
 package net.pms.image;
 
 import com.drew.metadata.Metadata;
+import com.google.gson.JsonObject;
 import java.awt.color.ColorSpace;
 import java.awt.image.ColorModel;
 import java.io.Serializable;
@@ -941,6 +942,17 @@ public abstract class ImageInfo implements Serializable {
 	public abstract ImageInfo copy();
 
 	protected abstract void buildToString(StringBuilder sb);
+
+	public JsonObject toJson() {
+		JsonObject result = new JsonObject();
+		result.addProperty("format", getFormat().toString());
+		String widthStr = (getWidth() == UNKNOWN) ? "Unknown" : Integer.toString(getWidth());
+		String heightStr = (getHeight() == UNKNOWN) ? "Unknown" : Integer.toString(getHeight());
+		result.addProperty("resolution", widthStr + "x" + heightStr);
+		result.addProperty("size", getSize());
+		result.addProperty("bitDepth", getBitDepth());
+		return result;
+	}
 
 	@Override
 	public String toString() {

--- a/src/main/java/net/pms/media/MediaInfo.java
+++ b/src/main/java/net/pms/media/MediaInfo.java
@@ -16,6 +16,8 @@
  */
 package net.pms.media;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -773,6 +775,74 @@ public class MediaInfo implements Cloneable {
 			}
 			sb.append(" [").append(subtitleTrack).append("]");
 		}
+	}
+
+	public JsonObject toJson() {
+		JsonObject result = new JsonObject();
+		if (getContainer() != null) {
+			result.addProperty("container", getContainer().toUpperCase(Locale.ROOT));
+		}
+		result.addProperty("size", getSize());
+		if (isVideo()) {
+			result.addProperty("mediaType", "video");
+			result.addProperty("bitrate", getBitRate());
+			if (StringUtils.isNotBlank(getTitle())) {
+				result.addProperty("title", getTitle());
+			}
+			if (getFrameRate() != null) {
+				result.addProperty("framerate", getFrameRate());
+			}
+			result.addProperty("duration", getDurationString());
+			if (getVideoTrackCount() > 0) {
+				JsonArray videotracks = new JsonArray();
+				for (MediaVideo video : getVideoTracks()) {
+					videotracks.add(video.toJson());
+				}
+				result.add("videotracks", videotracks);
+			}
+			if (getAudioTrackCount() > 0) {
+				JsonArray audiotracks = new JsonArray();
+				for (MediaAudio audio : getAudioTracks()) {
+					audiotracks.add(audio.toJson());
+				}
+				result.add("audiotracks", audiotracks);
+			}
+			if (getSubtitleTrackCount() > 0) {
+				JsonArray subtitlestracks = new JsonArray();
+				for (MediaSubtitle subtitlesTrack : getSubtitlesTracks()) {
+					subtitlestracks.add(subtitlesTrack.toJson());
+				}
+				result.add("subtitlestracks", subtitlestracks);
+			}
+		} else if (getAudioTrackCount() > 0) {
+			result.addProperty("mediaType", "audio");
+			result.addProperty("bitrate", getBitRate());
+			result.addProperty("duration", getDurationString());
+			JsonArray audiotracks = new JsonArray();
+			for (MediaAudio audio : getAudioTracks()) {
+				audiotracks.add(audio.toJson());
+			}
+			result.add("audiotracks", audiotracks);
+		}
+		if (getImageCount() > 0) {
+			if (getImageCount() > 1) {
+				result.addProperty("images", getImageCount());
+			}
+			if (getImageInfo() != null) {
+				result.add("image", getImageInfo().toJson());
+			} else {
+				JsonObject image = new JsonObject();
+				image.addProperty("resolution", getWidth() + "x" + getHeight());
+				result.add("image", image);
+			}
+		}
+
+		if (getThumbnail() != null && getThumbnail().getImageInfo() != null) {
+			result.add("thumbnail", getThumbnail().getImageInfo().toJson());
+		}
+
+		result.addProperty("mimetype", getMimeType());
+		return result;
 	}
 
 	@Override

--- a/src/main/java/net/pms/media/audio/MediaAudio.java
+++ b/src/main/java/net/pms/media/audio/MediaAudio.java
@@ -16,6 +16,7 @@
  */
 package net.pms.media.audio;
 
+import com.google.gson.JsonObject;
 import java.util.Locale;
 import net.pms.configuration.FormatConfiguration;
 import net.pms.media.MediaLang;
@@ -687,6 +688,27 @@ public class MediaAudio extends MediaLang implements Cloneable {
 			);
 	}
 
+	public JsonObject toJson() {
+		JsonObject result = new JsonObject();
+		result.addProperty("id", getId());
+		result.addProperty("default", isDefault());
+		result.addProperty("forced", isForced());
+		if (StringUtils.isNotBlank(getTitle())) {
+			result.addProperty("title", getTitle());
+		}
+		if (StringUtils.isNotBlank(getLang()) && !UND.equals(getLang())) {
+			result.addProperty("lang", getLang());
+		}
+		result.addProperty("codec", getAudioCodec());
+		result.addProperty("stream", getStreamOrder());
+		result.addProperty("bitrate", getBitRate());
+		result.addProperty("bitdepth", getBitDepth());
+		result.addProperty("channel", getNumberOfChannels());
+		result.addProperty("samplerate", getSampleRate());
+		result.addProperty("muxing", getMuxingMode());
+		return result;
+	}
+
 	@Override
 	public Object clone() throws CloneNotSupportedException {
 		return super.clone();
@@ -701,10 +723,10 @@ public class MediaAudio extends MediaLang implements Cloneable {
 	public String toString() {
 		StringBuilder result = new StringBuilder();
 		result.append("Audio Id: ").append(getId());
-		if (forcedFlag) {
+		if (isDefault()) {
 			result.append(", Default");
 		}
-		if (forcedFlag) {
+		if (isForced()) {
 			result.append(", Forced");
 		}
 		if (StringUtils.isNotBlank(getTitle())) {

--- a/src/main/java/net/pms/media/subtitle/MediaSubtitle.java
+++ b/src/main/java/net/pms/media/subtitle/MediaSubtitle.java
@@ -16,6 +16,7 @@
  */
 package net.pms.media.subtitle;
 
+import com.google.gson.JsonObject;
 import com.ibm.icu.text.CharsetMatch;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -328,6 +329,32 @@ public class MediaSubtitle extends MediaLang implements Cloneable {
 		return convertedFile;
 	}
 
+	public JsonObject toJson() {
+		JsonObject result = new JsonObject();
+		result.addProperty("embedded", isEmbedded());
+		if (isEmbedded()) {
+			result.addProperty("id", getId());
+			result.addProperty("default", isDefault());
+			result.addProperty("forced", isForced());
+		}
+		if (StringUtils.isNotBlank(getTitle())) {
+			result.addProperty("title", getTitle());
+		}
+		result.addProperty("lang", getLang());
+		result.addProperty("type", getType().getShortName());
+		if (getStreamOrder() != null) {
+			result.addProperty("stream", getStreamOrder());
+		}
+		if (isExternal()) {
+			result.addProperty("externalFile", getExternalFile().toString());
+			result.addProperty("subsCharacterSet", getSubCharacterSet());
+		}
+		if (getConvertedFile() != null) {
+			result.addProperty("convertedFile", getConvertedFile().toString());
+		}
+		return result;
+	}
+
 	@Override
 	public Object clone() throws CloneNotSupportedException {
 		return super.clone();
@@ -338,10 +365,10 @@ public class MediaSubtitle extends MediaLang implements Cloneable {
 		StringBuilder result = new StringBuilder();
 		if (isEmbedded()) {
 			result.append("Id: ").append(getId()).append(", Embedded");
-			if (forcedFlag) {
+			if (isDefault()) {
 				result.append(", Default");
 			}
-			if (forcedFlag) {
+			if (isForced()) {
 				result.append(", Forced");
 			}
 		} else {

--- a/src/main/java/net/pms/media/video/MediaVideo.java
+++ b/src/main/java/net/pms/media/video/MediaVideo.java
@@ -16,6 +16,7 @@
  */
 package net.pms.media.video;
 
+import com.google.gson.JsonObject;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -844,14 +845,88 @@ public class MediaVideo extends MediaLang implements Cloneable {
 		}
 	}
 
+	public JsonObject toJson() {
+		JsonObject result = new JsonObject();
+		result.addProperty("id", getId());
+		result.addProperty("default", isDefault());
+		result.addProperty("forced", isForced());
+		result.addProperty("codec", getCodec());
+		result.addProperty("stream", getStreamOrder());
+		result.addProperty("bitDepth", getBitDepth());
+		result.addProperty("resolution", getWidth() + "x" + getHeight());
+		if (StringUtils.isNotBlank(getTitle())) {
+			result.addProperty("title", getTitle());
+		}
+		if (StringUtils.isNotBlank(getLang()) && !UND.equals(getLang())) {
+			result.addProperty("lang", getLang());
+		}
+		if (StringUtils.isNotBlank(getFormatProfile())) {
+			result.addProperty("formatProfile", getFormatProfile());
+		}
+		if (StringUtils.isNotBlank(getFormatLevel())) {
+			result.addProperty("formatLevel", getFormatLevel());
+		}
+		if (StringUtils.isNotBlank(getFormatTier())) {
+			result.addProperty("formatTier", getFormatTier());
+		}
+		if (getDuration() != null) {
+			result.addProperty("duration", getDurationString());
+		}
+		if (getDisplayAspectRatio() != null) {
+			result.addProperty("displayaspectratio", getDisplayAspectRatio());
+		}
+		if (getPixelAspectRatio() != null && getPixelAspectRatio() != 1) {
+			result.addProperty("pixelaspectratio", getPixelAspectRatio());
+		}
+		ScanType scanTypeTemp = getScanType();
+		if (scanTypeTemp != null) {
+			result.addProperty("scantype", scanTypeTemp.toString());
+		}
+		ScanOrder scanOrderTemp = getScanOrder();
+		if (scanOrderTemp != null) {
+			result.addProperty("scanOrder", scanOrderTemp.toString());
+		}
+		if (getFrameRate() != null) {
+			result.addProperty("framerate", getFrameRate());
+		}
+		if (StringUtils.isNotBlank(getFrameRateMode())) {
+			result.addProperty("framerateMode", getFrameRateMode());
+		}
+		if (StringUtils.isNotBlank(getFrameRateModeRaw())) {
+			result.addProperty("framerateModeRaw", getFrameRateModeRaw());
+		}
+		if (StringUtils.isNotBlank(getMuxingMode())) {
+			result.addProperty("muxingMode", getMuxingMode());
+		}
+		if (StringUtils.isNotBlank(getMatrixCoefficients())) {
+			result.addProperty("matrixCoefficients", getMatrixCoefficients());
+		}
+		if (getReferenceFrameCount() > -1) {
+			result.addProperty("referenceFrameCount", getReferenceFrameCount());
+		}
+		if (StringUtils.isNotBlank(getHDRFormat())) {
+			result.addProperty("hdrFormat", getHDRFormat());
+		}
+		if (StringUtils.isNotBlank(getHDRFormatForRenderer())) {
+			result.addProperty("hdrFormatRenderer", getHDRFormatForRenderer());
+		}
+		if (StringUtils.isNotBlank(getHDRFormatCompatibility())) {
+			result.addProperty("hdrFormatCompatibility", getHDRFormatCompatibility());
+		}
+		if (StringUtils.isNotBlank(getHDRFormatCompatibilityForRenderer())) {
+			result.addProperty("hdrFormatCompatibilityRenderer", getHDRFormatCompatibilityForRenderer());
+		}
+		return result;
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder result = new StringBuilder();
 		result.append("Video Id: ").append(getId());
-		if (forcedFlag) {
+		if (isDefault()) {
 			result.append(", Default");
 		}
-		if (forcedFlag) {
+		if (isForced()) {
 			result.append(", Forced");
 		}
 		if (StringUtils.isNotBlank(getLang()) && !UND.equals(getLang())) {

--- a/src/test/java/net/pms/parsers/FFmpegParserTest.java
+++ b/src/test/java/net/pms/parsers/FFmpegParserTest.java
@@ -65,15 +65,15 @@ public class FFmpegParserTest {
 		 * - Frame Rate Mode
 		 */
 		assertEquals(
-			"Container: MP4, Size: 1325017, Overall Bitrate: 692224, Duration: 0:00:15.660, Video Tracks: 1 [Video Id: 0, Codec: h264, Format Profile: high, Stream Order: 0, Resolution: 640 x 360, Frame Rate: 23.98], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 1, Bitrate: 125000, Channels: 2, Sample Frequency: 48000 Hz], Mime Type: video/mp4",
+			"Container: MP4, Size: 1325017, Overall Bitrate: 692224, Duration: 0:00:15.660, Video Tracks: 1 [Video Id: 0, Default, Codec: h264, Format Profile: high, Stream Order: 0, Resolution: 640 x 360, Frame Rate: 23.98], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 1, Bitrate: 125000, Channels: 2, Sample Frequency: 48000 Hz], Mime Type: video/mp4",
 			getTestFileMediaInfo("video-h264-aac.mp4").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 2097841, Overall Bitrate: 1612800, Duration: 0:00:10.650, Video Tracks: 1 [Video Id: 0, Codec: mp4, Format Profile: simple profile, Stream Order: 0, Resolution: 1280 x 720, Frame Rate: 25.0], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 0, Bitrate: 0, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 2097841, Overall Bitrate: 1612800, Duration: 0:00:10.650, Video Tracks: 1 [Video Id: 0, Default, Codec: mp4, Format Profile: simple profile, Stream Order: 0, Resolution: 1280 x 720, Frame Rate: 25.0], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 0, Bitrate: 0, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-mpeg4-aac.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 5291494, Overall Bitrate: 2681856, Duration: 0:00:16.160, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main, Stream Order: 0, Resolution: 1920 x 960, Frame Rate: 25.0], Audio Tracks: 1 [Audio Id: 0, Title: Stereo, Language Code: eng, Codec: AAC-LC, Stream Order: 1, Bitrate: 0, Channels: 2, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 5291494, Overall Bitrate: 2681856, Duration: 0:00:16.160, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main, Stream Order: 0, Resolution: 1920 x 960, Frame Rate: 25.0], Audio Tracks: 1 [Audio Id: 0, Default, Title: Stereo, Language Code: eng, Codec: AAC-LC, Stream Order: 1, Bitrate: 0, Channels: 2, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265-aac.mkv").toString()
 		);
 		assertEquals(
@@ -81,11 +81,11 @@ public class FFmpegParserTest {
 			getTestFileMediaInfo("video-theora-vorbis.ogg").toString()
 		);
 		assertEquals(
-			"Container: M4V, Size: 3538130, Overall Bitrate: 555008, Duration: 0:00:52.210, Video Tracks: 1 [Video Id: 0, Codec: h264, Format Profile: high, Stream Order: 0, Resolution: 720 x 480, Frame Rate: 24.0], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 1, Bitrate: 128000, Channels: 2, Sample Frequency: 44100 Hz], Mime Type: video/x-m4v",
+			"Container: M4V, Size: 3538130, Overall Bitrate: 555008, Duration: 0:00:52.210, Video Tracks: 1 [Video Id: 0, Default, Codec: h264, Format Profile: high, Stream Order: 0, Resolution: 720 x 480, Frame Rate: 24.0], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 1, Bitrate: 128000, Channels: 2, Sample Frequency: 44100 Hz], Mime Type: video/x-m4v",
 			getTestFileMediaInfo("video-h264-aac.m4v").toString()
 		);
 		assertEquals(
-			"Container: 3G2, Size: 1792091, Overall Bitrate: 281600, Duration: 0:00:52.060, Video Tracks: 1 [Video Id: 0, Codec: mp4, Format Profile: simple profile, Stream Order: 0, Resolution: 360 x 240, Frame Rate: 18.0], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 1, Bitrate: 59000, Channels: 2, Sample Frequency: 22050 Hz], Mime Type: video/3gpp2",
+			"Container: 3G2, Size: 1792091, Overall Bitrate: 281600, Duration: 0:00:52.060, Video Tracks: 1 [Video Id: 0, Default, Codec: mp4, Format Profile: simple profile, Stream Order: 0, Resolution: 360 x 240, Frame Rate: 18.0], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 1, Bitrate: 59000, Channels: 2, Sample Frequency: 22050 Hz], Mime Type: video/3gpp2",
 			getTestFileMediaInfo("video-mp4-aac.3g2").toString()
 		);
 		assertEquals(
@@ -93,7 +93,7 @@ public class FFmpegParserTest {
 			getTestFileMediaInfo("video-mp4-adpcm.avi").toString()
 		);
 		assertEquals(
-			"Container: MOV, Size: 2658492, Overall Bitrate: 417792, Duration: 0:00:52.080, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: mp4, Format Profile: simple profile, Stream Order: 0, Resolution: 360 x 240, Frame Rate: 24.0], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: AAC-LC, Stream Order: 1, Bitrate: 125000, Channels: 2, Sample Frequency: 44100 Hz], Mime Type: video/quicktime",
+			"Container: MOV, Size: 2658492, Overall Bitrate: 417792, Duration: 0:00:52.080, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: mp4, Format Profile: simple profile, Stream Order: 0, Resolution: 360 x 240, Frame Rate: 24.0], Audio Tracks: 1 [Audio Id: 0, Default, Language Code: eng, Codec: AAC-LC, Stream Order: 1, Bitrate: 125000, Channels: 2, Sample Frequency: 44100 Hz], Mime Type: video/quicktime",
 			getTestFileMediaInfo("video-mp4-aac.mov").toString()
 		);
 		assertEquals(
@@ -101,7 +101,7 @@ public class FFmpegParserTest {
 			getTestFileMediaInfo("video-wmv-wma.wmv").toString()
 		);
 		assertEquals(
-			"Container: WEBM, Size: 901185, Overall Bitrate: 241664, Duration: 0:00:30.540, Video Tracks: 1 [Video Id: 0, Codec: vp8, Stream Order: 0, Resolution: 480 x 270, Frame Rate: 30.0], Audio Tracks: 1 [Audio Id: 0, Codec: Vorbis, Stream Order: 0, Bitrate: 0, Channels: 2, Sample Frequency: 48000 Hz], Mime Type: video/webm",
+			"Container: WEBM, Size: 901185, Overall Bitrate: 241664, Duration: 0:00:30.540, Video Tracks: 1 [Video Id: 0, Default, Codec: vp8, Stream Order: 0, Resolution: 480 x 270, Frame Rate: 30.0], Audio Tracks: 1 [Audio Id: 0, Default, Codec: Vorbis, Stream Order: 0, Bitrate: 0, Channels: 2, Sample Frequency: 48000 Hz], Mime Type: video/webm",
 			getTestFileMediaInfo("video-vp8-vorbis.webm").toString()
 		);
 		assertEquals(
@@ -113,31 +113,31 @@ public class FFmpegParserTest {
 			getTestFileMediaInfo("video-h264-aac.avi").toString()
 		);
 		assertEquals(
-			"Container: MP4, Size: 245747, Overall Bitrate: 133120, Duration: 0:00:15.040, Video Tracks: 1 [Video Id: 0, Codec: av1, Format Profile: libaom-av1, Stream Order: 1, Resolution: 960 x 540, Frame Rate: 25.0], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 0, Bitrate: 8000, Channel: 1, Sample Frequency: 32000 Hz], Mime Type: video/mp4",
+			"Container: MP4, Size: 245747, Overall Bitrate: 133120, Duration: 0:00:15.040, Video Tracks: 1 [Video Id: 0, Default, Codec: av1, Format Profile: libaom-av1, Stream Order: 1, Resolution: 960 x 540, Frame Rate: 25.0], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 0, Bitrate: 8000, Channel: 1, Sample Frequency: 32000 Hz], Mime Type: video/mp4",
 			getTestFileMediaInfo("video-av1-aac.mp4").toString()
 		);
 		assertEquals(
-			"Container: MP4, Size: 690235, Overall Bitrate: 974848, Duration: 0:00:05.800, Video Tracks: 1 [Video Id: 0, Codec: av1, Format Profile: libaom-av1, Stream Order: 0, Resolution: 480 x 270, Frame Rate: 23.98], Mime Type: video/mp4",
+			"Container: MP4, Size: 690235, Overall Bitrate: 974848, Duration: 0:00:05.800, Video Tracks: 1 [Video Id: 0, Default, Codec: av1, Format Profile: libaom-av1, Stream Order: 0, Resolution: 480 x 270, Frame Rate: 23.98], Mime Type: video/mp4",
 			getTestFileMediaInfo("video-av1.mp4").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 6291087, Overall Bitrate: 23007232, Duration: 0:00:02.240, Video Tracks: 1 [Video Id: 0, Codec: vc1, Format Profile: advanced, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 25.0], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 6291087, Overall Bitrate: 23007232, Duration: 0:00:02.240, Video Tracks: 1 [Video Id: 0, Default, Codec: vc1, Format Profile: advanced, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 25.0], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-vc1.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 8710128, Overall Bitrate: 7953408, Duration: 0:00:08.970, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h264, Format Profile: high, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 23.98], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 8710128, Overall Bitrate: 7953408, Duration: 0:00:08.970, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h264, Format Profile: high, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 23.98], Audio Tracks: 1 [Audio Id: 0, Default, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h264-dtshd.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 9513954, Overall Bitrate: 8687616, Duration: 0:00:08.970, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h264, Format Profile: high, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 23.98], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 9513954, Overall Bitrate: 8687616, Duration: 0:00:08.970, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h264, Format Profile: high, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 23.98], Audio Tracks: 1 [Audio Id: 0, Default, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h264-dtshd_x.mkv").toString()
 		);
 		assertEquals(
-			"Container: MP4, Size: 1099408, Overall Bitrate: 192512, Duration: 0:00:46.630, Video Tracks: 1 [Video Id: 0, Codec: h264, Format Profile: main, Stream Order: 0, Resolution: 800 x 600, Frame Rate: 8.0], Audio Tracks: 1 [Audio Id: 0, Codec: HE-AAC, Stream Order: 1, Bitrate: 159000, Channels: 6, Sample Frequency: 44100 Hz], Mime Type: video/mp4",
+			"Container: MP4, Size: 1099408, Overall Bitrate: 192512, Duration: 0:00:46.630, Video Tracks: 1 [Video Id: 0, Default, Codec: h264, Format Profile: main, Stream Order: 0, Resolution: 800 x 600, Frame Rate: 8.0], Audio Tracks: 1 [Audio Id: 0, Default, Codec: HE-AAC, Stream Order: 1, Bitrate: 159000, Channels: 6, Sample Frequency: 44100 Hz], Mime Type: video/mp4",
 			getTestFileMediaInfo("video-h264-heaac.mp4").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 6270615, Overall Bitrate: 8539136, Duration: 0:00:06.020, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h264, Format Profile: main, Stream Order: 0, Resolution: 1280 x 544, Frame Rate: 23.98], Audio Tracks: 1 [Audio Id: 0, Language Code: fre, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 1536000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 6270615, Overall Bitrate: 8539136, Duration: 0:00:06.020, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h264, Format Profile: main, Stream Order: 0, Resolution: 1280 x 544, Frame Rate: 23.98], Audio Tracks: 1 [Audio Id: 0, Default, Language Code: fre, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 1536000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h264-eac3.mkv").toString()
 		);
 		assertEquals(
@@ -145,19 +145,19 @@ public class FFmpegParserTest {
 			getTestFileMediaInfo("video-xvid-mp3.avi").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 8925360, Overall Bitrate: 12152832, Duration: 0:00:06.020, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 59.94, Bit Depth: 10, HDR Format: Dolby Vision (dolbyvision)], Audio Tracks: 1 [Audio Id: 0, Codec: Enhanced AC-3, Stream Order: 0, Bitrate: 640000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 8925360, Overall Bitrate: 12152832, Duration: 0:00:06.020, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 59.94, Bit Depth: 10, HDR Format: Dolby Vision (dolbyvision)], Audio Tracks: 1 [Audio Id: 0, Default, Codec: Enhanced AC-3, Stream Order: 0, Bitrate: 640000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_dolbyvision_p05.05-eac3_atmos.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 7799945, Overall Bitrate: 10620928, Duration: 0:00:06.020, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 59.94, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Codec: Enhanced AC-3, Stream Order: 0, Bitrate: 640000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 7799945, Overall Bitrate: 10620928, Duration: 0:00:06.020, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 1920 x 1080, Frame Rate: 59.94, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Default, Codec: Enhanced AC-3, Stream Order: 0, Bitrate: 640000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_dolbyvision_p08.05-eac3_atmos.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 2270734, Overall Bitrate: 6228992, Duration: 0:00:02.990, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 3840 x 2160, Frame Rate: 59.94, Bit Depth: 10, HDR Format: HDR10 (hdr10), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 0, Bitrate: 0, Channels: 2, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 2270734, Overall Bitrate: 6228992, Duration: 0:00:02.990, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 3840 x 2160, Frame Rate: 59.94, Bit Depth: 10, HDR Format: HDR10 (hdr10), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 0, Bitrate: 0, Channels: 2, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_hdr10-aac.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 8652028, Overall Bitrate: 62889984, Duration: 0:00:01.130, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 3840 x 2160, Frame Rate: 23.98, Bit Depth: 10, HDR Format: HDR10 (hdr10), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Title: DTS:X, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 8652028, Overall Bitrate: 62889984, Duration: 0:00:01.130, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 3840 x 2160, Frame Rate: 23.98, Bit Depth: 10, HDR Format: HDR10 (hdr10), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Default, Title: DTS:X, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_hdr10+-dtshd_x_imax.mkv").toString()
 		);
 		assertEquals(
@@ -181,15 +181,15 @@ public class FFmpegParserTest {
 			getTestFileMediaInfo("video-h265_dolbyvision_p08.12.ts").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 19121021, Overall Bitrate: 15014912, Duration: 0:00:10.430, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 3840 x 1608, Frame Rate: 23.98, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Title: DDP 7.1, Language Code: eng, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 1536000, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 19121021, Overall Bitrate: 15014912, Duration: 0:00:10.430, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 3840 x 1608, Frame Rate: 23.98, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Default, Title: DDP 7.1, Language Code: eng, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 1536000, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_dolbyvision_p08.06-eac3_dolby_surround_ex.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 11413502, Overall Bitrate: 6256640, Duration: 0:00:14.940, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 3840 x 2160, Frame Rate: 25.0, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 768000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 11413502, Overall Bitrate: 6256640, Duration: 0:00:14.940, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main 10, Stream Order: 0, Resolution: 3840 x 2160, Frame Rate: 25.0, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 768000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_dolbyvision_p08.07-eac3_atmos.mkv").toString()
 		);
 		assertEquals(
-			"Container: MP4, Size: 23449234, Overall Bitrate: 2670592, Duration: 0:01:11.910, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h264, Format Profile: main, Stream Order: 1, Resolution: 1280 x 720, Frame Rate: 29.97], Audio Tracks: 1 [Audio Id: 0, Codec: ac4, Stream Order: 0, Bitrate: 128000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/mp4",
+			"Container: MP4, Size: 23449234, Overall Bitrate: 2670592, Duration: 0:01:11.910, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h264, Format Profile: main, Stream Order: 1, Resolution: 1280 x 720, Frame Rate: 29.97], Audio Tracks: 1 [Audio Id: 0, Default, Codec: ac4, Stream Order: 0, Bitrate: 128000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/mp4",
 			getTestFileMediaInfo("video-h264-6ch-ac4.mp4").toString()
 		);
 

--- a/src/test/java/net/pms/parsers/MediaInfoParserTest.java
+++ b/src/test/java/net/pms/parsers/MediaInfoParserTest.java
@@ -130,11 +130,11 @@ public class MediaInfoParserTest {
 			getTestFileMediaInfo("video-h264-aac.mp4").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 2097841, Overall Bitrate: 1575843, Duration: 0:00:10.650, Video Tracks: 1 [Video Id: 0, Codec: mp4, Format Profile: simple, Format Level: 1, Stream Order: 0, Duration: 0:00:10.650, Resolution: 1280 x 720, Display Aspect Ratio: 16:9, Scan Type: Progressive, Frame Rate Mode: VFR (VFR)], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 1, Bitrate: 0, Channels: 6, Sample Frequency: 48000 Hz, Video Delay: 5], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 2097841, Overall Bitrate: 1575843, Duration: 0:00:10.650, Video Tracks: 1 [Video Id: 0, Default, Codec: mp4, Format Profile: simple, Format Level: 1, Stream Order: 0, Duration: 0:00:10.650, Resolution: 1280 x 720, Display Aspect Ratio: 16:9, Scan Type: Progressive, Frame Rate Mode: VFR (VFR)], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 1, Bitrate: 0, Channels: 6, Sample Frequency: 48000 Hz, Video Delay: 5], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-mpeg4-aac.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 5291494, Overall Bitrate: 2619551, Duration: 0:00:16.160, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main, Format Level: 4, Format Tier: main, Stream Order: 0, Duration: 0:00:16.160, Resolution: 1920 x 960, Display Aspect Ratio: 2.00:1, Frame Rate: 25.0, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.709], Audio Tracks: 1 [Audio Id: 0, Title: Stereo, Language Code: eng, Codec: AAC-LC, Stream Order: 1, Bitrate: 0, Channels: 2, Sample Frequency: 48000 Hz, Video Delay: -21], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 5291494, Overall Bitrate: 2619551, Duration: 0:00:16.160, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main, Format Level: 4, Format Tier: main, Stream Order: 0, Duration: 0:00:16.160, Resolution: 1920 x 960, Display Aspect Ratio: 2.00:1, Frame Rate: 25.0, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.709], Audio Tracks: 1 [Audio Id: 0, Default, Title: Stereo, Language Code: eng, Codec: AAC-LC, Stream Order: 1, Bitrate: 0, Channels: 2, Sample Frequency: 48000 Hz, Video Delay: -21], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265-aac.mkv").toString()
 		);
 		assertEquals(
@@ -142,11 +142,11 @@ public class MediaInfoParserTest {
 			getTestFileMediaInfo("video-theora-vorbis.ogg").toString()
 		);
 		assertEquals(
-			"Container: MP4, Size: 3538130, Overall Bitrate: 542149, Duration: 0:00:52.209, Video Tracks: 1 [Video Id: 0, Codec: h264, Format Profile: high, Format Level: 3, Stream Order: 0, Duration: 0:00:52.209, Resolution: 720 x 480, Display Aspect Ratio: 2.35:1, Pixel Aspect Ratio: 1.563, Scan Type: Progressive, Frame Rate: 24.0, Frame Rate Mode: CFR (CFR), Reference Frame Count: 4], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 1, Bitrate: 128290, Channels: 2, Sample Frequency: 44100 Hz], Mime Type: video/mp4",
+			"Container: MP4, Size: 3538130, Overall Bitrate: 542149, Duration: 0:00:52.209, Video Tracks: 1 [Video Id: 0, Codec: h264, Format Profile: high, Format Level: 3, Stream Order: 0, Duration: 0:00:52.209, Resolution: 720 x 480, Display Aspect Ratio: 2.35:1, Pixel Aspect Ratio: 1.563, Scan Type: Progressive, Frame Rate: 24.0, Frame Rate Mode: CFR (CFR), Reference Frame Count: 4], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 1, Bitrate: 128290, Channels: 2, Sample Frequency: 44100 Hz], Mime Type: video/mp4",
 			getTestFileMediaInfo("video-h264-aac.m4v").toString()
 		);
 		assertEquals(
-			"Container: 3G2, Size: 1792091, Overall Bitrate: 275410, Duration: 0:00:52.056, Video Tracks: 1 [Video Id: 0, Codec: mp4, Format Profile: simple, Format Level: 1, Stream Order: 0, Duration: 0:00:52.056, Resolution: 360 x 240, Display Aspect Ratio: 3:2, Scan Type: Progressive, Frame Rate: 18.0, Frame Rate Mode: CFR (CFR)], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 1, Bitrate: 59721, Channels: 2, Sample Frequency: 22050 Hz], Mime Type: video/3gpp2",
+			"Container: 3G2, Size: 1792091, Overall Bitrate: 275410, Duration: 0:00:52.056, Video Tracks: 1 [Video Id: 0, Codec: mp4, Format Profile: simple, Format Level: 1, Stream Order: 0, Duration: 0:00:52.056, Resolution: 360 x 240, Display Aspect Ratio: 3:2, Scan Type: Progressive, Frame Rate: 18.0, Frame Rate Mode: CFR (CFR)], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 1, Bitrate: 59721, Channels: 2, Sample Frequency: 22050 Hz], Mime Type: video/3gpp2",
 			getTestFileMediaInfo("video-mp4-aac.3g2").toString()
 		);
 		assertEquals(
@@ -154,7 +154,7 @@ public class MediaInfoParserTest {
 			getTestFileMediaInfo("video-mp4-adpcm.avi").toString()
 		);
 		assertEquals(
-			"Container: MOV, Size: 2658492, Overall Bitrate: 408339, Duration: 0:00:52.084, Video Tracks: 1 [Video Id: 0, Language Code: eng, Title: Sintel Trailer, Codec: mp4, Format Profile: simple, Format Level: 1, Stream Order: 0, Duration: 0:00:52.084, Resolution: 360 x 240, Display Aspect Ratio: 3:2, Scan Type: Progressive, Frame Rate: 24.0, Frame Rate Mode: CFR (CFR)], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: AAC-LC, Stream Order: 1, Bitrate: 125805, Channels: 2, Sample Frequency: 44100 Hz], Mime Type: video/quicktime",
+			"Container: MOV, Size: 2658492, Overall Bitrate: 408339, Duration: 0:00:52.084, Video Tracks: 1 [Video Id: 0, Language Code: eng, Title: Sintel Trailer, Codec: mp4, Format Profile: simple, Format Level: 1, Stream Order: 0, Duration: 0:00:52.084, Resolution: 360 x 240, Display Aspect Ratio: 3:2, Scan Type: Progressive, Frame Rate: 24.0, Frame Rate Mode: CFR (CFR)], Audio Tracks: 1 [Audio Id: 0, Default, Language Code: eng, Codec: AAC-LC, Stream Order: 1, Bitrate: 125805, Channels: 2, Sample Frequency: 44100 Hz], Mime Type: video/quicktime",
 			getTestFileMediaInfo("video-mp4-aac.mov").toString()
 		);
 		assertEquals(
@@ -162,7 +162,7 @@ public class MediaInfoParserTest {
 			getTestFileMediaInfo("video-wmv-wma.wmv").toString()
 		);
 		assertEquals(
-			"Container: WEBM, Size: 901185, Overall Bitrate: 236044, Duration: 0:00:30.543, Video Tracks: 1 [Video Id: 0, Codec: vp8, Stream Order: 0, Duration: 0:00:30.033, Resolution: 480 x 270, Display Aspect Ratio: 16:9, Frame Rate: 30.0, Frame Rate Mode: CFR (CFR)], Audio Tracks: 1 [Audio Id: 0, Codec: Vorbis, Stream Order: 1, Bitrate: 112000, Channels: 2, Sample Frequency: 48000 Hz, Video Delay: -3], Mime Type: video/webm",
+			"Container: WEBM, Size: 901185, Overall Bitrate: 236044, Duration: 0:00:30.543, Video Tracks: 1 [Video Id: 0, Default, Codec: vp8, Stream Order: 0, Duration: 0:00:30.033, Resolution: 480 x 270, Display Aspect Ratio: 16:9, Frame Rate: 30.0, Frame Rate Mode: CFR (CFR)], Audio Tracks: 1 [Audio Id: 0, Default, Codec: Vorbis, Stream Order: 1, Bitrate: 112000, Channels: 2, Sample Frequency: 48000 Hz, Video Delay: -3], Mime Type: video/webm",
 			getTestFileMediaInfo("video-vp8-vorbis.webm").toString()
 		);
 		assertEquals(
@@ -182,15 +182,15 @@ public class MediaInfoParserTest {
 			getTestFileMediaInfo("video-av1.mp4").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 6291087, Overall Bitrate: 22468168, Duration: 0:00:02.240, Video Tracks: 1 [Video Id: 0, Codec: vc1, Format Profile: advanced, Format Level: 3, Stream Order: 0, Duration: 0:00:02.240, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Scan Type: Interlaced, Scan Order: Top Field First, Frame Rate: 25.0, Frame Rate Mode: CFR (CFR)], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 6291087, Overall Bitrate: 22468168, Duration: 0:00:02.240, Video Tracks: 1 [Video Id: 0, Default, Codec: vc1, Format Profile: advanced, Format Level: 3, Stream Order: 0, Duration: 0:00:02.240, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Scan Type: Interlaced, Scan Order: Top Field First, Frame Rate: 25.0, Frame Rate Mode: CFR (CFR)], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-vc1.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 8710128, Overall Bitrate: 7767364, Duration: 0:00:08.971, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h264, Format Profile: high, Format Level: 4.1, Stream Order: 0, Duration: 0:00:08.967, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Scan Type: Progressive, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Reference Frame Count: 4], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Bits per Sample: 24, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 8710128, Overall Bitrate: 7767364, Duration: 0:00:08.971, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h264, Format Profile: high, Format Level: 4.1, Stream Order: 0, Duration: 0:00:08.967, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Scan Type: Progressive, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Reference Frame Count: 4], Audio Tracks: 1 [Audio Id: 0, Default, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Bits per Sample: 24, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h264-dtshd.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 9513954, Overall Bitrate: 8484186, Duration: 0:00:08.971, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h264, Format Profile: high, Format Level: 4.1, Stream Order: 0, Duration: 0:00:08.967, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Scan Type: Progressive, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Reference Frame Count: 4], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Bits per Sample: 24, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 9513954, Overall Bitrate: 8484186, Duration: 0:00:08.971, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h264, Format Profile: high, Format Level: 4.1, Stream Order: 0, Duration: 0:00:08.967, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Scan Type: Progressive, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Reference Frame Count: 4], Audio Tracks: 1 [Audio Id: 0, Default, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 0, Bits per Sample: 24, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h264-dtshd_x.mkv").toString()
 		);
 		assertEquals(
@@ -198,7 +198,7 @@ public class MediaInfoParserTest {
 			getTestFileMediaInfo("video-h264-heaac.mp4").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 6270615, Overall Bitrate: 8339970, Duration: 0:00:06.015, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h264, Format Profile: main, Format Level: 5.1, Stream Order: 0, Duration: 0:00:06.006, Resolution: 1280 x 544, Display Aspect Ratio: 2.35:1, Scan Type: Progressive, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Reference Frame Count: 1], Audio Tracks: 1 [Audio Id: 0, Language Code: fre, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 1536000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 6270615, Overall Bitrate: 8339970, Duration: 0:00:06.015, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h264, Format Profile: main, Format Level: 5.1, Stream Order: 0, Duration: 0:00:06.006, Resolution: 1280 x 544, Display Aspect Ratio: 2.35:1, Scan Type: Progressive, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Reference Frame Count: 1], Audio Tracks: 1 [Audio Id: 0, Default, Language Code: fre, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 1536000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h264-eac3.mkv").toString()
 		);
 		assertEquals(
@@ -206,19 +206,19 @@ public class MediaInfoParserTest {
 			getTestFileMediaInfo("video-xvid-mp3.avi").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 8925360, Overall Bitrate: 11868830, Duration: 0:00:06.016, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: main, Stream Order: 0, Duration: 0:00:06.006, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Frame Rate: 59.94, Frame Rate Mode: CFR (CFR), Bit Depth: 10, HDR Format: Dolby Vision (dolbyvision)], Audio Tracks: 1 [Audio Id: 0, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 640000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 8925360, Overall Bitrate: 11868830, Duration: 0:00:06.016, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: main, Stream Order: 0, Duration: 0:00:06.006, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Frame Rate: 59.94, Frame Rate Mode: CFR (CFR), Bit Depth: 10, HDR Format: Dolby Vision (dolbyvision)], Audio Tracks: 1 [Audio Id: 0, Default, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 640000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_dolbyvision_p05.05-eac3_atmos.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 7799945, Overall Bitrate: 10372267, Duration: 0:00:06.016, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: main, Stream Order: 0, Duration: 0:00:06.006, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Frame Rate: 59.94, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 / HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 640000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 7799945, Overall Bitrate: 10372267, Duration: 0:00:06.016, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: main, Stream Order: 0, Duration: 0:00:06.006, Resolution: 1920 x 1080, Display Aspect Ratio: 16:9, Frame Rate: 59.94, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 / HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Default, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 640000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_dolbyvision_p08.05-eac3_atmos.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 2270734, Overall Bitrate: 6083681, Duration: 0:00:02.986, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: main, Stream Order: 0, Duration: 0:00:02.853, Resolution: 3840 x 2160, Display Aspect Ratio: 16:9, Frame Rate: 58.535, Frame Rate Mode: VFR (VFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: SMPTE ST 2086, HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Codec: AAC-LC, Stream Order: 1, Bitrate: 117969, Channels: 2, Sample Frequency: 48000 Hz, Video Delay: -67], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 2270734, Overall Bitrate: 6083681, Duration: 0:00:02.986, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: main, Stream Order: 0, Duration: 0:00:02.853, Resolution: 3840 x 2160, Display Aspect Ratio: 16:9, Frame Rate: 58.535, Frame Rate Mode: VFR (VFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: SMPTE ST 2086, HDR Format Compatibility: HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Default, Codec: AAC-LC, Stream Order: 1, Bitrate: 117969, Channels: 2, Sample Frequency: 48000 Hz, Video Delay: -67], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_hdr10-aac.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 8652028, Overall Bitrate: 61416348, File Title from Metadata: A Beautiful Planet (2016), Duration: 0:00:01.127, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: high, Stream Order: 0, Duration: 0:00:01.001, Resolution: 3840 x 2160, Display Aspect Ratio: 16:9, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: SMPTE ST 2094 App 4, HDR Format Compatibility: HDR10+ Profile A (hdr10+)], Audio Tracks: 1 [Audio Id: 0, Title: DTS:X, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 8543871, Bits per Sample: 24, Channels: 8, Sample Frequency: 48000 Hz, Video Delay: 134], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 8652028, Overall Bitrate: 61416348, File Title from Metadata: A Beautiful Planet (2016), Duration: 0:00:01.127, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: high, Stream Order: 0, Duration: 0:00:01.001, Resolution: 3840 x 2160, Display Aspect Ratio: 16:9, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: SMPTE ST 2094 App 4, HDR Format Compatibility: HDR10+ Profile A (hdr10+)], Audio Tracks: 1 [Audio Id: 0, Default, Title: DTS:X, Language Code: eng, Codec: DTS-HD, Stream Order: 1, Bitrate: 8543871, Bits per Sample: 24, Channels: 8, Sample Frequency: 48000 Hz, Video Delay: 134], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_hdr10+-dtshd_x_imax.mkv").toString()
 		);
 		assertEquals(
@@ -242,15 +242,15 @@ public class MediaInfoParserTest {
 			getTestFileMediaInfo("video-h265_dolbyvision_p08.12.ts").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 19121021, Overall Bitrate: 14663360, Duration: 0:00:10.432, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: main, Stream Order: 0, Duration: 0:00:10.427, Resolution: 3840 x 1608, Display Aspect Ratio: 2.39:1, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2094 App 4 (dolbyvision), HDR Format Compatibility: HDR10 / HDR10+ Profile B (hdr10)], Audio Tracks: 1 [Audio Id: 0, Title: DDP 7.1, Language Code: eng, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 1536000, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 19121021, Overall Bitrate: 14663360, Duration: 0:00:10.432, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main 10, Format Level: 5.1, Format Tier: main, Stream Order: 0, Duration: 0:00:10.427, Resolution: 3840 x 1608, Display Aspect Ratio: 2.39:1, Frame Rate: 23.976, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2094 App 4 (dolbyvision), HDR Format Compatibility: HDR10 / HDR10+ Profile B (hdr10)], Audio Tracks: 1 [Audio Id: 0, Default, Title: DDP 7.1, Language Code: eng, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 1536000, Channels: 8, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_dolbyvision_p08.06-eac3_dolby_surround_ex.mkv").toString()
 		);
 		assertEquals(
-			"Container: MKV, Size: 11413502, Overall Bitrate: 6110012, Duration: 0:00:14.944, Video Tracks: 1 [Video Id: 0, Codec: h265, Format Profile: main 10, Format Level: 5, Format Tier: main, Stream Order: 0, Duration: 0:00:14.920, Resolution: 3840 x 2160, Display Aspect Ratio: 16:9, Frame Rate: 25.0, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 / HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 768000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
+			"Container: MKV, Size: 11413502, Overall Bitrate: 6110012, Duration: 0:00:14.944, Video Tracks: 1 [Video Id: 0, Default, Codec: h265, Format Profile: main 10, Format Level: 5, Format Tier: main, Stream Order: 0, Duration: 0:00:14.920, Resolution: 3840 x 2160, Display Aspect Ratio: 16:9, Frame Rate: 25.0, Frame Rate Mode: CFR (CFR), Matrix Coefficients: BT.2020 non-constant, Bit Depth: 10, HDR Format: Dolby Vision / SMPTE ST 2086 (dolbyvision), HDR Format Compatibility: HDR10 / HDR10 (hdr10)], Audio Tracks: 1 [Audio Id: 0, Language Code: eng, Codec: Enhanced AC-3, Stream Order: 1, Bitrate: 768000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/x-matroska",
 			getTestFileMediaInfo("video-h265_dolbyvision_p08.07-eac3_atmos.mkv").toString()
 		);
 		assertEquals(
-			"Container: MP4, Size: 23449234, Overall Bitrate: 2608913, Duration: 0:01:11.905, Video Tracks: 1 [Video Id: 0, Language Code: eng, Codec: h264, Format Profile: main, Format Level: 4, Stream Order: 1, Duration: 0:01:11.905, Resolution: 1280 x 720, Display Aspect Ratio: 16:9, Scan Type: Progressive, Frame Rate: 29.97, Frame Rate Mode: CFR (CFR), Reference Frame Count: 2], Audio Tracks: 1 [Audio Id: 0, Codec: ac4, Stream Order: 0, Bitrate: 128000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/mp4",
+			"Container: MP4, Size: 23449234, Overall Bitrate: 2608913, Duration: 0:01:11.905, Video Tracks: 1 [Video Id: 0, Default, Language Code: eng, Codec: h264, Format Profile: main, Format Level: 4, Stream Order: 1, Duration: 0:01:11.905, Resolution: 1280 x 720, Display Aspect Ratio: 16:9, Scan Type: Progressive, Frame Rate: 29.97, Frame Rate Mode: CFR (CFR), Reference Frame Count: 2], Audio Tracks: 1 [Audio Id: 0, Default, Codec: ac4, Stream Order: 0, Bitrate: 128000, Channels: 6, Sample Frequency: 48000 Hz], Mime Type: video/mp4",
 			getTestFileMediaInfo("video-h264-6ch-ac4.mp4").toString()
 		);
 


### PR DESCRIPTION
fix xxxTrack.tostring() Default checked on isForced instead of isDefault
(only affect tests and log)
fixed tests

added media info to the web player (see https://github.com/UniversalMediaServer/UniversalMediaServer/issues/5204#issuecomment-2759036406)

react web : do not put token if expired
added try catch for InvalidTokenError

# Description of code changes

...

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
