### PR TITLE
Add new renderer for LG oled 2025 models

### DIFF
--- a/src/main/external-resources/renderers/LG-TV-2023+.conf
+++ b/src/main/external-resources/renderers/LG-TV-2023+.conf
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-# Profile for LG TVs released from the year 2023 and beyond.
+# Profile for LG TVs released in the year 2023-2024.
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 
@@ -63,9 +63,8 @@ RendererIcon = lg-lb6500.png
 # ============================================================================
 #
 
-# Note: The 3-5 part includes a future prediction based on the tab-tv link above. If the naming convention changes it will need to be updated.
-UserAgentSearch = OLED\d{2}[ABCEGMRWZ][3-5]|LG*U[RT]\d{4}|QNED[89]
-UpnpDetailsSearch = OLED\d{2}[ABCEGMRWZ][3-5]|LG*U[RT]\d{4}|QNED[89]
+UserAgentSearch = OLED\d{2}[ABCEGMRWZ][3-4]|LG*U[RT]\d{4}|QNED[89]
+UpnpDetailsSearch = OLED\d{2}[ABCEGMRWZ][3-4]|LG*U[RT]\d{4}|QNED[89]
 LoadingPriority = 2
 
 TranscodeVideo = MPEGTS-H265-AC3

--- a/src/main/external-resources/renderers/LG-TV-2025+.conf
+++ b/src/main/external-resources/renderers/LG-TV-2025+.conf
@@ -1,0 +1,53 @@
+#----------------------------------------------------------------------------
+# Profile for LG TVs released from the year 2025 and beyond.
+# See DefaultRenderer.conf for descriptions of all the available options.
+#
+
+RendererName = LG TV 2025+
+RendererIcon = lg-lb6500.png
+
+# ============================================================================
+#
+# The main difference between 2025+ and previous models is that DTS(-HD) support has been removed.
+#
+# Page describing LG TV model numbers: https://en.tab-tv.com/?page_id=7111
+#
+# ============================================================================
+#
+
+# Note: The 5 at the end denotes the year 2025. 6 was already used for 2016, so
+# at the time of writing it is unclear what the model numbers of 2026 will be.
+UserAgentSearch = OLED\d{2}[ABCEGMRWZ]5
+UpnpDetailsSearch = OLED\d{2}[ABCEGMRWZ]5
+LoadingPriority = 2
+
+TranscodeVideo = MPEGTS-H265-AC3
+H264LevelLimit = 5.1
+MaxVideoWidth = 3840
+MaxVideoHeight = 2160
+DefaultVBVBufSize = true
+SeekByTime = exclusive
+ChunkedTransfer = true
+SupportedVideoBitDepths = 8,10,12
+DisableUmsResume = true
+MuxNonMod4Resolution = true
+
+# Supported video formats:
+Supported = f:3gp|3g2   v:h264|mp4                          a:aac-lc|aac-main                                                                                                                     m:video/3gpp
+Supported = f:avi       v:divx|h264|mjpeg|mp4               a:aac-lc|aac-main|ac3|he-aac|mp3|mpa                            gmc:0   qpel:no   mm:ub                                               m:video/avi
+Supported = f:mkv       v:av1|h264|h265|mp4|mpeg2|vp8|vp9   a:aac-lc|aac-main|ac3|he-aac|eac3|lpcm|mp3|mpa|opus                             si:ASS|SUBRIP   hdr:dolbyvision|hdr10|hlg             m:video/x-matroska
+Supported = f:mov       v:av1|h264|h265|mp4                 a:aac-lc|aac-main|ac3|ac4|eac3|he-aac|mp3                                                                                             m:video/quicktime
+Supported = f:mp4|m4v   v:av1|h264|h265|mp4                 a:aac-lc|aac-main|ac3|ac4|eac3|he-aac|mp3                                       si:TX3G         hdr:dolbyvision|hdr10|hlg   m:video/mp4
+Supported = f:mpegps    v:mpeg1|mpeg2                       a:ac3|lpcm|mpa                                                                                                                        m:video/mpeg
+Supported = f:mpegts    v:h264|h265|mpeg2                   a:aac-lc|aac-main|ac3|ac4|eac3|he-aac|lpcm|mp3|mpa                                              hdr:dolbyvision|hdr10|hlg   m:video/vnd.dlna.mpeg-tts
+Supported = f:wmv|asf   v:wmv|vc1                           a:wma                                                                                                                                 m:video/x-ms-wmv
+
+# Supported audio formats:
+Supported = f:mp3   m:audio/mpeg
+Supported = f:oga   m:audio/ogg
+Supported = f:wav   m:audio/L16
+Supported = f:wma   m:audio/x-ms-wma
+
+# Supported subtitles formats:
+SupportedExternalSubtitlesFormats = ASS,MICRODVD,SAMI,SUBRIP,TEXT,WEBVTT
+StreamSubsForTranscodedVideo = true


### PR DESCRIPTION
# Description of code changes

Introduces a new renderer for lg oled 2025 tvs, because dts support has been removed from the 2025 models. Basically a copy from the renderer before but removed dts support.

About the model numbers `LG*U[RT]\d{4}|QNED` I don't know anything, so I'm not sure if there are new ones for 2025. Therefore I only added `OLED\d{2}[ABCEGMRWZ]5` to the new renderer.

Tested with my lg tv from 2025.

fixes #5922