### PR TITLE
main - log cmd args

### DIFF
--- a/src/main/java/net/pms/configuration/UmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/UmsConfiguration.java
@@ -986,7 +986,7 @@ public class UmsConfiguration extends BaseConfiguration {
 	}
 
 	public LogSystemInformationMode getLogSystemInformation() {
-		LogSystemInformationMode defaultValue = LogSystemInformationMode.TRACE_ONLY;
+		LogSystemInformationMode defaultValue = LogSystemInformationMode.ALWAYS;
 		String value = getString(KEY_LOG_SYSTEM_INFO, defaultValue.toString());
 		LogSystemInformationMode result = LogSystemInformationMode.typeOf(value);
 		return result != null ? result : defaultValue;

--- a/src/main/java/net/pms/util/SystemInformation.java
+++ b/src/main/java/net/pms/util/SystemInformation.java
@@ -17,6 +17,7 @@
 package net.pms.util;
 
 import java.lang.management.ManagementFactory;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -100,13 +101,19 @@ public class SystemInformation extends Thread {
 		for (String jvmArg : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
 			sb.append(StringUtil.quoteArg(jvmArg)).append(" ");
 		}
+		result.add(sb.toString());
 		sb.setLength(0);
 		sb.append("Language: ")
 		.append(WordUtils.capitalize(PMS.getLocale().getDisplayName(Locale.ENGLISH)));
 		result.add(sb.toString());
 		sb.setLength(0);
 		sb.append("Encoding: ")
-		.append(System.getProperty("file.encoding"));
+		.append(System.getProperty("file.encoding"))
+		.append(" | resolved ").append(Charset.defaultCharset())
+		.append(" | native ").append(System.getProperty("native.encoding"))
+		.append(" | jnu ").append(System.getProperty("sun.jnu.encoding"))
+		.append(" | stdout ").append(System.getProperty("sun.stdout.encoding"))
+		.append(" | stderr ").append(System.getProperty("sun.stderr.encoding"));
 		result.add(sb.toString());
 		sb.setLength(0);
 		if (processor != null && processorIdentifier != null) {

--- a/src/main/java/net/pms/util/SystemInformation.java
+++ b/src/main/java/net/pms/util/SystemInformation.java
@@ -16,6 +16,7 @@
  */
 package net.pms.util;
 
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -94,6 +95,11 @@ public class SystemInformation extends Thread {
 			.append(System.getProperty("sun.arch.data.model")).append("-bit) by ")
 			.append(System.getProperty("java.vendor"));
 		result.add(sb.toString());
+		sb.setLength(0);
+		sb.append("JVM args: ");
+		for (String jvmArg : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
+			sb.append(StringUtil.quoteArg(jvmArg)).append(" ");
+		}
 		sb.setLength(0);
 		sb.append("Language: ")
 		.append(WordUtils.capitalize(PMS.getLocale().getDisplayName(Locale.ENGLISH)));


### PR DESCRIPTION
# Description of code changes

log Java Virtual Machine cmd args (flags)
log more encoding info
set LogSystemInformationMode ON by default

example output:

```
INFO  09:22:53.699 [System Information Logger] System information:
  OS: Microsoft Windows 11 build 26100 64-bit
  JVM: Java HotSpot(TM) 64-Bit Server VM 17.0.10 (64-bit) by Oracle Corporation
  JVM args: -Dfile.encoding=UTF-8 -agentlib:jdwp=transport=dt_socket,server=n,address=35377 
  Language: French
  Encoding: UTF-8 | resolved UTF-8 | native Cp1252 | jnu Cp1252 | stdout null | stderr null
```

@SubJunk @Mik-S-UMS  this will help for debug as you know what arguments was set on virtual-machine startup and the underlying operating system encoding.
