### PR TITLE
Support flexible 3-box UPnP setups when the authentication service is disabled

### DIFF
--- a/src/main/java/net/pms/iam/AuthService.java
+++ b/src/main/java/net/pms/iam/AuthService.java
@@ -196,7 +196,15 @@ public class AuthService {
 	}
 
 	public static void setEnabled(boolean value) {
+		boolean changed = CONFIGURATION.isAuthenticationEnabled() != value;
 		CONFIGURATION.setAuthenticationEnabled(value);
+		if (changed && PMS.isReady()) {
+			// Renderer identification and the CDS object tree depend on whether authentication is
+			// enabled (UUID-bound per-account renderer vs. the neutral control-point renderer with
+			// just-in-time identification). Rebuild the renderers' media stores so the change takes
+			// effect without requiring a restart.
+			PMS.get().resetRenderersMediaStore();
+		}
 	}
 
 	public static boolean isLocalhostAsAdmin() {

--- a/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
+++ b/src/main/java/net/pms/network/mediaserver/jupnp/support/contentdirectory/UmsContentDirectoryService.java
@@ -50,6 +50,7 @@ import org.jupnp.support.model.SortCriterion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
+import net.pms.PMS;
 import net.pms.dlna.DidlHelper;
 import net.pms.network.mediaserver.handlers.BaseSearchRequestHandler;
 import net.pms.network.mediaserver.handlers.DbSearchRequestHandler;
@@ -64,6 +65,7 @@ import net.pms.network.mediaserver.jupnp.support.contentdirectory.result.namespa
 import net.pms.network.mediaserver.jupnp.support.contentdirectory.updateobject.IUpdateObjectHandler;
 import net.pms.network.mediaserver.jupnp.support.contentdirectory.updateobject.UpdateObjectFactory;
 import net.pms.renderers.Renderer;
+import net.pms.renderers.devices.ControlPoint;
 import net.pms.store.MediaScanner;
 import net.pms.store.MediaStatusStore;
 import net.pms.store.MediaStoreIds;
@@ -356,6 +358,42 @@ public class UmsContentDirectoryService {
 		}
 	}
 
+	/**
+	 * Resolves the renderer used to access the CDS object tree.
+	 * <p>
+	 * When authentication is enabled, the renderer is identified from the (browsing) control
+	 * point request and its account/allow-list is enforced: returns NULL if the
+	 * renderer is unknown or not allowed.
+	 * <p>
+	 * When authentication is disabled we support the flexible 3-box UPnP setup: renderers do not
+	 * browse the CDS, control points do. The object tree is (currently) held by a single neutral
+	 * "control point" renderer, so we return that. The real playback renderer is identified
+	 * just-in-time when the resource itself is requested (see MediaServerServlet).
+	 *
+	 * @param remoteClientInfo the client info of the browsing request
+	 * @return the renderer to use, or "null}" when authentication is enabled and the renderer is unrecognized or not allowed
+	 */
+	private static Renderer getBrowseRenderer(RemoteClientInfo remoteClientInfo) {
+		if (!PMS.getConfiguration().isAuthenticationEnabled()) {
+			return ControlPoint.getRenderer();
+		}
+		UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
+		Renderer renderer = info.renderer;
+		if (renderer == null) {
+			if (LOGGER.isTraceEnabled()) {
+				LOGGER.trace("Unrecognized media renderer");
+			}
+			return null;
+		}
+		if (!renderer.isAllowed()) {
+			if (LOGGER.isTraceEnabled()) {
+				LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
+			}
+			return null;
+		}
+		return renderer;
+	}
+
 	@UpnpAction(out = {
 		@UpnpOutputArgument(name = "Result",
 				stateVariable = "A_ARG_TYPE_Result",
@@ -370,18 +408,8 @@ public class UmsContentDirectoryService {
 			RemoteClientInfo remoteClientInfo
 	) throws ContentDirectoryException {
 		try {
-			UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
-			Renderer renderer = info.renderer;
+			Renderer renderer = getBrowseRenderer(remoteClientInfo);
 			if (renderer == null) {
-				if (LOGGER.isTraceEnabled()) {
-					LOGGER.trace("Unrecognized media renderer");
-				}
-				return null;
-			}
-			if (!renderer.isAllowed()) {
-				if (LOGGER.isTraceEnabled()) {
-					LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
-				}
 				return null;
 			}
 
@@ -522,18 +550,8 @@ public class UmsContentDirectoryService {
 			RemoteClientInfo remoteClientInfo
 	) throws ContentDirectoryException {
 		try {
-			UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
-			Renderer renderer = info.renderer;
+			Renderer renderer = getBrowseRenderer(remoteClientInfo);
 			if (renderer == null) {
-				if (LOGGER.isTraceEnabled()) {
-					LOGGER.trace("Unrecognized media renderer");
-				}
-				return null;
-			}
-			if (!renderer.isAllowed()) {
-				if (LOGGER.isTraceEnabled()) {
-					LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
-				}
 				return null;
 			}
 			//FIXME : this is disabled by default as user should explicitly allow file modification/creation.
@@ -583,18 +601,8 @@ public class UmsContentDirectoryService {
 		RemoteClientInfo remoteClientInfo
 		) throws ContentDirectoryException {
 		try {
-			UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
-			Renderer renderer = info.renderer;
+			Renderer renderer = getBrowseRenderer(remoteClientInfo);
 			if (renderer == null) {
-				if (LOGGER.isTraceEnabled()) {
-					LOGGER.trace("Unrecognized media renderer");
-				}
-				return;
-			}
-			if (!renderer.isAllowed()) {
-				if (LOGGER.isTraceEnabled()) {
-					LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
-				}
 				return;
 			}
 			//FIXME : this is disabled by default as user should explicitly allow file modification/creation.
@@ -640,19 +648,24 @@ public class UmsContentDirectoryService {
 			RemoteClientInfo remoteClientInfo
 	) throws ContentDirectoryException {
 		try {
-			UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
-			Renderer renderer = info.renderer;
-			if (renderer == null) {
-				if (LOGGER.isTraceEnabled()) {
-					LOGGER.trace("Unrecognized media renderer");
+			Renderer renderer;
+			if (!PMS.getConfiguration().isAuthenticationEnabled()) {
+				renderer = ControlPoint.getRenderer();
+			} else {
+				UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
+				renderer = info.renderer;
+				if (renderer == null) {
+					if (LOGGER.isTraceEnabled()) {
+						LOGGER.trace("Unrecognized media renderer");
+					}
+					throw new ContentDirectoryException(714, "No such resource");
 				}
-				throw new ContentDirectoryException(714, "No such resource");
-			}
-			if (!renderer.isAllowed()) {
-				if (LOGGER.isTraceEnabled()) {
-					LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
+				if (!renderer.isAllowed()) {
+					if (LOGGER.isTraceEnabled()) {
+						LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
+					}
+					throw new ContentDirectoryException(715, "Source resource access denied");
 				}
-				throw new ContentDirectoryException(715, "Source resource access denied");
 			}
 			//FIXME : this is disabled by default as user should explicitly allow file modification/creation.
 			if (!renderer.getUmsConfiguration().isUpnpCdsWrite()) {
@@ -741,18 +754,8 @@ public class UmsContentDirectoryService {
 			SortCriterion[] sortCriteria,
 			RemoteClientInfo remoteClientInfo
 	) throws ContentDirectoryException {
-		UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
-		Renderer renderer = info.renderer;
+		Renderer renderer = getBrowseRenderer(remoteClientInfo);
 		if (renderer == null) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Unrecognized media renderer");
-			}
-			return null;
-		}
-		if (!renderer.isAllowed()) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
-			}
 			return null;
 		}
 
@@ -860,18 +863,8 @@ public class UmsContentDirectoryService {
 			SearchRequest searchRequest,
 			RemoteClientInfo remoteClientInfo
 	) throws ContentDirectoryException {
-		UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
-		Renderer renderer = info.renderer;
+		Renderer renderer = getBrowseRenderer(remoteClientInfo);
 		if (renderer == null) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Unrecognized media renderer");
-			}
-			return null;
-		}
-		if (!renderer.isAllowed()) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
-			}
 			return null;
 		}
 
@@ -1107,18 +1100,8 @@ public class UmsContentDirectoryService {
 			String rId,
 			RemoteClientInfo remoteClientInfo
 	) throws ContentDirectoryException {
-		UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
-		Renderer renderer = info.renderer;
+		Renderer renderer = getBrowseRenderer(remoteClientInfo);
 		if (renderer == null) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Unrecognized media renderer");
-			}
-			return null;
-		}
-		if (!renderer.isAllowed()) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
-			}
 			return null;
 		}
 
@@ -1143,18 +1126,8 @@ public class UmsContentDirectoryService {
 	private static String samsungGetFeaturesList(
 			RemoteClientInfo remoteClientInfo
 	) throws ContentDirectoryException {
-		UmsRemoteClientInfo info = new UmsRemoteClientInfo(remoteClientInfo);
-		Renderer renderer = info.renderer;
+		Renderer renderer = getBrowseRenderer(remoteClientInfo);
 		if (renderer == null) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Unrecognized media renderer");
-			}
-			return null;
-		}
-		if (!renderer.isAllowed()) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
-			}
 			return null;
 		}
 

--- a/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
+++ b/src/main/java/net/pms/network/mediaserver/servlets/MediaServerServlet.java
@@ -28,10 +28,12 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
+import net.pms.configuration.RendererConfigurations;
 import net.pms.dlna.DLNAImageInputStream;
 import net.pms.dlna.DLNAImageProfile;
 import net.pms.dlna.DLNAThumbnailInputStream;
@@ -62,6 +64,7 @@ import net.pms.store.StoreResource;
 import net.pms.util.ByteRange;
 import net.pms.util.FullyPlayed;
 import net.pms.util.Range;
+import net.pms.util.SortedHeaderMap;
 import net.pms.util.StringUtil;
 import net.pms.util.SubtitleUtils;
 import net.pms.util.TimeRange;
@@ -103,43 +106,52 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 				return;
 			}
 
-			//find renderer by uuid
-			renderer = ConnectedRenderers.getUuidRenderer(mediaServerRequest.getUuid());
+			if (CONFIGURATION.isAuthenticationEnabled()) {
+				// Authentication enabled: the renderer is bound to the browse UUID (2-box setup)
+				// and access is filtered per account/renderer.
+				renderer = ConnectedRenderers.getUuidRenderer(mediaServerRequest.getUuid());
 
-			if (renderer == null) {
-				//find renderer by uuid and ip for non registred upnp devices
-				renderer = ConnectedRenderers.getRendererBySocketAddress(getInetAddress(req));
-				if (renderer != null && !mediaServerRequest.getUuid().equals(renderer.getId())) {
-					if (LOGGER.isTraceEnabled()) {
-						LOGGER.trace("Recognized media renderer \"{}\" is not matching UUID \"{}\"", renderer.getRendererName(), mediaServerRequest.getUuid());
+				if (renderer == null) {
+					renderer = ConnectedRenderers.getRendererBySocketAddress(getInetAddress(req));
+					if (renderer != null && !mediaServerRequest.getUuid().equals(renderer.getId())) {
+						if (LOGGER.isTraceEnabled()) {
+							LOGGER.trace("Recognized media renderer \"{}\" is not matching UUID \"{}\"", renderer.getRendererName(), mediaServerRequest.getUuid());
+						}
 					}
-					/**
-					 * here, that mean the originated renderer advised is no more available.
-					 * It may be a caster/proxy control point, so let change to the real renderer.
-					 * fixme : non-renderer should advise a special uuid.
-					 * renderer = null;
-					 */
 				}
-			}
 
-			if (renderer == null) {
-				// If uuid not known, it mean the renderer is not registred
-				if (LOGGER.isTraceEnabled()) {
-					logHttpServletRequest(req, "");
+				if (renderer == null) {
+					// If uuid not known, it mean the renderer is not registred
+					if (LOGGER.isTraceEnabled()) {
+						logHttpServletRequest(req, "");
+					}
+					//Forbidden
+					respondForbidden(req, resp);
+					return;
 				}
-				//Forbidden
-				respondForbidden(req, resp);
-				return;
-			}
 
-			if (!renderer.isAllowed()) {
-				if (LOGGER.isTraceEnabled()) {
-					logHttpServletRequest(req, "", getRendererNameForLogging(req, renderer));
-					LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
+				if (!renderer.isAllowed()) {
+					if (LOGGER.isTraceEnabled()) {
+						logHttpServletRequest(req, "", getRendererNameForLogging(req, renderer));
+						LOGGER.trace("Recognized media renderer \"{}\" is not allowed", renderer.getRendererName());
+					}
+					//Unauthorized
+					respondUnauthorized(req, resp);
+					return;
 				}
-				//Unauthorized
-				respondUnauthorized(req, resp);
-				return;
+			} else {
+				// Authentication disabled: flexible 3-box UPnP setup. The browse UUID in the URL
+				// belongs to the control point, not the playback renderer, so identify the real
+				// renderer just-in-time from the request headers (User-Agent etc.) and IP.
+				// Transcoding is then resolved for that renderer via its own media store.
+				SortedHeaderMap headerMap = getHeaderMapFromRequest(req);
+				renderer = ConnectedRenderers.getRendererConfigurationByHeaders(headerMap, getInetAddress(req));
+				if (renderer == null) {
+					if (LOGGER.isTraceEnabled()) {
+						LOGGER.trace("Renderer not identified by header, using default renderer. Request headers were: {}", headerMap);
+					}
+					renderer = RendererConfigurations.getDefaultRenderer();
+				}
 			}
 
 			if (req.getHeader("X-PANASONIC-DMP-Profile") != null) {
@@ -189,6 +201,14 @@ public class MediaServerServlet extends MediaServerHttpServlet {
 				LOGGER.error("Http request error:", e);
 			}
 		}
+	}
+
+	private SortedHeaderMap getHeaderMapFromRequest(HttpServletRequest req) {
+		SortedHeaderMap headerMap = new SortedHeaderMap();
+		for (String headerField : Collections.list(req.getHeaderNames())) {
+			headerMap.put(headerField, req.getHeader(headerField));
+		}
+		return headerMap;
 	}
 
 	private static void sendResponse(HttpServletRequest req, HttpServletResponse resp, final Renderer renderer, int code, String message, String contentType) throws IOException {

--- a/src/main/java/net/pms/renderers/ConnectedRenderers.java
+++ b/src/main/java/net/pms/renderers/ConnectedRenderers.java
@@ -36,6 +36,7 @@ import net.pms.PMS;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.configuration.RendererConfigurations;
 import net.pms.network.SpeedStats;
+import net.pms.renderers.devices.ControlPoint;
 import net.pms.renderers.devices.WebGuiRenderer;
 import net.pms.store.MediaInfoStore;
 import net.pms.util.SortedHeaderMap;
@@ -354,6 +355,12 @@ public class ConnectedRenderers {
 	public static void resetAllRenderers() {
 		for (Renderer r : getConnectedRenderers()) {
 			r.resetMediaStore();
+		}
+		// The control-point renderer holds the CDS object tree in the non-authenticated (3-box)
+		// mode but is not part of the connected renderers, so reset its media store explicitly.
+		Renderer controlPoint = ControlPoint.getRenderer();
+		if (controlPoint != null) {
+			controlPoint.resetMediaStore();
 		}
 	}
 

--- a/src/main/java/net/pms/renderers/devices/ControlPoint.java
+++ b/src/main/java/net/pms/renderers/devices/ControlPoint.java
@@ -1,0 +1,63 @@
+package net.pms.renderers.devices;
+
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.pms.formats.Format;
+import net.pms.renderers.Renderer;
+import net.pms.store.StoreItem;
+
+public class ControlPoint extends Renderer {
+
+	static private ControlPoint cPoint = null;
+	private static final Logger LOGGER = LoggerFactory.getLogger(ControlPoint.class.getName());
+
+	private ControlPoint() throws ConfigurationException, InterruptedException {
+		super(null, null);
+	}
+
+	static public ControlPoint getRenderer() {
+		return cPoint;
+	}
+
+	@Override
+	public String getUUID() {
+		return "22a40c51-f735-4b62-a376-ab9450fcf1e2";
+	}
+
+	@Override
+	public boolean isActive() {
+		return true;
+	}
+
+	@Override
+	public boolean isControllable() {
+		return true;
+	}
+
+	@Override
+	public boolean isControllable(int type) {
+		return true;
+	}
+
+	@Override
+	public String getRendererName() {
+		return "ControlPoint";
+	}
+
+	/**
+	 * Control points do not play content.
+	 */
+	@Override
+	public boolean isCompatible(StoreItem resource, Format format) {
+		return true;
+	}
+
+	static {
+		try {
+			cPoint = new ControlPoint();
+		} catch (Exception e) {
+			LOGGER.error("ControlPoint", e);
+		}
+	}
+}


### PR DESCRIPTION
### Problem

This is a follow-up to the discussion in [#4886](https://github.com/UniversalMediaServer/UniversalMediaServer/pull/4886). Rather than choosing one model over the other, it **unifies both concepts** behind a single configuration switch: the UUID-based authentication/authorization model stays in place when the authentication service is enabled, and the just-in-time, browsing-agnostic 3-box model takes over when it is disabled.

Renderer authorization currently couples **browsing** and **rendering**: a resource URL embeds the UUID of the renderer that built the CDS tree (`StoreItem.getMediaURL()` → `renderer.getUUID()`), and `MediaServerServlet` looks the renderer up by that UUID when the resource is fetched.

This only holds in a **2-box setup**, where control point and media renderer are the same device (same IP, same UUID). In a classic **3-box UPnP setup** — a control point browsing on behalf of a *separate* renderer — the URL carries the control point's UUID, so the servlet resolves the **wrong renderer** (the control point instead of the actual player). Content and any transcoding decisions are then produced for the wrong device.

The authenticated model deliberately relies on this coupling: it maps the browse UUID to a user account and enforces per-group shared-folder restrictions and the renderer allow-list. Dropping the coupling outright would break that model, which is why this PR gates the two behaviors instead of replacing one with the other.

### Solution

Make the behavior conditional on the existing **authentication service** toggle (`UmsConfiguration.isAuthenticationEnabled()`):

| Authentication service | CDS tree / renderer |
|---|---|
| **enabled** (unchanged) | bound to the browse UUID → account → group-filtered shared folders | 
| **disabled** | one neutral `ControlPoint` renderer holds the tree (group 0 = default shared folders); the **real** renderer is identified just-in-time from request headers (User-Agent) + IP |

When authentication is disabled, the servlet resolves the resource via `renderer.getMediaStore().getResource(id)` against the **just-in-time identified** renderer, so transcoding is automatically decided for the correct device (resource IDs are global across media stores).

### Runtime toggle

Toggling the authentication service at runtime rebuilds all renderer media stores (including the control-point tree), so switching between modes doesn't require a restart.