### PR TITLE
FileWatcher UPDATE event / invalidate cache

### DIFF
--- a/src/main/java/net/pms/renderers/ConnectedRenderers.java
+++ b/src/main/java/net/pms/renderers/ConnectedRenderers.java
@@ -16,6 +16,7 @@
  */
 package net.pms.renderers;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -572,6 +573,16 @@ public class ConnectedRenderers {
 			}
 		}
 		return renderers;
+	}
+
+	/**
+	 * Invalidates renderer caches for given file resource.
+	 * @param file
+	 */
+	public static void invalidateRendererCache(File file) {
+		for (Renderer connectedRenderer : getConnectedRenderers()) {
+			connectedRenderer.getMediaStore().fileUpdated(file);
+		}
 	}
 
 }

--- a/src/main/java/net/pms/renderers/ConnectedRenderers.java
+++ b/src/main/java/net/pms/renderers/ConnectedRenderers.java
@@ -121,8 +121,8 @@ public class ConnectedRenderers {
 						List<String> identifiers = getIdentifiers(userAgentString, headers);
 						renderer.setIdentifiers(identifiers);
 						LOGGER.info(
-								"Media renderer was not recognized. Possible identifying HTTP headers:\n{}",
-								StringUtils.join(identifiers, "\n")
+								"Media renderer was not recognized from IP {}. Possible identifying HTTP headers:\n{}",
+								ia.toString(), StringUtils.join(identifiers, "\n")
 						);
 						PMS.get().setRendererFound(renderer);
 					}

--- a/src/main/java/net/pms/store/MediaInfoStore.java
+++ b/src/main/java/net/pms/store/MediaInfoStore.java
@@ -501,6 +501,12 @@ public class MediaInfoStore {
 		return removed;
 	}
 
+	public static void removeMediaEntryFromCache(String filename) {
+		synchronized (STORE) {
+			STORE.remove(filename);
+		}
+	}
+
 	public static void clear() {
 		synchronized (STORE) {
 			STORE.clear();

--- a/src/main/java/net/pms/store/MediaScanner.java
+++ b/src/main/java/net/pms/store/MediaScanner.java
@@ -40,10 +40,8 @@ import net.pms.renderers.devices.MediaScannerDevice;
 import net.pms.store.container.DVDISOFile;
 import net.pms.store.container.PlaylistFolder;
 import net.pms.store.container.RealFolder;
-import net.pms.store.item.RealFile;
 import net.pms.util.FileUtil;
 import net.pms.util.FileWatcher;
-import net.pms.util.InputFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
@@ -347,29 +345,6 @@ public class MediaScanner implements SharedContentListener {
 		}
 	}
 
-	private static void updateFileEntry(String filename) {
-		File file = new File(filename);
-		Runnable r = () -> {
-				// Advise renderers about added file.
-			File f = new File(filename);
-			InputFile input = new InputFile();
-			input.setFile(file);
-			StoreResource sr = RENDERER.getMediaStore().createResourceFromFile(f);
-			if (sr instanceof RealFile rf) {
-				rf.resolveFormat();
-				if (MediaInfoStore.updateMediaInfoFromFile(filename, f, rf.getFormat(), rf.getType(), null, input) != null) {
-					MediaStoreIds.incrementSystemUpdateId();
-				}
-
-				for (Renderer connectedRenderer : ConnectedRenderers.getConnectedRenderers()) {
-					connectedRenderer.getMediaStore().fileUpdated(file);
-				}
-			}
-		};
-		new Thread(r, "MediaScanner File Parser - update").start();
-	}
-
-
 	/**
 	 * Parses a file and adds it to the database along the way.
 	 *
@@ -529,22 +504,23 @@ public class MediaScanner implements SharedContentListener {
 			 * give us information about those new files, as it wasn't listening
 			 * when they were created, so make sure we parse them.
 			 */
+			File f = new File(filename);
 			if (isDir) {
 				if (ENTRY_CREATE.equals(event)) {
-					addFolderEntry(new File(filename));
+					addFolderEntry(f);
 				} else if (ENTRY_DELETE.equals(event)) {
 					removeFolderEntry(filename);
 				}
 			} else {
 				if (ENTRY_CREATE.equals(event)) {
-					parseFileEntry(new File(filename), true, false);
+					parseFileEntry(f, true, false);
 				} else if (ENTRY_DELETE.equals(event)) {
 					removeFileEntry(filename);
 				} else if (ENTRY_MODIFY.equals(event)) {
-					// TODO Rescan file (read file info's)
-					updateFileEntry(filename);
+					parseFileEntry(f, false, false);
+					ConnectedRenderers.invalidateRendererCache(f);
 				} else {
-					parseFileEntry(new File(filename), false, false);
+					LOGGER.warn("unknown event : {}", event);
 				}
 			}
 		}

--- a/src/main/java/net/pms/store/MediaScanner.java
+++ b/src/main/java/net/pms/store/MediaScanner.java
@@ -40,8 +40,10 @@ import net.pms.renderers.devices.MediaScannerDevice;
 import net.pms.store.container.DVDISOFile;
 import net.pms.store.container.PlaylistFolder;
 import net.pms.store.container.RealFolder;
+import net.pms.store.item.RealFile;
 import net.pms.util.FileUtil;
 import net.pms.util.FileWatcher;
+import net.pms.util.InputFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
@@ -345,6 +347,29 @@ public class MediaScanner implements SharedContentListener {
 		}
 	}
 
+	private static void updateFileEntry(String filename) {
+		File file = new File(filename);
+		Runnable r = () -> {
+				// Advise renderers about added file.
+			File f = new File(filename);
+			InputFile input = new InputFile();
+			input.setFile(file);
+			StoreResource sr = RENDERER.getMediaStore().createResourceFromFile(f);
+			if (sr instanceof RealFile rf) {
+				rf.resolveFormat();
+				if (MediaInfoStore.updateMediaInfoFromFile(filename, f, rf.getFormat(), rf.getType(), null, input) != null) {
+					MediaStoreIds.incrementSystemUpdateId();
+				}
+
+				for (Renderer connectedRenderer : ConnectedRenderers.getConnectedRenderers()) {
+					connectedRenderer.getMediaStore().fileUpdated(file);
+				}
+			}
+		};
+		new Thread(r, "MediaScanner File Parser - update").start();
+	}
+
+
 	/**
 	 * Parses a file and adds it to the database along the way.
 	 *
@@ -515,6 +540,9 @@ public class MediaScanner implements SharedContentListener {
 					parseFileEntry(new File(filename), true, false);
 				} else if (ENTRY_DELETE.equals(event)) {
 					removeFileEntry(filename);
+				} else if (ENTRY_MODIFY.equals(event)) {
+					// TODO Rescan file (read file info's)
+					updateFileEntry(filename);
 				} else {
 					parseFileEntry(new File(filename), false, false);
 				}

--- a/src/main/java/net/pms/store/MediaStore.java
+++ b/src/main/java/net/pms/store/MediaStore.java
@@ -726,11 +726,17 @@ public class MediaStore extends StoreContainer {
 		}
 	}
 
+	/**
+	 * File can have different structure after an update. Therefore, read file metadata again.
+	 * @param file
+	 */
 	public void fileUpdated(File file) {
-		// invalidate cache
-		File parentFile = file.getParentFile();
-		for (StoreResource storeResource : findSystemFileResources(parentFile)) {
-			renderer.getMediaStore().deleteWeakResource(storeResource);
+		for (StoreResource storeResource : findSystemFileResources(file)) {
+			if (storeResource instanceof RealFile rf) {
+				rf.setMediaInfo(null);
+				MediaInfoStore.removeMediaEntryFromCache(file.getAbsolutePath());
+				rf.resolve();
+			}
 		}
 	}
 

--- a/src/main/java/net/pms/store/MediaStore.java
+++ b/src/main/java/net/pms/store/MediaStore.java
@@ -726,6 +726,15 @@ public class MediaStore extends StoreContainer {
 		}
 	}
 
+	public void fileUpdated(File file) {
+		// invalidate cache
+		File parentFile = file.getParentFile();
+		for (StoreResource storeResource : findSystemFileResources(parentFile)) {
+			renderer.getMediaStore().deleteWeakResource(storeResource);
+		}
+	}
+
+
 	private StoreResource findResourceFromFile(List<StoreResource> resources, File file) {
 		if (file == null || file.isHidden() || !file.canRead() || !(file.isFile() || file.isDirectory())) {
 			return null;
@@ -957,5 +966,4 @@ public class MediaStore extends StoreContainer {
 			Thread.sleep(100);
 		}
 	}
-
 }


### PR DESCRIPTION
This PR fixes an issue where file updates (e.g. metadata changes) weren’t reflected at the control point.

Previously, the database was updated correctly, but because `MediaInfo` was cached, the control point was still receiving a stale object.

The changes address this by refreshing the cached MediaInfo when a file is rescanned, so both control points and the UMS UI always see the latest metadata.
