### PR TITLE
main fix #5139

### DIFF
--- a/src/main/java/net/pms/parsers/JaudiotaggerParser.java
+++ b/src/main/java/net/pms/parsers/JaudiotaggerParser.java
@@ -40,14 +40,10 @@ import org.jaudiotagger.audio.AudioFile;
 import org.jaudiotagger.audio.AudioFileIO;
 import org.jaudiotagger.audio.AudioHeader;
 import org.jaudiotagger.audio.exceptions.CannotReadException;
-import org.jaudiotagger.audio.exceptions.InvalidAudioFrameException;
-import org.jaudiotagger.audio.exceptions.NullBoxIdException;
-import org.jaudiotagger.audio.exceptions.ReadOnlyFileException;
 import org.jaudiotagger.logging.ErrorMessage;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.KeyNotFoundException;
 import org.jaudiotagger.tag.Tag;
-import org.jaudiotagger.tag.TagException;
 import org.jaudiotagger.tag.flac.FlacTag;
 import org.jaudiotagger.tag.id3.AbstractID3v2Tag;
 import org.jaudiotagger.tag.id3.ID3v11Tag;
@@ -158,7 +154,7 @@ public class JaudiotaggerParser {
 					LOGGER.error("Error reading audio tag for \"{}\": {}", file.getName(), e.getMessage());
 					LOGGER.trace("", e);
 				}
-			} catch (IOException | TagException | ReadOnlyFileException | InvalidAudioFrameException | NumberFormatException | KeyNotFoundException e) {
+			} catch (Exception e) {
 				LOGGER.debug("Error parsing audio file tag for \"{}\": {}", file.getName(), e.getMessage());
 				LOGGER.trace("", e);
 			}
@@ -200,7 +196,7 @@ public class JaudiotaggerParser {
 			}
 			addMusicBrainzIDs(af, audioMetadata);
 			addAudioTrackRating(af, audioMetadata);
-		} catch (IOException | CannotReadException | InvalidAudioFrameException | NullBoxIdException | ReadOnlyFileException | TagException e) {
+		} catch (Exception e) {
 			LOGGER.debug("Could not parse audio file");
 		}
 	}
@@ -225,7 +221,7 @@ public class JaudiotaggerParser {
 					LOGGER.error("Error reading audio tag for \"{}\": {}", file.getName(), e.getMessage());
 					LOGGER.trace("", e);
 				}
-			} catch (IOException | TagException | ReadOnlyFileException | InvalidAudioFrameException | NumberFormatException | KeyNotFoundException e) {
+			} catch (Exception e) {
 				LOGGER.debug("Error parsing audio file tag for \"{}\": {}", file.getName(), e.getMessage());
 				LOGGER.trace("", e);
 			}

--- a/src/main/java/net/pms/parsers/JaudiotaggerParser.java
+++ b/src/main/java/net/pms/parsers/JaudiotaggerParser.java
@@ -41,6 +41,7 @@ import org.jaudiotagger.audio.AudioFileIO;
 import org.jaudiotagger.audio.AudioHeader;
 import org.jaudiotagger.audio.exceptions.CannotReadException;
 import org.jaudiotagger.audio.exceptions.InvalidAudioFrameException;
+import org.jaudiotagger.audio.exceptions.NullBoxIdException;
 import org.jaudiotagger.audio.exceptions.ReadOnlyFileException;
 import org.jaudiotagger.logging.ErrorMessage;
 import org.jaudiotagger.tag.FieldKey;
@@ -199,7 +200,7 @@ public class JaudiotaggerParser {
 			}
 			addMusicBrainzIDs(af, audioMetadata);
 			addAudioTrackRating(af, audioMetadata);
-		} catch (IOException | CannotReadException | InvalidAudioFrameException | ReadOnlyFileException | TagException e) {
+		} catch (IOException | CannotReadException | InvalidAudioFrameException | NullBoxIdException | ReadOnlyFileException | TagException e) {
 			LOGGER.debug("Could not parse audio file");
 		}
 	}

--- a/src/main/java/net/pms/store/StoreContainer.java
+++ b/src/main/java/net/pms/store/StoreContainer.java
@@ -604,6 +604,7 @@ public class StoreContainer extends StoreResource {
 		}
 
 		TranscodeVirtualFolder transcodeFolder = new TranscodeVirtualFolder(renderer, renderer.getUmsConfiguration());
+		transcodeFolder.setChildrenSorted(isChildrenSorted);
 		addChildInternal(transcodeFolder);
 		return transcodeFolder;
 	}

--- a/src/main/java/net/pms/store/StoreContainer.java
+++ b/src/main/java/net/pms/store/StoreContainer.java
@@ -456,7 +456,7 @@ public class StoreContainer extends StoreResource {
 		}
 	}
 
-	protected void sortChildrenIfNeeded() {
+	protected synchronized void sortChildrenIfNeeded() {
 		if (isChildrenSorted()) {
 			StoreResourceSorter.sortResourcesByDefault(children);
 		}

--- a/src/main/java/net/pms/store/container/ChapterFileTranscodeVirtualFolder.java
+++ b/src/main/java/net/pms/store/container/ChapterFileTranscodeVirtualFolder.java
@@ -46,6 +46,7 @@ public class ChapterFileTranscodeVirtualFolder extends LocalizedStoreContainer {
 		super(renderer, "ChapterX", null, name);
 		this.interval = interval;
 		addChildInternal(child);
+		setSortable(false);
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/net/pms/store/container/FileTranscodeVirtualFolder.java
+++ b/src/main/java/net/pms/store/container/FileTranscodeVirtualFolder.java
@@ -45,6 +45,7 @@ public class FileTranscodeVirtualFolder extends TranscodeVirtualFolder {
 	public FileTranscodeVirtualFolder(Renderer renderer, StoreItem resource) {
 		super(renderer, resource.getDisplayNameBase());
 		originalResource = resource;
+		setSortable(false);
 	}
 
 	/**

--- a/src/main/java/net/pms/store/utils/StoreResourceSorter.java
+++ b/src/main/java/net/pms/store/utils/StoreResourceSorter.java
@@ -133,11 +133,11 @@ public class StoreResourceSorter {
 		sortResourcesByTitle(resources, true, null);
 	}
 
-	public static void sortResourcesByTitle(List<StoreResource> resources, String lang) {
+	private static void sortResourcesByTitle(List<StoreResource> resources, String lang) {
 		sortResourcesByTitle(resources, true, lang);
 	}
 
-	public static void sortResourcesByTitle(List<StoreResource> resources, boolean asc, String lang) {
+	private static void sortResourcesByTitle(List<StoreResource> resources, boolean asc, String lang) {
 		Collections.sort(resources, (StoreResource resources1, StoreResource resources2) -> {
 			if (resources1 instanceof StoreResource && resources2 instanceof StoreResource) {
 				if (resources1 instanceof StoreItem && resources2 instanceof StoreContainer) {
@@ -166,7 +166,7 @@ public class StoreResourceSorter {
 		});
 	}
 
-	public static void sortResourcesByModifiedDate(List<StoreResource> resources, boolean asc) {
+	private static void sortResourcesByModifiedDate(List<StoreResource> resources, boolean asc) {
 		try {
 			Collections.sort(resources, (StoreResource resources1, StoreResource resources2) -> {
 				if (resources1 instanceof SystemFileResource systemFileResource1 && resources2 instanceof SystemFileResource systemFileResource2) {
@@ -195,35 +195,11 @@ public class StoreResourceSorter {
 					} else if (resources1 instanceof StoreContainer && resources2 instanceof StoreItem) {
 						return -1;
 					}
-					if (!resources1.isSortable()) {
-						if (!resources2.isSortable()) {
-							return 0;
-						}
-						return asc ? -1 : 1;
-					} else if (!resources2.isSortable()) {
-						return asc ? 1 : -1;
-					}
 					return 0;
 				}
 			});
 		} catch (IllegalArgumentException e) {
 			LOGGER.trace("sortResourcesByModifiedDate error: {}", e.getMessage());
-		}
-	}
-
-	private static long getFileLastModifiedTime(File file) {
-		Path path;
-		try {
-			path = file.toPath();
-		} catch (InvalidPathException e) {
-			LOGGER.trace("Invalid path for file \"{}\": {}", file.toString(), e.getMessage());
-			return 0;
-		}
-		try {
-			return Files.getLastModifiedTime(path).toMillis();
-		} catch (IOException | SecurityException e) {
-			LOGGER.trace("getLastModifiedTime thrown an error for \"{}\" ({}): {}", path.toString(), file.toString(), e.getMessage());
-			return 0;
 		}
 	}
 
@@ -246,6 +222,22 @@ public class StoreResourceSorter {
 	public static void sortResourcesByGenre(List<StoreResource> resources, boolean asc, String lang) {
 		//todo implement lang
 		Collections.sort(resources, (StoreResource resources1, StoreResource resources2) -> compareToNormalizedString(resources1.getGenre(), resources2.getGenre(), asc));
+	}
+
+	private static long getFileLastModifiedTime(File file) {
+		Path path;
+		try {
+			path = file.toPath();
+		} catch (InvalidPathException e) {
+			LOGGER.trace("Invalid path for file \"{}\": {}", file.toString(), e.getMessage());
+			return 0;
+		}
+		try {
+			return Files.getLastModifiedTime(path).toMillis();
+		} catch (IOException | SecurityException e) {
+			LOGGER.trace("getLastModifiedTime thrown an error for \"{}\" ({}): {}", path.toString(), file.toString(), e.getMessage());
+			return 0;
+		}
 	}
 
 	private static int compareToNormalizedString(String str1, String str2, boolean asc) {

--- a/src/main/java/net/pms/store/utils/StoreResourceSorter.java
+++ b/src/main/java/net/pms/store/utils/StoreResourceSorter.java
@@ -190,6 +190,19 @@ public class StoreResourceSorter {
 						return Long.compare(lastModified2, lastModified1);
 					}
 				} else {
+					if (resources1 instanceof StoreItem && resources2 instanceof StoreContainer) {
+						return 1;
+					} else if (resources1 instanceof StoreContainer && resources2 instanceof StoreItem) {
+						return -1;
+					}
+					if (!resources1.isSortable()) {
+						if (!resources2.isSortable()) {
+							return 0;
+						}
+						return asc ? -1 : 1;
+					} else if (!resources2.isSortable()) {
+						return asc ? 1 : -1;
+					}
 					return 0;
 				}
 			});


### PR DESCRIPTION
# Description of code changes

fix #5139

trace Invalid path for file
trace `IOException` & `SecurityException`
catch error and trace `sortResourcesByModifiedDate`
implements sort `#--TRANSCODE--#` folder children reflecting the base folder
do not sort `ChapterFileTranscodeVirtualFolder` (chapters order)
lock instance before sort children (may be filled by `runnable`)

catch `NullBoxIdException` on `JaudiotaggerParser`

https://github.com/UniversalMediaServer/UniversalMediaServer/issues/5189#issuecomment-2815265561
