### PR TITLE
Do not subscribe to UPnP events while getting DeviceControls.

### DIFF
--- a/src/main/java/net/pms/renderers/JUPnPDeviceHelper.java
+++ b/src/main/java/net/pms/renderers/JUPnPDeviceHelper.java
@@ -372,7 +372,6 @@ public class JUPnPDeviceHelper {
 			} else if (sid.contains(RENDERING_CONTROL_SERVICE)) {
 				ctrl |= RC;
 			}
-			MediaServer.upnpService.getControlPoint().execute(new UmsSubscriptionCallback(s));
 		}
 		return ctrl;
 	}


### PR DESCRIPTION
Subscribing to UPnP events shall not be done while getting the DeviceControls but only if the renderer needs a renewal. This might also help to reduce log messages (not checked) reported in #5689.