### PR TITLE
Docs: Fix and clarify ffmpeg_gpu_decoding_acceleration_method default and usage

### DIFF
--- a/src/main/external-resources/UMS.conf
+++ b/src/main/external-resources/UMS.conf
@@ -914,15 +914,22 @@ ffmpeg_sox =
 
 # GPU decoding acceleration method
 # -----------------------
-# Recommendation is "auto" because other methods don't fallback to software
-# decoding when errors appear.
-# Also accepts custom options, e.g.
+# Controls the hardware acceleration method used for video decoding.
+#
+# Default: none
+# Possible values: none, auto, vaapi, cuda, dxva2, videotoolbox (platform dependent)
+#
+# Note:
+# - "none" disables GPU decoding (safe default)
+# - "auto" enables automatic GPU acceleration with fallback to software decoding
+# - Only used when gpu_acceleration=true
+#
+# Advanced:
+# Custom FFmpeg options are also supported, e.g.
 # -hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format vaapi
-# for not only GPU decoding but also GPU encoding.
-# -init_hw_device vaapi=amd:/dev/dri/renderD129 -hwaccel vaapi -hwaccel vaapi -hwaccel_device amd
-# for using a AMD device when a PC has Intel and AMD GPUs.
-# See https://trac.ffmpeg.org/wiki/HWAccelIntro.
-# Default: "auto"
+# -init_hw_device vaapi=amd:/dev/dri/renderD129 -hwaccel vaapi -hwaccel_device amd
+#
+# See https://trac.ffmpeg.org/wiki/HWAccelIntro
 ffmpeg_gpu_decoding_acceleration_method =
 
 # GPU decoding thread count


### PR DESCRIPTION
Fixes #5682

There was previous confusion about whether the default for
ffmpeg_gpu_decoding_acceleration_method should be "auto" or "none".

After checking the code in UmsConfiguration.java:

getString(KEY_FFMPEG_GPU_DECODING_ACCELERATION_METHOD, "none")

The default is explicitly set to "none".

This appears intentional:
- GPU decoding is disabled by default (safe fallback)
- Similar to encoding default "libx264"
- Avoids GPU-related issues on unsupported systems

Changes in this PR:
- Update documentation to reflect correct default ("none")
- Clarify behavior and interaction with gpu_acceleration
- List possible values
- Improve formatting and readability

This PR does not change behavior, only documentation.

Supersedes #5938