### PR TITLE
Publish resourceId on DIDL object

### DIFF
--- a/src/main/java/net/pms/dlna/DidlHelper.java
+++ b/src/main/java/net/pms/dlna/DidlHelper.java
@@ -490,7 +490,6 @@ public class DidlHelper extends DlnaHelper {
 				endTag(sb);
 				addXMLTagAndAttribute(sb, "musicbrainztrackid", audioMetadata.getMbidTrack());
 				addXMLTagAndAttribute(sb, "musicbrainzreleaseid", audioMetadata.getMbidRecord());
-				addXMLTagAndAttribute(sb, "audiotrackid", Integer.toString(audioMetadata.getAudiotrackId()));
 				addXMLTagAndAttribute(sb, "resourceid", mediaInfo.getResourceId());
 				if (audioMetadata.getDisc() > 0) {
 					addXMLTagAndAttribute(sb, "numberOfThisDisc", Integer.toString(audioMetadata.getDisc()));

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/StoreResourceHelper.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/StoreResourceHelper.java
@@ -575,7 +575,6 @@ public class StoreResourceHelper {
 				desc.setType("ums-tags");
 				desc.addMetadata("musicbrainztrackid", audioMetadata.getMbidTrack());
 				desc.addMetadata("musicbrainzreleaseid", audioMetadata.getMbidRecord());
-				desc.addMetadata("audiotrackid", Integer.toString(audioMetadata.getAudiotrackId()));
 				desc.addMetadata("resourceid", mediaInfo.getResourceId());
 				if (audioMetadata.getDisc() > 0) {
 					desc.addMetadata("numberOfThisDisc", Integer.toString(audioMetadata.getDisc()));


### PR DESCRIPTION
This PR published the resourceID for identifying objects. audiotrackId can therefore be removed. 