### PR TITLE
Changed the directory enable/disable button to a switch

### DIFF
--- a/react-client/src/components/SharedContent/SharedContentItemMenu.tsx
+++ b/react-client/src/components/SharedContent/SharedContentItemMenu.tsx
@@ -14,7 +14,7 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-import { ActionIcon, Group, Menu } from '@mantine/core'
+import { ActionIcon, Group, Menu, Switch } from '@mantine/core'
 import { IconEdit, IconMenu2, IconShare, IconShareOff, IconSquareX } from '@tabler/icons-react'
 import _ from 'lodash'
 
@@ -59,18 +59,14 @@ export default function SharedContentItemMenu({
 
   return (
     <Group justify="flex-end">
-      <ActionIcon
-        variant="subtle"
-        size={30}
-        color={value.active ? 'blue' : 'orange'}
+      <Switch
+        className="shared-content-switch"
+        color="blue"
         disabled={!canModify}
-        visibleFrom="sm"
-        onClick={() => toogleSharedContentItemActive(value)}
+        checked={value.active}
+        onChange={() => toogleSharedContentItemActive(value)}
       >
-        {value.active
-          ? <IconShare size={16} />
-          : <IconShareOff size={16} />}
-      </ActionIcon>
+      </Switch>
       <Menu zIndex={5000}>
         <Menu.Target>
           <ActionIcon variant="default" size={30}>

--- a/react-client/src/index.css
+++ b/react-client/src/index.css
@@ -123,3 +123,6 @@ nav button .mantine-Button-inner:hover {
   bottom: 20px;
   right: 20px;
 }
+[data-mantine-color-scheme="dark"] .shared-content-switch .mantine-Switch-input:disabled ~ .mantine-Switch-track  {
+  background-color: var(--mantine-color-dimmed);
+}


### PR DESCRIPTION
Fixes #5829 

### Changes

Converts the enable/disable button to a switch as detailed in the issue.
Changes track colour when in dark mode and the switch is disabled to ensure it doesn't blend with the background
