### PR TITLE
Docs: Update ffmpeg_gpu_decoding_acceleration_method default to none

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -922,7 +922,7 @@ ffmpeg_sox =
 # -init_hw_device vaapi=amd:/dev/dri/renderD129 -hwaccel vaapi -hwaccel vaapi -hwaccel_device amd
 # for using a AMD device when a PC has Intel and AMD GPUs.
 # See https://trac.ffmpeg.org/wiki/HWAccelIntro.
-# Default: "auto"
+# Default: "none"
 ffmpeg_gpu_decoding_acceleration_method =
 
 # GPU decoding thread count


### PR DESCRIPTION
Fixes #5682 
Corrected the documentation in UMS.conf. The comment for `ffmpeg_gpu_decoding_acceleration_method`, changed the default from "auto" to "none"

This is my first time contributing to Open Source Organizations! Excited to be part of the community.

# Checklist
- [x] Any relevant issues are referenced
- [ ] Any relevant Knowledge Base articles are written/modified
- [ ] Any relevant tests have been written/modified