### PR TITLE
ci: mark stale issues automatically

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,30 @@
+name: Mark stale issues
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v11
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          stale-issue-label: 'stale'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has had no
+            activity for 90 days. It will be closed in 30 days if no further activity
+            occurs. Thank you for your contributions.
+          close-issue-message: >
+            This issue has been automatically closed after 30 days of inactivity
+            following the stale warning.
+          exempt-issue-labels: 'bug:confirmed,high priority,regression'
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          operations-per-run: 100


### PR DESCRIPTION
## Summary
Adds `actions/stale` for issues only (PRs are explicitly untouched — `days-before-pr-stale: -1` — that's a separate concern per the project's own scoped-PR convention).

- 90 days of inactivity → labelled `stale`
- 30 more days → auto-closed
- Exempts `bug:confirmed`, `high priority`, `regression` so real, triaged bugs never get swept up regardless of how old they are

Native GitHub tooling only, no third-party/AI moderation — this repo already has 387 open issues and a single maintainer doing nearly all the triage; automatic staleness handling is standard practice for reducing that load without any judgement calls being made by a bot.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Version pinned to `actions/stale@v11` (latest major), matching this repo's existing pinning convention (`actions/cache@v6`, `actions/upload-artifact@v7`)
- [ ] Not dry-run against live issues — a cron/schedule-triggered workflow can't be meaningfully tested locally, and I didn't want to `workflow_dispatch` it against real open issues without your say-so first. Happy to do that, or leave the first real run to the scheduled cron, whichever you'd prefer.

Note: the `stale` label doesn't exist yet in the repo's label list — `actions/stale` should create it automatically on first run, but I haven't verified that against this specific version, so flagging it rather than asserting it.