### PR TITLE
Fix NumberFormatException when episode number contains non-numeric characters

### DIFF
--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/StoreResourceHelper.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/result/StoreResourceHelper.java
@@ -345,8 +345,9 @@ public class StoreResourceHelper {
 				if (videoMetadata.getTvSeason() != null) {
 					movie.setEpisodeSeason(UnsignedInteger.valueOf(videoMetadata.getTvSeason()));
 				}
-				if (StringUtils.isNotBlank(videoMetadata.getTvEpisodeNumber())) {
-					movie.setEpisodeNumber(UnsignedInteger.valueOf(videoMetadata.getTvEpisodeNumber()));
+				Integer episodeNumber = videoMetadata.getFirstTvEpisodeNumber();
+				if (episodeNumber != null) {
+					movie.setEpisodeNumber(UnsignedInteger.valueOf(episodeNumber));
 				}
 				if (StringUtils.isNotBlank(videoMetadata.getTvSeriesTitle())) {
 					movie.setSeriesTitle(videoMetadata.getTvSeriesTitle());


### PR DESCRIPTION
## Summary

Fixes #6065

- Filenames like `S01E02a` caused a `NumberFormatException` crash in `StoreResourceHelper.getItem()` because `getTvEpisodeNumber()` returns a raw string that may not be a valid integer
- Replaced the direct `UnsignedInteger.valueOf(getTvEpisodeNumber())` call with `getFirstTvEpisodeNumber()`, which already exists on `MediaVideoMetadata` and handles non-numeric suffixes gracefully via a try/catch
- For filenames like `S01E02a`, the DLNA client simply won't receive an episode number rather than the entire content directory request failing

## Test plan

- [ ] Place a video file named with a non-integer episode suffix (e.g. `ShowName.S01E02a.mkv`) in a shared folder
- [ ] Browse the folder from a DLNA client — verify no `NumberFormatException` appears in the log and the file is listed correctly
- [ ] Verify normal episode files (e.g. `S01E02`) still expose the correct episode number to the DLNA client

🤖 Generated with [Claude Code](https://claude.com/claude-code)