### PR TITLE
Remove reference to unsupported yt-dlp for armhf (32-bit)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1704,7 +1704,6 @@
 
 										<!-- Download binaries -->
 										<get src="${project.binaries-base}/linux/armhf/ffmpeg/ffmpeg" dest="${project.binaries}/linux/armhf/ffmpeg/ffmpeg" usetimestamp="true" />
-										<get src="https://github.com/yt-dlp/yt-dlp/releases/download/2025.09.05/yt-dlp_linux_armv7l" dest="${project.binaries}/linux/youtube-dl" usetimestamp="true" />
 									</target>
 								</configuration>
 							</execution>

--- a/src/main/assembly/assembly-linux-armhf.xml
+++ b/src/main/assembly/assembly-linux-armhf.xml
@@ -38,14 +38,6 @@
 			<fileMode>0755</fileMode>
 			<lineEnding>unix</lineEnding>
 		</file>
-
-		<!-- Include the youtube-dl binary -->
-		<file>
-			<source>${project.binaries}/linux/youtube-dl</source>
-			<outputDirectory>./linux</outputDirectory>
-			<fileMode>0755</fileMode>
-			<lineEnding>keep</lineEnding>
-		</file>
 	</files>
 	<fileSets>
 		<!-- Include documentation -->


### PR DESCRIPTION
# Description of code changes

Fixes #5760

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
