### PR TITLE
Ubuntu docker build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3682,10 +3682,10 @@
 								<configuration>
 									<target>
 										<exec executable="docker" dir="${project.basedir}/target/docker">
-											<arg line="build . -f Dockerfile-ubuntu -t universalmediaserver/ums-ubuntu -t universalmediaserver/ums:${project.version}-ubuntu -t universalmediaserver/ums:latest-ubuntu" />
+											<arg line="build . -f Dockerfile-ubuntu -t universalmediaserver/ums-ubuntu:${project.version} -t universalmediaserver/ums-ubuntu:latest" />
 										</exec>
 										<exec executable="docker" dir="${project.basedir}/target/docker">
-											<arg line="build . -t universalmediaserver/ums -t universalmediaserver/ums:${project.version} -t universalmediaserver/ums:latest" />
+											<arg line="build . -t universalmediaserver/ums:${project.version} -t universalmediaserver/ums:latest" />
 										</exec>
 									</target>
 								</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -3652,6 +3652,8 @@
 										<mkdir dir="${project.basedir}/target/docker/profile/data" />
 										<mkdir dir="${project.basedir}/target/docker/profile/database" />
 										<mkdir dir="${project.basedir}/target/docker/profile/renderers" />
+										<copy file="${project.external-resources}/docker/Dockerfile-ubuntu"
+											  tofile="${project.basedir}/target/docker/Dockerfile-ubuntu" overwrite="true" />
 										<copy file="${project.external-resources}/docker/Dockerfile"
 											  tofile="${project.basedir}/target/docker/Dockerfile" overwrite="true" />
 										<copy file="${project.basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar"
@@ -3679,6 +3681,12 @@
 								</goals>
 								<configuration>
 									<target>
+										<exec executable="docker" dir="${project.basedir}/target/docker">
+											<arg line="build . -f Dockerfile-ubuntu -t universalmediaserver/ums-ubuntu -t universalmediaserver/ums:${project.version}-ubuntu" />
+										</exec>
+										<exec executable="docker" dir="${project.basedir}/target/docker">
+											<arg line="build . -f Dockerfile-ubuntu -t universalmediaserver/ums-ubuntu -t universalmediaserver/ums:latest-ubuntu" />
+										</exec>
 										<exec executable="docker" dir="${project.basedir}/target/docker">
 											<arg line="build . -t universalmediaserver/ums -t universalmediaserver/ums:${project.version}" />
 										</exec>

--- a/pom.xml
+++ b/pom.xml
@@ -3682,16 +3682,10 @@
 								<configuration>
 									<target>
 										<exec executable="docker" dir="${project.basedir}/target/docker">
-											<arg line="build . -f Dockerfile-ubuntu -t universalmediaserver/ums-ubuntu -t universalmediaserver/ums:${project.version}-ubuntu" />
+											<arg line="build . -f Dockerfile-ubuntu -t universalmediaserver/ums-ubuntu -t universalmediaserver/ums:${project.version}-ubuntu -t universalmediaserver/ums:latest-ubuntu" />
 										</exec>
 										<exec executable="docker" dir="${project.basedir}/target/docker">
-											<arg line="build . -f Dockerfile-ubuntu -t universalmediaserver/ums-ubuntu -t universalmediaserver/ums:latest-ubuntu" />
-										</exec>
-										<exec executable="docker" dir="${project.basedir}/target/docker">
-											<arg line="build . -t universalmediaserver/ums -t universalmediaserver/ums:${project.version}" />
-										</exec>
-										<exec executable="docker" dir="${project.basedir}/target/docker">
-											<arg line="build . -t universalmediaserver/ums -t universalmediaserver/ums:latest" />
+											<arg line="build . -t universalmediaserver/ums -t universalmediaserver/ums:${project.version} -t universalmediaserver/ums:latest" />
 										</exec>
 									</target>
 								</configuration>

--- a/src/main/external-resources/docker/Dockerfile-ubuntu
+++ b/src/main/external-resources/docker/Dockerfile-ubuntu
@@ -1,0 +1,27 @@
+FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.title="Universal Media Server"
+
+RUN apk add --no-cache coreutils ffmpeg mediainfo openjdk17-jre iputils mplayer ttf-dejavu
+
+WORKDIR /profile
+
+COPY ./profile /profile
+
+COPY ./app/UMS.conf /profile
+
+WORKDIR /ums
+
+COPY ./app /ums
+
+VOLUME /media
+
+VOLUME /profile
+
+EXPOSE 1900/udp 5001/tcp 5353/udp 9001/tcp 9002/tcp
+
+ENV UMS_PROFILE=/profile
+
+ENV JDK_JAVA_OPTIONS="-Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -Djna.nosys=true"
+
+ENTRYPOINT [ "java", "-jar", "ums.jar" ]

--- a/src/main/external-resources/docker/Dockerfile-ubuntu
+++ b/src/main/external-resources/docker/Dockerfile-ubuntu
@@ -2,6 +2,7 @@ FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.title="Universal Media Server"
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install coreutils ffmpeg mediainfo openjdk-17-jdk-headless iputils-ping mplayer fonts-dejavu -y
 

--- a/src/main/external-resources/docker/Dockerfile-ubuntu
+++ b/src/main/external-resources/docker/Dockerfile-ubuntu
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 LABEL org.opencontainers.image.title="Universal Media Server"
 
 RUN apt-get update
-RUN apt-get install coreutils ffmpeg mediainfo openjdk17-jre iputils-ping mplayer fonts-dejavu-web fonts-dejavu -y
+RUN apt-get install coreutils ffmpeg mediainfo openjdk-17-jdk-headless iputils-ping mplayer fonts-dejavu -y
 
 WORKDIR /profile
 

--- a/src/main/external-resources/docker/Dockerfile-ubuntu
+++ b/src/main/external-resources/docker/Dockerfile-ubuntu
@@ -2,7 +2,8 @@ FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.title="Universal Media Server"
 
-RUN apk add --no-cache coreutils ffmpeg mediainfo openjdk17-jre iputils mplayer ttf-dejavu
+RUN apt-get update
+RUN apt-get install coreutils ffmpeg mediainfo openjdk17-jre iputils-ping mplayer fonts-dejavu-web fonts-dejavu -y
 
 WORKDIR /profile
 


### PR DESCRIPTION
This PR adds an additional Ubuntu build besides the ALPINE build and most likely fixes #5746, #5264 and #4923. 

```
# docker images | grep ums

universalmediaserver/ums                 15.0.0-SNAPSHOT     643d894b2b7e   47 seconds ago      812MB
universalmediaserver/ums                 latest              643d894b2b7e   47 seconds ago      812MB
universalmediaserver/ums-ubuntu          15.0.0-SNAPSHOT     3b71153b0599   49 seconds ago      1.14GB
universalmediaserver/ums-ubuntu          latest              3b71153b0599   49 seconds ago      1.14GB
```

> [!NOTE]  
> Pipeline update to push the additional container to docker hub has still to be done.