### PR TITLE
Revert "FileWatcher UPDATE event / invalidate cache"

### DIFF
--- a/src/main/java/net/pms/renderers/ConnectedRenderers.java
+++ b/src/main/java/net/pms/renderers/ConnectedRenderers.java
@@ -16,7 +16,6 @@
  */
 package net.pms.renderers;
 
-import java.io.File;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -122,8 +121,8 @@ public class ConnectedRenderers {
 						List<String> identifiers = getIdentifiers(userAgentString, headers);
 						renderer.setIdentifiers(identifiers);
 						LOGGER.info(
-								"Media renderer was not recognized from IP {}. Possible identifying HTTP headers:\n{}",
-								ia.toString(), StringUtils.join(identifiers, "\n")
+								"Media renderer was not recognized. Possible identifying HTTP headers:\n{}",
+								StringUtils.join(identifiers, "\n")
 						);
 						PMS.get().setRendererFound(renderer);
 					}
@@ -573,16 +572,6 @@ public class ConnectedRenderers {
 			}
 		}
 		return renderers;
-	}
-
-	/**
-	 * Invalidates renderer caches for given file resource.
-	 * @param file
-	 */
-	public static void invalidateRendererCache(File file) {
-		for (Renderer connectedRenderer : getConnectedRenderers()) {
-			connectedRenderer.getMediaStore().fileUpdated(file);
-		}
 	}
 
 }

--- a/src/main/java/net/pms/store/MediaInfoStore.java
+++ b/src/main/java/net/pms/store/MediaInfoStore.java
@@ -153,7 +153,37 @@ public class MediaInfoStore {
 				}
 
 				if (mediaInfo == null) {
-					mediaInfo = updateMediaInfoFromFile(filename, file, format, type, connection, input);
+					mediaInfo = new MediaInfo();
+					String resourceHash = ResourceIdentifier.getResourceIdentifier(filename);
+					mediaInfo.setResourceId(resourceHash);
+					if (format != null) {
+						Parser.parse(mediaInfo, input, format, type);
+					} else {
+						// Don't think that will ever happen
+						FFmpegParser.parse(mediaInfo, input, format, type);
+					}
+
+					mediaInfo.waitMediaParsing(5);
+					if (connection != null && mediaInfo.isMediaParsed()) {
+						try {
+							MediaTableFiles.insertOrUpdateData(connection, filename, file.lastModified(), type, mediaInfo);
+						} catch (SQLException e) {
+							LOGGER.error(
+								"Database error while trying to add parsed information for \"{}\" to the cache: {}",
+								filename,
+								e.getMessage());
+							if (LOGGER.isTraceEnabled()) {
+								LOGGER.trace("SQL error code: {}", e.getErrorCode());
+								if (
+									e.getCause() instanceof SQLException &&
+									((SQLException) e.getCause()).getErrorCode() != e.getErrorCode()
+								) {
+									LOGGER.trace("Cause SQL error code: {}", ((SQLException) e.getCause()).getErrorCode());
+								}
+								LOGGER.trace("", e);
+							}
+						}
+					}
 				}
 			} catch (Exception e) {
 				LOGGER.error("Error in RealFile.resolve: {}", e.getMessage());
@@ -175,50 +205,6 @@ public class MediaInfoStore {
 			}
 			return mediaInfo;
 		}
-	}
-
-	public static MediaInfo updateMediaInfoFromFile(String filename, File file, Format format, int type, Connection connection, InputFile input) {
-		MediaInfo mediaInfo;
-		mediaInfo = new MediaInfo();
-		String resourceHash = ResourceIdentifier.getResourceIdentifier(filename);
-		mediaInfo.setResourceId(resourceHash);
-		if (format != null) {
-			Parser.parse(mediaInfo, input, format, type);
-		} else {
-			// Don't think that will ever happen
-			FFmpegParser.parse(mediaInfo, input, format, type);
-		}
-
-		mediaInfo.waitMediaParsing(5);
-
-		if (connection == null) {
-			connection = MediaDatabase.getConnectionIfAvailable();
-		}
-		try {
-			if (connection != null && mediaInfo.isMediaParsed()) {
-				try {
-					MediaTableFiles.insertOrUpdateData(connection, filename, file.lastModified(), type, mediaInfo);
-				} catch (SQLException e) {
-					LOGGER.error(
-						"Database error while trying to add parsed information for \"{}\" to the cache: {}",
-						filename,
-						e.getMessage());
-					if (LOGGER.isTraceEnabled()) {
-						LOGGER.trace("SQL error code: {}", e.getErrorCode());
-						if (
-							e.getCause() instanceof SQLException &&
-							((SQLException) e.getCause()).getErrorCode() != e.getErrorCode()
-						) {
-							LOGGER.trace("Cause SQL error code: {}", ((SQLException) e.getCause()).getErrorCode());
-						}
-						LOGGER.trace("", e);
-					}
-				}
-			}
-		} catch (Exception e) {
-			LOGGER.error("update media info error.", e);
-		}
-		return mediaInfo;
 	}
 
 	public static MediaInfo getWebStreamMediaInfo(String url, int type) {
@@ -499,12 +485,6 @@ public class MediaInfoStore {
 		}
 		removed = MediaStatusStore.removeMediaEntry(filename) || removed;
 		return removed;
-	}
-
-	public static void removeMediaEntryFromCache(String filename) {
-		synchronized (STORE) {
-			STORE.remove(filename);
-		}
 	}
 
 	public static void clear() {

--- a/src/main/java/net/pms/store/MediaStore.java
+++ b/src/main/java/net/pms/store/MediaStore.java
@@ -726,21 +726,6 @@ public class MediaStore extends StoreContainer {
 		}
 	}
 
-	/**
-	 * File can have different structure after an update. Therefore, read file metadata again.
-	 * @param file
-	 */
-	public void fileUpdated(File file) {
-		for (StoreResource storeResource : findSystemFileResources(file)) {
-			if (storeResource instanceof RealFile rf) {
-				rf.setMediaInfo(null);
-				MediaInfoStore.removeMediaEntryFromCache(file.getAbsolutePath());
-				rf.resolve();
-			}
-		}
-	}
-
-
 	private StoreResource findResourceFromFile(List<StoreResource> resources, File file) {
 		if (file == null || file.isHidden() || !file.canRead() || !(file.isFile() || file.isDirectory())) {
 			return null;
@@ -972,4 +957,5 @@ public class MediaStore extends StoreContainer {
 			Thread.sleep(100);
 		}
 	}
+
 }


### PR DESCRIPTION
@ik666 I have been getting an unresponsive server over both UPnP and the web player since this merged, it has happened 3 times now. It works at first, but then after I add or delete files, the server can't be browsed.

Reverts UniversalMediaServer/UniversalMediaServer#5777