### PR TITLE
make multi module build (linux x86_64/arm64)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3706,7 +3706,7 @@
 								<configuration>
 									<target>
 										<exec executable="docker" dir="${project.basedir}/target/docker">
-											<arg line="build . -f Dockerfile -t universalmediaserver/ums:${project.version} -t universalmediaserver/ums:latest" />
+											<arg line="buildx build --platform linux/amd64,linux/arm64 . -f Dockerfile -t universalmediaserver/ums:${project.version} -t universalmediaserver/ums:latest" />
 										</exec>
 										<exec executable="docker" dir="${project.basedir}/target/docker">
 											<arg line="build . -f Dockerfile-alpine -t universalmediaserver/ums-alpine:${project.version} -t universalmediaserver/ums-alpine:latest" />


### PR DESCRIPTION
This PR make a docker multi-platform build and adds an arm64 target. If this works, it should resolve #4770. However, I'm not sure, if further steps to the build pipeline are needed ... we have to check it.
.