### PR TITLE
Fix wrong Linux yt-dlp binary being packaged (#6011)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1443,7 +1443,7 @@
 
 										<!-- Download binaries -->
 										<get src="${project.binaries-base}/linux/arm64/ffmpeg/ffmpeg" dest="${project.binaries}/linux/arm64/ffmpeg/ffmpeg" usetimestamp="true" />
-										<get src="https://github.com/yt-dlp/yt-dlp/releases/download/2026.02.04/yt-dlp_linux_aarch64" dest="${project.binaries}/linux/youtube-dl" usetimestamp="true" />
+										<get src="https://github.com/yt-dlp/yt-dlp/releases/download/2026.02.04/yt-dlp_linux_aarch64" dest="${project.binaries}/linux/arm64/youtube-dl" usetimestamp="true" />
 									</target>
 								</configuration>
 							</execution>
@@ -1581,7 +1581,7 @@
 
 										<!-- Download binaries -->
 										<get src="${project.binaries-base}/linux/armel/ffmpeg/ffmpeg" dest="${project.binaries}/linux/armel/ffmpeg/ffmpeg" usetimestamp="true" />
-										<get src="https://github.com/yt-dlp/yt-dlp/releases/download/2026.02.04/yt-dlp" dest="${project.binaries}/linux/youtube-dl" usetimestamp="true" />
+										<get src="https://github.com/yt-dlp/yt-dlp/releases/download/2026.02.04/yt-dlp" dest="${project.binaries}/linux/armel/youtube-dl" usetimestamp="true" />
 									</target>
 								</configuration>
 							</execution>
@@ -1859,7 +1859,7 @@
 										<get src="${project.binaries-base}/linux/x86/ffmpeg/ffmpeg" dest="${project.binaries}/linux/x86/ffmpeg/ffmpeg" usetimestamp="true" />
 										<get src="${project.binaries-base}/linux/x86/tsMuxeR" dest="${project.binaries}/linux/x86/tsMuxeR" usetimestamp="true" />
 										<get src="${project.binaries-base}/linux/x86/tsMuxeR_licence.txt" dest="${project.binaries}/linux/x86/tsMuxeR_license.txt" usetimestamp="true" />
-										<get src="https://github.com/yt-dlp/yt-dlp/releases/download/2026.02.04/yt-dlp" dest="${project.binaries}/linux/youtube-dl" usetimestamp="true" />
+										<get src="https://github.com/yt-dlp/yt-dlp/releases/download/2026.02.04/yt-dlp" dest="${project.binaries}/linux/x86/youtube-dl" usetimestamp="true" />
 										<get src="https://github.com/bell-sw/Liberica/releases/download/17.0.18%2B10/bellsoft-jre17.0.18+10-linux-i586.tar.gz" dest="${project.binaries}/linux/x86/jre${project.jre-version}.tar.gz" usetimestamp="true" />
 										<untar src="${project.binaries}/linux/x86/jre${project.jre-version}.tar.gz" dest="${project.binaries}/linux/x86/jre${project.jre-version}" compression="gzip">
 											<cutdirsmapper dirs="1" />
@@ -2004,7 +2004,7 @@
 										<get src="${project.binaries-base}/linux/x86_64/ffmpeg/ffmpeg" dest="${project.binaries}/linux/x86_64/ffmpeg/ffmpeg" usetimestamp="true" />
 										<get src="${project.binaries-base}/linux/x86_64/tsMuxeR" dest="${project.binaries}/linux/x86_64/tsMuxeR" usetimestamp="true" />
 										<get src="${project.binaries-base}/linux/x86_64/tsMuxeR_licence.txt" dest="${project.binaries}/linux/x86_64/tsMuxeR_license.txt" usetimestamp="true" />
-										<get src="https://github.com/yt-dlp/yt-dlp/releases/download/2026.02.04/yt-dlp_linux" dest="${project.binaries}/linux/youtube-dl" usetimestamp="true" />
+										<get src="https://github.com/yt-dlp/yt-dlp/releases/download/2026.02.04/yt-dlp_linux" dest="${project.binaries}/linux/x86_64/youtube-dl" usetimestamp="true" />
 										<get src="https://github.com/bell-sw/Liberica/releases/download/17.0.18%2B10/bellsoft-jre17.0.18+10-linux-amd64.tar.gz" dest="${project.binaries}/linux/x86_64/jre${project.jre-version}.tar.gz" usetimestamp="true" />
 										<untar src="${project.binaries}/linux/x86_64/jre${project.jre-version}.tar.gz" dest="${project.binaries}/linux/x86_64/jre${project.jre-version}" compression="gzip">
 											<cutdirsmapper dirs="1" />

--- a/src/main/assembly/assembly-linux-arm64.xml
+++ b/src/main/assembly/assembly-linux-arm64.xml
@@ -41,7 +41,7 @@
 
 		<!-- Include the youtube-dl binary -->
 		<file>
-			<source>${project.binaries}/linux/youtube-dl</source>
+			<source>${project.binaries}/linux/arm64/youtube-dl</source>
 			<outputDirectory>./linux</outputDirectory>
 			<fileMode>0755</fileMode>
 			<lineEnding>keep</lineEnding>

--- a/src/main/assembly/assembly-linux-armel.xml
+++ b/src/main/assembly/assembly-linux-armel.xml
@@ -41,7 +41,7 @@
 
 		<!-- Include the youtube-dl binary -->
 		<file>
-			<source>${project.binaries}/linux/youtube-dl</source>
+			<source>${project.binaries}/linux/armel/youtube-dl</source>
 			<outputDirectory>./linux</outputDirectory>
 			<fileMode>0755</fileMode>
 			<lineEnding>keep</lineEnding>

--- a/src/main/assembly/assembly-linux-x86.xml
+++ b/src/main/assembly/assembly-linux-x86.xml
@@ -49,7 +49,7 @@
 
 		<!-- Include the youtube-dl binary -->
 		<file>
-			<source>${project.binaries}/linux/youtube-dl</source>
+			<source>${project.binaries}/linux/x86/youtube-dl</source>
 			<outputDirectory>./linux</outputDirectory>
 			<fileMode>0755</fileMode>
 			<lineEnding>keep</lineEnding>

--- a/src/main/assembly/assembly-linux-x86_64.xml
+++ b/src/main/assembly/assembly-linux-x86_64.xml
@@ -49,7 +49,7 @@
 
 		<!-- Include the youtube-dl binary -->
 		<file>
-			<source>${project.binaries}/linux/youtube-dl</source>
+			<source>${project.binaries}/linux/x86_64/youtube-dl</source>
 			<outputDirectory>./linux</outputDirectory>
 			<fileMode>0755</fileMode>
 			<lineEnding>keep</lineEnding>


### PR DESCRIPTION
# Description of code changes

...

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
