### PR TITLE
Tests : stable database fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -776,6 +776,16 @@
 					<version>${surefire-version}</version>
 					<configuration>
 						<argLine>-Dfile.encoding=${project.encoding} --add-opens java.base/sun.nio.ch=ALL-UNNAMED</argLine>
+						<!--
+							Mark the whole forked JVM as a test run before any UMS class is loaded.
+						-->
+						<systemPropertyVariables>
+							<ums.running.tests>true</ums.running.tests>
+							<ums.test.db.dir>${project.build.directory}/test-db</ums.test.db.dir>
+						</systemPropertyVariables>
+						<environmentVariables>
+							<RUNNING_TESTS>true</RUNNING_TESTS>
+						</environmentVariables>
 					</configuration>
 				</plugin>
 

--- a/src/main/java/net/pms/PMS.java
+++ b/src/main/java/net/pms/PMS.java
@@ -124,6 +124,12 @@ public class PMS {
 	private static final String TRACE = "trace";
 	private static final String DBLOG = "dblog";
 	private static final String DBTRACE = "dbtrace";
+
+	/**
+	 * System property that marks the current JVM as a test run.
+	 */
+	public static final String PROPERTY_RUNNING_TESTS = "ums.running.tests";
+
 	/**
 	 * The logger used for all logging.
 	 */
@@ -1396,15 +1402,16 @@ public class PMS {
 	/**
 	 * @return whether UMS is being run by Surefire, Playwright, or a CI
 	 * environment like GitHub Actions.
+	 *
+	 * Tests that are not started by Surefire (for example when run from an IDE)
+	 * can announce themselves by setting the {@link #PROPERTY_RUNNING_TESTS}
+	 * system property before any UMS class is loaded.
 	 */
 	public static boolean isRunningTests() {
-		return System.getProperty("surefire.real.class.path") != null || (
-			System.getenv("CI") != null &&
-			System.getenv("CI").equals("true")
-		) || (
-			System.getenv("RUNNING_TESTS") != null &&
-			System.getenv("RUNNING_TESTS").equals("true")
-		);
+		return System.getProperty("surefire.real.class.path") != null ||
+			"true".equalsIgnoreCase(System.getProperty(PROPERTY_RUNNING_TESTS)) ||
+			"true".equalsIgnoreCase(System.getenv("CI")) ||
+			"true".equalsIgnoreCase(System.getenv("RUNNING_TESTS"));
 	}
 
 	/**

--- a/src/main/java/net/pms/database/DatabaseEmbedded.java
+++ b/src/main/java/net/pms/database/DatabaseEmbedded.java
@@ -26,6 +26,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 import net.pms.PMS;
 import net.pms.configuration.UmsConfiguration;
 import net.pms.gui.GuiManager;
@@ -40,9 +41,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DatabaseEmbedded {
+	/**
+	 * System property to override the directory holding the databases while running tests.
+	 */
+	public static final String PROPERTY_TEST_DB_DIR = "ums.test.db.dir";
+
+	private static final String DEFAULT_TEST_DB_DIR = "target" + File.separator + "test-db";
 	private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseEmbedded.class);
 	private static final UmsConfiguration CONFIGURATION = PMS.getConfiguration();
 	private static final Profiler PROFILER = new Profiler();
+	private static final AtomicBoolean TEST_DB_DIR_CLEANED = new AtomicBoolean();
 	private static boolean collecting = false;
 
 	/**
@@ -92,8 +100,35 @@ public class DatabaseEmbedded {
 	}
 
 	private static String getDbDir() {
+		if (PMS.isRunningTests()) {
+			return getTestDbDir();
+		}
 		File profileDirectory = new File(UmsConfiguration.getProfileDirectory());
-		return new File(PMS.isRunningTests() || profileDirectory.isDirectory() ? UmsConfiguration.getProfileDirectory() : null, "database").getAbsolutePath();
+		return new File(profileDirectory.isDirectory() ? UmsConfiguration.getProfileDirectory() : null, "database").getAbsolutePath();
+	}
+
+	/**
+	 * Returns the database directory used while running tests.
+	 *
+	 * The location is deliberately not derived from the profile directory: the
+	 * profile directory name is frozen when {@link UmsConfiguration} is class
+	 * loaded, so it depends on whether {@link PMS#isRunningTests()} was already
+	 * true at that moment. Resolving the test location here instead keeps tests
+	 * off the production database regardless of class loading order.
+	 *
+	 * The directory is emptied once per JVM so that every test run starts with
+	 * an empty database instead of inheriting the state - and the accumulated
+	 * H2 MVStore layout - of previous runs.
+	 *
+	 * @return The absolute path of the test database directory
+	 */
+	private static String getTestDbDir() {
+		File testDbDir = new File(System.getProperty(PROPERTY_TEST_DB_DIR, DEFAULT_TEST_DB_DIR)).getAbsoluteFile();
+		if (TEST_DB_DIR_CLEANED.compareAndSet(false, true) && testDbDir.exists()) {
+			LOGGER.info("Deleting test database directory \"{}\" to start this test run with an empty database", testDbDir);
+			FileUtils.deleteQuietly(testDbDir);
+		}
+		return testDbDir.getPath();
 	}
 
 	public static String getDbUser() {

--- a/src/test/java/net/pms/network/mediaserver/handlers/SearchRequestDatabaseTest.java
+++ b/src/test/java/net/pms/network/mediaserver/handlers/SearchRequestDatabaseTest.java
@@ -106,7 +106,7 @@ public class SearchRequestDatabaseTest {
 
 	@BeforeAll
 	public void setupTestDatabase() throws Exception {
-		System.setProperty("surefire.real.class.path", "/tmp");
+		System.setProperty(PMS.PROPERTY_RUNNING_TESTS, "true");
 
 		testMusicFolder = Files.createTempDirectory("music");
 		testMusicFolder.toFile().deleteOnExit();

--- a/src/test/java/net/pms/store/container/PlaylistFolderTest.java
+++ b/src/test/java/net/pms/store/container/PlaylistFolderTest.java
@@ -22,7 +22,7 @@ public class PlaylistFolderTest {
 
 	@BeforeAll
 	static void initTest() throws Exception {
-		System.setProperty("surefire.real.class.path", "/tmp");
+		System.setProperty(PMS.PROPERTY_RUNNING_TESTS, "true");
 
 		PMS.get();
 		PMS.setConfiguration(new UmsConfiguration(false));


### PR DESCRIPTION
Fixes a situation, where test database and production database are being mixed while running tests. DB is now held in `target` directory. `mvn clean` therefore removes the old DB, beginning with a clean one. This should fix #6270 .