### PR TITLE
Retry failed API lookups before marking them as failed

### DIFF
--- a/src/main/java/net/pms/external/umsapi/APIUtils.java
+++ b/src/main/java/net/pms/external/umsapi/APIUtils.java
@@ -969,14 +969,14 @@ public class APIUtils {
 		return getJson(url);
 	}
 
-    private static final int MAX_RETRIES = 3;
-    private static final long RETRY_DELAY_MS = 5000; // 5 seconds
+	private static final int MAX_RETRIES = 3;
+	private static final long RETRY_DELAY_MS = 5000; // 5 seconds
 
 	private static String getJson(URL url) throws IOException {
 		HttpURLConnection connection = null;
-        int retries = 0;
+		int retries = 0;
 
-        while (retries < MAX_RETRIES) {
+		while (retries < MAX_RETRIES) {
 			try {
 				connection = (HttpURLConnection) url.openConnection();
 				connection.setAllowUserInteraction(false);
@@ -1007,7 +1007,7 @@ public class APIUtils {
 					}
 					default -> {
 						// we didn't get a success response from the API, so retry or fail
-            			retries++;
+						retries++;
 						if (retries == MAX_RETRIES) {
 							StringBuilder errorMessage = new StringBuilder();
 							if (connection.getErrorStream() != null) {
@@ -1041,16 +1041,16 @@ public class APIUtils {
 				}
 			}
 
-            if (retries < MAX_RETRIES) {
-                try {
-                    LOGGER.debug("Retrying API request in {} seconds...", (RETRY_DELAY_MS / 1000));
-                    Thread.sleep(RETRY_DELAY_MS);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt(); // Restore the interrupted status
-                    LOGGER.error("Retry delay interrupted");
-                    break; // Exit the loop if interrupted
-                }
-            }
+			if (retries < MAX_RETRIES) {
+				try {
+					LOGGER.debug("Retrying API request in {} seconds...", (RETRY_DELAY_MS / 1000));
+					Thread.sleep(RETRY_DELAY_MS);
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt(); // Restore the interrupted status
+					LOGGER.error("Retry delay interrupted");
+					break; // Exit the loop if interrupted
+				}
+			}
 		}
 
 		return null;

--- a/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/JakartaServletUpnpStream.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/transport/impl/JakartaServletUpnpStream.java
@@ -80,9 +80,8 @@ public abstract class JakartaServletUpnpStream extends UpnpStream {
 					HttpServletHelper.logHttpServletResponse(getRequest(), getResponse(), null, false);
 				}
 			}
-
 		} catch (IOException e) {
-			LOGGER.info("Exception occurred during UPnP stream processing", e);
+			LOGGER.error("Exception occurred during UPnP stream processing", e);
 			if (!getResponse().isCommitted()) {
 				LOGGER.trace("Response hasn't been committed, returning INTERNAL SERVER ERROR to client");
 				getResponse().setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -90,7 +89,7 @@ public abstract class JakartaServletUpnpStream extends UpnpStream {
 					HttpServletHelper.logHttpServletResponse(getRequest(), getResponse(), null, false);
 				}
 			} else {
-				LOGGER.info("Could not return INTERNAL SERVER ERROR to client, response was already committed");
+				LOGGER.error("Could not return INTERNAL SERVER ERROR to client, response was already committed");
 			}
 			responseException(e);
 		} finally {
@@ -150,11 +149,9 @@ public abstract class JakartaServletUpnpStream extends UpnpStream {
 		if (bodyBytes.length > 0 && requestMessage.isContentTypeMissingOrText()) {
 			LOGGER.trace("Request contains textual entity body, converting then setting string on message");
 			requestMessage.setBodyCharacters(bodyBytes);
-
 		} else if (bodyBytes.length > 0) {
 			LOGGER.trace("Request contains binary entity body, setting bytes on message");
 			requestMessage.setBody(UpnpMessage.BodyType.BYTES, bodyBytes);
-
 		} else {
 			LOGGER.trace("Request did not contain entity body");
 		}


### PR DESCRIPTION
Lets the server recover from transient API failures, though we should eventually use different status codes to indicate that instead

# Description of code changes

...

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
