### PR TITLE
Update LG-WebOS.conf - disable chunked transfer

### DIFF
--- a/src/main/external-resources/renderers/LG-WebOS.conf
+++ b/src/main/external-resources/renderers/LG-WebOS.conf
@@ -34,7 +34,7 @@ LoadingPriority = 1
 H264LevelLimit = 5.1
 DefaultVBVBufSize = true
 SeekByTime = true
-ChunkedTransfer = true
+ChunkedTransfer = false
 MuxNonMod4Resolution = true
 
 # Supported video formats:


### PR DESCRIPTION
This tweak fixes random lags and file skipping during playback. Tested on LG with WebOS v25.

# Description of code changes

...

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
