### PR TITLE
Fix binaries not updating on Windows

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,6 +28,7 @@ There are a number of manual steps involved in a new version release. This list 
 
      When you know the version number to choose, it should be updated in the `<version>` and the `<project.version.short>` parts of pom.xml. That will include removing `-SNAPSHOT` from `<version>`, which will be added back later.
 
+1. If any binaries (files in /bin like FFmpeg, MediaInfo, yt-dlp, etc.) have changed since the last release, bump `binary-revision`  in [pom.xml](./pom.xml).
 1. Commit those changes in a commit message with the version name
 1. Tag the release with the same version name
 1. Push the commit and tag to GitHub

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,8 @@
 
 		<project.binaries-base>https://www.universalmediaserver.com/binaries</project.binaries-base>
 
-		<binary-revision>218</binary-revision>
+		<!-- This MUST be bumped every time binaries (files in /bin) are changed, or the Windows installer will not replace them -->
+		<binary-revision>219</binary-revision>
 
 		<exec-maven-plugin-version>3.6.2</exec-maven-plugin-version>
 		<maven-antrun-plugin-version>3.2.0</maven-antrun-plugin-version>


### PR DESCRIPTION
# Description of code changes

NSIS installer has logic to not install new binaries unless we bump the number in pom.xml

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
