### PR TITLE
Fix: Save button disappears instead of showing loading state in Shared Content settings

### DIFF
--- a/react-client/src/components/SharedContent/SharedContent.tsx
+++ b/react-client/src/components/SharedContent/SharedContent.tsx
@@ -131,7 +131,7 @@ export default function SharedContent({ i18n, session }: { i18n: I18nInterface, 
           {sharedContents && configuration && (
             <SharedContentSettings i18n={i18n} canModify={canModify} scan={session.mediaScan} sharedContents={sharedContents} setSharedContents={setSharedContents} configuration={configuration} />
           )}
-          {canModify && modified && (
+          {canModify && (modified || isLoading) &&(   
             <Box h={50}>
               <Affix withinPortal={false} position={{ bottom: 20, right: 20 }}>
                 <Button


### PR DESCRIPTION

Fixes #6037

The Save button in the Shared Content area was disappearing when clicked 
because the button visibility was tied only to the `modified` state. 
When save is triggered, `modified` becomes false before the loading 
completes, causing the button to vanish.

The fix adds `isLoading` to the visibility condition so the button 
stays visible with a loading spinner while the save operation is in progress.

Changed:
{canModify && modified && (
to:
{canModify && (modified || isLoading) && (

Note: Unable to run the full Java backend locally for testing, 
but the UI logic has been verified.