### PR TITLE
fix: use JRE instead of JDK in Docker image

### DIFF
--- a/src/main/external-resources/docker/Dockerfile
+++ b/src/main/external-resources/docker/Dockerfile
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.title="Universal Media Server"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install coreutils ffmpeg mediainfo openjdk-17-jdk-headless iputils-ping mplayer fonts-dejavu -y
+RUN apt-get install coreutils ffmpeg mediainfo openjdk-17-jre-headless iputils-ping mplayer fonts-dejavu -y
 
 WORKDIR /profile
 


### PR DESCRIPTION
Swaps JDK for JRE in the Ubuntu Docker image.

## Why this matters

The server doesn't compile Java. It just runs it. JDK adds ~200MB for tools nobody uses in production. The Alpine Dockerfile already uses JRE.

## Changes

- **docker/Dockerfile**: Changed `openjdk-17-jdk-headless` to `openjdk-17-jre-headless`

## Testing

Built locally. Container starts and serves media.

Fixes #6044

This contribution was developed with AI assistance (Claude Code).