### PR TITLE
main CI - Ubuntu 20.04 brownout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: Run tests
         run: mvn verify -P testing-windows
 
-  linux-focal:
+  linux-jammy:
     needs: changes
     if: |
       (
@@ -203,8 +203,8 @@ jobs:
         needs.changes.outputs.javafiles == 'true' ||
         needs.changes.outputs.cifile == 'true'
       )
-    name: Linux 20.04
-    runs-on: ubuntu-20.04
+    name: Linux 22.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
@@ -225,10 +225,10 @@ jobs:
       - name: Run tests
         run: |
           sudo apt-get -y install libmms0
-          wget --no-check-certificate https://mediaarea.net/download/binary/libzen0/0.4.41/libzen0v5_0.4.41-1_amd64.xUbuntu_20.04.deb
-          sudo dpkg -i libzen0v5_0.4.41-1_amd64.xUbuntu_20.04.deb
-          wget --no-check-certificate https://mediaarea.net/download/binary/libmediainfo0/24.12/libmediainfo0v5_24.12-1_amd64.xUbuntu_20.04.deb
-          sudo dpkg -i libmediainfo0v5_24.12-1_amd64.xUbuntu_20.04.deb
+          wget --no-check-certificate https://mediaarea.net/download/binary/libzen0/0.4.41/libzen0v5_0.4.41-1_amd64.xUbuntu_22.04.deb
+          sudo dpkg -i libzen0v5_0.4.41-1_amd64.xUbuntu_22.04.deb
+          wget --no-check-certificate https://mediaarea.net/download/binary/libmediainfo0/24.12/libmediainfo0v5_24.12-1_amd64.xUbuntu_22.04.deb
+          sudo dpkg -i libmediainfo0v5_24.12-1_amd64.xUbuntu_22.04.deb
           mvn verify -P testing -DdisableXmlReport=true
 
   linux-noble:


### PR DESCRIPTION
# Description of code changes
Fix error : This is a scheduled Ubuntu 20.04 brownout.
Ubuntu 20.04 LTS runner will be removed on 2025-04-15.

This error was "ON" 2 days ago to inform us we cannot use the `ubuntu 20.04` runner anymore after tomorrow.

https://github.com/actions/runner-images/issues/11101

Modified CI to runs on :
`ubuntu-20.04` -> `ubuntu-22.04`
`ubuntu-24.04` -> no change
