### PR TITLE
Update SubtitleUtils.java: additional flags on external subtitle files

### DIFF
--- a/src/main/java/net/pms/util/SubtitleUtils.java
+++ b/src/main/java/net/pms/util/SubtitleUtils.java
@@ -1096,7 +1096,7 @@ public class SubtitleUtils {
 
 		String language = null;
 		boolean forced = false;
-		boolean default_ = false;
+		boolean difault = false;
 		boolean hearingImpaired = false;
 		if (suffixParts != null && !suffixParts.isEmpty()) {
 			ArrayList<String> modifiableSuffixParts = new ArrayList<>(suffixParts);
@@ -1110,7 +1110,7 @@ public class SubtitleUtils {
 				} else if (part.equals("default")) {
 					// Default: default
 					// Marks the stream as the default.
-					default_ = true;
+					difault = true;
 					iterator.remove();
 				} else if (part.equals("forced") || part.equals("foreign")) {
 					// Forced: forced, foreign
@@ -1136,7 +1136,7 @@ public class SubtitleUtils {
 		}
 
 		try {
-			subtitles.setDefault(default_);
+			subtitles.setDefault(difault);
 			subtitles.setForced(forced);
 			// TODO: support for marking a hearingImpaired subtitle track if this
 			// feature will be added in the future.


### PR DESCRIPTION
Add the following markers in the file name of an external subtitle file:
default: Marks the stream as the default.
forced, foreign: Marks the subtitle stream as forced, typically used for translation of segments of audio/text that differ from the primary language. 
sdh, cc: Indicates that the subtitle stream has additional information to help viewers that are hearing impaired. This is at the moment without integration as it seems there is no possibility to mark a subtitle for that (maybe in the future?) Note that it doesn't support the "hi" keyword as this clashes with the "hi" marker for the hindi language.

It seems it is a common standard to mark external subtitle files that way (in Jellyfin but also on other media servers). See: https://jellyfin.org/docs/general/server/media/external-files/

# Description of code changes
This is a contribution according to my code analysis in Universal Media Server. I don't have the infrastructure to test it, so please take it with a grain of salt. Especially "copilot" aims that UMS already supports this feature, but for me it doesn't seem as it is already there (if it is already there and i've just missed it: Sorry for the inconvenience).