### PR TITLE
Disable YouTube tests (Fixes #6124)

### DIFF
--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -204,7 +204,7 @@ jobs:
         with:
           distribution: 'liberica'
           java-version: 17
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/react-client/tests/SharedContent.spec.ts
+++ b/react-client/tests/SharedContent.spec.ts
@@ -8,31 +8,31 @@ test('should be able to navigate to Shared Content', async ({ page }) => {
   await expect(page).toHaveURL(/.*shared/)
 })
 
-test('should be able to add a YouTube channel as a video feed', async ({ page }) => {
-  await page.goto('/shared')
+// test('should be able to add a YouTube channel as a video feed', async ({ page }) => {
+//   await page.goto('/shared')
 
-  await page.getByText('Add new shared content').click()
+//   await page.getByText('Add new shared content').click()
 
-  await page.getByLabel('Type').first().click()
+//   await page.getByLabel('Type').first().click()
 
-  await page.getByRole('option', { name: 'Video feed' }).locator('span').click()
+//   await page.getByRole('option', { name: 'Video feed' }).locator('span').click()
 
-  await page.getByLabel('Source/URL').fill('https://www.youtube.com/@kurzgesagt')
+//   await page.getByLabel('Source/URL').fill('https://www.youtube.com/@kurzgesagt')
 
-  await page.getByText('Add', { exact: true }).click()
+//   await page.getByText('Add', { exact: true }).click()
 
-  await expect(page.getByText('Kurzgesagt – In a Nutshell')).toBeVisible()
+//   await expect(page.getByText('Kurzgesagt – In a Nutshell')).toBeVisible()
 
-  await page.getByText('Save').click()
-})
+//   await page.getByText('Save').click()
+// })
 
-test('should be able to select a YouTube video to watch', async ({ page }) => {
-  await page.goto('/player')
+// test('should be able to select a YouTube video to watch', async ({ page }) => {
+//   await page.goto('/player')
 
-  await page.getByText('Kurzgesagt – In a Nutshell').click()
-  // will update this part of test once fix has been made
-  await page.locator('.thumbnail-container').first().click()
-  await page.getByText('Play', { exact: true }).click()
-  await page.screenshot({ path: 'screenshot.png' })
-  // await expect(page.getByTitle('Play Video')).toBeVisible()
-})
+//   await page.getByText('Kurzgesagt – In a Nutshell').click()
+//   // will update this part of test once fix has been made
+//   await page.locator('.thumbnail-container').first().click()
+//   await page.getByText('Play', { exact: true }).click()
+//   await page.screenshot({ path: 'screenshot.png' })
+//   // await expect(page.getByTitle('Play Video')).toBeVisible()
+// })


### PR DESCRIPTION
YouTube itself has significant daily downtimes on their RSS feeds which is how this feature works, so until we figure out another way to support YouTube, it's too flaky to test for

# Description of code changes

...

# Checklist
- [ ] Any relevant issues are [referenced](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
- [ ] Any relevant [Knowledge Base](https://github.com/UniversalMediaServer/knowledge-base) articles are written/modified
- [ ] Any relevant tests have been written/modified
