### PR TITLE
Added native support for Dolby Vision in MKV files on LG TVs from 2022 onwards

### DIFF
--- a/src/main/external-resources/renderers/LG-OLED-2020+.conf
+++ b/src/main/external-resources/renderers/LG-OLED-2020+.conf
@@ -1,61 +1,20 @@
 #----------------------------------------------------------------------------
-# Profile for LG OLED TVs released from the year 2020 and beyond.
+# Profile for LG OLED TVs released in 2020 and 2021.
 # See DefaultRenderer.conf for descriptions of all the available options.
 # See https://github.com/UniversalMediaServer/UniversalMediaServer/issues/1929
 # for discussion.
 #
 
-RendererName = LG OLED 2020+
+RendererName = LG OLED 2020/2021
 RendererIcon = lg-lb6500.png
 
-# ============================================================================
-# This renderer has sent the following string/s:
-#
-# The following block is all sent from OLED65C24LA
-# friendlyName=[LG] webOS TV OLED65C24LA
-# modelNumber=OLED65C24LA
-#
-# The manual lists the following similar devices:
-# OLED48A2AUA
-# OLED48A2PUA
-# OLED55A2AUA
-# OLED55A2PUA
-# OLED65A2AUA
-# OLED65A2PUA
-# OLED77A2AUA
-# OLED77A2PUA
-# OLED55B2AUA
-# OLED55B2PUA
-# OLED65B2AUA
-# OLED65B2PUA
-# OLED77B2AUA
-# OLED77B2PUA
-# OLED42C2AUA
-# OLED42C2PUA
-# OLED48C2AUA
-# OLED48C2PUA
-# OLED55C2AUA
-# OLED55C2PUA
-# OLED65C2AUA
-# OLED65C2SW
-# OLED65C2PUA
-# OLED77C2AUA
-# OLED77C2PUA
-# OLED83C2AUA
-# OLED83C2PUA
-#
-# Manual link:
-# https://kr.eguide.lgappstv.com/manual/w24_mr2/userguide_w24_mr2_us18.html
-#
+# ============================================================================#
 # Page describing LG OLED model numbers: https://en.tab-tv.com/?page_id=7111
-#
-# Response from getProtocolInfo on C2:
-# http-get:*:audio/L16;rate=44100;channels=1:DLNA.ORG_PN=LPCM,http-get:*:audio/L16;rate=44100;channels=2:DLNA.ORG_PN=LPCM,http-get:*:audio/mpeg:DLNA.ORG_PN=MP3,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_SM,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_MED,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_LRG,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_LRG_ICO,http-get:*:image/png:DLNA.ORG_PN=PNG_TN,http-get:*:image/png:DLNA.ORG_PN=PNG_SM_ICO,http-get:*:image/png:DLNA.ORG_PN=PNG_LRG_ICO,http-get:*:image/png:DLNA.ORG_PN=PNG_LRG,http-get:*:video/mp4:DLNA.ORG_PN=AVC_MP4_BL_CIF15_AAC_520,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_PS_NTSC,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_PS_PAL,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_KO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_KO_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_KO_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_KO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_KO_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_KO_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_NA,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_NA_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_NA_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_NA,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_NA_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_NA_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_EU_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_JP_T,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVHIGH_FULL,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVHIGH_PRO,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVMED_BASE,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVMED_FULL,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVMED_PRO,http-get:*:audio/x-ms-wma:DLNA.ORG_PN=WMABASE,http-get:*:audio/x-ms-wma:DLNA.ORG_PN=WMAFULL,http-get:*:audio/vnd.dlna.adts:DLNA.ORG_PN=AAC_ADTS_320,http-get:*:audio/mp4:DLNA.ORG_PN=AAC_ISO_320,http-get:*:audio/mp3:*,http-get:*:audio/flac:*,http-get:*:audio/x-flac:*,http-get:*:audio/mpeg:*,http-get:*:audio/wav:*,http-get:*:audio/mpeg3:*,http-get:*:video/x-ms-wmv:*,http-get:*:video/x-ms-asf:*,http-get:*:video/x-ms-avi:*,http-get:*:video/mpeg:*,http-get:*:video/avi:*,http-get:*:video/mp4:*,http-get:*:video/x-matroska:*,http-get:*:image/jps:*,http-get:*:image/x-jps:*,http-get:*:image/mpo:*,http-get:*:image/png:*,http-get:*:image/bmp:*,http-get:*:image/jpeg:*,http-get:*:audio/x-wav:*,http-get:*:audio/wma:*,http-get:*:audio/x-ogg:*,http-get:*:video/mts:*,http-get:*:video/mp2ts:*,http-get:*:video/mp2t:*,http-get:*:video/x-msvideo:*,http-get:*:video/realvideo:*,http-get:*:video/realmedia:*,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_NA_T,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_NA_ISO,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_NA_ISO
 # ============================================================================
 #
 
-UserAgentSearch = OLED\d{2}[ABCEGRWZ][1-2X]
-UpnpDetailsSearch = OLED\d{2}[ABCEGRWZ][1-2X]
+UserAgentSearch = OLED\d{2}[ABCEGRWZ][1X]
+UpnpDetailsSearch = OLED\d{2}[ABCEGRWZ][1X]
 LoadingPriority = 2
 
 TranscodeVideo = MPEGTS-H265-AC3

--- a/src/main/external-resources/renderers/LG-OLED-2022.conf
+++ b/src/main/external-resources/renderers/LG-OLED-2022.conf
@@ -1,0 +1,92 @@
+#----------------------------------------------------------------------------
+# Profile for LG OLED TVs released from the year 2022.
+# See DefaultRenderer.conf for descriptions of all the available options.
+# See https://github.com/UniversalMediaServer/UniversalMediaServer/issues/1929
+# for discussion.
+#
+
+RendererName = LG OLED 2022
+RendererIcon = lg-lb6500.png
+
+# ============================================================================
+# This renderer has sent the following string/s:
+#
+# The following block is all sent from OLED65C24LA
+# friendlyName=[LG] webOS TV OLED65C24LA
+# modelNumber=OLED65C24LA
+#
+# The manual lists the following similar devices:
+# OLED48A2AUA
+# OLED48A2PUA
+# OLED55A2AUA
+# OLED55A2PUA
+# OLED65A2AUA
+# OLED65A2PUA
+# OLED77A2AUA
+# OLED77A2PUA
+# OLED55B2AUA
+# OLED55B2PUA
+# OLED65B2AUA
+# OLED65B2PUA
+# OLED77B2AUA
+# OLED77B2PUA
+# OLED42C2AUA
+# OLED42C2PUA
+# OLED48C2AUA
+# OLED48C2PUA
+# OLED55C2AUA
+# OLED55C2PUA
+# OLED65C2AUA
+# OLED65C2SW
+# OLED65C2PUA
+# OLED77C2AUA
+# OLED77C2PUA
+# OLED83C2AUA
+# OLED83C2PUA
+#
+# Manual link:
+# https://kr.eguide.lgappstv.com/manual/w24_mr2/userguide_w24_mr2_us18.html
+#
+# Page describing LG OLED model numbers: https://en.tab-tv.com/?page_id=7111
+#
+# Response from getProtocolInfo on C2:
+# http-get:*:audio/L16;rate=44100;channels=1:DLNA.ORG_PN=LPCM,http-get:*:audio/L16;rate=44100;channels=2:DLNA.ORG_PN=LPCM,http-get:*:audio/mpeg:DLNA.ORG_PN=MP3,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_SM,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_MED,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_LRG,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN,http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_LRG_ICO,http-get:*:image/png:DLNA.ORG_PN=PNG_TN,http-get:*:image/png:DLNA.ORG_PN=PNG_SM_ICO,http-get:*:image/png:DLNA.ORG_PN=PNG_LRG_ICO,http-get:*:image/png:DLNA.ORG_PN=PNG_LRG,http-get:*:video/mp4:DLNA.ORG_PN=AVC_MP4_BL_CIF15_AAC_520,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_PS_NTSC,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_PS_PAL,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_KO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_KO_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_KO_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_KO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_KO_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_KO_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_NA,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_HD_NA_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_HD_NA_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_NA,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_NA_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_NA_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_SD_EU_T,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_SD_EU_ISO,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=MPEG_TS_JP_T,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVHIGH_FULL,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVHIGH_PRO,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVMED_BASE,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVMED_FULL,http-get:*:video/x-ms-wmv:DLNA.ORG_PN=WMVMED_PRO,http-get:*:audio/x-ms-wma:DLNA.ORG_PN=WMABASE,http-get:*:audio/x-ms-wma:DLNA.ORG_PN=WMAFULL,http-get:*:audio/vnd.dlna.adts:DLNA.ORG_PN=AAC_ADTS_320,http-get:*:audio/mp4:DLNA.ORG_PN=AAC_ISO_320,http-get:*:audio/mp3:*,http-get:*:audio/flac:*,http-get:*:audio/x-flac:*,http-get:*:audio/mpeg:*,http-get:*:audio/wav:*,http-get:*:audio/mpeg3:*,http-get:*:video/x-ms-wmv:*,http-get:*:video/x-ms-asf:*,http-get:*:video/x-ms-avi:*,http-get:*:video/mpeg:*,http-get:*:video/avi:*,http-get:*:video/mp4:*,http-get:*:video/x-matroska:*,http-get:*:image/jps:*,http-get:*:image/x-jps:*,http-get:*:image/mpo:*,http-get:*:image/png:*,http-get:*:image/bmp:*,http-get:*:image/jpeg:*,http-get:*:audio/x-wav:*,http-get:*:audio/wma:*,http-get:*:audio/x-ogg:*,http-get:*:video/mts:*,http-get:*:video/mp2ts:*,http-get:*:video/mp2t:*,http-get:*:video/x-msvideo:*,http-get:*:video/realvideo:*,http-get:*:video/realmedia:*,http-get:*:video/vnd.dlna.mpeg-tts:DLNA.ORG_PN=AVC_TS_NA_T,http-get:*:video/mpeg:DLNA.ORG_PN=AVC_TS_NA_ISO,http-get:*:video/mpeg:DLNA.ORG_PN=MPEG_TS_NA_ISO
+#
+# This model supports WebOS 25, which is similar to WebOS 24 found on 2020/2021 models, but with support for Dolby Vision in MKV containers.
+# ============================================================================
+#
+
+UserAgentSearch = OLED\d{2}[ABCEGRWZ]2
+UpnpDetailsSearch = OLED\d{2}[ABCEGRWZ]2
+LoadingPriority = 2
+
+TranscodeVideo = MPEGTS-H265-AC3
+H264LevelLimit = 5.1
+MaxVideoWidth = 3840
+MaxVideoHeight = 2160
+DefaultVBVBufSize = true
+SeekByTime = exclusive
+ChunkedTransfer = true
+SupportedVideoBitDepths = 8,10,12
+DisableUmsResume = true
+MuxNonMod4Resolution = true
+
+# Supported video formats:
+Supported = f:3gp|3g2   v:h264|mp4                          a:aac-lc|aac-main                                                                                                           m:video/3gpp
+Supported = f:avi       v:divx|h264|mjpeg|mp4               a:aac-lc|aac-main|ac3|he-aac|mp3|mpa                  gmc:0   qpel:no   mm:ub                                               m:video/avi
+Supported = f:mkv       v:av1|h264|h265|mp4|mpeg2|vp8|vp9   a:aac-lc|aac-main|he-aac|ac3|eac3|lpcm|mp3|mpa|opus                             si:ASS|SUBRIP   hdr:dolbyvision|hdr10|hlg   m:video/x-matroska
+Supported = f:mov       v:av1|h264|h265|mp4                 a:aac-lc|aac-main|ac3|ac4|eac3|he-aac|mp3                                                                                   m:video/quicktime
+Supported = f:mp4|m4v   v:av1|h264|h265|mp4                 a:aac-lc|aac-main|ac3|ac4|eac3|he-aac|mp3                                       si:TX3G         hdr:dolbyvision|hdr10|hlg   m:video/mp4
+Supported = f:mpegps    v:mpeg1|mpeg2                       a:ac3|lpcm|mpa                                                                                                              m:video/mpeg
+Supported = f:mpegts    v:h264|h265|mpeg2                   a:aac-lc|aac-main|ac3|ac4|eac3|he-aac|lpcm|mp3|mpa                                              hdr:dolbyvision|hdr10|hlg   m:video/vnd.dlna.mpeg-tts
+Supported = f:wmv|asf   v:wmv|vc1                           a:wma                                                                                                                       m:video/x-ms-wmv
+
+# Supported audio formats:
+Supported = f:mp3   m:audio/mpeg
+Supported = f:oga   m:audio/ogg
+Supported = f:wav   m:audio/L16
+Supported = f:wma   m:audio/x-ms-wma
+
+# Supported subtitles formats:
+SupportedExternalSubtitlesFormats = ASS,MICRODVD,SAMI,SUBRIP,TEXT,WEBVTT
+StreamSubsForTranscodedVideo = true

--- a/src/main/external-resources/renderers/LG-TV-2023+.conf
+++ b/src/main/external-resources/renderers/LG-TV-2023+.conf
@@ -82,7 +82,7 @@ MuxNonMod4Resolution = true
 # Supported video formats:
 Supported = f:3gp|3g2   v:h264|mp4                          a:aac-lc|aac-main                                                                                                                     m:video/3gpp
 Supported = f:avi       v:divx|h264|mjpeg|mp4               a:aac-lc|aac-main|ac3|he-aac|mp3|mpa                            gmc:0   qpel:no   mm:ub                                               m:video/avi
-Supported = f:mkv       v:av1|h264|h265|mp4|mpeg2|vp8|vp9   a:aac-lc|aac-main|ac3|dts|dtshd|he-aac|eac3|lpcm|mp3|mpa|opus                             si:ASS|SUBRIP   hdr:hdr10|hlg               m:video/x-matroska
+Supported = f:mkv       v:av1|h264|h265|mp4|mpeg2|vp8|vp9   a:aac-lc|aac-main|ac3|dts|dtshd|he-aac|eac3|lpcm|mp3|mpa|opus                             si:ASS|SUBRIP   hdr:dolbyvision|hdr10|hlg   m:video/x-matroska
 Supported = f:mov       v:av1|h264|h265|mp4                 a:aac-lc|aac-main|ac3|ac4|eac3|he-aac|mp3                                                                                             m:video/quicktime
 Supported = f:mp4|m4v   v:av1|h264|h265|mp4                 a:aac-lc|aac-main|ac3|ac4|dts|dtshd|eac3|he-aac|mp3                                       si:TX3G         hdr:dolbyvision|hdr10|hlg   m:video/mp4
 Supported = f:mpegps    v:mpeg1|mpeg2                       a:ac3|lpcm|mpa                                                                                                                        m:video/mpeg

--- a/src/test/java/net/pms/configuration/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/configuration/RendererConfigurationTest.java
@@ -145,7 +145,13 @@ public class RendererConfigurationTest {
 			"friendlyName=[LG] webOS TV OLED55B9SLA"
 		);
 
-		testUPNPDetails("LG OLED 2020+", "modelNumber=OLED65C24LA");
+		testUPNPDetails(
+			"LG OLED 2020/2021",
+			"modelNumber=OLED65CX4LA",
+			"modelNumber=OLED65C14LA"
+		);
+
+		testUPNPDetails("LG OLED 2022", "modelNumber=OLED65C24LA");
 
 // 		This does not match the OLED[0-9]{2} configuration for the LG 2023+ config ...
 //		testUPNPDetails("LG TV 2023+", "modelNumber=UR73003LA");


### PR DESCRIPTION
# Description of code changes

Added native support for Dolby Vision in MKV files on LG TVs from 2022 onwards

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
