### PR TITLE
spelling fix in setup-x86_64.nsi

### DIFF
--- a/src/main/external-resources/windows/nsis-scripts/setup-x86_64.nsi
+++ b/src/main/external-resources/windows/nsis-scripts/setup-x86_64.nsi
@@ -76,7 +76,7 @@ Function InstallTypeShow
 	Pop $0
 
 	${If} $CurrentInstallType == ""
-		${NSD_CreateRadioButton} 0% 20% 100% 12u "Install for all users (recommanded)"
+		${NSD_CreateRadioButton} 0% 20% 100% 12u "Install for all users (recommended)"
 		pop $InstallSystemButton
 		${NSD_CreateLabel} 3% 30% 100% 12u "This will install ${PROJECT_NAME} on this computer for all users"
 		${NSD_CreateAdditionalRadioButton} 0% 40% 100% 12u "Install for the current user only"


### PR DESCRIPTION
# Description of code changes

Spelling change in a text string in setup-x86_64.nsi

# Checklist
- [x] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [x] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [x] Any relevant tests have been written/modified
