### PR TITLE
ci: fix conflict-labeling workflow so push events actually check all PRs

### DIFF
--- a/.github/workflows/pull-request-conflict.yaml
+++ b/.github/workflows/pull-request-conflict.yaml
@@ -18,11 +18,24 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - name: check if prs are dirty
-      if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    - name: check if dependabot PR is dirty
+      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]' }}
       uses: eps1lon/actions-label-merge-conflict@v3
-      id: check
       with:
         dirtyLabel: "conflicting"
         repoToken: "${{ secrets.AUTOMATION_TOKEN }}"
         commentOnDirty: '@dependabot recreate'
+
+    # The `if` above only ever matches a dependabot PR being synchronized, so a plain `push` to
+    # the base branch (which doesn't have a `pull_request` context at all) never reached this
+    # step for anyone -- bot or human. This second step covers that path: on `push`, the action
+    # checks every open PR against the base branch directly (it doesn't use
+    # `github.event.pull_request`), so this is what actually surfaces conflicts for human PRs
+    # like #6025 and #4727.
+    - name: check if any open PRs are dirty
+      if: ${{ github.event_name == 'push' }}
+      uses: eps1lon/actions-label-merge-conflict@v3
+      with:
+        dirtyLabel: "conflicting"
+        repoToken: "${{ secrets.AUTOMATION_TOKEN }}"
+        commentOnDirty: "This pull request now has a merge conflict with the base branch. Please rebase or merge the latest changes to resolve it."


### PR DESCRIPTION
The `Label conflicted PRs` workflow (`pull-request-conflict.yaml`) is triggered by both `push` and `pull_request_target: synchronize`, but its single step's condition (`github.event.pull_request.user.login == 'dependabot[bot]'`) only ever matches on `pull_request_target` — that context doesn't exist on a plain `push` event. So the `push` trigger, which the workflow's own comment says exists "so that PRs touching the same files as the push are updated," has never actually run for anyone, bot or human.

[`eps1lon/actions-label-merge-conflict`](https://github.com/eps1lon/actions-label-merge-conflict) doesn't use `github.event.pull_request` when triggered by `push` — it checks every open PR against the base branch directly. So this is the reason PRs like #6025 and #4727 (both genuinely conflicting right now, confirmed via the API) never got auto-labeled.

Split into two steps:
- Dependabot-PR-synchronized check: unchanged behaviour, still gated to `pull_request_target` + dependabot only.
- All-open-PRs check: runs on `push`, with a plain human-readable comment instead of the dependabot-specific `@dependabot recreate`.

Verified: YAML parses cleanly; traced the logic against the action's documented `push`-mode behaviour. I can't locally exercise a GitHub Actions trigger, so the real proof will be the next push to `main` — happy to add anything else you'd want checked first.