### PR TITLE
Fix endless rescan loop when a new folder appears

### DIFF
--- a/src/main/java/net/pms/store/DbIdResourceLocator.java
+++ b/src/main/java/net/pms/store/DbIdResourceLocator.java
@@ -73,7 +73,8 @@ public class DbIdResourceLocator {
 					return resource;
 				}
 			}
-			LOGGER.error("{} not found as RealFile in database.", realFileName);
+			//a resource that is not indexed yet is an expected state, not an error
+			LOGGER.debug("{} not found as RealFile in database.", realFileName);
 		}
 		return null;
 	}

--- a/src/main/java/net/pms/store/MediaScanner.java
+++ b/src/main/java/net/pms/store/MediaScanner.java
@@ -309,13 +309,8 @@ public class MediaScanner implements SharedContentListener {
 			} else {
 				LOGGER.debug("Scanning folder \"{}\"", file.getAbsolutePath());
 			}
+
 			List<StoreResource> systemFileResources = RENDERER.getMediaStore().findSystemFileResources(file);
-			if (systemFileResources.isEmpty()) {
-				if (isInSharedFolders(filename)) {
-					internalScanFileOrFolder(filename);
-					systemFileResources = RENDERER.getMediaStore().findSystemFileResources(file);
-				}
-			}
 			if (!systemFileResources.isEmpty()) {
 				//if it is still empty, it mean the tree is no more accessible
 				for (StoreResource storeResource : systemFileResources) {
@@ -325,7 +320,9 @@ public class MediaScanner implements SharedContentListener {
 					}
 				}
 			} else {
-				LOGGER.warn("Given folder was not found in store : " + file.getAbsolutePath());
+				// A folder that is not in the store yet is a normal state during a scan,
+				// not something the user has to act on.
+				LOGGER.debug("Given folder was not found in store : " + file.getAbsolutePath());
 			}
 		} else {
 			LOGGER.warn("Given file or folder doesn't share same base path as this server : " + filename);

--- a/src/main/java/net/pms/store/MediaScanner.java
+++ b/src/main/java/net/pms/store/MediaScanner.java
@@ -25,6 +25,8 @@ import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -68,6 +70,32 @@ public class MediaScanner implements SharedContentListener {
 	private static final Renderer RENDERER = MediaScannerDevice.getRenderer();
 	private static final MediaScanner INSTANCE = new MediaScanner();
 	private static final List<String> FILES_PARSING = Collections.synchronizedList(new ArrayList<>());
+
+	/**
+	 * File events used to spawn one thread per file! Keep a small pool.
+	 */
+	private static final ExecutorService FILE_EVENT_EXECUTOR = Executors.newFixedThreadPool(
+			Math.max(2, Math.min(4, Runtime.getRuntime().availableProcessors())),
+			runnable -> {
+				Thread thread = new Thread(runnable, "MediaScanner File Parser");
+				thread.setPriority(Thread.MIN_PRIORITY);
+				return thread;
+			});
+
+	/**
+	 * Partial scans all wait for SCANNER_LOCK anyway, so running them one after another avoids a pile of parked threads.
+	 */
+	private static final ExecutorService PARTIAL_SCAN_EXECUTOR = Executors.newSingleThreadExecutor(
+			runnable -> {
+				Thread thread = new Thread(runnable, "scanFileOrFolder");
+				thread.setPriority(Thread.MIN_PRIORITY);
+				return thread;
+			});
+
+	/**
+	 * Upper bound for the wait on a file that is still being written.
+	 */
+	private static final int MAX_FILE_SETTLE_WAITS = 120;
 
 	@GuardedBy("DEFAULT_FOLDERS_LOCK")
 	private static List<String> defaultFolders = null;
@@ -239,8 +267,7 @@ public class MediaScanner implements SharedContentListener {
 					scanFileOrFolder(filename);
 				}
 			};
-			Thread scanThread = new Thread(scan, "scanFileOrFolder");
-			scanThread.start();
+			PARTIAL_SCAN_EXECUTOR.execute(scan);
 		}
 	}
 
@@ -363,7 +390,7 @@ public class MediaScanner implements SharedContentListener {
 				}
 			}
 		};
-		new Thread(r, "MediaScanner File Parser - update").start();
+		FILE_EVENT_EXECUTOR.execute(r);
 	}
 
 	private synchronized static final Pattern getFileExtensionAllowlistPattern() {
@@ -435,8 +462,16 @@ public class MediaScanner implements SharedContentListener {
 				//wait 500 ms
 				Thread.sleep(500);
 				//Check if size changed (copying, downloading)
+				int waits = 0;
 				while (file.exists() && (currentSize != file.length() || FileUtil.isLocked(file))) {
 					//loop until file size is not changing anymore and file is unlocked.
+					if (waits++ >= MAX_FILE_SETTLE_WAITS) {
+						LOGGER.debug("Giving up waiting for file {} to be fully written", filename);
+						synchronized (FILES_PARSING) {
+							FILES_PARSING.remove(filename);
+						}
+						return;
+					}
 					LOGGER.trace("Waiting until file {} is fully written", filename);
 					currentSize = file.length();
 					Thread.sleep(500);
@@ -510,7 +545,7 @@ public class MediaScanner implements SharedContentListener {
 				Thread.currentThread().interrupt();
 			}
 		};
-		new Thread(r, "MediaScanner File Parser").start();
+		FILE_EVENT_EXECUTOR.execute(r);
 	}
 
 	private static void addFolderEntry(File directory) {

--- a/src/main/java/net/pms/util/FileWatcher.java
+++ b/src/main/java/net/pms/util/FileWatcher.java
@@ -41,6 +41,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -403,23 +404,40 @@ public class FileWatcher {
 			return (ignoredFolderNames != null) ? ignoredFolderNames : List.of();
 		}
 
+		/**
+		 * Two watches are the same watchpoint when they notify the same listener
+		 * about the same file spec.
+		 */
 		@Override
 		public boolean equals(Object o) {
-			if (o instanceof Watch other) {
-				if (item == null || other.item == null) {
-					return false;
-				}
-				return listener.get() == other.listener.get() &&
-						(fspec != null && fspec.equals(other.fspec)) &&
-						(item == other.item || (item != null && other.item != null && (item.get() == other.item.get() || item.get().equals(other.item.get())))) &&
-						flag == other.flag;
+			if (!(o instanceof Watch other)) {
+				return false;
 			}
-			return false;
+			Listener thisListener = listener.get();
+			Listener otherListener = other.listener.get();
+			if (thisListener == null || thisListener != otherListener) {
+				//a collected listener cannot be matched anymore
+				return false;
+			}
+			if (flag != other.flag || fspec == null || !fspec.equals(other.fspec)) {
+				return false;
+			}
+			if (item == null || other.item == null) {
+				//without an item the listener and the file spec identify the watch
+				return item == other.item;
+			}
+			Object thisItem = item.get();
+			Object otherItem = other.item.get();
+			return thisItem == otherItem || (thisItem != null && thisItem.equals(otherItem));
 		}
 
+		/**
+		 * Only the fields that are always part of the identity are used. The listener is left out because it is held by a WeakReference,
+		 * whose hash is its own identity and therefore differs between two watches that are equal.
+		 */
 		@Override
 		public int hashCode() {
-			return fspec.hashCode() + listener.hashCode();
+			return Objects.hash(fspec, flag);
 		}
 
 		public static boolean isRecursive(Watch w) {
@@ -440,11 +458,14 @@ public class FileWatcher {
 
 		private static final long serialVersionUID = 66052264663459389L;
 
+		/**
+		 * Registering an already watched directory returns the same WatchKey to prevent copies.
+		 */
 		public void put(WatchKey k, Watch w) {
-			if (!containsKey(k)) {
-				put(k, new ArrayList<>());
+			ArrayList<Watch> watches = computeIfAbsent(k, key -> new ArrayList<>());
+			if (!watches.contains(w)) {
+				watches.add(w);
 			}
-			get(k).add(w);
 		}
 
 		public boolean contains(Watch w) {

--- a/src/test/java/net/pms/util/FileWatcherTest.java
+++ b/src/test/java/net/pms/util/FileWatcherTest.java
@@ -1,0 +1,70 @@
+package net.pms.util;
+
+import net.pms.util.FileWatcher.Listener;
+import net.pms.util.FileWatcher.Watch;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+public class FileWatcherTest {
+
+	private static final Listener NOOP = (String filename, String event, Watch watch, boolean isDir) -> {
+		// no-op listener for testing purposes
+	};
+
+	@Test
+	public void testWatchWithoutItemEqualsItself() {
+		Watch watch = new Watch("/media/**", NOOP);
+		assertEquals(watch, watch);
+		assertEquals(watch.hashCode(), watch.hashCode());
+	}
+
+	@Test
+	public void testWatchesWithSameSpecAndListenerAreEqual() {
+		Watch first = new Watch("/media/**", NOOP);
+		Watch second = new Watch("/media/**", NOOP);
+		assertEquals(first, second);
+		assertEquals(first.hashCode(), second.hashCode(), "equal watches must share a hash code");
+	}
+
+	@Test
+	public void testWatchesDifferInFileSpecOrListener() {
+		Watch media = new Watch("/media/**", NOOP);
+		assertNotEquals(media, new Watch("/other/**", NOOP));
+		assertNotEquals(media, new Watch("/media/**", (String f, String e, Watch w, boolean d) -> {
+			//a different listener is a different watchpoint
+		}));
+	}
+
+	/**
+	 * An item makes the watch specific to that object, so two watches carrying different items must stay apart even when spec and listener match.
+	 */
+	@Test
+	public void testWatchesWithDifferentItemsDiffer() {
+		Object first = new Object();
+		Object second = new Object();
+		assertNotEquals(new Watch("/media/**", NOOP, first), new Watch("/media/**", NOOP, second));
+		assertEquals(new Watch("/media/**", NOOP, first), new Watch("/media/**", NOOP, first));
+	}
+
+	/**
+	 * A watch with an item and one without are not the same watchpoint.
+	 */
+	@Test
+	public void testItemAndItemlessWatchDiffer() {
+		assertNotEquals(new Watch("/media/**", NOOP), new Watch("/media/**", NOOP, new Object()));
+	}
+
+	/**
+	 * We rely on equals to drop duplicates, which stops event multiplication.
+	 */
+	@Test
+	public void testEqualWatchIsRecognizedInAList() {
+		java.util.ArrayList<Watch> watches = new java.util.ArrayList<>();
+		watches.add(new Watch("/media/**", NOOP));
+		assertTrue(watches.contains(new Watch("/media/**", NOOP)), "a duplicate watch has to be recognized");
+		assertTrue(watches.remove(new Watch("/media/**", NOOP)), "a watch has to be removable again");
+		assertEquals(0, watches.size());
+	}
+}


### PR DESCRIPTION
I've seen that a new directory (with some content) in a shared folder makes UMS stop answering browse requests, because of an error in duplicate check. Then the scanner logs the same paths for ever.

I also added some test to make usage of FileWatcher.Watch clear for future use.