### PR TITLE
fix: allow folder.jpg as thumbnail for video files

### DIFF
--- a/src/main/java/net/pms/store/item/RealFile.java
+++ b/src/main/java/net/pms/store/item/RealFile.java
@@ -283,7 +283,7 @@ public class RealFile extends StoreItem implements SystemFileResource {
 					break;
 				}
 			}
-			if (cachedThumbnail == null && mediaType == MediaType.AUDIO && getParent() instanceof VirtualFolder virtualFolder) {
+			if (cachedThumbnail == null && (mediaType == MediaType.AUDIO || mediaType == MediaType.VIDEO) && getParent() instanceof VirtualFolder virtualFolder) {
 				cachedThumbnail = virtualFolder.getPotentialCover();
 			}
 		}


### PR DESCRIPTION
## Description

Since v6.7.0, `folder.jpg` in a media folder no longer works as thumbnail cover art for video files. It still works for audio files. This is a regression.

## Root Cause

In `RealFile.getThumbnailInputStream()`, the check for `VirtualFolder.getPotentialCover()` (which finds `folder.jpg/png`) is gated on `mediaType == MediaType.AUDIO` only:

```java
if (cachedThumbnail == null && mediaType == MediaType.AUDIO && getParent() instanceof VirtualFolder virtualFolder) {
```

This means video files never get `folder.jpg` as a thumbnail candidate, even though it worked before v6.7.0.

## Fix

Extended the condition to also allow `MediaType.VIDEO`:

```java
if (cachedThumbnail == null && (mediaType == MediaType.AUDIO || mediaType == MediaType.VIDEO) && getParent() instanceof VirtualFolder virtualFolder) {
```

This restores the pre-v6.7.0 behavior where `folder.jpg` is used as a thumbnail for video files when no per-file sidecar thumbnail exists.

## Thumbnail priority after this fix (for video)

1. `videofilename.jpg/png` (sidecar)
2. `folder.jpg/png` (from parent folder)
3. TMDB poster / generated / embedded (from mediaInfo)
4. Default icon

Fixes #1440
