### PR TITLE
Implemented subtree search

### DIFF
--- a/src/main/java/net/pms/database/DatabaseHelper.java
+++ b/src/main/java/net/pms/database/DatabaseHelper.java
@@ -200,8 +200,8 @@ public abstract class DatabaseHelper {
 	protected static final String VARCHAR_20000 = VARCHAR + "(20000)";
 
 	protected static final String VARCHAR_IGNORECASE = " VARCHAR_IGNORECASE";
-	protected static final String VARCHAR_IGNORECASE_255 = VARCHAR_IGNORECASE + "(255)";
-	protected static final String VARCHAR_IGNORECASE_1024 = VARCHAR_IGNORECASE + "(1024)";
+	protected static final String VARCHAR_IGNORECASE_MAX = VARCHAR_IGNORECASE + "(" + SIZE_MAX + ")";
+	protected static final String VARCHAR_IGNORECASE_1024 = VARCHAR_IGNORECASE + "(" + SIZE_1024 + ")";
 
 	protected static final String AUTO_INCREMENT = " AUTO_INCREMENT";
 	protected static final String CONSTRAINT_SEPARATOR = "_";

--- a/src/main/java/net/pms/database/DatabaseHelper.java
+++ b/src/main/java/net/pms/database/DatabaseHelper.java
@@ -199,6 +199,10 @@ public abstract class DatabaseHelper {
 	protected static final String VARCHAR_1024 = VARCHAR + "(" + SIZE_1024 + ")";
 	protected static final String VARCHAR_20000 = VARCHAR + "(20000)";
 
+	protected static final String VARCHAR_IGNORECASE = " VARCHAR_IGNORECASE";
+	protected static final String VARCHAR_IGNORECASE_255 = VARCHAR_IGNORECASE + "(255)";
+	protected static final String VARCHAR_IGNORECASE_1024 = VARCHAR_IGNORECASE + "(1024)";
+
 	protected static final String AUTO_INCREMENT = " AUTO_INCREMENT";
 	protected static final String CONSTRAINT_SEPARATOR = "_";
 	protected static final String PRIMARY_KEY = " PRIMARY KEY";

--- a/src/main/java/net/pms/database/MediaTableAudioMetadata.java
+++ b/src/main/java/net/pms/database/MediaTableAudioMetadata.java
@@ -133,15 +133,15 @@ public class MediaTableAudioMetadata extends MediaTable {
 					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_FILEID + BIGINT);
 				}
 				case 2 -> {
-					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_ALBUM + VARCHAR_IGNORECASE_255);
-					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_ARTIST + VARCHAR_IGNORECASE_255);
-					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_ALBUMARTIST + VARCHAR_IGNORECASE_255);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_ALBUM + VARCHAR_IGNORECASE_MAX);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_ARTIST + VARCHAR_IGNORECASE_MAX);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_ALBUMARTIST + VARCHAR_IGNORECASE_MAX);
 					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_COMPOSER + VARCHAR_IGNORECASE_1024);
 					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_CONDUCTOR + VARCHAR_IGNORECASE_1024);
-					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_GENRE + VARCHAR_IGNORECASE_255);
-					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_SONGNAME + VARCHAR_IGNORECASE_255);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_GENRE + VARCHAR_IGNORECASE_MAX);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_SONGNAME + VARCHAR_IGNORECASE_MAX);
 
-					executeUpdate(connection, CREATE_INDEX + IF_NOT_EXISTS + "IDX_AUDIO_METADATA_FILEID_SONGNAME on " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_SONGNAME + ")");
+					executeUpdate(connection, CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_SONGNAME + IDX_MARKER + ON + TABLE_NAME + " (" + COL_SONGNAME + ")");
 				}
 				default -> {
 					throw new IllegalStateException(
@@ -165,19 +165,19 @@ public class MediaTableAudioMetadata extends MediaTable {
 			CREATE_TABLE + TABLE_NAME + " (" +
 				COL_FILEID              + BIGINT                         + PRIMARY_KEY       + COMMA +
 				COL_AUDIOTRACK_ID       + INTEGER                        + AUTO_INCREMENT    + COMMA +
-				COL_ALBUM               + VARCHAR_SIZE_MAX                                   + COMMA +
-				COL_ARTIST              + VARCHAR_SIZE_MAX                                   + COMMA +
-				COL_ALBUMARTIST         + VARCHAR_SIZE_MAX                                   + COMMA +
-				COL_SONGNAME            + VARCHAR_SIZE_MAX                                   + COMMA +
-				COL_GENRE               + VARCHAR_SIZE_MAX                                   + COMMA +
+				COL_ALBUM               + VARCHAR_IGNORECASE_MAX                             + COMMA +
+				COL_ARTIST              + VARCHAR_IGNORECASE_MAX                             + COMMA +
+				COL_ALBUMARTIST         + VARCHAR_IGNORECASE_MAX                             + COMMA +
+				COL_SONGNAME            + VARCHAR_IGNORECASE_MAX                             + COMMA +
+				COL_GENRE               + VARCHAR_IGNORECASE_MAX                             + COMMA +
 				COL_MEDIA_YEAR          + INTEGER                                            + COMMA +
 				COL_MBID_RECORD         + UUID_TYPE                                          + COMMA +
 				COL_MBID_TRACK          + UUID_TYPE                                          + COMMA +
 				COL_TRACK               + INTEGER                                            + COMMA +
 				COL_DISC                + INTEGER                                            + COMMA +
 				COL_RATING              + INTEGER                                            + COMMA +
-				COL_COMPOSER            + VARCHAR_1024                                       + COMMA +
-				COL_CONDUCTOR           + VARCHAR_1024                                       + COMMA +
+				COL_COMPOSER            + VARCHAR_IGNORECASE_1024                            + COMMA +
+				COL_CONDUCTOR           + VARCHAR_IGNORECASE_1024                            + COMMA +
 				CONSTRAINT + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_FILEID + FK_MARKER + FOREIGN_KEY + "(" + COL_FILEID + ")" + REFERENCES + MediaTableFiles.REFERENCE_TABLE_COL_ID + ON_DELETE_CASCADE +
 			")",
 			CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_ARTIST + IDX_MARKER + ON + TABLE_NAME + " (" + COL_ARTIST + ASC + ")",
@@ -188,7 +188,8 @@ public class MediaTableAudioMetadata extends MediaTable {
 			CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_AUDIOTRACK_ID + IDX_MARKER + ON + TABLE_NAME + " (" + COL_AUDIOTRACK_ID + ")",
 			CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_COMPOSER + IDX_MARKER + ON + TABLE_NAME + " (" + COL_COMPOSER + ")",
 			CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_CONDUCTOR + IDX_MARKER + ON + TABLE_NAME + " (" + COL_CONDUCTOR + ")",
-			CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_MEDIA_YEAR + IDX_MARKER + ON + TABLE_NAME + " (" + COL_MEDIA_YEAR + ")"
+			CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_MEDIA_YEAR + IDX_MARKER + ON + TABLE_NAME + " (" + COL_MEDIA_YEAR + ")",
+			CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_SONGNAME + IDX_MARKER + ON + TABLE_NAME + " (" + COL_SONGNAME + ")"
 		);
 	}
 

--- a/src/main/java/net/pms/database/MediaTableAudioMetadata.java
+++ b/src/main/java/net/pms/database/MediaTableAudioMetadata.java
@@ -47,7 +47,7 @@ public class MediaTableAudioMetadata extends MediaTable {
 	 * Version notes:
 	 * - 2: FILEID as BIGINT
 	 */
-	private static final int TABLE_VERSION = 2;
+	private static final int TABLE_VERSION = 3;
 
 	/**
 	 * COLUMNS NAMES
@@ -131,6 +131,17 @@ public class MediaTableAudioMetadata extends MediaTable {
 			switch (version) {
 				case 1 -> {
 					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_FILEID + BIGINT);
+				}
+				case 2 -> {
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_ALBUM + VARCHAR_IGNORECASE_255);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_ARTIST + VARCHAR_IGNORECASE_255);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_ALBUMARTIST + VARCHAR_IGNORECASE_255);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_COMPOSER + VARCHAR_IGNORECASE_1024);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_CONDUCTOR + VARCHAR_IGNORECASE_1024);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_GENRE + VARCHAR_IGNORECASE_255);
+					executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ALTER_COLUMN + IF_EXISTS + COL_SONGNAME + VARCHAR_IGNORECASE_255);
+
+					executeUpdate(connection, CREATE_INDEX + IF_NOT_EXISTS + "IDX_AUDIO_METADATA_FILEID_SONGNAME on " + TABLE_NAME + " (" + COL_FILEID + ", " + COL_SONGNAME + ")");
 				}
 				default -> {
 					throw new IllegalStateException(

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -502,7 +502,7 @@ public class MediaTableFiles extends MediaTable {
 						executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ADD + COLUMN + IF_NOT_EXISTS + COL_RESOURCE_UID + VARCHAR);
 					}
 					case 44 -> {
-						executeUpdate(connection, CREATE_INDEX + IF_NOT_EXISTS + "FILES_FILENAME on " + TABLE_NAME + " (FILENAME)");
+						executeUpdate(connection, CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + IDX_MARKER + COL_FILENAME + ON + TABLE_NAME + " (" + COL_FILENAME + ")");
 					}
 					default -> {
 						// Do the dumb way
@@ -587,6 +587,9 @@ public class MediaTableFiles extends MediaTable {
 
 		LOGGER.trace("Creating index on " + COL_THUMBID);
 		execute(connection, CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_THUMBID + IDX_MARKER + ON + TABLE_NAME + "(" + COL_THUMBID + ")");
+
+		LOGGER.trace("Creating index on " + COL_FILENAME);
+		execute(connection, CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + IDX_MARKER + COL_FILENAME + ON + TABLE_NAME + " (" + COL_FILENAME + ")");
 	}
 
 	/**

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -503,7 +503,6 @@ public class MediaTableFiles extends MediaTable {
 					}
 					case 44 -> {
 						executeUpdate(connection, CREATE_INDEX + IF_NOT_EXISTS + "FILES_FILENAME on " + TABLE_NAME + " (FILENAME)");
-//						CREATE INDEX idx_files_filename ON PUBLIC.FILES(FILENAME);
 					}
 					default -> {
 						// Do the dumb way

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -502,7 +502,7 @@ public class MediaTableFiles extends MediaTable {
 						executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ADD + COLUMN + IF_NOT_EXISTS + COL_RESOURCE_UID + VARCHAR);
 					}
 					case 44 -> {
-						executeUpdate(connection, CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + IDX_MARKER + COL_FILENAME + ON + TABLE_NAME + " (" + COL_FILENAME + ")");
+						executeUpdate(connection, CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_FILENAME + IDX_MARKER + ON + TABLE_NAME + " (" + COL_FILENAME + ")");
 					}
 					default -> {
 						// Do the dumb way
@@ -589,7 +589,7 @@ public class MediaTableFiles extends MediaTable {
 		execute(connection, CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_THUMBID + IDX_MARKER + ON + TABLE_NAME + "(" + COL_THUMBID + ")");
 
 		LOGGER.trace("Creating index on " + COL_FILENAME);
-		execute(connection, CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + IDX_MARKER + COL_FILENAME + ON + TABLE_NAME + " (" + COL_FILENAME + ")");
+		execute(connection, CREATE_INDEX + IF_NOT_EXISTS + TABLE_NAME + CONSTRAINT_SEPARATOR + COL_FILENAME + IDX_MARKER + ON + TABLE_NAME + " (" + COL_FILENAME + ")");
 	}
 
 	/**

--- a/src/main/java/net/pms/database/MediaTableFiles.java
+++ b/src/main/java/net/pms/database/MediaTableFiles.java
@@ -98,7 +98,7 @@ public class MediaTableFiles extends MediaTable {
 	 * - 43: clear ffmpeg data parsed
 	 * - 44: added DATEADDED and RUID
 	 */
-	private static final int TABLE_VERSION = 44;
+	private static final int TABLE_VERSION = 45;
 
 	/**
 	 * COLUMNS NAMES
@@ -500,6 +500,10 @@ public class MediaTableFiles extends MediaTable {
 					case 43 -> {
 						executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ADD + COLUMN + IF_NOT_EXISTS + COL_DATEADDED + TIMESTAMP + DEFAULT + CURRENT_TIMESTAMP);
 						executeUpdate(connection, ALTER_TABLE + TABLE_NAME + ADD + COLUMN + IF_NOT_EXISTS + COL_RESOURCE_UID + VARCHAR);
+					}
+					case 44 -> {
+						executeUpdate(connection, CREATE_INDEX + IF_NOT_EXISTS + "FILES_FILENAME on " + TABLE_NAME + " (FILENAME)");
+//						CREATE INDEX idx_files_filename ON PUBLIC.FILES(FILENAME);
 					}
 					default -> {
 						// Do the dumb way

--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -241,7 +241,7 @@ public class SearchRequestHandler {
 				return "select count (DISTINCT A.ALBUMARTIST) from AUDIO_METADATA as A where ";
 			}
 			case TYPE_ALBUM -> {
-				return "select count(DISTINCT A.AUDIOTRACK_ID) from AUDIO_METADATA as A where ";
+				return "select count(DISTINCT A.ALBUM) from AUDIO_METADATA as A where ";
 			}
 			case TYPE_PLAYLIST -> {
 				return "select count(DISTINCT F.id) from FILES as F where ";
@@ -280,7 +280,7 @@ public class SearchRequestHandler {
 				return "select count (DISTINCT A.ALBUMARTIST) from AUDIO_METADATA as A where ";
 			}
 			case TYPE_ALBUM -> {
-				return "select count(DISTINCT A.AUDIOTRACK_ID) from AUDIO_METADATA as A where ";
+				return "select count(DISTINCT A.ALBUM) from AUDIO_METADATA as A where ";
 			}
 			case TYPE_PLAYLIST -> {
 				return getTreeStatement(subtreeId) + "select count(DISTINCT F.id) FROM tree JOIN FILES F ON F.FILENAME = tree.name where ";

--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -289,7 +289,7 @@ public class SearchRequestHandler {
 				return getTreeStatement(subtreeId) + "select count(DISTINCT F.id) FROM tree JOIN FILES F ON F.FILENAME = tree.name where ";
 			}
 			case TYPE_FOLDER -> {
-				return getTreeStatement(subtreeId) + "select count(DISTINCT child.NAME) from STORE_IDS child, STORE_IDS parent where tree.name = child.name and ";
+				return getTreeStatement(subtreeId) + "select count(DISTINCT child.NAME) from tree JOIN STORE_IDS child on tree.id = child.id, STORE_IDS parent where ";
 			}
 			default -> throw new RuntimeException("not implemented request type : " + (requestType != null ? requestType : "NULL"));
 		}

--- a/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
+++ b/src/main/java/net/pms/network/mediaserver/handlers/SearchRequestHandler.java
@@ -126,9 +126,9 @@ public class SearchRequestHandler {
 		StringBuilder dlnaItems = new StringBuilder();
 		DbIdMediaType requestType = getRequestType(requestMessage.getSearchCriteria());
 
-		int totalMatches = getLibraryResourceCountFromSQL(convertToCountSql(requestMessage.getSearchCriteria(), requestType));
+		int totalMatches = getLibraryResourceCountFromSQL(convertToCountSql(requestMessage.getSearchCriteria(), requestType, requestMessage.getContainerId()));
 
-		String sqlFiles = convertToFilesSql(requestMessage, requestType);
+		String sqlFiles = convertToFilesSql(requestMessage, requestType, requestMessage.getContainerId());
 		for (StoreResource resource : getLibraryResourceFromSQL(renderer, sqlFiles, requestType)) {
 			numberReturned++;
 			dlnaItems.append(DidlHelper.getDidlString(resource));
@@ -184,6 +184,45 @@ public class SearchRequestHandler {
 	 * @param requestType
 	 * @return
 	 */
+	private static String addSqlSelectByType(DbIdMediaType requestType, String subtreeId) {
+		switch (requestType) {
+			case TYPE_AUDIO -> {
+				return getTreeStatement(subtreeId) + "select A.RATING, A.GENRE, FILENAME, MODIFIED, F.ID as FID, F.ID as oid FROM tree JOIN FILES F ON F.FILENAME = tree.name left outer join AUDIO_METADATA as A on F.ID = A.FILEID where ";
+			}
+			case TYPE_PERSON -> {
+				return "select DISTINCT ON (FILENAME) A.ARTIST as FILENAME, A.AUDIOTRACK_ID as oid from AUDIO_METADATA as A where ";
+			}
+			case TYPE_PERSON_CONDUCTOR -> {
+				return "select DISTINCT ON (FILENAME) A.CONDUCTOR as FILENAME, A.A.AUDIOTRACK_ID as oid from AUDIO_METADATA as A where ";
+			}
+			case TYPE_PERSON_COMPOSER -> {
+				return "select DISTINCT ON (FILENAME) A.COMPOSER as FILENAME, A.AUDIOTRACK_ID as oid from AUDIO_METADATA as A where ";
+			}
+			case TYPE_PERSON_ALBUMARTIST -> {
+				return "select DISTINCT ON (FILENAME) A.ALBUMARTIST as FILENAME, A.AUDIOTRACK_ID as oid from AUDIO_METADATA as A where ";
+			}
+			case TYPE_ALBUM -> {
+				return "select DISTINCT ON (album) mbid_release as liked, MBID_RECORD, album, artist, media_year, genre, ALBUM as FILENAME, A.AUDIOTRACK_ID as oid, A.MBID_RECORD from MUSIC_BRAINZ_RELEASE_LIKE as m right outer join AUDIO_METADATA as a on m.mbid_release = A.mbid_record where ";
+			}
+			case TYPE_PLAYLIST -> {
+				return getTreeStatement(subtreeId) + "select DISTINCT ON (FILENAME) FILENAME, MODIFIED, F.ID as FID, F.ID as oid FROM tree JOIN FILES F ON F.FILENAME = tree.name where ";
+			}
+			case TYPE_FOLDER -> {
+				return getTreeStatement(subtreeId) + "select DISTINCT ON (child.NAME) child.NAME, child.ID as FID, child.ID as oid, parent.ID as parent_id from tree JOIN STORE_IDS child on tree.name = child.name, STORE_IDS parent where ";
+			}
+			case TYPE_VIDEO, TYPE_IMAGE -> {
+				return getTreeStatement(subtreeId) + "select FILENAME, MODIFIED, F.ID as FID, F.ID as oid FROM tree JOIN FILES F ON F.FILENAME = tree.name where ";
+			}
+			default -> throw new RuntimeException("not implemented request type : " + (requestType != null ? requestType : "NULL"));
+		}
+	}
+
+	/**
+	 * Beginning part of SQL statement, by type.
+	 *
+	 * @param requestType
+	 * @return
+	 */
 	private static String addSqlSelectCountByType(DbIdMediaType requestType) {
 		switch (requestType) {
 			case TYPE_AUDIO -> {
@@ -217,9 +256,52 @@ public class SearchRequestHandler {
 		}
 	}
 
-	public static String convertToFilesSql(SearchRequest requestMessage, DbIdMediaType requestType) {
+	/**
+	 * Beginning part of SQL statement, by type.
+	 *
+	 * @param requestType
+	 * @return
+	 */
+	private static String addSqlSelectCountByType(DbIdMediaType requestType, String subtreeId) {
+		switch (requestType) {
+			case TYPE_AUDIO -> {
+				return getTreeStatement(subtreeId) + "select count(DISTINCT F.id) FROM tree JOIN FILES F ON F.FILENAME = tree.name left outer join AUDIO_METADATA as A on F.ID = A.FILEID where ";
+			}
+			case TYPE_PERSON -> {
+				return "select count (DISTINCT A.ARTIST) from AUDIO_METADATA as A where ";
+			}
+			case TYPE_PERSON_CONDUCTOR -> {
+				return "select count (DISTINCT A.CONDUCTOR) from AUDIO_METADATA as A where ";
+			}
+			case TYPE_PERSON_COMPOSER -> {
+				return "select count (DISTINCT A.COMPOSER) from AUDIO_METADATA as A where ";
+			}
+			case TYPE_PERSON_ALBUMARTIST -> {
+				return "select count (DISTINCT A.ALBUMARTIST) from AUDIO_METADATA as A where ";
+			}
+			case TYPE_ALBUM -> {
+				return "select count(DISTINCT A.AUDIOTRACK_ID) from AUDIO_METADATA as A where ";
+			}
+			case TYPE_PLAYLIST -> {
+				return getTreeStatement(subtreeId) + "select count(DISTINCT F.id) FROM tree JOIN FILES F ON F.FILENAME = tree.name where ";
+			}
+			case TYPE_VIDEO, TYPE_IMAGE -> {
+				return getTreeStatement(subtreeId) + "select count(DISTINCT F.id) FROM tree JOIN FILES F ON F.FILENAME = tree.name where ";
+			}
+			case TYPE_FOLDER -> {
+				return getTreeStatement(subtreeId) + "select count(DISTINCT child.NAME) from STORE_IDS child, STORE_IDS parent where tree.name = child.name and ";
+			}
+			default -> throw new RuntimeException("not implemented request type : " + (requestType != null ? requestType : "NULL"));
+		}
+	}
+
+	public static String convertToFilesSql(SearchRequest requestMessage, DbIdMediaType requestType, String subtreeId) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(addSqlSelectByType(requestType));
+		if ("0".equals(subtreeId) || StringUtils.isAllBlank(subtreeId)) {
+			sb.append(addSqlSelectByType(requestType));
+		} else {
+			sb.append(addSqlSelectByType(requestType, subtreeId));
+		}
 		addSqlWherePart(requestMessage.getSearchCriteria(), requestType, sb);
 		addOrderBy(requestMessage.getSortCriteria(), requestType, sb);
 		addLimit(requestMessage.getStartingIndex(), requestMessage.getRequestedCount(), sb);
@@ -228,9 +310,13 @@ public class SearchRequestHandler {
 	}
 
 	public static String convertToFilesSql(String searchCriteria, long startingIndex, long requestedCount, SortCriterion[] orderBy,
-		DbIdMediaType requestType) {
+		DbIdMediaType requestType, String subtreeId) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(addSqlSelectByType(requestType));
+		if ("0".equals(subtreeId) || StringUtils.isAllBlank(subtreeId)) {
+			sb.append(addSqlSelectByType(requestType));
+		} else {
+			sb.append(addSqlSelectByType(requestType, subtreeId));
+		}
 		addSqlWherePart(searchCriteria, requestType, sb);
 		addOrderBy(orderBy, requestType, sb);
 		addLimit(startingIndex, requestedCount, sb);
@@ -296,9 +382,13 @@ public class SearchRequestHandler {
 		sb.append(String.format(" LIMIT %d OFFSET %d ", limit, startingIndex));
 	}
 
-	public static String convertToCountSql(String upnpSearch, DbIdMediaType requestType) {
+	public static String convertToCountSql(String upnpSearch, DbIdMediaType requestType, String subtreeId) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(addSqlSelectCountByType(requestType));
+		if ("0".equals(subtreeId) || StringUtils.isAllBlank(subtreeId)) {
+			sb.append(addSqlSelectCountByType(requestType));
+		} else {
+			sb.append(addSqlSelectCountByType(requestType, subtreeId));
+		}
 		addSqlWherePart(upnpSearch, requestType, sb);
 		return sb.toString();
 	}
@@ -337,7 +427,7 @@ public class SearchRequestHandler {
 		if ("=".equals(op)) {
 			sb.append(String.format(" %s = '%s' ", getField(property, requestType), val));
 		} else if ("contains".equals(op)) {
-			sb.append(String.format("LOWER(%s) LIKE '%%%s%%'", getField(property, requestType), escapeH2dbSql(val).toLowerCase()));
+			sb.append(String.format("%s ILIKE '%%%s%%'", getField(property, requestType), escapeH2dbSql(val)));
 		} else {
 			throw new RuntimeException("unknown or unimplemented operator : " + op);
 		}
@@ -638,4 +728,20 @@ public class SearchRequestHandler {
 		return response;
 	}
 
+	private static String getTreeStatement(String subtreeId) {
+		String tree = String.format("WITH RECURSIVE tree(id, parent_id, name) AS (" +
+			"    SELECT id, parent_id, name" +
+			"    FROM STORE_IDS" +
+			"    WHERE id = %s" +
+			"\n" +
+			"    UNION ALL" +
+			"\n" +
+			"    SELECT t.id, t.parent_id, t.name" +
+			"    FROM STORE_IDS t" +
+			"    INNER JOIN tree ON t.parent_id = tree.id " +
+			")\n" +
+			"", subtreeId);
+
+		return tree;
+	}
 }

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
@@ -876,8 +876,8 @@ public class UmsContentDirectoryService {
 
 		try {
 			DbIdMediaType requestType = SearchRequestHandler.getRequestType(searchCriteria);
-			int totalMatches = SearchRequestHandler.getLibraryResourceCountFromSQL(SearchRequestHandler.convertToCountSql(searchCriteria, requestType));
-			String sqlFiles = SearchRequestHandler.convertToFilesSql(searchCriteria, startingIndex, requestedCount, orderBy, requestType);
+			int totalMatches = SearchRequestHandler.getLibraryResourceCountFromSQL(SearchRequestHandler.convertToCountSql(searchCriteria, requestType, containerId));
+			String sqlFiles = SearchRequestHandler.convertToFilesSql(searchCriteria, startingIndex, requestedCount, orderBy, requestType, containerId);
 			List<StoreResource> resultResources = SearchRequestHandler.getLibraryResourceFromSQL(renderer, sqlFiles, requestType);
 
 			long containerUpdateID = MediaStoreIds.getSystemUpdateId().getValue();

--- a/src/test/java/net/pms/network/mediaserver/handlers/SearchRequestHandlerTest.java
+++ b/src/test/java/net/pms/network/mediaserver/handlers/SearchRequestHandlerTest.java
@@ -42,7 +42,7 @@ public class SearchRequestHandlerTest {
 		sr.setSearchCriteria(s);
 		sr.setRequestedCount(0);
 		sr.setStartingIndex(0);
-		String result = SearchRequestHandler.convertToFilesSql(sr, SearchRequestHandler.getRequestType(s));
+		String result = SearchRequestHandler.convertToFilesSql(sr, SearchRequestHandler.getRequestType(s), "0");
 		LOG.info(result);  // \\s+
 		assertTrue(result.matches(
 				"select\\s+FILENAME\\s*,\\s*MODIFIED\\s*,\\s*F\\.ID\\s+as\\s+FID\\s*,\\s*F\\.ID\\s+as\\s+oid\\s+from\\s+FILES\\s+as\\s+F\\s+where\\s*\\(\\s*F\\.FORMAT_TYPE\\s*=\\s*4\\s*\\)\\s*ORDER\\s+BY\\s+oid\\s+LIMIT\\s+999\\s+OFFSET\\s+0\\s*"));
@@ -54,10 +54,10 @@ public class SearchRequestHandlerTest {
 	@Test
 	public void testLinnAppComposerSearch() {
 		String searchCriteria = "upnp:class derivedfrom \"object.container.person.musicArtist\" and upnp:artist[@role=\"Composer\"] contains \"tchaikovsky\"";
-		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria));
+		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria), "0");
 		LOG.info(countSQL);
 		assertTrue(countSQL.matches(
-				"select\\s+count\\s+\\(\\s*DISTINCT\\s+A.COMPOSER\\s*\\)\\s+from\\s+AUDIO_METADATA\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.COMPOSER\\s*\\)\\s+LIKE\\s+'%tchaikovsky%'"));
+				"select\\s+count\\s+\\(\\s*DISTINCT\\s+A.COMPOSER\\s*\\)\\s+from\\s+AUDIO_METADATA\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+ \\s*A.COMPOSER\\s+ILIKE\\s+'%tchaikovsky%'"));
 	}
 
 	/**
@@ -66,28 +66,28 @@ public class SearchRequestHandlerTest {
 	@Test
 	public void testLinnAppConductorSearch() {
 		String searchCriteria = "upnp:class derivedfrom \"object.container.person.musicArtist\" and upnp:artist[@role=\"Conductor\"] contains \"bernstein\"";
-		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria));
+		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria), "0");
 		LOG.info(countSQL);
 		assertTrue(countSQL.matches(
-				"select\\s+count\\s+\\(\\s*DISTINCT\\s+A.CONDUCTOR\\s*\\)\\s+from\\s+AUDIO_METADATA\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.CONDUCTOR\\s*\\)\\s+LIKE\\s+'%bernstein%'"));
+				"select\\s+count\\s+\\(\\s*DISTINCT\\s+A.CONDUCTOR\\s*\\)\\s+from\\s+AUDIO_METADATA\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s*A.CONDUCTOR\\s+ILIKE\\s+'%bernstein%'"));
 	}
 
 	@Test
 	public void testAlbumArtistSearch() {
 		String searchCriteria = "upnp:class derivedfrom \"object.container.person.musicArtist\" and upnp:artist[@role=\"AlbumArtist\"] contains \"tchaikovsky\"";
-		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria));
+		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria), "0");
 		LOG.info(countSQL);
 		assertTrue(countSQL.matches(
-				"select\\s+count\\s+\\(\\s*DISTINCT\\s+A.ALBUMARTIST\\s*\\)\\s+from\\s+AUDIO_METADATA\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.ALBUMARTIST\\s*\\)\\s+LIKE\\s+'%tchaikovsky%'"));
+				"select\\s+count\\s+\\(\\s*DISTINCT\\s+A.ALBUMARTIST\\s*\\)\\s+from\\s+AUDIO_METADATA\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+A.ALBUMARTIST\\s+ILIKE\\s+'%tchaikovsky%'"));
 	}
 
 	@Test
 	public void testArtistSearch() {
 		String searchCriteria = "upnp:class derivedfrom \"object.container.person.musicArtist\" and upnp:artist contains \"tchaikovsky\"";
-		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria));
+		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria), "0");
 		LOG.info(countSQL);
 		assertTrue(countSQL.matches(
-				"select\\s+count\\s+\\(\\s*DISTINCT\\s+A.ARTIST\\s*\\)\\s+from\\s+AUDIO_METADATA\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.ARTIST\\s*\\)\\s+LIKE\\s+'%tchaikovsky%'"));
+				"select\\s+count\\s+\\(\\s*DISTINCT\\s+A.ARTIST\\s*\\)\\s+from\\s+AUDIO_METADATA\\s+as\\s+A\\s+where\\s+1\\s*=\\s*1\\s+and\\s+A.ARTIST\\s+ILIKE\\s+'%tchaikovsky%'"));
 	}
 
 	/**
@@ -96,10 +96,30 @@ public class SearchRequestHandlerTest {
 	@Test
 	public void testLinnAppSpecialCharSearch() {
 		String searchCriteria = "upnp:class derivedfrom \"object.item.audioItem\" and dc:title contains \"love don't\"";
-		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria));
+		String countSQL = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria), "0");
 		LOG.info(countSQL);
 		assertTrue(countSQL.matches(
-				"select\\s+count\\s*\\(\\s*DISTINCT\\s+F.id\\s*\\)\\s+from\\s+FILES\\s+as\\s+F\\s+left\\s+outer\\s+join\\s+AUDIO_METADATA\\s+as\\s+A\\s+on\\s+F.ID\\s*=\\s*A.FILEID\\s+where\\s+F.FORMAT_TYPE\\s*=\\s*1\\s+and\\s+LOWER\\s*\\(\\s*A.SONGNAME\\s*\\)\\s+LIKE\\s+'%love don''t%'"));
+				"select\\s+count\\s*\\(\\s*DISTINCT\\s+F.id\\s*\\)\\s+from\\s+FILES\\s+as\\s+F\\s+left\\s+outer\\s+join\\s+AUDIO_METADATA\\s+as\\s+A\\s+on\\s+F.ID\\s*=\\s*A.FILEID\\s+where\\s+F.FORMAT_TYPE\\s*=\\s*1\\s+and\\s+A.SONGNAME\\s+ILIKE\\s+'%love don''t%'"));
+	}
+
+	/**
+	 * Convinience method to test various SearchCriteria and the resulting SQL statements
+	 */
+	@Test
+	public void testSQL() {
+//		String searchCriteria = "upnp:class derivedfrom \"object.item.audioItem\" and dc:title contains \"minimal\"";
+//		String searchCriteria = "upnp:class derivedfrom \"object.container.playlistcontainer\" and dc:title contains \"pop\"";
+//		String searchCriteria = "upnp:class derivedfrom \"object.item.videoitem\" and dc:title contains \"\"";
+//		String searchCriteria = "upnp:class derivedfrom \"object.item.imageitem\" and dc:title contains \"\"";
+
+		String searchCriteria = "upnp:class derivedfrom \"object.container\" and dc:title contains \"music\"";
+
+
+
+		String countSql = SearchRequestHandler.convertToCountSql(searchCriteria, SearchRequestHandler.getRequestType(searchCriteria), "134");
+		LOG.info(countSql);
+		String sql = SearchRequestHandler.convertToFilesSql(searchCriteria, 0, 200, null, SearchRequestHandler.getRequestType(searchCriteria), "134");
+		LOG.info(sql);
 	}
 
 	@Test


### PR DESCRIPTION
This PR implements subtree search support for containers other than the root container (`0`). It may resolve the issue reported in #5994.

Additionally, this PR includes performance improvements for case-insensitive searches.